### PR TITLE
Moves paraneue to profile specific make file.  Downloads neue as library

### DIFF
--- a/build-dosomething.make
+++ b/build-dosomething.make
@@ -8,8 +8,3 @@ includes[] = drupal-org-core.make
 projects[dosomething][type] = profile
 projects[dosomething][download][type] = git
 projects[dosomething][download][url] = "git@github.com:DoSomething/dosomething.git"
-
-; Paraneue subtheme
-projects[dosomething][type] = theme
-projects[dosomething][download][type] = git
-projects[dosomething][download][url] = "git@github.com:DoSomething/paraneue.git"

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -82,6 +82,12 @@ projects[environment_indicator][subdir] = "contrib"
 
 ; THEMES
 
+; Paraneue subtheme
+projects[paraneue][type] = theme
+projects[paraneue][download][type] = git
+projects[paraneue][download][url] = "git@github.com:DoSomething/paraneue.git"
+projects[paraneue][subdir] = "dosomething/paraneue"
+
 ; LIBRARIES
 
 ; CKEditor 
@@ -91,3 +97,7 @@ libraries[ckeditor][download][url] = "http://download.cksource.com/CKEditor/CKEd
 ; DSAPI PHP Library
 libraries[dsapi][download][type] = "git"
 libraries[dsapi][download][url] = "git@github.com:DoSomething/dsapi-php.git"
+
+; NEUE
+libraries[neue][download][type] = "git"
+libraries[neue][download][url] = "git@github.com:DoSomething/ds-neue.git"


### PR DESCRIPTION
Paraneue must be downloading form the profile specific make file.  This also downloads neue as an independent library

Related to #43
