### PR TITLE
Adds more core/contrib modules to install profile

### DIFF
--- a/dosomething.info
+++ b/dosomething.info
@@ -4,17 +4,30 @@ core = 7.x
 
 ; CORE
 dependencies[] = block
-dependencies[] = node
+dependencies[] = field_ui
+dependencies[] = file
+dependencies[] = image
+dependencies[] = list
+dependencies[] = number
+dependencies[] = options
+dependencies[] = path
 dependencies[] = search
+dependencies[] = simpletest
+dependencies[] = taxonomy
 
 ; CONTRIB
 dependencies[] = admin_menu
+dependencies[] = ctools
 dependencies[] = date
 dependencies[] = features
+dependencies[] = libraries
 dependencies[] = mandrill
 dependencies[] = module_filter
 dependencies[] = metatag
+dependencies[] = pathauto
 dependencies[] = strongarm
 dependencies[] = views
+dependencies[] = views_ui
+dependencies[] = wysiwyg
 
 ; DOSOMETHING


### PR DESCRIPTION
Removes "node" from the list, as it's required by Drupal core.  Adds more stuff to the stuff.
