### PR TITLE
Resolves #98 by using Salt

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,8 +13,9 @@ Vagrant.configure("2") do |config|
   ## For masterless, mount your salt file root
   config.vm.synced_folder "salt/roots/", "/srv/"
   
-  # Without Varnish
+  # Bare Apache httpd (http and https)
   config.vm.network :forwarded_port, guest: 8888, host: 8888
+  config.vm.network :forwarded_port, guest: 443, host: 8889
   
   # With Varnish
   config.vm.network :forwarded_port, guest: 6081, host: 9999

--- a/salt/minion.conf
+++ b/salt/minion.conf
@@ -14,7 +14,7 @@ master: localhost
 #root_dir: /
 
 # The directory to store the pki information in
-#pki_dir: /etc/salt/pki
+pki_dir: /etc/salt/pki
 
 # Explicitly declare the id for this minion to use, if left commented the id
 # will be the hostname as returned by the python call: socket.getfqdn()
@@ -217,3 +217,9 @@ file_client: local
 #
 # A dict for the test module:
 #test.baz: {spam: sausage, cheese: bread}
+
+######          SSL module            #####
+###########################################
+# See http://docs.saltstack.com/ref/modules/all/salt.modules.tls.html
+
+ca.cert_base_path: '/etc/pki'

--- a/salt/roots/salt/apache2/ssl.conf
+++ b/salt/roots/salt/apache2/ssl.conf
@@ -1,0 +1,73 @@
+<IfModule mod_ssl.c>
+#
+# Pseudo Random Number Generator (PRNG):
+# Configure one or more sources to seed the PRNG of the SSL library.
+# The seed data should be of good random quality.
+# WARNING! On some platforms /dev/random blocks if not enough entropy
+# is available. This means you then cannot use the /dev/random device
+# because it would lead to very long connection times (as long as
+# it requires to make more entropy available). But usually those
+# platforms additionally provide a /dev/urandom device which doesn't
+# block. So, if available, use this one instead. Read the mod_ssl User
+# Manual for more details.
+#
+SSLRandomSeed startup builtin
+SSLRandomSeed startup file:/dev/urandom 512
+SSLRandomSeed connect builtin
+SSLRandomSeed connect file:/dev/urandom 512
+
+##
+##  SSL Global Context
+##
+##  All SSL configuration in this context applies both to
+##  the main server and all SSL-enabled virtual hosts.
+##
+
+#
+#   Some MIME-types for downloading Certificates and CRLs
+#
+AddType application/x-x509-ca-cert .crt
+AddType application/x-pkcs7-crl    .crl
+
+#   Pass Phrase Dialog:
+#   Configure the pass phrase gathering process.
+#   The filtering dialog program (`builtin' is a internal
+#   terminal dialog) has to provide the pass phrase on stdout.
+SSLPassPhraseDialog  exec:/usr/share/apache2/ask-for-passphrase
+
+#   Inter-Process Session Cache:
+#   Configure the SSL Session Cache: First the mechanism 
+#   to use and second the expiring timeout (in seconds).
+#   (The mechanism dbm has known memory leaks and should not be used).
+#SSLSessionCache         dbm:${APACHE_RUN_DIR}/ssl_scache
+SSLSessionCache        shmcb:${APACHE_RUN_DIR}/ssl_scache(512000)
+SSLSessionCacheTimeout  300
+
+#   Semaphore:
+#   Configure the path to the mutual exclusion semaphore the
+#   SSL engine uses internally for inter-process synchronization. 
+SSLMutex  file:${APACHE_RUN_DIR}/ssl_mutex
+
+#   SSL Cipher Suite:
+#   List the ciphers that the client is permitted to negotiate.
+#   See the mod_ssl documentation for a complete list.
+#   enable only secure ciphers:
+SSLCipherSuite HIGH:MEDIUM:!ADH:!MD5
+#   Use this instead if you want to allow cipher upgrades via SGC facility.
+#   In this case you also have to use something like 
+#        SSLRequire %{SSL_CIPHER_USEKEYSIZE} >= 128
+#   see http://httpd.apache.org/docs/2.2/ssl/ssl_howto.html.en#upgradeenc
+#SSLCipherSuite ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP:+eNULL
+
+# enable only secure protocols: SSLv3 and TLSv1, but not SSLv2
+SSLProtocol all -SSLv2
+
+# Allow insecure renegotiation with clients which do not yet support the
+# secure renegotiation protocol. Default: Off
+#SSLInsecureRenegotiation on
+
+# Whether to forbid non-SNI clients to access name based virtual hosts.
+# Default: Off
+#SSLStrictSNIVHostCheck On
+
+</IfModule>

--- a/salt/roots/salt/apache2/vhost-ssl.conf
+++ b/salt/roots/salt/apache2/vhost-ssl.conf
@@ -1,0 +1,163 @@
+<IfModule mod_ssl.c>
+<VirtualHost _default_:443>
+	ServerAdmin webmaster@localhost
+
+	DocumentRoot /vagrant/html
+	<Directory />
+		Options FollowSymLinks
+		AllowOverride None
+	</Directory>
+	<Directory /vagrant/html/>
+		Options Indexes FollowSymLinks MultiViews
+		AllowOverride None
+		Order allow,deny
+		allow from all
+	</Directory>
+
+	ScriptAlias /cgi-bin/ /usr/lib/cgi-bin/
+	<Directory "/usr/lib/cgi-bin">
+		AllowOverride None
+		Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+		Order allow,deny
+		Allow from all
+	</Directory>
+
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+
+	# Possible values include: debug, info, notice, warn, error, crit,
+	# alert, emerg.
+	LogLevel warn
+
+	CustomLog ${APACHE_LOG_DIR}/ssl_access.log combined
+
+	#   SSL Engine Switch:
+	#   Enable/Disable SSL for this virtual host.
+	SSLEngine on
+
+	#   A self-signed (snakeoil) certificate can be created by installing
+	#   the ssl-cert package. See
+	#   /usr/share/doc/apache2.2-common/README.Debian.gz for more info.
+	#   If both key and certificate are stored in the same file, only the
+	#   SSLCertificateFile directive is needed.
+	SSLCertificateFile    /etc/ssl/certs/ssl-cert-snakeoil.pem
+	SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
+
+	#   Server Certificate Chain:
+	#   Point SSLCertificateChainFile at a file containing the
+	#   concatenation of PEM encoded CA certificates which form the
+	#   certificate chain for the server certificate. Alternatively
+	#   the referenced file can be the same as SSLCertificateFile
+	#   when the CA certificates are directly appended to the server
+	#   certificate for convinience.
+	#SSLCertificateChainFile /etc/apache2/ssl.crt/server-ca.crt
+
+	#   Certificate Authority (CA):
+	#   Set the CA certificate verification path where to find CA
+	#   certificates for client authentication or alternatively one
+	#   huge file containing all of them (file must be PEM encoded)
+	#   Note: Inside SSLCACertificatePath you need hash symlinks
+	#         to point to the certificate files. Use the provided
+	#         Makefile to update the hash symlinks after changes.
+	SSLCACertificatePath /etc/pki/salt/certs/
+	#SSLCACertificateFile /etc/apache2/ssl.crt/ca-bundle.crt
+
+	#   Certificate Revocation Lists (CRL):
+	#   Set the CA revocation path where to find CA CRLs for client
+	#   authentication or alternatively one huge file containing all
+	#   of them (file must be PEM encoded)
+	#   Note: Inside SSLCARevocationPath you need hash symlinks
+	#         to point to the certificate files. Use the provided
+	#         Makefile to update the hash symlinks after changes.
+	#SSLCARevocationPath /etc/apache2/ssl.crl/
+	#SSLCARevocationFile /etc/apache2/ssl.crl/ca-bundle.crl
+
+	#   Client Authentication (Type):
+	#   Client certificate verification type and depth.  Types are
+	#   none, optional, require and optional_no_ca.  Depth is a
+	#   number which specifies how deeply to verify the certificate
+	#   issuer chain before deciding the certificate is not valid.
+	#SSLVerifyClient require
+	#SSLVerifyDepth  10
+
+	#   Access Control:
+	#   With SSLRequire you can do per-directory access control based
+	#   on arbitrary complex boolean expressions containing server
+	#   variable checks and other lookup directives.  The syntax is a
+	#   mixture between C and Perl.  See the mod_ssl documentation
+	#   for more details.
+	#<Location />
+	#SSLRequire (    %{SSL_CIPHER} !~ m/^(EXP|NULL)/ \
+	#            and %{SSL_CLIENT_S_DN_O} eq "Snake Oil, Ltd." \
+	#            and %{SSL_CLIENT_S_DN_OU} in {"Staff", "CA", "Dev"} \
+	#            and %{TIME_WDAY} >= 1 and %{TIME_WDAY} <= 5 \
+	#            and %{TIME_HOUR} >= 8 and %{TIME_HOUR} <= 20       ) \
+	#           or %{REMOTE_ADDR} =~ m/^192\.76\.162\.[0-9]+$/
+	#</Location>
+
+	#   SSL Engine Options:
+	#   Set various options for the SSL engine.
+	#   o FakeBasicAuth:
+	#     Translate the client X.509 into a Basic Authorisation.  This means that
+	#     the standard Auth/DBMAuth methods can be used for access control.  The
+	#     user name is the `one line' version of the client's X.509 certificate.
+	#     Note that no password is obtained from the user. Every entry in the user
+	#     file needs this password: `xxj31ZMTZzkVA'.
+	#   o ExportCertData:
+	#     This exports two additional environment variables: SSL_CLIENT_CERT and
+	#     SSL_SERVER_CERT. These contain the PEM-encoded certificates of the
+	#     server (always existing) and the client (only existing when client
+	#     authentication is used). This can be used to import the certificates
+	#     into CGI scripts.
+	#   o StdEnvVars:
+	#     This exports the standard SSL/TLS related `SSL_*' environment variables.
+	#     Per default this exportation is switched off for performance reasons,
+	#     because the extraction step is an expensive operation and is usually
+	#     useless for serving static content. So one usually enables the
+	#     exportation for CGI and SSI requests only.
+	#   o StrictRequire:
+	#     This denies access when "SSLRequireSSL" or "SSLRequire" applied even
+	#     under a "Satisfy any" situation, i.e. when it applies access is denied
+	#     and no other module can change it.
+	#   o OptRenegotiate:
+	#     This enables optimized SSL connection renegotiation handling when SSL
+	#     directives are used in per-directory context.
+	#SSLOptions +FakeBasicAuth +ExportCertData +StrictRequire
+	<FilesMatch "\.(cgi|shtml|phtml|php)$">
+		SSLOptions +StdEnvVars
+	</FilesMatch>
+	<Directory /usr/lib/cgi-bin>
+		SSLOptions +StdEnvVars
+	</Directory>
+
+	#   SSL Protocol Adjustments:
+	#   The safe and default but still SSL/TLS standard compliant shutdown
+	#   approach is that mod_ssl sends the close notify alert but doesn't wait for
+	#   the close notify alert from client. When you need a different shutdown
+	#   approach you can use one of the following variables:
+	#   o ssl-unclean-shutdown:
+	#     This forces an unclean shutdown when the connection is closed, i.e. no
+	#     SSL close notify alert is send or allowed to received.  This violates
+	#     the SSL/TLS standard but is needed for some brain-dead browsers. Use
+	#     this when you receive I/O errors because of the standard approach where
+	#     mod_ssl sends the close notify alert.
+	#   o ssl-accurate-shutdown:
+	#     This forces an accurate shutdown when the connection is closed, i.e. a
+	#     SSL close notify alert is send and mod_ssl waits for the close notify
+	#     alert of the client. This is 100% SSL/TLS standard compliant, but in
+	#     practice often causes hanging connections with brain-dead browsers. Use
+	#     this only for browsers where you know that their SSL implementation
+	#     works correctly.
+	#   Notice: Most problems of broken clients are also related to the HTTP
+	#   keep-alive facility, so you usually additionally want to disable
+	#   keep-alive for those clients, too. Use variable "nokeepalive" for this.
+	#   Similarly, one has to force some clients to use HTTP/1.0 to workaround
+	#   their broken HTTP/1.1 implementation. Use variables "downgrade-1.0" and
+	#   "force-response-1.0" for this.
+	BrowserMatch "MSIE [2-6]" \
+		nokeepalive ssl-unclean-shutdown \
+		downgrade-1.0 force-response-1.0
+	# MSIE 7 and newer should be able to use keepalive
+	BrowserMatch "MSIE [17-9]" ssl-unclean-shutdown
+
+</VirtualHost>
+</IfModule>

--- a/salt/roots/salt/lamp-drupal.sls
+++ b/salt/roots/salt/lamp-drupal.sls
@@ -139,18 +139,4 @@ apt-update:
   cmd.run:
     - name: sudo apt-get update
 
-git:
-  pkg:
-    - installed
-
-vim:
-  cmd.run:
-    - name: sudo apt-get install vim --yes
-
-bash-fix:
-  cmd.run:
-    - name: sudo rm /bin/sh && sudo ln -s /bin/bash /bin/sh
-  require:
-    - pkg: apache2
-
 {% endif %}

--- a/salt/roots/salt/ssl.sls
+++ b/salt/roots/salt/ssl.sls
@@ -1,0 +1,78 @@
+python-dev:
+  pkg:
+    - installed
+
+python-openssl:
+  pkg:
+    - installed
+    - require:
+      - pkg: python-dev
+
+# Example here: http://intothesaltmine.org/install_and_configure_halite_alpha_on_arch_linux.html
+# How to call in a State file?
+#
+# tls.create_ca salt
+# tls.create_csr salt
+# tls.create_ca_signed_cert salt localhost
+#
+# Could be explicit calls, e.g.,
+#
+# sudo salt-call -l debug tls.create_ca_signed_cert salt localhost
+#
+# But shouldn't that be possible as a declaration here?
+
+tls-create-ca:
+  cmd.run:
+    - name: sudo salt-call tls.create_ca salt
+    - require:
+      - pkg: python-openssl
+
+tls-create-csr:
+  cmd.run:
+    - name: sudo salt-call tls.create_csr salt
+    - require:
+      - cmd: tls-create-ca
+
+tls-create-cert:
+  cmd.run:
+    - name: sudo salt-call tls.create_ca_signed_cert salt localhost
+    - require:
+      - cmd: tls-create-csr
+
+# This doesn't work:
+#
+# ssl-cert:
+#  tls.create_self_signed_cert:
+#    - tls_dir: tls
+#    - CN: localhost
+#    - C: US
+#    - ST: New York
+#    - L: New York
+#    - O: DoSomething.org
+#    - emailAddress: machines@dosomething.org
+
+apache2-vhosts-ssl:
+  file.managed:
+    - name: /etc/apache2/sites-available/default-ssl
+    - source: salt://apache2/vhost-ssl.conf
+    - require:
+      - pkg: apache2
+      - cmd: tls-create-cert
+
+apache2-enable-ssl-1:
+  cmd.run:
+    - name: a2enmod ssl ; service apache2 restart
+    - require:
+      - file: apache2-vhosts
+
+apache2-enable-ssl-2:
+  cmd.run:
+    - name: a2ensite default-ssl ; service apache2 restart
+    - require:
+      - cmd: apache2-enable-ssl-1
+
+apache2-ssl-restart:
+  cmd.run:
+    - name: service apache2 restart
+    - require:
+      - cmd: apache2-enable-ssl-2

--- a/salt/roots/salt/top.sls
+++ b/salt/roots/salt/top.sls
@@ -2,5 +2,6 @@ base:
   '*':
     - utils
     - lamp-drupal
+    - ssl
     - selenium
     - install

--- a/salt/roots/salt/utils.sls
+++ b/salt/roots/salt/utils.sls
@@ -8,4 +8,20 @@ sendmail:
   pkg:
     - installed
 
+python-pip:
+  pkg:
+    - installed
+
+git:
+  pkg:
+    - installed
+
+vim:
+  pkg:
+    - installed
+
+bash-fix:
+  cmd.run:
+    - name: sudo rm /bin/sh && sudo ln -s /bin/bash /bin/sh
+
 {% endif %}


### PR DESCRIPTION
http is still on 8888; https is on 8889.

Auto-generated certs live in /etc/pki/salt.

Also refactors a few utility packages into utils.sls for clarity.
