### PR TITLE
Remove scripts from ds file

### DIFF
--- a/ds
+++ b/ds
@@ -14,12 +14,6 @@ ds build [--install]
   --install
     Runs "drush site-install" to actually install the Drupal instance.
 
-ds dbup
-  Gets the latest copy of the database and updates your local copy.
-
-ds dbdump
-  Dumps your copy of the database to an archive.
-
 ds --help
   Displays this help message.
 
@@ -111,20 +105,4 @@ if [[ $1 == "build" ]]
     #drush fra -y;
     #drush cc all;
     echo 'Build complete.'
-fi
-
-if [[ $1 == "dbup" ]]
-  then
-    echo "Coming soon!"
-    exit 1
-fi
-
-if [[ $1 == "dbdump" ]]
-  then
-    echo 'Dumping database...'
-    NOW=$(date +%s)
-    mysqldump -uroot dosomething > ~/db_dumps/$NOW.sql
-    cd ~/db_dumps
-    tar -czf db_dump_$NOW.tgz $NOW.sql
-    echo "Done.  The file can be found at '~/db_dumps/db_dump_$NOW.tgz"
 fi

--- a/ds
+++ b/ds
@@ -57,19 +57,6 @@ if [[ $1 == "build" ]]
     drush make $DRUSH_OPTS "$ABS_CALLPATH/$MAKEFILE" "$TARGET"
     set +e
 
-    # echo 'Symlink profile, module and themes'
-    # echo 'Linking dosomething.info'
-    # rm -rf "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.info"
-    # ln -s "$ABS_CALLPATH/dosomething.info" "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.info"
-
-    # echo 'Linking dosomething.install'
-    # rm -rf "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.install"
-    # ln -s "$ABS_CALLPATH/dosomething.install" "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.install"
-
-    # echo 'Linking dosomething.profile'
-    # rm -rf "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.profile"
-    # ln -s "$ABS_CALLPATH/dosomething.profile" "$ABS_CALLPATH/$TARGET/profiles/dosomething/dosomething.profile"
-
     echo 'Linking modules'
     rm -rf "$ABS_CALLPATH/$TARGET/profiles/dosomething/modules/dosomething"
     ln -s "$ABS_CALLPATH/modules/dosomething" "$ABS_CALLPATH/$TARGET/profiles/dosomething/modules/dosomething"
@@ -97,12 +84,5 @@ if [[ $1 == "build" ]]
     echo 'Clearing caches...'
     drush cc all
 
-    #echo 'Running updates...'
-    #drush updb -y;
-    # @TODO Figure out why this cc all is needed
-    #drush cc drush;
-    #echo 'Reverting all features...'
-    #drush fra -y;
-    #drush cc all;
     echo 'Build complete.'
 fi

--- a/ds
+++ b/ds
@@ -81,6 +81,9 @@ if [[ $1 == "build" ]]
     echo 'Replacing settings.php file...'
     rm -f $CALLPATH/$TARGET/sites/default/settings.php && ln -s $CALLPATH/settings.php $CALLPATH/$TARGET/sites/default/settings.php
 
+    echo 'Updating database...'
+    drush updb -y
+
     echo 'Clearing caches...'
     drush cc all
 


### PR DESCRIPTION
- Removes `dbup` and `dbdump` scripts from `ds` file.  There's a new `import.sh` file in the `Devel-Scripts` repository.
- Cleans up the file a bit.

Resolves #113, #114, #115.

Will need to investigate #112 re: symlinking profile.
