### PR TITLE
Drupal core make file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 sites/*/*settings*.php
 
 # Ignore paths that contain generated content.
+build/
 cache/
 files/
 sites/*/files

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,0 +1,15 @@
+; Drupal core
+
+; API version
+; ------------
+; Every makefile needs to declare it's Drush Make API version. This version of
+; drush make uses API version `2`.
+
+api = 2
+
+; The version of Drupal the profile is built for. Although you can leave this
+; as '7.x', it's better to be precise and define the exact version of core your
+; distribution works with.  This value should be updated when we update core.
+core = 7.23
+
+projects[] = drupal


### PR DESCRIPTION
- Closes #8 with the addition of drupal-org-core.make
- Updates the .gitignore to ignore build directory
