### PR TITLE
Campaign column start + Admin settings form

### DIFF
--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -11,7 +11,7 @@
  */
 function campaign_form($form, &$form_state, $campaign, $op = 'edit') {
   // Prefix for form description variables:
-  $desc_prefix = 'dosomething_campaign_form_desc_';
+  $desc_prefix = DOSOMETHING_CAMPAIGN_FORM_DESC_PREFIX;
 
   // Basic info:
   $form['title'] = array(
@@ -89,4 +89,32 @@ function campaign_form_submit($form, &$form_state) {
   $campaign = entity_ui_form_submit_build_entity($form, $form_state);
   $campaign->save();
   $form_state['redirect'] = 'admin/campaign';
+}
+
+/**
+ * Form constructor for the admin settings for Campaign entity form.
+ *
+ * @ingroup forms
+ */
+function dosomething_campaign_admin_settings_form($form, &$form_state) {
+  // List all the campaign_form form element names for which we are storing help text for:
+  $elements = array(
+    'cta_text',
+    'season_high_low',
+    'season_high_start',
+    'season_low_start',
+    'season_low_end',
+    'timing',
+    'title',
+  );
+  // For each element:
+  foreach ($elements as $field_name) {
+    // Output a textarea to set its coresponding Form Description variable.
+    $form[DOSOMETHING_CAMPAIGN_FORM_DESC_PREFIX . $field_name] = array(
+      '#title' => $field_name,
+      '#type' => 'textarea',
+      '#default_value' => variable_get(DOSOMETHING_CAMPAIGN_FORM_DESC_PREFIX . $field_name, ''),
+    );
+  }
+  return system_settings_form($form);
 }

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -10,13 +10,65 @@
  * @ingroup forms
  */
 function campaign_form($form, &$form_state, $campaign, $op = 'edit') {
+  // Prefix for form description variables:
+  $desc_prefix = 'dosomething_campaign_form_desc_';
+
+  // Basic info:
   $form['title'] = array(
     '#title' => t('Title'),
     '#type' => 'textfield',
     '#default_value' => isset($campaign->title) ? $campaign->title : '',
-    '#description' => t('Campaign title.'),
+    '#description' => variable_get($desc_prefix . 'title', ''),
     '#required' => TRUE,
-    '#weight' => -50,
+  );
+  $form['cta_text'] = array(
+    '#title' => t('Call to action'),
+    '#type' => 'textfield',
+    '#default_value' => isset($campaign->cta_text) ? $campaign->cta_text : '',
+    '#description' => variable_get($desc_prefix . 'cta_text', ''),
+    '#required' => TRUE,
+  );
+
+  // Timing:
+  $form['timing'] = array(
+    '#type' => 'fieldset', 
+    '#title' => t('Timing'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#description' => variable_get($desc_prefix . 'timing', ''),
+  );
+  $form['timing']['season_high_start'] = array(
+    '#title' => t('High Season - Start Date'),
+    '#type' => 'textfield',
+    '#default_value' => isset($campaign->season_high_start) ? $campaign->season_high_start : '',
+    '#attributes' =>array('placeholder' => t('MM/DD')),
+    '#description' => variable_get($desc_prefix . 'season_high_start', ''),
+  );
+  $form['timing']['season_high_end'] = array(
+    '#title' => t('High Season - End Date'),
+    '#type' => 'textfield',
+    '#default_value' => isset($campaign->season_high_end) ? $campaign->season_high_end : '',
+    '#attributes' =>array('placeholder' => t('MM/DD')),
+    '#description' => variable_get($desc_prefix . 'season_high_end', ''),
+  );
+  $form['timing']['is_season_high_end_displayed'] = array(
+    '#title' => t('Show End Date on Pitch & Action Page'),
+    '#type' => 'checkbox',
+    '#default_value' => isset($campaign->is_season_high_end_displayed) ? $campaign->is_season_high_end_displayed : 0,
+  );
+  $form['timing']['season_low_start'] = array(
+    '#title' => t('Low Season - Start Date'),
+    '#type' => 'textfield',
+    '#default_value' => isset($campaign->season_low_start) ? $campaign->season_low_start : '',
+    '#attributes' =>array('placeholder' => t('MM/DD')),
+    '#description' => variable_get($desc_prefix . 'season_low_start', ''),
+  );
+  $form['timing']['season_low_end'] = array(
+    '#title' => t('Low Season - End Date'),
+    '#type' => 'textfield',
+    '#default_value' => isset($campaign->season_low_end) ? $campaign->season_low_end : '',
+    '#attributes' =>array('placeholder' => t('MM/DD')),
+    '#description' => variable_get($desc_prefix . 'season_low_end', ''),
   );
   $form['actions'] = array(
     '#type' => 'actions',

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.install
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.install
@@ -48,6 +48,42 @@ function dosomething_campaign_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'cta_text' => array(
+        'description' => 'Describes the action the user is taking by completing the campaign.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => FALSE,
+      ),
+      'season_high_start' => array(
+        'description' => 'Date string of the start of the campaign high season.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => FALSE,
+      ),
+      'season_high_end' => array(
+        'description' => 'Date string of the end of the campaign high season.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => FALSE,
+      ),
+      'is_season_high_end_displayed' => array(
+        'description' => 'Boolean indicating whether campaign high season end should be displayed.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'season_low_start' => array(
+        'description' => 'Date string of the start of the campaign low season.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => FALSE,
+      ),
+      'season_low_end' => array(
+        'description' => 'Date string of the end of the campaign low season.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => FALSE,
+      ),
     ),
     'primary key' => array('id'),
   );

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -3,7 +3,7 @@
  * @file
  * Provides a Campaign custom entity type named 'campaign'.
  */
-
+define('DOSOMETHING_CAMPAIGN_FORM_DESC_PREFIX', 'dosomething_campaign_form_desc_');
 /**
  * Implements hook_entity_info().
  */
@@ -42,6 +42,14 @@ function dosomething_campaign_menu() {
     'page callback' => 'dosomething_campaign_view_entity',
     'page arguments' => array(1),
     'access callback' => TRUE,
+  );
+  $items['admin/config/dosomething/dosomething_campaign'] = array(
+    'title' => 'DoSomething Campaign Settings',
+    'description' => t('Configure DoSomething Campaign settings.'),
+    'access arguments' => array('administer modules'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_campaign_admin_settings_form'),
+    'file' => 'dosomething_campaign.admin.inc',
   );
   return $items;
 }


### PR DESCRIPTION
Adds a "CTA Text" column and columns / fieldset for Timing in both the table schema, and admin `campaign_form`.

Also adds an admin settings form to store form descriptions in variables via admin settings form (instead of hardcoding descriptions).

Begins work for #189
