### PR TITLE
Removes profile symlinking for now. 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,18 +28,18 @@ echo 'Running drush make...'
 drush make $DRUSH_OPTS "$ABS_CALLPATH/$MAKEFILE" "$TARGET"
 set +e
 
-echo 'Symlink profile, module and themes'
-echo 'Linking dosomething.info'
-rm -rf "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.info"
-ln -s "$ABS_CALLPATH/dosomething.info" "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.info"
+# echo 'Symlink profile, module and themes'
+# echo 'Linking dosomething.info'
+# rm -rf "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.info"
+# ln -s "$ABS_CALLPATH/dosomething.info" "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.info"
 
-echo 'Linking dosomething.install'
-rm -rf "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.install"
-ln -s "$ABS_CALLPATH/dosomething.install" "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.install"
+# echo 'Linking dosomething.install'
+# rm -rf "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.install"
+# ln -s "$ABS_CALLPATH/dosomething.install" "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.install"
 
-echo 'Linking dosomething.profile'
-rm -rf "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.profile"
-ln -s "$ABS_CALLPATH/dosomething.profile" "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.profile"
+# echo 'Linking dosomething.profile'
+# rm -rf "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.profile"
+# ln -s "$ABS_CALLPATH/dosomething.profile" "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.profile"
 
 echo 'Linking modules'
 rm -rf "$ABS_CALLPATH/$TARGET/profiles/dosomething/modules/dosomething"


### PR DESCRIPTION
This is a hotfix that presents a temporary fix to #60 to get builds working properly again.

The symlinks for the profile specific files were not being referenced properly by the install script.
