### PR TITLE
Coder

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -80,6 +80,10 @@ projects[devel][subdir] = "contrib"
 projects[environment_indicator] = "7.x-2.0"
 projects[environment_indicator][subdir] = "contrib"
 
+; Coder
+projects[coder] = "7.x-2.0"
+projects[coder][subdir] = "contrib"
+
 ; THEMES
 
 ; Paraneue subtheme

--- a/ds
+++ b/ds
@@ -87,5 +87,12 @@ if [[ $1 == "build" ]]
     echo 'Clearing caches...'
     drush cc all
 
+    if [ ! -e "~/.bash_profile" ]
+    then
+      echo 'Setting up PHP CodeSniffer...'
+      echo 'alias codercs="phpcs --standard=/vagrant/html/profiles/dosomething/modules/contrib/coder/coder_sniffer/Drupal/ruleset.xml --extensions=php,module,inc,install,test,profile,theme"' > ~/.bash_profile
+      source ~/.bash_profile
+    fi
+
     echo 'Build complete.'
 fi

--- a/salt/roots/salt/lamp-drupal.sls
+++ b/salt/roots/salt/lamp-drupal.sls
@@ -38,6 +38,12 @@ pear-misc:
     - require:
       - pkg: php5-pkgs
 
+pear-codersniffer:
+  cmd.run:
+    - name: pear install PHP_CodeSniffer
+    - require:
+      - cmd: pear-misc
+
 apache2-env:
   file.managed:
     - name: /etc/apache2/envvars


### PR DESCRIPTION
- Includes `coder` module in make file.
- Sets up PHP CodeSniffer command as `codercs` in .bash_profile -- will be available after running `ds build [--install]`.
- Installs PHP_CodeSniffer pear package through salt.

Documentation for all of this coming soon.
