### PR TITLE
Removes themes symlinking for now

### DIFF
--- a/ds
+++ b/ds
@@ -61,9 +61,9 @@ if [[ $1 == "build" ]]
     rm -rf "$ABS_CALLPATH/$TARGET/profiles/dosomething/modules/dosomething"
     ln -s "$ABS_CALLPATH/modules/dosomething" "$ABS_CALLPATH/$TARGET/profiles/dosomething/modules/dosomething"
 
-    echo 'Linking themes'
-    rm -rf "$ABS_CALLPATH/$TARGET/profiles/dosomething/themes/dosomething"
-    ln -s "$ABS_CALLPATH/themes/dosomething" "$ABS_CALLPATH/$TARGET/profiles/dosomething/themes/dosomething"
+    # echo 'Linking themes'
+    # rm -rf "$ABS_CALLPATH/$TARGET/profiles/dosomething/themes/dosomething"
+    # ln -s "$ABS_CALLPATH/themes/dosomething" "$ABS_CALLPATH/$TARGET/profiles/dosomething/themes/dosomething"
 
     # Clear caches and Run updates
     cd "$TARGET"


### PR DESCRIPTION
This is borked currently.  Removing this symlink + pulling in paraneue via the make file, places the theme directories properly.
