### PR TITLE
Enables dosomething campaigns & taxonomy modules from the installation profile

### DIFF
--- a/dosomething.info
+++ b/dosomething.info
@@ -36,3 +36,5 @@ dependencies[] = wysiwyg
 
 ; DOSOMETHING
 dependencies[] = dosomething_user
+dependencies[] = dosomething_campaign
+dependencies[] = dosomething_taxonomy


### PR DESCRIPTION
@aaronschachter Any reason why we cannot enable these now?  It will make it easier for others to jump and contribute to both
