### PR TITLE
Enable Mailsystem on install

### DIFF
--- a/dosomething.info
+++ b/dosomething.info
@@ -21,6 +21,7 @@ dependencies[] = ctools
 dependencies[] = date
 dependencies[] = features
 dependencies[] = libraries
+dependencies[] = mailsystem
 dependencies[] = module_filter
 dependencies[] = pathauto
 dependencies[] = strongarm

--- a/modules/dosomething/dosomething_user/dosomething_user.test
+++ b/modules/dosomething/dosomething_user/dosomething_user.test
@@ -77,8 +77,7 @@ class DosomethingUserWebTestCase extends DrupalWebTestCase {
       'administer features',
       'administer filters',
       'administer image styles',
-      //@todo: investigate why mailsystem permission is failing for admin.
-      //'administer mailsystem',
+      'administer mailsystem',
       'administer module filter',
       'administer modules',
       'administer nodes',


### PR DESCRIPTION
Fixes #131

Running `drush test-run --verbose` from command line showed that Mailsystem was being enabled after the dosomething_user feature was enabled, causing the missing permission.  Adding Mailsystem to the profile install fixes this.
