### PR TITLE
Campaign "Know it" Section columns

### DIFF
--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -70,6 +70,47 @@ function campaign_form($form, &$form_state, $campaign, $op = 'edit') {
     '#attributes' =>array('placeholder' => t('MM/DD')),
     '#description' => variable_get($desc_prefix . 'season_low_end', ''),
   );
+
+  // Know It:
+  $form['know'] = array(
+    '#type' => 'fieldset', 
+    '#title' => t('Know It'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#description' => variable_get($desc_prefix . 'know', ''),
+  );
+  $form['know']['stat_problem'] = array(
+    '#title' => t('Statement on the Problem'),
+    '#type' => 'textfield',
+    '#default_value' => isset($campaign->stat_problem) ? $campaign->stat_problem : '',
+    '#description' => variable_get($desc_prefix . 'stat_problem', ''),
+  );
+  $form['know']['stat_problem_source'] = array(
+    '#title' => t('Source for Problem Statement'),
+    '#type' => 'textfield',
+    '#default_value' => isset($campaign->stat_problem_source) ? $campaign->stat_problem_source : '',
+    '#description' => variable_get($desc_prefix . 'stat_problem_source', ''),
+  );
+  $form['know']['stat_solution'] = array(
+    '#title' => t('Statement on the Solution'),
+    '#type' => 'textfield',
+    '#default_value' => isset($campaign->stat_solution) ? $campaign->stat_solution : '',
+    '#description' => variable_get($desc_prefix . 'stat_solution', ''),
+  );
+  $form['know']['stat_solution_source'] = array(
+    '#title' => t('Source for Solution Statement'),
+    '#type' => 'textfield',
+    '#default_value' => isset($campaign->stat_solution_source) ? $campaign->stat_solution_source : '',
+    '#description' => variable_get($desc_prefix . 'stat_solution_source', ''),
+  );
+  $form['know']['url_psa'] = array(
+    '#title' => t('PSA'),
+    '#type' => 'textfield',
+    '#default_value' => isset($campaign->url_psa) ? $campaign->url_psa : '',
+    '#description' => variable_get($desc_prefix . 'url_psa', ''),
+  );
+
+  // Form actions:
   $form['actions'] = array(
     '#type' => 'actions',
     'submit' => array(
@@ -100,12 +141,18 @@ function dosomething_campaign_admin_settings_form($form, &$form_state) {
   // List all the campaign_form form element names for which we are storing help text for:
   $elements = array(
     'cta_text',
+    'know',
     'season_high_low',
     'season_high_start',
     'season_low_start',
     'season_low_end',
+    'stat_problem',
+    'stat_problem_source',
+    'stat_solution',
+    'stat_solution_source',
     'timing',
     'title',
+    'url_psa',
   );
   // For each element:
   foreach ($elements as $field_name) {

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.install
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.install
@@ -84,6 +84,36 @@ function dosomething_campaign_schema() {
         'length' => '255',
         'not null' => FALSE,
       ),
+      'stat_problem' => array(
+        'description' => 'Statistic or statement on the problem.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => FALSE,
+      ),
+      'stat_problem_source' => array(
+        'description' => 'Source of the stat_problem.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => FALSE,
+      ),
+      'stat_solution' => array(
+        'description' => 'Statistic or statement on the solution.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => FALSE,
+      ),
+      'stat_solution_source' => array(
+        'description' => 'Source of the stat_solution.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => FALSE,
+      ),
+      'url_psa' => array(
+        'description' => 'URL For PSA.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => FALSE,
+      ),
     ),
     'primary key' => array('id'),
   );


### PR DESCRIPTION
Adds simple varchar columns for the "Know it" section into the table schema, and updates the campaign_edit form and admin_settings_form accordingly.

Opening this PR up in order to make it easier to review, instead of opening up a massive PR for all of the various columns we need to add.

Continues work for #189
