### PR TITLE
Campaign properties

### DIFF
--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.install
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.install
@@ -24,20 +24,30 @@ function dosomething_campaign_schema() {
         'length' => '255',
         'not null' => TRUE,
       ),
-      /*
-      'created' => array(
-        'description' => 'Date and time the campaign record was created.',
+      'uid' => array(
+        'description' => 'The {users}.uid that owns this campaign; initially, this is the user that created it.',
         'type' => 'int',
-        'length' => 10,
-        'not null' => FALSE,
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'status' => array(
+        'description' => 'Boolean indicating whether the campaign is published (visible to non-administrators).',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'created' => array(
+        'description' => 'The Unix timestamp when the campaign was created.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
       ),
       'changed' => array(
-        'description' => 'Date and time the campaign record was last modified.',
+        'description' => 'The Unix timestamp when the campaign was most recently saved.',
         'type' => 'int',
-        'length' => 10,
-        'not null' => FALSE,
+        'not null' => TRUE,
+        'default' => 0,
       ),
-      */
     ),
     'primary key' => array('id'),
   );

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -112,6 +112,56 @@ class CampaignEntityController extends EntityAPIController {
  * Our custom controller for the admin ui.
  */
 class CampaignEntityUIController extends EntityDefaultUIController {
+
+  /**
+   * Generates the render array for a overview table for arbitrary entities
+   * matching the given conditions.
+   *
+   * @param $conditions
+   *   An array of conditions as needed by entity_load().
+
+   * @return Array
+   *   A renderable array.
+   */
+  public function overviewTable($conditions = array()) {
+
+    $query = new EntityFieldQuery();
+    $query->entityCondition('entity_type', $this->entityType);
+    $query->propertyOrderBy('changed', 'DESC');
+
+    // Add all conditions to query.
+    foreach ($conditions as $key => $value) {
+      $query->propertyCondition($key, $value);
+    }
+
+    if ($this->overviewPagerLimit) {
+      $query->pager($this->overviewPagerLimit);
+    }
+
+    $results = $query->execute();
+
+    $ids = isset($results[$this->entityType]) ? array_keys($results[$this->entityType]) : array();
+    $entities = $ids ? entity_load($this->entityType, $ids) : array();
+
+    $rows = array();
+    foreach ($entities as $entity) {
+      // Add additional columns for table rows:
+      $rows[] = $this->overviewTableRow($conditions, entity_id($this->entityType, $entity), $entity, array(
+        format_date($entity->changed, 'short'),
+        )
+      );
+    }
+
+    $render = array(
+      '#theme' => 'table',
+      // Add additional columns for table header:
+      '#header' => $this->overviewTableHeaders($conditions, $rows, array(t('Updated'))),
+      '#rows' => $rows,
+      '#empty' => t('None.'),
+    );
+    return $render;
+  }
+
   /**
    * Generates the table headers for the overview table.
    */

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -92,6 +92,20 @@ class CampaignEntity extends Entity {
  */
 class CampaignEntityController extends EntityAPIController {
 
+  /**
+   * Overrides save() method.
+   *
+   * Populates created, updated, and uid automatically.
+   */
+  public function save($entity, DatabaseTransaction $transaction = NULL) {
+    if (isset($entity->is_new)) {
+      $entity->created = REQUEST_TIME;
+      global $user;
+      $entity->uid = $user->uid;
+    }
+    $entity->changed = REQUEST_TIME;
+    return parent::save($entity, $transaction);
+  }
 }
 
 /**

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -112,5 +112,17 @@ class CampaignEntityController extends EntityAPIController {
  * Our custom controller for the admin ui.
  */
 class CampaignEntityUIController extends EntityDefaultUIController {
-
+  /**
+   * Generates the table headers for the overview table.
+   */
+  protected function overviewTableHeaders($conditions, $rows, $additional_header = array()) {
+    $header = $additional_header;
+    array_unshift($header, t('Title'));
+    if (!empty($this->entityInfo['exportable'])) {
+      $header[] = t('Status');
+    }
+    // Add operations with the right colspan.
+    $header[] = array('data' => t('Operations'), 'colspan' => $this->operationCount());
+    return $header;
+  }
 }

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -98,12 +98,13 @@ class CampaignEntityController extends EntityAPIController {
    * Populates created, updated, and uid automatically.
    */
   public function save($entity, DatabaseTransaction $transaction = NULL) {
+    $current_timestamp = REQUEST_TIME;
     if (isset($entity->is_new)) {
-      $entity->created = REQUEST_TIME;
+      $entity->created = $current_timestamp;
       global $user;
       $entity->uid = $user->uid;
     }
-    $entity->changed = REQUEST_TIME;
+    $entity->changed = $current_timestamp;
     return parent::save($entity, $transaction);
   }
 }


### PR DESCRIPTION
Populates the created, updated, and uid properties on a Campaign.
- Overrides Entity API `save()` method to save created, updated, and values on submitting campaign edit form
- Overrides overviewTable() to display the "changed" value as a column and sort by it

Resolves #192
