### PR TITLE
Salt configuration to install site.

### DIFF
--- a/salt/roots/salt/apache2/vhost.conf
+++ b/salt/roots/salt/apache2/vhost.conf
@@ -1,12 +1,12 @@
 <VirtualHost *:8888>
 	ServerAdmin webmaster@localhost
 
-	DocumentRoot /vagrant
+	DocumentRoot /vagrant/html
 	<Directory />
 		Options FollowSymLinks
 		AllowOverride None
 	</Directory>
-	<Directory /vagrant/>
+	<Directory /vagrant/html>
 		Options Indexes FollowSymLinks MultiViews
 		AllowOverride All
 		Order allow,deny

--- a/salt/roots/salt/install.sls
+++ b/salt/roots/salt/install.sls
@@ -2,7 +2,7 @@
 
 drush-make:
   cmd.run:
-    - name: cd /vagrant && drush make drupal-org-core.make html
+    - name: cd /vagrant && drush make build-dosomething.make html
     - require:
       - cmd: pear-drush
 
@@ -14,7 +14,7 @@ database-setup:
 
 site-install:
   cmd.run:
-    - name: cd /vagrant/html && drush site-install standard -y --db-url=mysql://root@localhost/dosomething --site-name=DoSomething
+    - name: cd /vagrant/html && drush site-install dosomething -y --db-url=mysql://root@localhost/dosomething --site-name=DoSomething
     - require:
       - cmd: database-setup
 

--- a/salt/roots/salt/install.sls
+++ b/salt/roots/salt/install.sls
@@ -1,0 +1,27 @@
+{% if grains['os'] == 'Ubuntu' %}
+
+drush-make:
+  cmd.run:
+    - name: cd /vagrant && drush make drupal-org-core.make html
+    - require:
+      - cmd: pear-drush
+
+database-setup:
+  cmd.run:
+    - name: sudo mysqladmin -uroot create dosomething
+    - require:
+      - cmd: drush-make
+
+site-install:
+  cmd.run:
+    - name: cd /vagrant/html && drush site-install standard -y --db-url=mysql://root@localhost/dosomething --site-name=DoSomething
+    - require:
+      - cmd: database-setup
+
+site-symlinks:
+  cmd.run:
+    - name: cd /vagrant && ln -s /vagrant/files /vagrant/html/files
+    - require:
+      - cmd: site-install
+
+{% endif %}

--- a/salt/roots/salt/lamp-drupal.sls
+++ b/salt/roots/salt/lamp-drupal.sls
@@ -135,4 +135,8 @@ git:
   pkg:
     - installed
 
+vim:
+  cmd.run:
+    - name: sudo apt-get install vim --yes
+
 {% endif %}

--- a/salt/roots/salt/top.sls
+++ b/salt/roots/salt/top.sls
@@ -3,3 +3,4 @@ base:
     - utils
     - lamp-drupal
     - selenium
+    - install


### PR DESCRIPTION
Updates salt configuration to actually install the app.
- Runs `drush make`
- Creates `dosomething` database
- Creates **DoSomething** site through `drush site-install standard`
- Changes document root to `/vagrant/files`
- Symlinks `files` directory to `/vagrant/html/files`

Unrelated:
- Installs vim

The admin user has an unknown password because Salt doesn't display output.  Use `drush upwd admin --password="your password"` to reset it.

Resolves #34 
