### PR TITLE
Add dosomething_campaign module

### DIFF
--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @file
+ * Admin pages for dosomething_campaign.module.
+ */
+
+/**
+ * Form constructor for the Campaign entity form.
+ *
+ * @ingroup forms
+ */
+function campaign_form($form, &$form_state, $campaign, $op = 'edit') {
+  $form['title'] = array(
+    '#title' => t('Title'),
+    '#type' => 'textfield',
+    '#default_value' => isset($campaign->title) ? $campaign->title : '',
+    '#description' => t('Campaign title.'),
+    '#required' => TRUE,
+    '#weight' => -50,
+  );
+  $form['actions'] = array(
+    '#type' => 'actions',
+    'submit' => array(
+      '#type' => 'submit',
+      '#value' => isset($campaign->id) ? t('Update Campaign') : t('Save Campaign'),
+    ),
+  );
+  return $form;
+}
+
+/**
+ * Form submission handler for campaign_form().
+ *
+ * @see campaign_form()
+ */
+function campaign_form_submit($form, &$form_state) {
+  $campaign = entity_ui_form_submit_build_entity($form, $form_state);
+  $campaign->save();
+  $form_state['redirect'] = 'admin/campaign';
+}

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.info
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.info
@@ -1,0 +1,4 @@
+name = DoSomething Campaign
+description = Provides a custom Campaign Entity and its functionality.
+core = 7.x
+dependencies[] = entity

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.install
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.install
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @file
+ * Installation and schema hooks for dosomething_campaign.module.
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function dosomething_campaign_schema() {
+  $schema = array();
+  $schema['dosomething_campaign'] = array(
+    'description' => 'The base table for the Campaign entity',
+    'fields' => array(
+      'id' => array(
+        'description' => 'Primary key of the Campaign entity',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'title' => array(
+        'description' => 'Human readable title of the Campaign.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => TRUE,
+      ),
+      /*
+      'created' => array(
+        'description' => 'Date and time the campaign record was created.',
+        'type' => 'int',
+        'length' => 10,
+        'not null' => FALSE,
+      ),
+      'changed' => array(
+        'description' => 'Date and time the campaign record was last modified.',
+        'type' => 'int',
+        'length' => 10,
+        'not null' => FALSE,
+      ),
+      */
+    ),
+    'primary key' => array('id'),
+  );
+  return $schema;
+}

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @file
+ * Provides a Campaign custom entity type named 'campaign'.
+ */
+
+/**
+ * Implements hook_entity_info().
+ */
+function dosomething_campaign_entity_info() {
+  $info = array();
+  $info['campaign'] = array(
+    'label' => t('Campaign'),
+    'base table' => 'dosomething_campaign',
+    'entity keys' => array(
+      'id' => 'id',
+      'label' => 'title',
+    ),
+    'entity class' => 'CampaignEntity',
+    'uri callback' => 'entity_class_uri',
+    'controller class' => 'CampaignEntityController',
+    'admin ui' => array(
+       'path' => 'admin/campaign',
+       'controller class' => 'CampaignEntityUIController',
+       'menu wildcard' => '%campaign',
+       'file' => 'dosomething_campaign.admin.inc',
+     ),
+     'module' => 'dosomething_campaign',
+     // Controls who can access entity CRUD.
+     'access callback' => 'dosomething_campaign_access',
+  );
+  return $info;
+}
+
+/**
+ * Implements hook_menu().
+ */
+function dosomething_campaign_menu() {
+  $items = array();
+  $items['campaign/%campaign'] = array(
+    'title' => 'Campaign',
+    'page callback' => 'dosomething_campaign_view_entity',
+    'page arguments' => array(1),
+    'access callback' => TRUE,
+  );
+  return $items;
+}
+
+/**
+ * Access callback for CampaignEntity CRUD operations.
+ */
+function dosomething_campaign_access($op, $dosomething_campaign = NULL, $account = NULL) {
+  return TRUE;
+}
+
+/**
+ * Menu autoloader for /campaign.
+ */
+function campaign_load($id) {
+  $campaign = entity_load('campaign', array($id));
+  return array_pop($campaign);
+}
+
+/**
+ * Callback for /campaign/ID page.
+ *
+ * Just a place to render a complete campaign entity.
+ */
+function dosomething_campaign_view_entity($campaign) {
+  $campaign_entity = entity_view('campaign', array($campaign->id => $campaign));
+  //@todo: Make me pretty.
+  return print_r($campaign_entity, TRUE);
+}
+
+/**
+ * Our custom entity class.
+ */
+class CampaignEntity extends Entity {
+  /**
+   * Override this in order to implement a custom default URI.
+   */
+  protected function defaultUri() {
+    return array('path' => 'campaign/' . $this->identifier());
+  }
+}
+
+/**
+ * Our custom controller for the dosomething_campaign type.
+ *
+ * We're choosing to extend the controller provided by the entity module so that we'll have
+ * full CRUD support for CampaignEntities.
+ */
+class CampaignEntityController extends EntityAPIController {
+
+}
+
+/**
+ * Our custom controller for the admin ui.
+ */
+class CampaignEntityUIController extends EntityDefaultUIController {
+
+}


### PR DESCRIPTION
Provides a Campaign entity, which for now, just simply has an id and a title field.

Makes use the contrib Entity module to provide an admin UI for CRUD operations at /admin/campaigns.

Resolves #31
