### PR TITLE
Beginning of the great SMS code migration

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -125,8 +125,8 @@ libraries[ckeditor][download][type] = "get"
 libraries[ckeditor][download][url] = "http://download.cksource.com/CKEditor/CKEditor/CKEditor%204.2.2/ckeditor_4.2.2_standard.tar.gz"
 
 ; Mobile Commons PHP
-libraries[mobilecommons_php][download][type] = "git"
-libraries[mobilecommons_php][download][url] = "https://github.com/DoSomething/mobilecommons-php.git"
+libraries['mobilecommons-php'][download][type] = "git"
+libraries['mobilecommons-php'][download][url] = "https://github.com/DoSomething/mobilecommons-php.git"
 
 ; DSAPI PHP Library
 libraries[dsapi][download][type] = "git"

--- a/modules/dosomething/dosomething_sms/dosomething_sms.admin.inc
+++ b/modules/dosomething/dosomething_sms/dosomething_sms.admin.inc
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @file
+ * Admin page callback for the DoSomething SMS module.
+ */
+
+/**
+ * Builds and returns the Optimizely Add/Update form.
+ * If there are only 3 arguments in the path it builds the add form and it adds a record.
+ * Otherwise it builds the update form where the fourth argument is the record ID in
+ * in the optimizely table.
+ */
+function dosomething_sms_settings_form() {
+
+  $form = array();
+
+  $form['configuration'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Configuration of DoSomething.org SMS cron()'),
+  );
+
+  $form['configuration']['dosomething_sms_cron_enable'] = array(
+    '#type' => 'radios',
+    '#title' => t('Cron Status'),
+    '#options' => array(
+      TRUE => t('Enabled'),
+      FALSE => t('Disabled'),
+    ),
+    '#default_value' => variable_get('dosomething_sms_cron_enable', FALSE),
+    '#weight' => 10,
+  );
+
+  $form['configuration']['dosomething_sms_cron_interval'] = array(
+    '#type' => 'select',
+    '#title' => t('Cron interval'),
+    '#description' => t('Time after which cron_example_cron will respond to a processing request.'),
+    '#default_value' => variable_get('dosomething_sms_cron_interval', 60 * 60 * 24 * 7),
+    '#options' => array(
+      60 * 60 => t('1 hour'),
+      60 * 60 * 24 * 1 => t('1 day'),
+      60 * 60 * 24 * 2 => t('2 days'),
+      60 * 60 * 24 * 5 => t('5 days'),
+      60 * 60 * 24 * 7 => t('1 week'),
+      60 * 60 * 24 * 7 * 2 => t('2 weeks'),
+      60 * 60 * 24 * 7 * 4 => t('4 weeks'),
+    ),
+    '#weight' => 20,
+  );
+
+  // Where to send the report
+  $form['configuration']['dosomething_sms_cron_recipients'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Email Recipients'),
+    '#description' => t('Seperate email addresses with commas.'),
+    '#default_value' => variable_get('dosomething_sms_cron_recipients', 'dlee@dosomething.org'),
+    '#size' => 60,
+    '#maxlength' => 256,
+    '#required' => TRUE,
+    '#weight' => 30,
+  );
+
+  $form['status'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('DoSomething.org SMS Cron Status'),
+  );
+
+  // Run job every interval (week by default)
+  $interval = variable_get('dosomething_sms_cron_interval', 60 * 60 * 24 * 7);
+  $next_run = variable_get('dosomething_sms_cron_next_execution', REQUEST_TIME);
+
+  $form['status']['dosomething_sms_cron_status'] = array(
+    '#type' => 'markup',
+    '#markup' => '<ul><li>'. t('The next run is scheduled for '. date('l - j F Y - g:i:s', $next_run)) . '</li>',
+  );
+
+  $form['status']['dosomething_sms_cron_test'] = array(
+    '#type' => 'markup',
+    '#markup' => '<li>'. t('Run ') .'<strong>' . l(t('test cron'), 'admin/config/dosomething/dosomething_sms/cron_test') . '</strong>'. t(' job.') .'</li></ul>',
+  );
+
+  return system_settings_form($form);
+
+}

--- a/modules/dosomething/dosomething_sms/dosomething_sms.info
+++ b/modules/dosomething/dosomething_sms/dosomething_sms.info
@@ -1,0 +1,6 @@
+name = DoSomething SMS
+description = Provides SMS integration for DoSomething.org
+core = 7.x
+dependencies[] = conductor_sms
+package = DoSomething
+configure = admin/config/dosomething/dosomething_sms

--- a/modules/dosomething/dosomething_sms/dosomething_sms.info
+++ b/modules/dosomething/dosomething_sms/dosomething_sms.info
@@ -2,5 +2,6 @@ name = DoSomething SMS
 description = Provides SMS integration for DoSomething.org
 core = 7.x
 dependencies[] = conductor_sms
+files[] = dosomething_sms.test
 package = DoSomething
 configure = admin/config/dosomething/dosomething_sms

--- a/modules/dosomething/dosomething_sms/dosomething_sms.install
+++ b/modules/dosomething/dosomething_sms/dosomething_sms.install
@@ -1,0 +1,139 @@
+<?php
+/**
+ * @file
+ * Install/Update/Uninstall functions for dosomething_sms module
+ */
+
+/**
+ * Define the table schemas used for this module.
+ */
+function dosomething_sms_schema() {
+  $schema = array();
+
+  $schema['sms_flow_game'] = array(
+    'description' => 'Stores details to SAS games relative to a user / unique phone number.',
+    'fields' => array(
+      'game_id' => array(
+        'description' => 'Unique identifier for the game/quiz.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE
+      ),
+      'phone' => array(
+        'description' => 'Phone number',
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => true
+      ),
+      'started_paths' => array(
+        'description' => 'Serialized array of opt-in paths that the user has been sent to.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => true
+      ),
+      'answers' => array(
+        'description' => 'Serialized struct of answers given by the user {optin-path: {array of answers}}',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => true
+      ),
+    ),
+  );
+
+  $schema['sms_flow_records'] = array(
+    'description' => 'Stores alphas and betas who go through the SMS flow.',
+    'primary key' => array('sid'),
+    'fields' => array(
+      'sid' => array(
+        'description' => 'The id of the record.',
+        'type' => 'serial',
+        'unsigned' => true,
+        'not null' => true,
+      ),
+      'alpha' => array(
+        'description' => 'The alpha\'s phone number.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => true,
+      ),
+      'beta' => array(
+        'description' => 'The beta\'s phone number.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => true,
+      ),
+      'type' => array(
+        'description' => 'The type of object that the beta has been invited to.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => true
+      ),
+      'nid' => array(
+        'description' => 'The ID of the page / whatever that the person was invited to.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE
+      ),
+      'accepted_invite' => array(
+        'description' => 'Whether or not the user accepted the invitation.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'default' => 0,
+        'not null' => TRUE,
+      ),
+      'timestamp' => array(
+        'description' => 'The time that it all began...',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE
+      )
+    ),
+  );
+
+  return $schema;
+}
+
+/**
+ * Implements hook_field_schema_alter().
+ */
+function dosomething_sms_schema_alter(&$schema) {
+  // Add field to existing schema.
+  $schema['conductor_instance_pointer']['fields']['timestamp'] = array(
+    'type' => 'int',
+    'description' => 'A Unix timestamp indicating when the instance pointer was generated.',
+  );
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function dosomething_sms_uninstall() {
+  db_drop_field('conductor_instance_pointer', 'timestamp');
+  drupal_set_message('dosomething_sms: The "timestamp" field has been removed from the conductor_instance_pointer table.', 'status');
+
+  db_drop_table('sms_flow_game');
+  drupal_set_message('dosomething_sms: The "sms_flow_game" table has been dropped.');
+
+  db_drop_table('sms_flow_records');
+  drupal_set_message('dosomething_sms: The "sms_flow_records" table has been dropped.');
+}
+
+/**
+ * dosomething_sms_update_7001()
+ *
+ * Alter conductor_instance_pointer table to include timestamp field.
+ */
+function dosomething_sms_update_7001(&$sandbox) {
+  // Load exsisting schema from "conductor" module
+  $schema = drupal_get_schema('conductor_instance_pointer');
+
+  $status_ok = db_add_field('conductor_instance_pointer', 'timestamp', $schema['fields']['timestamp']);
+
+  // Make timestamp field set to the current timestamp value when row is created.
+  // MODIFY made using "non" Drupal/ SQL direct method as MySQL TIMESTAMP defaults
+  // are not supported on all database types (non-MySQL dbs). Drupal database
+  // abstraction does not support DEFAULT CURRENT_TIMESTAMP.
+  db_query("ALTER TABLE conductor_instance_pointer MODIFY timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP");
+
+  drupal_set_message('dosomething_sms: conductor_instance_pointer table has been updated to include "timestamp" field.', 'status');
+}

--- a/modules/dosomething/dosomething_sms/dosomething_sms.module
+++ b/modules/dosomething/dosomething_sms/dosomething_sms.module
@@ -337,12 +337,12 @@ function dosomething_sms_flow_start($alpha_number, $alpha_optin, $beta_optin, $b
     }
 
     // Array of phone numbers passed to function
-    if (dosomething_general_valid_cell($field)) {
+    if (dosomething_user_valid_cell($field)) {
       $beta_number = preg_replace('#[^0-9]#', '', $field);
     }
 
     // Check if valid cell and opt in to Mobile Commons.
-    if (dosomething_general_valid_cell($beta_number)) {
+    if (dosomething_user_valid_cell($beta_number)) {
       $valid_beta_numbers[] = $beta_number;
 
       $record = array(
@@ -356,7 +356,8 @@ function dosomething_sms_flow_start($alpha_number, $alpha_optin, $beta_optin, $b
       drupal_write_record('sms_flow_records', $record);
 
       // Create and update the beta's Mobile Commons profile
-      sms_mobile_commons_profile_update($beta_number, $beta_variables);
+      // @todo Convert to use mobilecommons module
+      // sms_mobile_commons_profile_update($beta_number, $beta_variables);
     }
   }
 

--- a/modules/dosomething/dosomething_sms/dosomething_sms.module
+++ b/modules/dosomething/dosomething_sms/dosomething_sms.module
@@ -189,7 +189,6 @@ function dosomething_sms_incoming_callback($path) {
  * Filter to ensure incoming texts are coming from Mobile Commons' IP.
  */
 function dosomething_sms_incoming_check() {
-return TRUE; // TODO: DO NOT COMMIT
   // Valid IP range as specified by Mobile Commons is: 64.22.127.0/24.
   // This translates to any IP 64.22.127.0 - 64.22.127.255
   $valid = FALSE;

--- a/modules/dosomething/dosomething_sms/dosomething_sms.module
+++ b/modules/dosomething/dosomething_sms/dosomething_sms.module
@@ -1,0 +1,737 @@
+<?php
+/**
+ * @file
+ * Provides Do Something-specific SMS functionality.
+ */
+
+/**
+ * Implements hook_conductor_sms_keywords().
+ *
+ * Specifies conductor workflows that should trigger for a given endpoint
+ *   [endpoint] => [conductor workflow]
+ */
+function dosomething_sms_conductor_sms_keywords() {
+  $keywords = array();
+
+  // Find files in this directory tree with the .keywords.inc extension and
+  // include them to populate the keywords array.
+  $files = array();
+  _dosomething_sms_list_files_by_extension(dirname(__FILE__), '.keywords.inc', $files);
+
+  foreach ($files as $file) {
+    include $file;
+  }
+
+  return $keywords;
+}
+
+/**
+ * Implements hook_default_conductor_workflows().
+ * Searches for local .workflows.inc files for instantiated ConductorWorkflows to add to array.
+ */
+function dosomething_sms_default_conductor_workflows() {
+  $workflows = array();
+
+  // Find files in this directory tree with the .workflows.inc extension and
+  // include them to populate the workflows array.
+  $files = array();
+  _dosomething_sms_list_files_by_extension(dirname(__FILE__), '.workflows.inc', $files);
+
+  foreach ($files as $file) {
+    include $file;
+  }
+
+  return $workflows;
+}
+
+/**
+ * Implements hook_ctools_plugin_api().
+ */
+function dosomething_sms_ctools_plugin_api($owner, $api) {
+  if ($owner == 'conductor') {
+    return array('version' => 1.0);
+  }
+}
+
+/**
+ * Implements hook_ctools_plugin_directory().
+ */
+function dosomething_sms_ctools_plugin_directory($owner, $plugin_type) {
+  if ($owner == 'conductor') {
+    return "plugins/$plugin_type";
+  }
+}
+
+/**
+ * Impliments hook_cron().
+ */
+function dosomething_sms_cron() {
+  dosomething_sms_cron_test();
+}
+
+/**
+ * hook_cron() functionality that can be called as a cron job or as a test.
+ */
+function dosomething_sms_cron_test($manual_test=FALSE) {
+
+  $enabled = variable_get('dosomething_sms_cron_enable', FALSE);
+
+  // Run job every interval (week by default)
+  $interval = variable_get('dosomething_sms_cron_interval', 60 * 60 * 24 * 7);
+  $next_run = variable_get('dosomething_sms_cron_next_execution', REQUEST_TIME + $interval);
+
+  // Check to see if it's time to run the cleanup task, default to now plus the interval for next run if nothing found for setting
+  if ((($enabled) && (REQUEST_TIME >= $next_run)) || $manual_test) {
+
+    $workflows = _dosomething_sms_flow_info();
+    $markup = theme('dosomething_sms_cron_report', array('workflows' => $workflows));
+
+    // Delete entries that are older than dosomething_sms_interval)
+    if (!$manual_test) {
+      $number_deleted = (string) db_delete('conductor_instance_pointer')
+        ->condition('timestamp', date('Y-m-d g:i:s', REQUEST_TIME - $interval), '<=')
+        ->execute();
+    }
+    else {
+      $query = db_query('SELECT workflow_name FROM {conductor_instance_pointer} WHERE timestamp <= :target_date', array(':target_date' => date('Y-m-d g:i:s', REQUEST_TIME - $interval)));
+      $number_deleted = (string) $query->rowCount();
+    }
+
+    $human_date = date('l - j F Y - g:i:s');
+
+    // Send Report
+    if ($manual_test) {
+      $to = 'dlee@dosomething.org';
+    }
+    else {
+      $to = variable_get('dosomething_sms_cron_recipients', 'dlee@dosomething.org');
+    }
+
+    $language = '';
+    $from = 'dosomething@dosomething.org';
+
+    $params['subject'] = 'dosomething_sms cron Report - '. $human_date;
+
+    $params['body']  = t('<h2>DoSomething.org SMS Cron</h2><br />');
+    $params['body'] .= t('<p>Cron run at %current_date. <strong>%number_deleted</stront> old entries purged.</p><p>', array('%current_date' => $human_date, '%number_deleted' => $number_deleted));
+    $params['body'] .= $markup;
+    $params['body'] .= t('</p><p>See you on the next run at %next_run.', array('%next_run' => date('l - j F Y - g:i:s', REQUEST_TIME + $interval)));
+
+    $result = drupal_mail('dosomething_mandrill', 'dsplain', $to, language_default(), $params,  $from, TRUE);
+
+    $sent = print_r($params, TRUE);
+    $results = print_r($result, TRUE);
+
+    if (isset($result['result']) && $result['result'] == 'true') {
+      watchdog('dosomething_sms', t('Mandrill "dsplain" email sent from %from to %to. Details sent %sent, results: %results.'), array('%from' => $result['from'], '%to' => $result['to'], '%sent' => $sent, '%results' => $results), WATCHDOG_INFO);
+    }
+    else {
+      watchdog('dosomething_sms', t('Failed to send report via Mandrill "dsplain" email message from %from to %to. Details sent %sent, results: %results.'), array('%from' => $result['from'], '%to' => $result['to'], '%sent' => $sent), WATCHDOG_ERROR);
+    }
+    // Log report in Watchdog
+    watchdog('dosomething_sms', t('Cron run at %current_date. %number_deleted entries deleted.'), array('%current_date' => $human_date, '%number_deleted' => $number_deleted), WATCHDOG_INFO);
+
+    // Schedule new cron run
+    if (!$manual_test) {
+      variable_set('dosomething_sms_cron_next_execution', REQUEST_TIME + $interval);
+    }
+  }
+}
+
+/**
+ * Callback for Mobile Commons mData requests. Allows for different endpoints
+ * to trigger different keyword paths.
+ */
+function dosomething_sms_incoming_callback($path) {
+  // Direct correlation between path endpoint and keyword used. If the path doesn't
+  // match any keyword specified in the array of keywords, then error out.
+  $keyword = $path;
+  $keyword_map = module_invoke_all('conductor_sms_keywords');
+  if (!array_key_exists($path, $keyword_map)) {
+    watchdog('dosomething_sms', "Received message at unsupported path: /sms/sms_flow/$path");
+    return NULL;
+  }
+
+  // Build context for the conductor workflow
+  $message = isset($_REQUEST['args']) ? $_REQUEST['args'] : FALSE;
+  $carrier = isset($_REQUEST['carrier']) ? $_REQUEST['carrier'] : FALSE;
+  $sender = isset($_REQUEST['phone']) ? $_REQUEST['phone'] : FALSE;
+
+  $context = array(
+    'message' => $message,
+    'keyword' => $keyword,
+    'carrier' => $carrier,
+    'sender' => $sender,
+  );
+
+  // Pass message on to Conductor to handle and generate a response
+  $output = '';
+  conductor_sms_response($output, $context);
+
+  // If an output is given, reply in the xml format expected from Mobile Commons
+  if (!empty($output)) {
+    $output =
+    '<?xml version="1.0" encoding="UTF-8"?>
+    <response>
+     <reply>
+      <text>
+       <![CDATA[' . $output . ']]>
+      </text>
+     </reply>
+    </response>';
+    print $output;
+  }
+
+  return NULL;
+}
+
+/**
+ * Filter to ensure incoming texts are coming from Mobile Commons' IP.
+ */
+function dosomething_sms_incoming_check() {
+return TRUE; // TODO: DO NOT COMMIT
+  // Valid IP range as specified by Mobile Commons is: 64.22.127.0/24.
+  // This translates to any IP 64.22.127.0 - 64.22.127.255
+  $valid = FALSE;
+  $ip = ip_address();
+  $valid = FALSE;
+
+  if (strpos($ip, '64.22.127') === 0) {
+    if ((int) substr($ip, 9, 3) >= 0 && (int) substr($ip, 10, 3) <= 255) {
+      $valid = TRUE;
+    }
+  }
+
+  return $valid;
+}
+
+/**
+ * Implements hook_menu().
+ */
+function dosomething_sms_menu() {
+  $items = array();
+
+  $items['admin/config/dosomething/dosomething_sms'] = array(
+    'title' => 'DoSomething SMS',
+    'description' => 'A collection of SMS tools related to DoSomething.org.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_sms_settings_form'),
+    'access arguments' => array('administer dosomething_sms'),
+    'file' => 'dosomething_sms.admin.inc',
+    'file path' => drupal_get_path('module', 'dosomething_sms'),
+    'type' => MENU_NORMAL_ITEM,
+  );
+
+  $items['admin/config/dosomething/dosomething_sms/cron_test'] = array(
+    'title' => 'DoSomething SMS Cron Test',
+    'description' => 'Submit same functionality as cron job a test run.',
+    'page callback' => 'dosomething_sms_cron_test',
+    'page arguments' => array(TRUE),
+    'access arguments' => array('administer dosomething_sms'),
+    'type' => MENU_CALLBACK,
+  );
+
+  $items['sms/sms_flow/%'] = array(
+    'title' => 'SMS Receiver for Mobile Commons mData Requests',
+    'page callback' => 'dosomething_sms_incoming_callback',
+    'access callback' => 'dosomething_sms_incoming_check',
+    'page arguments' => array(2),
+    'type' => MENU_CALLBACK,
+  );
+
+  return $items;
+}
+
+/**
+ * Implements hook_permission().
+ */
+function dosomething_sms_permission() {
+  return array(
+    'administer dosomething_sms' => array(
+      'title' => t('Administer dosomething_sms module'),
+      'description' => t('Administer access to everything in module'),
+      'restrict access' => TRUE,
+    ),
+  );
+}
+
+/**
+ * Impliments hook_theme().
+ */
+function dosomething_sms_theme($existing, $type, $theme, $path) {
+  return array(
+    'dosomething_sms_cron_report' => array(
+      'variables' => array('$workflows' => NULL),
+      'template' => 'dosomething-sms-cron-report',
+    ),
+  );
+}
+
+/**
+ * Begins the most epic SMS flow ever. But seriously, opts an Alpha into a
+ * Mobile Commons campaign. Then opts in Betas into another Mobile Commons
+ * campaign. Sends $variables (an array of custom variables, surprisingly) along
+ * with those opt-ins. Apply this function in a form submit function.
+ *
+ * @param string $alpha_number
+ *   The phone number of the alpha who invited the betas.
+ * @param int $alpha_optin
+ *   A campaign number on mobile commons that the ALPHA will be opted in to.
+ * @param int $beta_optin
+ *   A campaign on mobile commons that the BETA will be opted into.
+ * @param array $beta_numbers
+ *   Field keys that represent the phone numbers that the alpha invited through the form.
+ *   ALTERNATELY: An array of valid phone numbers to opt in through the opt-in path.
+ * @param array $form_values
+ *   Form values from the submitted webform.
+ * @param array $beta_variables
+ *   Custom variables to send with the opt-in. Are only applied to the Beta profiles.
+ *   These translate to {{variables}} on Mobile Commons.
+ * @param int $beta_to_alpha_campaign
+ *   (optional) A campaign that the beta (then Gamma, then whatever is after Gamma)
+ *   should be opted into when they invite their friends.
+ * @param string $type_override
+ *   (optional) Set a custom value to the 'type' column. Particularly useful for
+ *   cases where there is no appropriate NID or Drupal type for this invite. ex: the MLK day SMS game.
+ *
+ * Example (found in dosomething_clubs_preserve_shortform_email() in dosomething_clubs.module):
+ * @code
+ * dosomething_sms_flow_start(
+ *   '555-555-5555', 128441, 128441, array('field_webform_mobile'),
+ *   $form_state['values'],
+ *   array(
+ *     'first_name' => 'Mike',
+ *     'club_name' => "Mike's cool DoSomething.org Club."
+ *   )
+ * );
+ * @endcode
+ */
+function dosomething_sms_flow_start($alpha_number, $alpha_optin, $beta_optin, $beta_numbers, $form_values, $beta_variables, $beta_to_alpha_campaign = FALSE, $type_override = NULL) {
+
+  $nid = 0;
+  if (!empty($form_values['details']['nid'])) {
+    $nid = $form_values['details']['nid'];
+  }
+
+  if (empty($type_override)) {
+    $n = node_load($nid);
+    $type = $n->type;
+  }
+  else {
+    $type = $type_override;
+  }
+
+  $alpha_number = preg_replace('#[^0-9]#', '', $alpha_number);
+
+  $valid_beta_numbers = array();
+  foreach ($beta_numbers AS $key => $field) {
+    $beta_number = '';
+
+    // Generic $form_state['values']['submitted_tree']
+    if (isset($form_values['submitted_tree']) && isset($form_values['submitted_tree'][$field][LANGUAGE_NONE][0])) {
+      $beta_number = current($form_values['submitted_tree'][$field][LANGUAGE_NONE][0]);
+    }
+
+    // Security for the multiple form_state['values'] that we have migrating around the site.
+    else if (isset($form_values[$field][LANGUAGE_NONE][0])) {
+      $beta_number = current($form_values[$field][LANGUAGE_NONE][0]);
+    }
+
+    // Array of phone numbers passed to function
+    if (dosomething_general_valid_cell($field)) {
+      $beta_number = preg_replace('#[^0-9]#', '', $field);
+    }
+
+    // Check if valid cell and opt in to Mobile Commons.
+    if (dosomething_general_valid_cell($beta_number)) {
+      $valid_beta_numbers[] = $beta_number;
+
+      $record = array(
+        'alpha' => $alpha_number,
+        'beta' => $beta_number,
+        'timestamp' => REQUEST_TIME,
+        'type' => $type,
+        'nid' => $nid
+      );
+
+      drupal_write_record('sms_flow_records', $record);
+
+      // Create and update the beta's Mobile Commons profile
+      sms_mobile_commons_profile_update($beta_number, $beta_variables);
+    }
+  }
+
+  // Opt-in alpha and beta to their respective paths
+  if (module_exists('dosomething_subscribe_mobilecommons')) {
+    dosomething_subscribe_mobilecommons_referral_signup(
+      $alpha_number,
+      (!$beta_to_alpha_campaign ? $alpha_optin : $beta_to_alpha_campaign),
+      $valid_beta_numbers,
+      $beta_optin
+    );
+  }
+}
+
+/**
+ * Accepts a phone number and returns the alpha who invited that phone number, if applicable.
+ *
+ * @param string $beta
+ *   The beta's phone number. Accepts with punctuation (e.g. xxx-xxx-xxxx) or without.
+ * @param int $nid
+ *   (optional) The node id that is being referenced. This will ensure that we
+ *   pull the correct alpha, when we have multiple flow types running at the same time.
+ * @param string $type
+ *   (optional) Type of invite being referenced. Possible some 'nid' values could
+ *   overlap depending on the type.
+ *
+ * @return string
+ *   The alpha's phone number, if applicable, or false.
+ *
+ * Example:
+ * @code
+ * dosomething_sms_find_alpha('555-555-5555');
+ * @endcode
+ */
+function dosomething_sms_find_alpha($beta, $nid = 0, $type = '') {
+  $beta_parsed = preg_replace('#[^0-9]#i', '', $beta);
+  $select = db_query("
+    SELECT alpha
+    FROM sms_flow_records
+    WHERE
+       (beta = '" . $beta . "'
+       OR beta = '" . $beta_parsed . "')
+       " . ($nid > 0 ? "AND `nid` = " . intval($nid) : '') . "
+       " . (!empty($type) ? "AND `type` = '" . $type . "'" : '') . "
+    ORDER BY sid DESC
+    LIMIT 1
+  ");
+
+  $r = current($select->fetchAll());
+  return ($r->alpha ? $r->alpha : false);
+}
+
+/**
+ * Checks whether an alpha in the sms_flow_records table has received a message
+ * from an invited beta before, given a particular type and node ID.
+ *
+ * @param int $alpha
+ *   The phone number without ANY punctuation of the alpha.
+ * @param int $nid
+ *   The nid of the invitation, as found in the sms_flow_records table.
+ * @param string $type
+ *   The "type" of invitation, as seen in the sms_flow_records table.
+ *
+ * @return boolean
+ *   TRUE if there is at least one message from beta -> alpha sent. FALSE if there
+ *   have not been any messages sent from beta -> alpha.
+ */
+function dosomething_sms_alpha_received_message($alpha, $nid, $type) {
+  // Query the sms_flow_records table.
+  $select = db_query("
+    SELECT
+      COUNT(*) AS sent
+    FROM sms_flow_records
+    WHERE `accepted_invite` = 1
+      AND REPLACE(
+        REPLACE(
+          REPLACE(
+            REPLACE(
+              `alpha`, ')', ''
+            ),
+          '(', ''),
+        ' ', ''),
+      '-', '') = '" . $alpha . "'
+      AND `type` = :type
+      AND `nid` = :nid
+  ", array(':type' => $type, ':nid' => $nid));
+
+  // Get just what we need...
+  $r = reset($select->fetchAll());
+
+  // Return true if there's at least one response sent.
+  return ($r->sent > 0);
+}
+
+/**
+ * Updates the "accepted invite" status for a particular beta number in the
+ * sms_flow_records table.
+ *
+ * @param string $alpha_number
+ *   The number of the alpha user who sent the invite.
+ * @param string $beta_number
+ *   The beta number to look up.
+ * @param int $nid
+ *   The nid that the user is being invited to, as seen in the sms_flow_records table.
+ * @param string $type
+ *   The type of invite to check against.
+ *
+ * @return
+ *   Returns true.
+ */
+function dosomething_sms_update_accepted_status($alpha_number, $beta_number, $nid, $type) {
+  db_update('sms_flow_records')
+    ->fields(array(
+      'accepted_invite' => 1
+    ))
+    ->condition('alpha', $alpha_number)
+    ->condition('beta', $beta_number)
+    ->condition('nid', $nid)
+    ->condition('type', $type)
+    ->execute();
+
+    return TRUE;
+}
+
+/**
+ * Create record in sms_flow_game table.
+ *
+ * @param string $phone
+ *   Phone number to add to the table.
+ * @param int $game_id
+ *   The game ID for this record.
+ *   @see sms_flow_game_constants.inc
+ *
+ * @return
+ *   If the record insert or update failed, returns FALSE. If it succeeded,
+ *   returns SAVED_NEW or SAVED_UPDATED, depending on the operation performed.
+ */
+function dosomething_sms_game_create_record($phone, $game_id) {
+  $phone = substr($phone, -10);
+
+  $record = array(
+    'phone' => $phone,
+    'game_id' => $game_id,
+    'started_paths' => '',
+    'answers' => '',
+  );
+
+  $ret = drupal_write_record('sms_flow_game', $record);
+}
+
+/**
+ * Retrieve the opt-in paths a user has been sent to.
+ *
+ * @param string $phone
+ *   Phone number of the user to lookup.
+ * @param int $game_id
+ *   The game ID to query for.
+ *   @see sms_flow_game_constants.inc
+ *
+ * @return array
+ *   The paths a user has been opted-in to.
+ */
+function dosomething_sms_game_get_paths($phone, $game_id) {
+  $phone = preg_replace('#[^0-9]#i', '', $phone);
+  $phone = substr($phone, -10);
+
+  $select = db_query("
+    SELECT started_paths
+    FROM sms_flow_game
+    WHERE
+       phone = '" . $phone . "'
+       AND game_id = '" . $game_id . "'
+    LIMIT 1
+  ");
+
+  $record = current($select->fetchAll());
+
+  if ($record && !empty($record->started_paths)) {
+    // Deserialize string into array
+    $return = explode(',', $record->started_paths);
+  }
+
+  return !empty($return) ? $return : array();
+}
+
+/**
+ * Save the opt-in paths a user has been sent to to the sms_flow_game table.
+ *
+ * @param string $phone
+ *   Phone number of the user.
+ * @param int $game_id
+ *   The game ID the paths are associated with.
+ *   @see sms_flow_game_constants.inc
+ * @param array $paths
+ *   The opt-in paths a user has been sent to.
+ */
+function dosomething_sms_game_set_paths($phone, $game_id, $paths) {
+  $phone = substr($phone, -10);
+
+  // Serialize array before writing it to the database
+  $serialized_paths = implode(',', $paths);
+
+  db_update('sms_flow_game')
+    ->fields(array(
+      'started_paths' => $serialized_paths
+    ))
+    ->condition('phone', $phone)
+    ->condition('game_id', $game_id)
+    ->execute();
+}
+
+/**
+ * Return answers from sms_flow_game.
+ *
+ * @param string $phone
+ *   Phone number of the user.
+ * @param int $game_id
+ *   Game ID to get the answers for.
+ *   @see sms_flow_game_constants.inc
+ *
+ * @return
+ *   Associative array of the user's answers to the given game. Otherwise, NULL.
+ */
+function dosomething_sms_game_get_answers($phone, $game_id) {
+  $phone = preg_replace('#[^0-9]#i', '', $phone);
+  $phone = substr($phone, -10);
+
+  $select = db_query("
+    SELECT answers
+    FROM sms_flow_game
+    WHERE
+      phone = '" . $phone . "'
+      AND game_id = '" . $game_id . "'
+    LIMIT 1
+  ");
+
+  $record = current($select ->fetchAll());
+
+  if ($record && !empty($record->answers)) {
+    $return = json_decode($record->answers, TRUE);
+  }
+
+  return !empty($return) ? $return : NULL;
+}
+
+/**
+ * Convert answers from associative array to json string and save to sms_flow_game.
+ *
+ * @param string $phone
+ *   Phone number of the user.
+ * @param int $game_id
+ *   Game ID the answers are associated with.
+ *   @see sms_flow_game_constants.inc
+ * @param array $answers
+ *   The answers to convert and save.
+ */
+function dosomething_sms_game_set_answers($phone, $game_id, $answers) {
+  $phone = substr($phone, -10);
+  $serialized_answers = json_encode($answers);
+
+  db_update('sms_flow_game')
+    ->fields(array(
+      'answers' => $serialized_answers
+    ))
+    ->condition('phone', $phone)
+    ->condition('game_id', $game_id)
+    ->execute();
+}
+
+/**
+ * Build array of flow details. Used by dosomething_sms_report_markup() to determine
+ * markup of flow report.
+ */
+function _dosomething_sms_flow_info() {
+
+  // Get list of all report back workflows
+  $workflows = array();
+  include(module_load_include('inc', 'sms_flow', 'plugins/activity/report_backs/report_backs.workflows'));
+
+  // SELECT all of the unique workflow names that have entries - stalled SMS users
+  $results = db_query('
+    SELECT DISTINCT workflow_name
+    FROM {conductor_instance_pointer} cip
+    ORDER BY cip.workflow_name'
+  );
+
+  $active_workflows = array();
+  $x = 0;
+  $y = 0;
+  $output_count = 1;
+
+  // Gather all of the activities for each work flow and initalize the count to zero
+  foreach ($results as $row) {
+    $max_y = 0;
+    $activities = $workflows[$row->workflow_name]->activities;
+
+    foreach ($activities as $activity_counter => $activity_details) {
+      // Count the number of entries for this activity
+      // @todo: Move query outside of loop
+      $activity_count = db_query('
+          SELECT activity_name
+          FROM {conductor_instance_pointer}
+          WHERE workflow_name = :workflow_name AND activity_name = :activity_name',
+          array('workflow_name' => $row->workflow_name, 'activity_name' => $activity_details->name)
+        )->rowCount();
+
+      $activity_detail['workflow_name'] = $row->workflow_name;
+      $activity_detail['activity_name'] = $activity_details->name;
+      $activity_detail['activity_count'] = $activity_count;
+      $activity_detail['activity_inputs'] = $activity_details->inputs;
+      $activity_detail['activity_outputs'] = $activity_details->outputs;
+
+      $x++;
+
+      $activity = $active_workflows[$row->workflow_name][$activity_counter - 1];
+      if ($activity['activity_outputs'] != NULL && ($activity['y'] + count($activity['activity_outputs']) - 1) > $y) {
+        $y++;
+      }
+
+      // Start / End resets
+      if ($activity_detail['activity_name'] == 'start') {
+        $x = 0;
+        $y = 0;
+      }
+      elseif ($activity_detail['activity_name'] == 'end') {
+        $y = 0;
+      }
+
+      $activity_detail['x'] = $x;
+      $activity_detail['y'] = $y;
+
+      // Keep track of maximum width
+      if ($y > $max_y) {
+        $max_y = $y;
+      }
+
+      // Keep tract of the activity details
+      $active_workflows[$row->workflow_name][] = $activity_detail;
+    }
+
+    // Note max width or Clean up
+    if ($active_workflows[$row->workflow_name][0] != NULL) {
+      $active_workflows[$row->workflow_name]['max_y'] = $max_y;
+    }
+    else {
+      unset($active_workflows[$row->workflow_name]);
+    }
+  }
+
+  return $active_workflows;
+}
+
+/**
+ * Helper function to find all files within a directory that end with the given extension.
+ *
+ * @param string $dir
+ *   Directory to search for files.
+ * @param string $file_ext
+ *   File extension of files to search for.
+ * @param array $matching_files
+ *   The files that match the $file_ext being searched for.
+ */
+function _dosomething_sms_list_files_by_extension($dir, $file_ext, &$matching_files) {
+  $files = scandir($dir);
+  foreach ($files as $file) {
+    if ($file != '.' && $file != '..') {
+      $path = $dir . '/' . $file;
+
+      if (is_dir($path)) {
+        _dosomething_sms_list_files_by_extension($path, $file_ext, $matching_files);
+      }
+      elseif (preg_match('/'  . $file_ext . '$/', $path) === 1) {
+        $matching_files[] = $path;
+      }
+    }
+  }
+}

--- a/modules/dosomething/dosomething_sms/dosomething_sms.module
+++ b/modules/dosomething/dosomething_sms/dosomething_sms.module
@@ -355,9 +355,14 @@ function dosomething_sms_flow_start($alpha_number, $alpha_optin, $beta_optin, $b
 
       drupal_write_record('sms_flow_records', $record);
 
+      // Add beta number to args to send in the update request
+      if (!is_array($beta_variables)) {
+        $beta_variables = array();
+      }
+      $beta_variables['phone_number'] = $beta_number;
+
       // Create and update the beta's Mobile Commons profile
-      // @todo Convert to use mobilecommons module
-      // sms_mobile_commons_profile_update($beta_number, $beta_variables);
+      mobilecommons_request('profiles_update', $beta_variables);
     }
   }
 
@@ -625,6 +630,74 @@ function dosomething_sms_game_set_answers($phone, $game_id, $answers) {
     ->condition('phone', $phone)
     ->condition('game_id', $game_id)
     ->execute();
+}
+
+/**
+ * Subscribe to a Mobile Commons opt-in path.
+ *
+ * @param string $phone
+ *   Phone number of the user.
+ * @param int $opt_in_path
+ *   Mobile Commons opt-in path id.
+ * @param array $args
+ *   Additional arguments.
+ */
+function dosomething_sms_mobile_commons_opt_in($phone, $opt_in_path, $args = array()) {
+  $content = array(
+    'opt_in_path[]' => $opt_in_path,
+    'person' => array(
+      'phone' => $phone,
+    ),
+  );
+
+  if (!empty($args)) {
+    foreach ($args as $key => $val) {
+      $content[$key] = urlencode($val);
+    }
+  }
+
+  mobilecommons_request('opt_in', $content);
+}
+
+/**
+ * Unsubscribe the user from a Mobile Commons campaign.
+ *
+ * @param string $phone
+ *   Phone number of the user.
+ * @param mixed $campaigns
+ *   A single campaign ID to opt out of, or an array of multiple IDs.
+ */
+function dosomething_sms_mobile_commons_opt_out($phone, $campaigns) {
+  $content = array(
+    'person' => array(
+      'phone' => $phone,
+    ),
+  );
+
+  if (is_array($campaigns)) {
+    if (count($campaigns) > 1) {
+      // Manually concatenating additional campaigns onto the build query.
+      // Additional campaigns must be in the format "&campaign[]="
+      $content_query = http_build_query($content);
+      foreach ($campaigns as $id) {
+        $campaign_key = urlencode('campaign[]');
+        $content_query .= '&' . $campaign_key . '=' . $id;
+      }
+    }
+    else {
+      if (count($campaigns) == 1) {
+        $content['campaign'] = $campaigns[0];
+      }
+    }
+  }
+  elseif (is_numeric($campaigns) && $campaigns > 0) {
+    $content['campaign'] = $campaigns;
+  }
+  else {
+    return;
+  }
+
+  mobilecommons_request('opt_out', $content);
 }
 
 /**

--- a/modules/dosomething/dosomething_sms/dosomething_sms.test
+++ b/modules/dosomething/dosomething_sms/dosomething_sms.test
@@ -2,7 +2,64 @@
 
 /**
  * @file
- * Unit testing for the dosomething_sms module.
+ * Tests for the dosomething_sms module.
+ */
+
+/**
+ * Class for dosomething_sms unit test cases.
+ */
+class DosomethingSmsUnitTestCase extends DrupalUnitTestCase {
+  public static function getInfo() {
+    return array(
+      'name' => 'DoSomething SMS Unit Tests',
+      'description' => 'Unit tests for DoSomething SMS.',
+      'group' => 'DoSomething',
+    );
+  }
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * Tests dosomething_sms_incoming_check().
+   * We won't be able to simulate a query from Mobile Commons for these tests, so
+   * just make sure it returns FALSE.
+   */
+  public function testIncomingCheck() {
+    $this->assertFalse(dosomething_sms_incoming_check(), 'Non-Mobile Commons IP denied access.');
+  }
+
+  /**
+   * Tests that all expected .keywords.inc and .workflows.inc files can be found.
+   * @see _dosomething_sms_list_files_by_extension()
+   * @see dosomething_sms_conductor_sms_keywords()
+   * @see dosomething_sms_default_conductor_workflows
+   */
+  public function testListFilesByExtension() {
+    $keywordCheck = array(
+      dirname(__FILE__) . '/workflows/test.keywords.inc',
+    );
+
+    $keywordFiles = array();
+    _dosomething_sms_list_files_by_extension(dirname(__FILE__), '.keywords.inc', $keywordFiles);
+    $keywordResult = array_intersect($keywordCheck, $keywordFiles);
+    $this->assertTrue(count($keywordResult) == count($keywordCheck), 'All .keywords.inc files found.');
+
+    $workflowCheck = array(
+      dirname(__FILE__) . '/workflows/test.workflows.inc',
+    );
+
+    $workflowFiles = array();
+    _dosomething_sms_list_files_by_extension(dirname(__FILE__), '.workflows.inc', $workflowFiles);
+    $workflowResult = array_intersect($workflowCheck, $workflowFiles);
+    $this->assertTrue(count($workflowResult) == count($workflowCheck), 'All .workflows.inc files found.');
+  }
+
+}
+
+/**
+ * Class for dosomething_sms web test cases.
  */
 class DosomethingSmsWebTestCase extends DrupalWebTestCase {
   // Required to test inside the DoSomething profile:

--- a/modules/dosomething/dosomething_sms/dosomething_sms.test
+++ b/modules/dosomething/dosomething_sms/dosomething_sms.test
@@ -38,6 +38,7 @@ class DosomethingSmsUnitTestCase extends DrupalUnitTestCase {
    */
   public function testListFilesByExtension() {
     $keywordCheck = array(
+      dirname(__FILE__) . '/workflows/games.keywords.inc',
       dirname(__FILE__) . '/workflows/test.keywords.inc',
     );
 
@@ -47,6 +48,7 @@ class DosomethingSmsUnitTestCase extends DrupalUnitTestCase {
     $this->assertTrue(count($keywordResult) == count($keywordCheck), 'All .keywords.inc files found.');
 
     $workflowCheck = array(
+      dirname(__FILE__) . '/workflows/games.workflows.inc',
       dirname(__FILE__) . '/workflows/test.workflows.inc',
     );
 

--- a/modules/dosomething/dosomething_sms/dosomething_sms.test
+++ b/modules/dosomething/dosomething_sms/dosomething_sms.test
@@ -43,7 +43,7 @@ class DosomethingSmsWebTestCase extends DrupalWebTestCase {
   }
 
   /**
-   * Verify that each "keyword" value has a matching workflow
+   * Verify that each "keyword" value has a matching workflow.
    */
   public function testKeywordMatch() {
     $workflowNames = array();
@@ -57,7 +57,7 @@ class DosomethingSmsWebTestCase extends DrupalWebTestCase {
   }
 
   /**
-   * Verify all workflow names have a matching "keyword"
+   * Verify all workflow names have a matching "keyword."
    */
   public function testWorkflowMatch() {
     $this->workflows = dosomething_sms_default_conductor_workflows();
@@ -66,6 +66,78 @@ class DosomethingSmsWebTestCase extends DrupalWebTestCase {
 
     foreach ($this->workflows as $w) {
       $this->assertTrue(in_array($w->name, $keywordValues), t('Workflow %workflow has matching keyword', array('%workflow' => $w->name)));
+    }
+  }
+
+  /**
+   * Verify no workflow activity has missing input or output links.
+   */
+  public function testWorkflowActivityLinks() {
+    foreach ($this->workflows as $w) {
+      $activities = $w->activities;
+      $numActivities = count($activities);
+
+      for($i = 0; $i < $numActivities; $i++) {
+        $a = $activities[$i];
+
+        // First activity should be 'start'
+        if ($i == 0) {
+          $this->assertTrue(strcmp($a->name, 'start') == 0, t('Workflow %name begins with the \'start\' activity.', array('%name' => $w->name)));
+        }
+
+        // Verify input -> output links
+        if (count($a->inputs) > 0) {
+          foreach ($a->inputs as $input) {
+            // Find the activity the input is referring to, and verify that that
+            // activity ($checkActivity) has an output referring to the current activity ($a).
+            for ($j = 0; $j < $numActivities; $j++) {
+              $checkActivity = $activities[$j];
+
+              $isDifferentActivity = $j != $i;
+              $checkedNameMatchesInput = strcmp($checkActivity->name, $input) == 0;
+              $checkedActivityHasMatchingOutput = in_array($a->name, $checkActivity->outputs);
+
+              if ($isDifferentActivity && $checkedNameMatchesInput && $checkedActivityHasMatchingOutput) {
+                $this->assert(TRUE, t('Link verified for %name input: %input', array('%name' => $a->name, '%input' => $input)));
+                break;
+              }
+              // Assert failure if all activities were checked and no matching output was found
+              else if ($j == $numActivities - 1) {
+                $this->assert(FALSE, t('Cannot find matching activity with output to match test activity: %name input: %input', array('%name' => $a->name, '%input' => $input)));
+              }
+            }
+          }
+        }
+
+        // Verify output -> input links
+        if (count($a->outputs) > 0) {
+          foreach ($a->outputs as $output) {
+            // Find the activity the output is referring to, and verify that that
+            // activity ($checkActivity) has an input referring at the current activity ($a).
+            for ($j = 0; $j < $numActivities; $j++) {
+              $checkActivity = $activities[$j];
+
+              $isDifferentActivity = $j != $i;
+              $checkedNameMatchesOutput = strcmp($checkActivity->name, $output) == 0;
+              $checkedActivityHasMatchingInput = in_array($a->name, $checkActivity->inputs);
+
+              if ($isDifferentActivity && $checkedNameMatchesOutput && $checkedActivityHasMatchingInput) {
+                $this->assert(TRUE, t('Link found for %activity output: %output', array('%activity' => $a->name, '%output' => $output)));
+                break;
+              }
+              // Assert failure if all activities were checked and no matching input was found
+              else if ($j == $numActivities - 1) {
+                $this->assert(FALSE, t('Cannot find matching activity with input to match test activity: %activity output: %output', array('%activity' => $a->name, '%output' => $output)));
+              }
+            }
+          }
+        }
+
+        // Last activity should be 'end'
+        if ($i == $numActivities - 1) {
+          $this->assertTrue(strcmp($a->name, 'end') == 0, "Workflow $w->name ends with the 'end' activity.");
+        }
+      }
     }
   }
 }

--- a/modules/dosomething/dosomething_sms/dosomething_sms.test
+++ b/modules/dosomething/dosomething_sms/dosomething_sms.test
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @file
+ * Unit testing for the dosomething_sms module.
+ */
+class DosomethingSmsWebTestCase extends DrupalWebTestCase {
+  // Required to test inside the DoSomething profile:
+  protected $profile = 'dosomething';
+
+  /**
+   * Key/value array where key specifies the URL endpoint and value is its
+   * corresponding ConductorWorkflow.
+   *
+   * @var array
+   */
+  private $keywords;
+
+  /**
+   * ConductorWorkflow objects that define the behavior of our SMS conversations.
+   *
+   * @var array
+   */
+  private $workflows;
+
+  public static function getInfo() {
+    return array(
+      'name' => 'DoSomething SMS Web Tests',
+      'description' => 'Web tests for DoSomething SMS.',
+      'group' => 'DoSomething',
+    );
+  }
+
+  public function setUp() {
+    // Enable the module
+    parent::setUp('dosomething_sms');
+
+    // Get list of all keywords
+    $this->keywords = dosomething_sms_conductor_sms_keywords();
+
+    // Get list of all workflows
+    $this->workflows = dosomething_sms_default_conductor_workflows();
+  }
+
+  /**
+   * Verify that each "keyword" value has a matching workflow
+   */
+  public function testKeywordMatch() {
+    $workflowNames = array();
+    foreach ($this->workflows as $w) {
+      $workflowNames[] = $w->name;
+    }
+
+    foreach ($this->keywords as $key => $val) {
+      $this->assertTrue(in_array($val, $workflowNames), t('Keyword %key has matching workflow %workflow', array('%key' => $key, '%workflow' => $val)));
+    }
+  }
+
+  /**
+   * Verify all workflow names have a matching "keyword"
+   */
+  public function testWorkflowMatch() {
+    $this->workflows = dosomething_sms_default_conductor_workflows();
+
+    $keywordValues = array_values($this->keywords);
+
+    foreach ($this->workflows as $w) {
+      $this->assertTrue(in_array($w->name, $keywordValues), t('Workflow %workflow has matching keyword', array('%workflow' => $w->name)));
+    }
+  }
+}

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_ordered_paths/ConductorActivityMobileCommonsOrderedPath.class.php
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_ordered_paths/ConductorActivityMobileCommonsOrderedPath.class.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Given the mdata_id that the request comes from, the activity selects
+ * the opt-in path to send the user to from an ordered list. The sms_flow_game
+ * table is used to determine which opt-in path the user will be sent to next.
+ */
+class ConductorActivityMobileCommonsOrderedPath extends ConductorActivity {
+
+  /**
+   * Nested array of ordered lists of Mobile Commons opt-in paths.
+   *
+   * Definition:
+   * @code
+   * array(
+   *   array(
+   *     'mdata_id' => mData ID associated with this set
+   *     'game_id' => Unique identifier. Needs to be unique also compared to random pathing workflow and other SMS games
+   *     'opt_in_paths' => Array of ordered paths
+   *     'paths_finished_msg' => Optional. Number. Opt-in path to send user to if they've finished all tips.
+   *     'should_loop' => Optional. Set to TRUE if you want the tips to loop through again after going through them all.
+   *   ), ...
+   * )
+   * @endcode
+   */
+  public $sets = array();
+
+  public function run($workflow) {
+    $state = $this->getState();
+    $mobile = $state->getContext('sms_number');
+    $mdataID = intval($_REQUEST['mdata_id']);
+
+    // Find the set with the matching mdata_id
+    $setIndex = -1;
+    for ($i = 0; $i < count($this->sets); $i++) {
+      if ($this->sets[$i]['mdata_id'] == $mdataID) {
+        $setIndex = $i;
+        break;
+      }
+    }
+
+    if ($setIndex >= 0) {
+      $set = $this->sets[$setIndex];
+      if (count($set['opt_in_paths']) == 0) {
+        watchdog('sms_flow_game', "ConductorActivityMobileCommonsOrderedPath set missing opt_in_paths for mdata_id $mdataID");
+      }
+      else {
+        // Get last opt-in path user was sent to. Function returns an array
+        $lastOptIn = dosomething_sms_game_get_paths($mobile, $set['game_id']);
+
+        // Select next opt-in path to send user to
+        $nextOptInIndex = 0;
+        if (!empty($lastOptIn)) {
+          // Array should always only contain one item
+          if (count($lastOptIn) == 1) {
+            $lastOptIn = $lastOptIn[0];
+            $lastOptInIndex = array_search($lastOptIn, $set['opt_in_paths']);
+            $nextOptInIndex = $lastOptInIndex + 1;
+
+            if ($nextOptInIndex >= count($set['opt_in_paths']) && $set['should_loop'] === TRUE) {
+              $nextOptInIndex = 0;
+            }
+          }
+          else {
+            watchdog('sms_flow_game', "ConductorActivityMobileCommonsOrderedPath accessing multi-item array when trying to find last opt in. $mobile / ".$set['game_id']);
+            $nextOptInIndex = -1;
+          }
+        }
+
+        // Send user to selected opt-in path or nothing if they've already received the last path
+        if ($nextOptInIndex >= 0 && $nextOptInIndex < count($set['opt_in_paths'])) {
+
+          // @todo Convert to use mobilecommons module
+          // sms_mobile_commons_opt_in($mobile, $set['opt_in_paths'][$nextOptInIndex]);
+
+          // Save path to database
+          try {
+            // If no existing record, create one
+            if (empty($lastOptIn)) {
+              dosomething_sms_game_create_record($mobile, $set['game_id']);
+            }
+
+            // Update existing record, adding the newly selected path
+            $lastOptIn = array($set['opt_in_paths'][$nextOptInIndex]);
+            dosomething_sms_game_set_paths($mobile, $set['game_id'], $lastOptIn);
+          }
+          catch (Exception $e) {
+            watchdog('sms_flow_game', 'ConductorActivityMobileCommonsOrderedPath exception - ' . $e->getMessage());
+          }
+        }
+        elseif (!empty($set['paths_finished_msg'])) {
+          // @todo Convert to use mobilecommons module
+          // sms_mobile_commons_opt_in($mobile, $set['paths_finished_msg']);
+        }
+      }
+    }
+
+    $state->setContext('ignore_no_response_error', TRUE);
+    $state->markCompleted();
+  }
+}

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_ordered_paths/ConductorActivityMobileCommonsOrderedPath.class.php
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_ordered_paths/ConductorActivityMobileCommonsOrderedPath.class.php
@@ -70,8 +70,7 @@ class ConductorActivityMobileCommonsOrderedPath extends ConductorActivity {
         // Send user to selected opt-in path or nothing if they've already received the last path
         if ($nextOptInIndex >= 0 && $nextOptInIndex < count($set['opt_in_paths'])) {
 
-          // @todo Convert to use mobilecommons module
-          // sms_mobile_commons_opt_in($mobile, $set['opt_in_paths'][$nextOptInIndex]);
+          dosomething_sms_mobile_commons_opt_in($mobile, $set['opt_in_paths'][$nextOptInIndex]);
 
           // Save path to database
           try {
@@ -89,8 +88,7 @@ class ConductorActivityMobileCommonsOrderedPath extends ConductorActivity {
           }
         }
         elseif (!empty($set['paths_finished_msg'])) {
-          // @todo Convert to use mobilecommons module
-          // sms_mobile_commons_opt_in($mobile, $set['paths_finished_msg']);
+          dosomething_sms_mobile_commons_opt_in($mobile, $set['paths_finished_msg']);
         }
       }
     }

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_ordered_paths/mcommons_ordered_paths.inc
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_ordered_paths/mcommons_ordered_paths.inc
@@ -1,0 +1,11 @@
+<?php
+
+if (module_exists('entity')) {
+  $plugin = array(
+    'title' => t('Mobile Commons Ordered Pathing'),
+    'description' => t('Users are sent to Mobile Commons opt-in paths in the specified order.'),
+    'handler' => array(
+      'class' => 'ConductorActivityMobileCommonsOrderedPath',
+    ),
+  );
+}

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_random_paths/ConductorActivityMobileCommonsRandomPath.class.php
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_random_paths/ConductorActivityMobileCommonsRandomPath.class.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Given the mdata_id that the request comes from, the activity selects a
+ * random Mobile Commons opt-in path to send the user to. It also ensures that
+ * the same opt-in path does not get sent again until they're all exhausted.
+ */
+class ConductorActivityMobileCommonsRandomPath extends ConductorActivity {
+
+  /**
+   * Entity containing info for each grouped set of opt-in paths to be randomized
+   *
+   * Defintion:
+   * $sets = array(
+   *           array(
+   *             'mdata_id'     //
+   *             'game_id'      // Unique identifier for an SMS game
+   *             'opt_in_paths' // Array of possible opt-in paths to send the user to
+   *             'path_special' // Specific opt-in path to send user to after a specific number of times through this randomizer
+   *             'send_to_special_on' // If > 0, send user to path_special on this iteration through the randomizer
+   *           ),
+   *           ...
+   *         )
+   */
+  public $sets = array();
+
+  public function run($workflow) {
+    $state = $this->getState();
+    $mobile = $state->getContext('sms_number');
+    $mdataID = intval($_REQUEST['mdata_id']);
+
+    // Find the set with the matching mdata_id
+    $setIndex = -1;
+    for ($i = 0; $i < count($this->sets); $i++) {
+      if ($this->sets[$i]['mdata_id'] == $mdataID) {
+        $setIndex = $i;
+        break;
+      }
+    }
+
+    if ($setIndex >= 0) {
+      $set = $this->sets[$setIndex];
+      if (count($set['opt_in_paths']) == 0) {
+        watchdog('sms_flow_game', 'ConductorActivityMobileCommonsRandomPath set missing opt_in_paths for mdata_id = ' . $mdataID);
+      }
+      else {
+        // Check DB for question sets we already sent this user to
+        $started_paths = dosomething_sms_game_get_paths($mobile, $set['game_id']);
+
+        // Randomly select opt-in path to send user to
+        $opt_in_path = 0;
+        if (isset($set['send_to_special_on']) && $set['send_to_special_on'] > 0
+            && isset($set['path_special']) && $set['path_special'] > 0
+            && count($started_paths) == $set['send_to_special_on'] - 1) {
+          $opt_in_path = $set['path_special'];
+        }
+        else {
+          $opt_in_paths = $set['opt_in_paths'];
+
+          // If started_paths is less than opt_in_paths, indicates there are still
+          // untravelled paths for the user to select. Remove the started paths from
+          // the array of paths to choose from.
+          if (count($started_paths) < count($opt_in_paths)) {
+            foreach($started_paths as $path) {
+              if (($index = array_search($path, $opt_in_paths)) !== FALSE) {
+                unset($opt_in_paths[$index]);
+              }
+            }
+
+            // Re-index the array
+            $opt_in_paths = array_values($opt_in_paths);
+          }
+
+          $selected_idx = array_rand($opt_in_paths);
+          $opt_in_path = $opt_in_paths[$selected_idx];
+        }
+
+        // Send user to selected opt-in path
+        // @todo Convert to use mobilecommons module
+        // dosomething_general_mobile_commons_subscribe($mobile, $opt_in_path);
+
+        try {
+          // If no existing record, create one
+          if (empty($started_paths)) {
+            dosomething_sms_game_create_record($mobile, $set['game_id']);
+          }
+
+          // Update existing record, adding the newly selected path
+          if (in_array($opt_in_path, $started_paths) == FALSE && $opt_in_path > 0) {
+            $started_paths[] = $opt_in_path;
+          }
+          dosomething_sms_game_set_paths($mobile, $set['game_id'], $started_paths);
+        }
+        catch (Exception $e) {
+          watchdog('sms_flow_game', 'ConductorActivityMobileCommonsRandomPath exception - ' . $e->getMessage());
+        }
+      }
+
+      $state->setContext('ignore_no_response_error', TRUE);
+    }
+    else {
+      $state->setContext('sms_response', 'Sorry. We\'ve run into a problem. :(');
+    }
+
+    $state->markCompleted();
+  }
+}

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_random_paths/ConductorActivityMobileCommonsRandomPath.class.php
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_random_paths/ConductorActivityMobileCommonsRandomPath.class.php
@@ -76,8 +76,7 @@ class ConductorActivityMobileCommonsRandomPath extends ConductorActivity {
         }
 
         // Send user to selected opt-in path
-        // @todo Convert to use mobilecommons module
-        // dosomething_general_mobile_commons_subscribe($mobile, $opt_in_path);
+        dosomething_sms_mobile_commons_opt_in($mobile, $opt_in_path);
 
         try {
           // If no existing record, create one

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_random_paths/mcommons_random_paths.inc
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_random_paths/mcommons_random_paths.inc
@@ -1,0 +1,11 @@
+<?php
+
+if (module_exists('entity')) {
+  $plugin = array(
+    'title' => t('Mobile Commons Random Pathing'),
+    'description' => t('Users are sent to a random Mobile Commons opt-in path they have yet to be sent to.'),
+    'handler' => array(
+      'class' => 'ConductorActivityMobileCommonsRandomPath',
+    ),
+  );
+}

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_timed_paths/ConductorActivityMobileCommonsTimedPath.class.php
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_timed_paths/ConductorActivityMobileCommonsTimedPath.class.php
@@ -74,8 +74,7 @@ class ConductorActivityMobileCommonsTimedPath extends ConductorActivity {
       }
 
       if ($optInPath > 0) {
-        // @todo Convert to use mobilecommons module
-        // dosomething_general_mobile_commons_subscribe($mobile, $optInPath);
+        dosomething_sms_mobile_commons_opt_in($mobile, $optInPath);
       }
     }
 

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_timed_paths/ConductorActivityMobileCommonsTimedPath.class.php
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_timed_paths/ConductorActivityMobileCommonsTimedPath.class.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Given the mdata_id that the request comes from, this activity will select
+ * the Mobile Commons opt-in path to send the user to next based on time.
+ */
+class ConductorActivityMobileCommonsTimedPath extends ConductorActivity {
+
+  /**
+   * Contains the info for sets of opt-in paths and the earliest possible time
+   * they can be sent to. Sets are grouped by their unique mdata_id from Mobile Commons.
+   *
+   * Defintion:
+   * $sets = array(
+   *   array(
+   *     'mdata_id'         // Number. ID provided by the mData setup in Mobile Commons.
+   *     'timezone'         // String. Timezone to process times in. ex: 'America/New_York'
+   *     'paths' => array(
+   *       array(
+   *         'time'         // String. Earliest time when users will be sent to this opt-in path.
+   *                        //  Format: Y-m-d H:i:s ex: '2013-07-16 10:00:00'
+   *         'opt_in_path'  // Number. Opt-in path to send user to.
+   *       ),
+   *       ...
+   *     )
+   *   ), ...
+   */
+  public $sets = array();
+
+  public function run($workflow) {
+    $state = $this->getState();
+    $mobile = $state->getContext('sms_number');
+    $mdataId = intval($_REQUEST['mdata_id']);
+
+    // Find the set with the matching mdata_id
+    $setIndex = -1;
+    for ($i = 0; $i < count($this->sets); $i++) {
+      if ($this->sets[$i]['mdata_id'] == $mdataId) {
+        $setIndex = $i;
+        break;
+      }
+    }
+
+    if ($setIndex >= 0) {
+      $set = $this->sets[$setIndex];
+      $optInPath = 0;
+
+      $dateOverride = check_plain($_REQUEST['date_override']);
+      if (!empty($dateOverride)) {
+        // For testing, use the override time provided in the params.
+        // Expected dateOverride format: Y-m-d H:i:s
+        $dateObj = new DateTime($dateOverride, new DateTimeZone($set['timezone']));
+        $currTime = $dateObj->getTimestamp();
+      }
+      else {
+        // Otherwise, get current time for timezone specified. eg: America/New_York
+        $dateObj = new DateTime(NULL, new DateTimeZone($set['timezone']));
+        $currTime = $dateObj->getTimestamp();
+      }
+
+      // Assumption is that arrays are ordered from earliest time to latest.
+      // So traverse the list in descending order, searching for the first
+      // instance of a time that's before the current time.
+      $paths = $set['paths'];
+      for ($i = count($paths) - 1; $i >= 0; $i--) {
+        $pathTimeStr = $set['paths'][$i]['time'];
+        $pathTimeObj = new DateTime($pathTimeStr, new DateTimeZone($set['timezone']));
+        $pathTime = $pathTimeObj->getTimestamp();
+
+        if ($currTime >= $pathTime) {
+          $optInPath = $set['paths'][$i]['opt_in_path'];
+          break;
+        }
+      }
+
+      if ($optInPath > 0) {
+        // @todo Convert to use mobilecommons module
+        // dosomething_general_mobile_commons_subscribe($mobile, $optInPath);
+      }
+    }
+
+    $state->setContext('ignore_no_response_error', TRUE);
+    $state->markCompleted();
+  }
+}

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_timed_paths/mcommons_timed_paths.inc
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/mcommons_timed_paths/mcommons_timed_paths.inc
@@ -1,0 +1,11 @@
+<?php
+
+if (module_exists('entity')) {
+  $plugin = array(
+    'title' => t('Mobile Commons Timed Pathing'),
+    'description' => t('Users are sent to a Mobile Commons opt-in path depending on the date and time'),
+    'handler' => array(
+      'class' => 'ConductorActivityMobileCommonsTimedPath',
+    ),
+  );
+}

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/mobile_commons_opt_in/ConductorActivityMobileCommonsOptIn.class.php
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/mobile_commons_opt_in/ConductorActivityMobileCommonsOptIn.class.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Opt-in the mobile user into a given Mobile Commons opt-in path.
+ */
+class ConductorActivityMobileCommonsOptIn extends ConductorActivity {
+
+  /**
+   * The Mobile Commons opt-in path to join the user into.
+   *
+   * @var int
+   */
+  public $opt_in_path_id;
+
+  public function run() {
+    $state = $this->getState();
+    $mobile = $state->getContext('sms_number');
+
+    dosomething_sms_mobile_commons_opt_in($mobile, $this->opt_in_path_id);
+
+    $state->setContext('ignore_no_response_error', TRUE);
+    $state->markCompleted();
+  }
+
+}

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/mobile_commons_opt_in/mobile_commons_opt_in.inc
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/mobile_commons_opt_in/mobile_commons_opt_in.inc
@@ -1,0 +1,11 @@
+<?php
+
+if (module_exists('entity')) {
+  $plugin = array(
+    'title' => t('Mobile Commons Opt-In'),
+    'description' => t('Opt the user into a specified Mobile Commons opt-in path.'),
+    'handler' => array(
+      'class' => 'ConductorActivityMobileCommonsOptIn',
+    ),
+  );
+}

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/mobile_commons_opt_in_prompt/ConductorActivityMobileCommonsOptInPrompt.class.php
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/mobile_commons_opt_in_prompt/ConductorActivityMobileCommonsOptInPrompt.class.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Extends ConductorActivitySMSPrompt. Opts the user into a Mobile Commons
+ * opt-in path and suspends the workflow until a response is received.
+ */
+class ConductorActivityMobileCommonsOptInPrompt extends ConductorActivitySMSPrompt {
+
+  /**
+   * The Mobile Commons opt-in path to join the user into.
+   *
+   * @var int
+   */
+  public $opt_in_path_id;
+
+  public function run() {
+    $state = $this->getState();
+
+    if ($state->getContext($this->name . ':message') === FALSE && !empty($this->opt_in_path_id)) {
+      $mobile = $state->getContext('sms_number');
+      dosomething_sms_mobile_commons_opt_in($mobile, $this->opt_in_path_id);
+
+      $state->setContext('ignore_no_response_error', TRUE);
+      $state->markSuspended();
+      return;
+    }
+
+    parent::run();
+  }
+
+  /**
+   * Implements ConductorActivity::getSuspendPointers().
+   */
+  public function getSuspendPointers() {
+    return array(
+      'sms_prompt:' . $this->getState()->getContext('sms_number')
+    );
+  }
+
+}

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/mobile_commons_opt_in_prompt/mobile_commons_opt_in_prompt.inc
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/mobile_commons_opt_in_prompt/mobile_commons_opt_in_prompt.inc
@@ -1,0 +1,11 @@
+<?php
+
+if (module_exists('entity')) {
+  $plugin = array(
+    'title' => t('Mobile Commons Opt-In Prompt'),
+    'description' => t('Opt the user into a specified Mobile Commons opt-in path, and suspend the workflow until a response is received.'),
+    'handler' => array(
+      'class' => 'ConductorActivityMobileCommonsOptInPrompt',
+    ),
+  );
+}

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/mobile_commons_opt_out/ConductorActivityMobileCommonsOptOut.class.php
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/mobile_commons_opt_out/ConductorActivityMobileCommonsOptOut.class.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Opt-out the mobile user from a given campaign id(s)
+ */
+class ConductorActivityMobileCommonsOptOut extends ConductorActivity {
+
+  /**
+   * Array of campaign id(s) to opt the user out of.
+   *
+   * @var array
+   */
+  public $opt_out_ids = array();
+
+  public function run() {
+    $state = $this->getState();
+    $mobile = $state->getContext('sms_number');
+
+    dosomething_sms_mobile_commons_opt_out($mobile, $this->opt_out_ids);
+
+    $state->markCompleted();
+  }
+
+}

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/mobile_commons_opt_out/mobile_commons_opt_out.inc
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/mobile_commons_opt_out/mobile_commons_opt_out.inc
@@ -1,0 +1,11 @@
+<?php
+
+if (module_exists('entity')) {
+  $plugin = array(
+    'title' => t('Mobile Commons Opt-Out'),
+    'description' => t('Opt the user out of the specified Mobile Commons campaign(s) messages.'),
+    'handler' => array(
+      'class' => 'ConductorActivityMobileCommonsOptOut',
+    ),
+  );
+}

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/out_of_flow_responder/ConductorActivityOutOfFlowResponder.class.php
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/out_of_flow_responder/ConductorActivityOutOfFlowResponder.class.php
@@ -204,8 +204,7 @@ class ConductorActivityOutOfFlowResponder extends ConductorActivity {
       $set = $this->response_sets[$matchingSet];
 
       if (isset($set['trigger_opt_out']) && $set['trigger_opt_out'] > 0) {
-        // @todo Convert to use mobilecommons module
-        // sms_mobile_commons_campaign_opt_out($mobile, $set['trigger_opt_out']);
+        dosomething_sms_mobile_commons_opt_out($mobile, $set['trigger_opt_out']);
         $response = self::selectResponse($set['response']);
       }
       elseif ($isNegativeForm) {
@@ -221,8 +220,7 @@ class ConductorActivityOutOfFlowResponder extends ConductorActivity {
       $response = self::selectResponse($this->no_match_responses);
       if (is_numeric($this->no_match_responses[0])) {
         // If it's an array of numbers, then push user to the selected opt-in path id
-        // @todo Convert to use mobilecommons module
-        // sms_mobile_commons_opt_in($mobile, $response);
+        dosomething_sms_mobile_commons_opt_in($mobile, $response);
         $state->setContext('ignore_no_response_error', TRUE);
       }
       else {

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/out_of_flow_responder/ConductorActivityOutOfFlowResponder.class.php
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/out_of_flow_responder/ConductorActivityOutOfFlowResponder.class.php
@@ -1,0 +1,314 @@
+<?php
+
+/**
+ * Parses user message and sends back a response if match is found. If no match
+ * is found, should just remain silent unless $no_match_responses are specified.
+ */
+class ConductorActivityOutOfFlowResponder extends ConductorActivity {
+
+  /**
+   * Nested array of responses and their matching criteria.
+   *
+   * Definition:
+   * @code
+   * array(
+   *   array(
+   *     'phrase_match' => array('phrase 1', 'phrase 2'),
+   *     'AND_match'    => array(
+   *       array('word1A', 'word1B'),
+   *       array('word2A', 'word2B', 'phrase 2 C'),
+   *       ...
+   *     ),
+   *     'word_match'   => array('word1', 'word2', ...),
+   *     'word_match_exact' => boolean. If true, will not do a levenshtein distance check.
+   *     'response'     => string. Message to send back to user if match is found.
+   *     'response_negative' => string. Message to send back to user if match is found and user message is a negative form.
+   *                            ex: User responds with, "I do NOT love you"
+   *     'trigger_opt_out'   => mixed. Could be either a single number or array of numbers for campaign ids to opt out of.
+   *   )
+   * )
+   * @endcode
+   *
+   * Sets at the beginning of the array will match against the user response
+   * first and take priority over later sets.
+   *
+   * @var array
+   */
+  public $response_sets = array();
+
+  /**
+   * Response to send to the user if no match is found.
+   *
+   * @var array
+   */
+  public $no_match_responses = array();
+
+  /**
+   * Responses to send if MMS was received from the user.
+   *
+   * @var array
+   */
+  public $mms_match_responses = array();
+
+  /**
+   * Maximum allowed string edit distance to trigger a successful match.
+   *
+   * @var int
+   */
+  public $match_threshold = 1;
+
+  public function run($workflow) {
+    $state = $this->getState();
+    $mobile = $state->getContext('sms_number');
+
+    // Check for MMS before attempting to do any message processing
+    if (!empty($_REQUEST['mms_image_url']) && count($this->mms_match_responses) > 0) {
+      $response = self::selectResponse($this->mms_match_responses);
+      $state->setContext('sms_response', $response);
+      $state->markCompleted();
+      return;
+    }
+
+    $userMessage = $_REQUEST['args'];
+
+    $userMessage = self::sanitizeMessage($userMessage);
+
+    // Break message into array of individual words
+    $userWords = explode(' ', $userMessage);
+
+    $bMatchFound = FALSE;
+    $bIgnoreNegativeForm = FALSE;
+    $isNegativeForm = FALSE;
+    $matchingSet = -1;
+    $bDoDistanceCheck = FALSE;
+
+    do {
+      for ($i = 0; $i < count($this->response_sets) && !$bMatchFound; $i++) {
+        $set = $this->response_sets[$i];
+
+        // Search for exactly matched responses
+        if (isset($set['exact_match'])) {
+          foreach ($set['exact_match'] as $exactMatch) {
+            if ((!$bDoDistanceCheck && strcasecmp($userMessage, $exactMatch) == 0)
+                || ($bDoDistanceCheck && levenshtein($exactMatch, $userMessage) <= $this->match_threshold)) {
+              $bMatchFound = TRUE;
+
+              if (self::hasNegativeFormWord($exactMatch)) {
+                $bIgnoreNegativeForm = TRUE;
+              }
+
+              break;
+            }
+          }
+        }
+
+        // Search for phrases within the user message
+        if (!$bMatchFound && isset($set['phrase_match'])) {
+          foreach ($set['phrase_match'] as $matchPhrase) {
+            if (self::isRegex($matchPhrase)) {
+              // All regular expressions should just be handled by preg_match. Skip the other
+              // compares and levenshtein distance checks. No need to check a second time
+              // during the distance check round.
+              if (!$bDoDistanceCheck && preg_match(strtolower($matchPhrase), strtolower($userMessage)) == 1) {
+                $bMatchFound = TRUE;
+                break;
+              }
+            }
+            elseif ((!$bDoDistanceCheck && stripos($userMessage, $matchPhrase) !== FALSE)
+                || ($bDoDistanceCheck && levenshtein($userMessage, $matchPhrase) <= $this->match_threshold)) {
+              $bMatchFound = TRUE;
+
+              if (self::hasNegativeFormWord($matchPhrase)) {
+                $bIgnoreNegativeForm = TRUE;
+              }
+
+              break;
+            }
+          }
+        }
+
+        // Search for sets of words in the user message to match against
+        if (!$bMatchFound && !$bDoDistanceCheck && isset($set['AND_match'])) {
+          foreach ($set['AND_match'] as $matchSet) {
+            $bSetMatches = TRUE;
+            foreach ($matchSet as $matchWord) {
+              if (!self::in_arrayi($matchWord, $userWords)) {
+                $bSetMatches = FALSE;
+                break;
+              }
+            }
+
+            if ($bSetMatches) {
+              $bMatchFound = TRUE;
+              break;
+            }
+          }
+        }
+
+        // Search for exactly matched words
+        if (!$bMatchFound && isset($set['word_match'])) {
+          $word_match_exact = isset($set['word_match_exact']) ? $set['word_match_exact'] : FALSE;
+          foreach ($set['word_match'] as $matchWord) {
+            foreach ($userWords as $userWord) {
+              if (self::isRegex($matchWord)) {
+                if (!$bDoDistanceCheck && preg_match(strtolower($matchWord), strtolower($userWord)) == 1) {
+                  $bMatchFound = TRUE;
+                  break;
+                }
+              }
+              elseif ((!$bDoDistanceCheck && strcasecmp($matchWord, $userWord) == 0)
+                  || ($bDoDistanceCheck && !$word_match_exact && levenshtein($matchWord, $userWord) <= $this->match_threshold)) {
+                $bMatchFound = TRUE;
+                break;
+              }
+            }
+
+            if ($bMatchFound) {
+              break;
+            }
+          }
+        }
+
+        // Check if user response is in negative form
+        // ie - "I do love you" vs "I do not love you"
+        if ($bMatchFound && !$bIgnoreNegativeForm) {
+          if (self::hasNegativeFormWord($userWords)) {
+            // Negative form response found. Make sure we have a response for that kind of message.
+            if (isset($set['response_negative'])) {
+              $isNegativeForm = TRUE;
+            }
+            else {
+              $bMatchFound = FALSE;
+            }
+          }
+        }
+
+        // Match is found. No need to check the rest.
+        if ($bMatchFound) {
+            $matchingSet = $i;
+            break;
+        }
+      }
+
+      // If we've already done a runthrough with the distance check, then ensure we exit out of the while loop
+      if ($bDoDistanceCheck) {
+        $bExecutedDistanceCheck = TRUE;
+      }
+      else {
+        $bDoDistanceCheck = TRUE;
+      }
+    } while (!$bMatchFound && !$bExecutedDistanceCheck);
+
+    // Reply back to the user with the appropriate response if available
+    if ($bMatchFound && $matchingSet >= 0) {
+      $set = $this->response_sets[$matchingSet];
+
+      if (isset($set['trigger_opt_out']) && $set['trigger_opt_out'] > 0) {
+        // @todo Convert to use mobilecommons module
+        // sms_mobile_commons_campaign_opt_out($mobile, $set['trigger_opt_out']);
+        $response = self::selectResponse($set['response']);
+      }
+      elseif ($isNegativeForm) {
+        $response = self::selectResponse($set['response_negative']);
+      }
+      else {
+        $response = self::selectResponse($set['response']);
+      }
+
+      $state->setContext('sms_response', $response);
+    }
+    elseif (count($this->no_match_responses) > 0) {
+      $response = self::selectResponse($this->no_match_responses);
+      if (is_numeric($this->no_match_responses[0])) {
+        // If it's an array of numbers, then push user to the selected opt-in path id
+        // @todo Convert to use mobilecommons module
+        // sms_mobile_commons_opt_in($mobile, $response);
+        $state->setContext('ignore_no_response_error', TRUE);
+      }
+      else {
+        // Otherwise, expect it's an array of strings, then respond with a selected string
+        $state->setContext('sms_response', $response);
+      }
+    }
+    else {
+      $state->setContext('ignore_no_response_error', TRUE);
+    }
+
+    $state->markCompleted();
+  }
+
+  // Case-insensitive version of in_array()
+  function in_arrayi($needle, $haystack) {
+    return in_array(strtolower($needle), array_map('strtolower', $haystack));
+  }
+
+  // Determine if negative-form word exists in $needles
+  function hasNegativeFormWord($needles) {
+    $negativeFormWords = array('no', 'not');
+
+    // If $needles is a string, convert it into an array of its words
+    if (is_string($needles)) {
+      $needles = explode(' ', $needles);
+    }
+
+    foreach ($negativeFormWords as $matchWord) {
+      if (self::in_arrayi($matchWord, $needles)) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Determines whether or not this string is actually a regular expression
+   */
+  function isRegex($str) {
+    $strLength = strlen($str);
+    if ($strLength > 1 && $str[0] == '/' && $str[$strLength - 1] == '/') {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  // Function to convert select words from their abbreviated form
+  function sanitizeMessage($message) {
+    // Single quote to be removed instead of replacing with whitespace to conserve integrity of word
+    $message = preg_replace('/\'/', '', $message);
+    // Remove all non alphanumeric characters from the user message
+    $message = preg_replace('/[^A-Za-z0-9 ]/', ' ', $message);
+    // Matches multi-character whitespace with a single space
+    $message = preg_replace('/\s+/', ' ', $message);
+    $message = check_plain($message);
+
+    $abbreviations = array(
+      'u' => 'you',
+      'ur' => 'your',
+      'urself' => 'yourself',
+    );
+
+    $words = explode(' ', $message);
+
+    for ($i = 0; $i < count($words); $i++) {
+      if(isset($abbreviations[$words[$i]])) {
+        $key = $words[$i];
+        $words[$i] = $abbreviations[$key];
+      }
+    }
+
+    $message = implode(' ', $words);
+    return $message;
+  }
+
+  // Selects a random response if multiple are given, or if $response is a string, just returns it back
+  function selectResponse($response) {
+    if (is_array($response)) {
+      $selectedIdx = array_rand($response);
+      return $response[$selectedIdx];
+    }
+    else {
+      return $response;
+    }
+  }
+}

--- a/modules/dosomething/dosomething_sms/plugins/activity/misc/out_of_flow_responder/out_of_flow_responder.inc
+++ b/modules/dosomething/dosomething_sms/plugins/activity/misc/out_of_flow_responder/out_of_flow_responder.inc
@@ -1,0 +1,11 @@
+<?php
+
+if (module_exists('entity')) {
+  $plugin = array(
+    'title' => t('Out of Flow Responder'),
+    'description' => t('Intended to be hooked up to the end of a conversation flow as a Mobile Commons mData. Parses incoming user messages to give custom responses.'),
+    'handler' => array(
+      'class' => 'ConductorActivityOutOfFlowResponder',
+    ),
+  );
+}

--- a/modules/dosomething/dosomething_sms/sms_flow_game_constants.inc
+++ b/modules/dosomething/dosomething_sms/sms_flow_game_constants.inc
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @file
+ * Class of constants to be used for sms_flow_game game_id's.
+ *
+ * Constants shouldn't be removed from this and repurposed for other SMS flows
+ * unless you know what you're getting yourself into.
+ */
+class SmsFlowGameConstants {
+  const WYR_GAME                = 2;
+  const FINANCIAL_ED_TIPS       = 3;
+  const PBJ_MARKETING_TIPS      = 4;
+  const PBJ_DRIVE_TIPS          = 5;
+  const PREGTEXT_WAIT_TIPS      = 6;
+  const PREGTEXT_SAFE_TIPS      = 7;
+  const PREGTEXT_PARENT_TIPS    = 8;
+  const PREGTEXT_RIGHTS_TIPS    = 9;
+  const THUMBWARS_IDEAS_TIPS    = 10;
+  const THUMBWARS_FACTS_TIPS    = 11;
+  const PUPPYTEXT_FAQ_TIPS      = 12;
+  const PUPPYTEXT_DOG_TIPS      = 13;
+  const OK_ART_TIPS             = 14;
+  const CLIMATE_SAS_NINJA       = 15;
+  const IHEARTDAD_BP_TIPS       = 16;
+  const IHEARTDAD_HEALTH_TIPS   = 17;
+  const IHEARTDAD_GUIDE         = 18;
+  const HUNT_INSPIRE            = 19;
+  const BDAYMAIL_TIPS           = 20;
+  const GIVEASPIT_ORDERED_TIPS  = 21;
+  const GIVEASPIT_RANDOM_TIPS   = 22;
+  const SURVIVORS_RANDOM_TIPS   = 23;
+  const FEDUP_RANDOM_TIPS       = 24;
+  const MARKT_50CANS_TIPS       = 25;
+  const RUN_50CANS_TIPS         = 26;
+  const STATS_50CANS_TIPS       = 27;
+  const GGW_EMAIL_TIPS          = 28;
+  const GGW_COMP_TIPS           = 29;
+  const GGW_PHONE_TIPS          = 30;
+  const GGW_FBOOK_TIPS          = 31;
+  const GGW_TWEET_TIPS          = 32;
+  const GGW_VIDCHAT_TIPS        = 33;
+  const GGW_INSTA_TIPS          = 34;
+  const GGW_TABLET_TIPS         = 35;
+  const TFJ_MARKET_TIPS         = 36;
+  const TFJ_RUN_TIPS            = 37;
+  const TFJ_PRIZE_GUIDE         = 38;
+}

--- a/modules/dosomething/dosomething_sms/workflows/games.keywords.inc
+++ b/modules/dosomething/dosomething_sms/workflows/games.keywords.inc
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @file
+ * Array of endpoints ("keywords") and the name of the workflows they are each
+ * associated with. Keyword/workflow pairs here are for SMS games.
+ */
+$keywords['preg-text-responder'] = 'sms_flow_preg_text_responder';
+$keywords['mcommons-ordered-paths'] = 'sms_flow_mcommons_ordered_paths';
+$keywords['mcommons-random-path'] = 'sms_flow_mcommons_random_path';
+$keywords['mcommons-timed-paths'] = 'sms_flow_mcommons_timed_paths';

--- a/modules/dosomething/dosomething_sms/workflows/games.workflows.inc
+++ b/modules/dosomething/dosomething_sms/workflows/games.workflows.inc
@@ -1,0 +1,678 @@
+<?php
+
+/**
+ * @file
+ * ConductorWorkflow definitions for SMS games.
+ */
+
+require_once drupal_get_path('module', 'dosomething_sms') . '/sms_flow_game_constants.inc';
+
+/**
+ * Handle all random pathing for randoming pathing and WYR-style games under one workflow
+ */
+$workflow = new ConductorWorkflow();
+$workflow->wid = 'new';
+$workflow->name = 'sms_flow_mcommons_random_path';
+$workflow->title = 'Handler for path randomizing.';
+$workflow->api_version = '1.0';
+
+$activity = $workflow->newActivity('start');
+$activity->name = 'start';
+$activity->outputs = array('mcommons_random_paths');
+
+$activity = $workflow->newActivity('mcommons_random_paths');
+$activity->name = 'mcommons_random_paths';
+$activity->inputs = array('start');
+$activity->outputs = array('end');
+$activity->sets = array(
+  // Pregnancy Text WAIT tips
+  array(
+    'mdata_id'     => 10223,
+    'game_id'      => SmsFlowGameConstants::PREGTEXT_WAIT_TIPS,
+    'opt_in_paths' => array(153193, 153203, 153213, 153223, 153233, 153243, 153253, 153263, 153273),
+    'path_special' => 153183,
+    'send_to_special_on' => 3,
+  ),
+  // Pregnancy Text SAFE tips
+  array(
+    'mdata_id'     => 10233,
+    'game_id'      => SmsFlowGameConstants::PREGTEXT_SAFE_TIPS,
+    'opt_in_paths' => array(153283, 153293, 153303, 153313, 153323, 153333, 153343, 153353),
+  ),
+  // Pregnancy Text PARENT tips
+  array(
+    'mdata_id'     => 10243,
+    'game_id'      => SmsFlowGameConstants::PREGTEXT_PARENT_TIPS,
+    'opt_in_paths' => array(153363, 153373, 153383),
+  ),
+  // Pregnancy Text RIGHTS tips
+  array(
+    'mdata_id'     => 10253,
+    'game_id'      => SmsFlowGameConstants::PREGTEXT_RIGHTS_TIPS,
+    'opt_in_paths' => array(153393, 153403, 153413),
+  ),
+  // Give A Spit 2013 - Random Fact Tips
+  array(
+    'mdata_id'     => 10923,
+    'game_id'      => SmsFlowGameConstants::GIVEASPIT_RANDOM_TIPS,
+    'opt_in_paths' => array(161195, 161197, 161199, 161201, 161203, 161205, 161207, 161209, 161211, 161213, 161215, 161217, 161219, 161221, 161223, 161225),
+  ),
+  // Cell Phones for Survivors 2013 - Random Tips
+  array(
+    'mdata_id'     => 10931,
+    'game_id'      => SmsFlowGameConstants::SURVIVORS_RANDOM_TIPS,
+    'opt_in_paths' => array(161399, 161401, 161405, 161407, 161409, 161521),
+    'path_special' => 161403,
+    'send_to_special_on' => 3,
+  ),
+  // Fed Up 2013 - Random Tips
+  array(
+    'mdata_id'     => 10951,
+    'game_id'      => SmsFlowGameConstants::FEDUP_RANDOM_TIPS,
+    'opt_in_paths' => array(161557, 161559, 161561, 161563, 161565, 161567, 161569, 161571, 161573, 161575),
+  ),
+  // 50 Cans - MARKT tips
+  array(
+    'mdata_id'     => 10957,
+    'game_id'      => SmsFlowGameConstants::MARKT_50CANS_TIPS,
+    'opt_in_paths' => array(161843, 161845, 161847, 161849, 161851, 161853, 161855, 161857, 161859),
+  ),
+  // 50 Cans - RUN tips
+  array(
+    'mdata_id'     => 10959,
+    'game_id'      => SmsFlowGameConstants::RUN_50CANS_TIPS,
+    'opt_in_paths' => array(161819, 161821, 161823, 161825, 161827, 161829, 161831, 161833, 161835, 161837, 161839, 161841),
+  ),
+);
+
+$activity = $workflow->newActivity('end');
+$activity->name = 'end';
+$activity->inputs = array('mcommons_random_paths');
+
+$workflows[$workflow->name] = $workflow;
+
+
+/**
+ * Handles all ordered pathing under one workflow
+ */
+$workflow = new ConductorWorkflow();
+$workflow->wid = 'new';
+$workflow->name = 'sms_flow_mcommons_ordered_paths';
+$workflow->title = 'Handler for MCommons Ordered Paths';
+$workflow->api_version = '1.0';
+
+$activity = $workflow->newActivity('start');
+$activity->name = 'start';
+$activity->outputs = array('mcommons_ordered_paths');
+
+$activity = $workflow->newActivity('mcommons_ordered_paths');
+$activity->name = 'mcommons_ordered_paths';
+$activity->inputs = array('start');
+$activity->outputs = array('end');
+$activity->sets = array(
+  // GUIDE path for I Heart Dad 2013
+  array(
+    'mdata_id' => 10843,
+    'game_id' => SmsFlowGameConstants::IHEARTDAD_GUIDE,
+    'opt_in_paths' => array(158861, 158863, 158865, 158869, 158871, 158873),
+  ),
+  // Birthday Mail 2013 Tips
+  array(
+    'mdata_id' => 10907,
+    'game_id' => SmsFlowGameConstants::BDAYMAIL_TIPS,
+    'opt_in_paths' => array(160625, 160627, 160629, 160631, 160633, 160635),
+  ),
+  // Give A Spit 2013 Idea Tips
+  array(
+    'mdata_id' => 10921,
+    'game_id' => SmsFlowGameConstants::GIVEASPIT_ORDERED_TIPS,
+    'opt_in_paths' => array(161183, 161185, 161187, 161189, 161191, 161193),
+    'should_loop' => TRUE,
+  ),
+  // 50 Cans STAT
+  array(
+    'mdata_id' => 9221,
+    'game_id' => SmsFlowGameConstants::STATS_50CANS_TIPS,
+    'opt_in_paths' => array(161861, 161863, 161865, 161867),
+  ),
+  // Grandparents Gone Wired 2013 - EMAIL tips
+  array(
+    'mdata_id' => 10975,
+    'game_id' => SmsFlowGameConstants::GGW_EMAIL_TIPS,
+    'opt_in_paths' => array(162747, 162423, 162425, 162427, 162429, 162431, 162433, 162435, 162437, 162439, 162441),
+    'should_loop' => TRUE,
+  ),
+  // Grandparents Gone Wired 2013 - COMP tips
+  array(
+    'mdata_id' => 10977,
+    'game_id' => SmsFlowGameConstants::GGW_COMP_TIPS,
+    'opt_in_paths' => array(162443, 162445, 162447, 162449, 162451, 162453, 162455, 162457, 162459, 162461, 162463, 162465),
+    'should_loop' => TRUE,
+  ),
+  // Grandparents Gone Wired 2013 - PHONE tips
+  array(
+    'mdata_id' => 10979,
+    'game_id' => SmsFlowGameConstants::GGW_PHONE_TIPS,
+    'opt_in_paths' => array(162467, 162469, 162471, 162473, 162475, 162477, 162479, 162481, 162483, 162485, 162487, 162489, 162491, 162493),
+    'should_loop' => TRUE,
+  ),
+  // Grandparents Gone Wired 2013 - FBOOK tips
+  array(
+    'mdata_id' => 10981,
+    'game_id' => SmsFlowGameConstants::GGW_FBOOK_TIPS,
+    'opt_in_paths' => array(162495, 162497, 162499, 162501, 162503, 162505, 162507, 162509, 162511, 162513, 162515, 162517, 162519, 162521),
+    'should_loop' => TRUE,
+  ),
+  // Grandparents Gone Wired 2013 - TWEET tips
+  array(
+    'mdata_id' => 10983,
+    'game_id' => SmsFlowGameConstants::GGW_TWEET_TIPS,
+    'opt_in_paths' => array(162523, 162525, 162527, 162529, 162531, 162533, 162535, 162537),
+    'should_loop' => TRUE,
+  ),
+  // Grandparents Gone Wired 2013 - VIDCHAT tips
+  array(
+    'mdata_id' => 10985,
+    'game_id' => SmsFlowGameConstants::GGW_VIDCHAT_TIPS,
+    'opt_in_paths' => array(162749, 162539, 162541, 162543, 162545, 162547, 162549, 162551),
+    'should_loop' => TRUE,
+  ),
+  // Grandparents Gone Wired 2013 - INSTA tips
+  array(
+    'mdata_id' => 10987,
+    'game_id' => SmsFlowGameConstants::GGW_INSTA_TIPS,
+    'opt_in_paths' => array(162589, 162591, 162593, 162595, 162597, 162599, 162601, 162603, 162605),
+    'should_loop' => TRUE,
+  ),
+  // Grandparents Gone Wired 2013 - TABLET tips
+  array(
+    'mdata_id' => 10989,
+    'game_id' => SmsFlowGameConstants::GGW_TABLET_TIPS,
+    'opt_in_paths' => array(162553, 162555, 162557, 162559, 162561, 162563, 162565, 162567, 162569, 162571),
+    'should_loop' => TRUE,
+  ),
+  // Teens for Jeans 2013 - PRIZE guide
+  array(
+    'mdata_id' => 11001,
+    'game_id' => SmsFlowGameConstants::TFJ_PRIZE_GUIDE,
+    'opt_in_paths' => array(162865, 162867),
+    'should_loop' => TRUE,
+  ),
+  // Teens for Jeans 2013 - MARKET tips
+  array(
+    'mdata_id'     => 11007,
+    'game_id'      => SmsFlowGameConstants::TFJ_MARKET_TIPS,
+    'opt_in_paths' => array(162875, 162877, 162879),
+    'should_loop'  => TRUE,
+  ),
+  // Teens for Jeans 2013 - RUN tips
+  array(
+    'mdata_id'     => 11009,
+    'game_id'      => SmsFlowGameConstants::TFJ_RUN_TIPS,
+    'opt_in_paths' => array(162881, 162883, 162885, 162887),
+    'should_loop'  => TRUE,
+  ),
+);
+
+$activity = $workflow->newActivity('end');
+$activity->name = 'end';
+$activity->inputs = array('mcommons_ordered_paths');
+
+$workflows[$workflow->name] = $workflow;
+
+/**
+ * Handles all time-based pathing under one workflow
+ */
+$workflow = new ConductorWorkflow();
+$workflow->wid = 'new';
+$workflow->name = 'sms_flow_mcommons_timed_paths';
+$workflow->title = 'Handler for MCommons Timed Paths';
+$workflow->api_version = '1.0';
+
+$activity = $workflow->newActivity('start');
+$activity->name = 'start';
+$activity->outputs = array('mcommons_timed_paths');
+
+$activity = $workflow->newActivity('mcommons_timed_paths');
+$activity->name = 'mcommons_timed_paths';
+$activity->inputs = array('start');
+$activity->outputs = array('end');
+$activity->sets = array(
+  // Hunt 2013 daily challenges
+  array(
+    'mdata_id' => 10855,
+    'timezone' => 'America/New_York',
+    'paths' => array(
+      array(
+        'time' => '2013-07-16 10:00:00',
+        'opt_in_path' => 159319,
+      ),
+      array(
+        'time' => '2013-07-17 10:00:00',
+        'opt_in_path' => 159321,
+      ),
+      array(
+        'time' => '2013-07-18 10:00:00',
+        'opt_in_path' => 159323,
+      ),
+      array(
+        'time' => '2013-07-19 10:00:00',
+        'opt_in_path' => 159325,
+      ),
+      array(
+        'time' => '2013-07-20 10:00:00',
+        'opt_in_path' => 159327,
+      ),
+      array(
+        'time' => '2013-07-21 10:00:00',
+        'opt_in_path' => 159329,
+      ),
+      array(
+        'time' => '2013-07-22 10:00:00',
+        'opt_in_path' => 159331,
+      ),
+      array(
+        'time' => '2013-07-23 10:00:00',
+        'opt_in_path' => 159333,
+      ),
+      array(
+        'time' => '2013-07-24 10:00:00',
+        'opt_in_path' => 159335,
+      ),
+      array(
+        'time' => '2013-07-25 10:00:00',
+        'opt_in_path' => 159337,
+      ),
+      array(
+        'time' => '2013-07-26 10:00:00',
+        'opt_in_path' => 159339,
+      ),
+      // Message for after the campaign ends
+      array(
+        'time' => '2013-07-27 10:00:00',
+        'opt_in_path' => 159381,
+      ),
+    ),
+  ),
+  // Hunt 2013 INSTA actions
+  array(
+    'mdata_id' => 10861,
+    'timezone' => 'America/New_York',
+    'paths' => array(
+      array(
+        'time' => '2013-07-16 10:00:00',
+        'opt_in_path' => 159397,
+      ),
+      array(
+        'time' => '2013-07-17 10:00:00',
+        'opt_in_path' => 159399,
+      ),
+      array(
+        'time' => '2013-07-18 10:00:00',
+        'opt_in_path' => 159401,
+      ),
+      array(
+        'time' => '2013-07-19 10:00:00',
+        'opt_in_path' => 159403,
+      ),
+      array(
+        'time' => '2013-07-20 10:00:00',
+        'opt_in_path' => 159405,
+      ),
+      array(
+        'time' => '2013-07-21 10:00:00',
+        'opt_in_path' => 159409,
+      ),
+      array(
+        'time' => '2013-07-22 10:00:00',
+        'opt_in_path' => 159411,
+      ),
+      array(
+        'time' => '2013-07-23 10:00:00',
+        'opt_in_path' => 159413,
+      ),
+      array(
+        'time' => '2013-07-24 10:00:00',
+        'opt_in_path' => 159415,
+      ),
+      array(
+        'time' => '2013-07-25 10:00:00',
+        'opt_in_path' => 159417,
+      ),
+      array(
+        'time' => '2013-07-26 10:00:00',
+        'opt_in_path' => 159419,
+      ),
+      // Message for after the campaign ends
+      array(
+        'time' => '2013-07-27 10:00:00',
+        'opt_in_path' => 159381,
+      ),
+    ),
+  ),
+);
+
+$activity = $workflow->newActivity('end');
+$activity->name = 'end';
+$activity->inputs = array('mcommons_timed_paths');
+
+$workflows[$workflow->name] = $workflow;
+
+/**
+ * Intended to be plugged in at the end of a pregnancy text drip message as an
+ * mData. Will respond to any user message that matches a given set.
+ */
+$workflow = new ConductorWorkflow();
+$workflow->wid = 'new';
+$workflow->name = 'sms_flow_preg_text_responder';
+$workflow->title = 'Pregnancy Text Out-of-Flow Responder';
+$workflow->api_version = '1.0';
+
+$activity = $workflow->newActivity('start');
+$activity->name = 'start';
+$activity->outputs = array('out_of_flow_responder');
+
+$activity = $workflow->newActivity('out_of_flow_responder');
+$activity->name = 'out_of_flow_responder';
+$activity->inputs = array('start');
+$activity->outputs = array('end');
+$activity->no_match_responses = array(155123, 155133, 155143, 155153);
+$activity->mms_match_responses = array(
+  "Now that's a good looking picture",
+);
+$activity->response_sets = array(
+  array(
+    'phrase_match' => array('I hate you', 'suck it', 'kill yourself', 'youre the worst', 'shut up'),
+    'word_match' => array('die'),
+    'response' => array("That's no way to talk to a baby. If you really really want me to go away, text AWAY and I'll be gone."),
+  ),
+  array(
+    'phrase_match' => array('i love you'),
+    'AND_match' => array(array('love', 'you')),
+    'response' => array("I love you too!"),
+  ),
+  array(
+    'phrase_match' => array('Who is this', 'Who are you', 'Who the hell is this', 'What is this'),
+    'response' => array("I'm a phone baby your friend sent from DoSomething.org. I'll only text you today, but if you want me to go away, text AWAY."),
+  ),
+  array(
+    'phrase_match' => array('Im not up', 'Im not awake'),
+    'response' => array("You are now!"),
+  ),
+  array(
+    'phrase_match' => array('I will feed you'),
+    'AND_match' => array(array('feed', 'you')),
+    'response' => array("Thanks!", "Thank you!", "You're the best."),
+  ),
+  array(
+    'phrase_match' => array('Im tired'),
+    'response' => array("Me too, being this cute is exhausting"),
+  ),
+  array(
+    'phrase_match' => array('I dont want to bring you breakfast', 'I dont want to bring you breakfast in bed'),
+    'response' => array("But I'm hungry!"),
+  ),
+  array(
+    'phrase_match' => array('Feeds baby', 'heres breakfast', 'Im making breakfast'),
+    'word_match' => array('Eggs', 'pancakes', 'waffles', 'bagles', 'milk', 'cereal', 'applesauce', 'bottle', 'feed'),
+    'response' => array("Yum! I'll totally get you when I learn how to walk", "Nom nom nom"),
+  ),
+  array(
+    'AND_match' => array(array('orange', 'juice')),
+    'response' => array("Yum! I'll totally get you when I learn how to walk", "Nom nom nom"),
+  ),
+  array(
+    'phrase_match' => array('good morning'),
+    'word_match' => array('Goodmorning', ' morning'),
+    'response' => array("Good morning!", "It IS a good morning!"),
+  ),
+  array(
+    'exact_match' => array('youre welcome'),
+    'response' => array("Now I know where I get my good manners. Such a good example!", "Such good manners"),
+  ),
+  array(
+    'phrase_match' => array('Youre cute', 'youre adorable'),
+    'response' => array("I get my good looks from my parents", "Daww you're making me blush", "You sure know how to make a baby feel good", "Remember you said that next time I poop :)"),
+  ),
+  array(
+    'phrase_match' => array('You get me breakfast'),
+    'response' => array("I can't even stand up on my own yet!"),
+  ),
+  array(
+    'exact_match' => array('no'),
+    'phrase_match' => array('I dont want to'),
+    'response' => array("But I'm the baby, you have to!", "Tough break, you've gotta!"),
+  ),
+  array(
+    'word_match' => array('Gross', 'disgusting', 'fowl', 'foul', 'smelly', 'stinky', '/ew+/'),
+    'response' => array("But my cute face balances it out...", "I'm a baby, what do you expect?", "I can't help it, I'm a baby, this is what I do!", "It's a good thing I'm so cute...it makes up for all of the smelly and gross."),
+  ),
+  array(
+    'phrase_match' => array('It smells', 'you smell', 'smelly', 'that smells'),
+    'response' => array("What can I say? Babies are stinky.", "I'm a baby, that's sort of my M.O."),
+  ),
+  array(
+    'exact_match' => array('poop', 'fart'),
+    'phrase_match' => array('its poop', 'its a poop', 'its a fart', 'it was a poop'),
+    'AND_match' => array(array('its', 'poop'), array('its', 'fart')),
+    'response' => array("There's no real right answer. You sort of lose either way."),
+  ),
+  array(
+    'phrase_match' => array('Its okay', 'thats okay'),
+    'response' => array("Thanks for understanding", "You're so understanding"),
+  ),
+  array(
+    'phrase_match' => array('Ill change my shirt', 'clean shirt'),
+    'response' => array("That wasn't my favorite color on you anyway, it does nothing for your eyes"),
+  ),
+  array(
+    'phrase_match' => array('you ruined my shirt'),
+    'response' => array("I'm sorry, sometimes these things just happen."),
+  ),
+  array(
+    'phrase_match' => array('im pregnant', 'i am pregnant'),
+    'response' => array("I'm not the best person to talk to about that, but if you need more info on that matter, you should try calling his hotline: 800-442-4673"),
+  ),
+  array(
+    'phrase_match' => array('fuck you', 'you suck', 'screw you', 'you bitch', 'blow job', 'butt plug', 'camel toe', 'dumb ass', 'hard on', 'jerk off', 'jungle bunny', 'pissed off', 'porch monkey', 'nut sack', 'sand nigger'),
+    'word_match' => array('anus', 'arse', 'arsehole', 'ass', 'asshat', 'assjabber', 'asspirate', 'assbag', 'assbandit', 'assbanger', 'assbite', 'assclown', 'asscock', 'asscracker', 'asses', 'assface', 'assfuck', 'assfucker', 'assgoblin', 'asshat', 'asshead', 'asshole', 'asshopper', 'assjacker', 'asslick', 'asslicker', 'assmonkey', 'assmunch', 'assmuncher', 'asspirate', 'assshit', 'assshole', 'asssucker', 'asswad', 'asswipe', 'axwound', 'bastard', 'beaner', 'bitch', 'bitchass', 'bitches', 'bitchtits', 'bitchy', 'blowjob', 'bollocks', 'bollox', 'boner', 'brotherfucker', 'bullshit', 'bumblefuck', 'buttpirate', 'buttfucka', 'buttfucker', 'carpetmuncher', 'chesticle', 'chinc', 'chink', 'choad', 'chode', 'clit', 'clitface', 'clitfuck', 'clusterfuck', 'cock', 'cockass', 'cockbite', 'cockburger', 'cockface', 'cockfucker', 'cockhead', 'cockjockey', 'cockknoker', 'cockmaster', 'cockmongler', 'cockmongruel', 'cockmonkey', 'cockmuncher', 'cocknose', 'cocknugget', 'cockshit', 'cocksmith', 'cocksmoke', 'cocksmoker', 'cocksniffer', 'cocksucker', 'cockwaffle', 'coochie', 'coochy', 'coon', 'cooter', 'cum', 'cumbubble', 'cumdumpster', 'cumguzzler', 'cumjockey', 'cumslut', 'cumtart', 'cunnie', 'cunnilingus', 'cunt', 'cuntass', 'cuntface', 'cunthole', 'cuntlicker', 'cuntrag', 'cuntslut', 'dago', 'damn', 'deggo', 'dick', 'dicksneeze', 'dickbag', 'dickbeaters', 'dickface', 'dickfuck', 'dickfucker', 'dickhead', 'dickhole', 'dickjuice', 'dickmilk', 'dickmonger', 'dicks', 'dickslap', 'dicksucker', 'dicksucking', 'dicktickler', 'dickwad', 'dickweasel', 'dickweed', 'dickwod', 'dike', 'dildo', 'dipshit', 'doochbag', 'dookie', 'douche', 'douchefag', 'douchebag', 'douchewaffle', 'dumass', 'dumbass', 'dumbfuck', 'dumbshit', 'dumshit', 'dyke', 'fag', 'fagbag', 'fagfucker', 'faggit', 'faggot', 'faggotcock', 'fagtard', 'fatass', 'fellatio', 'feltch', 'flamer', 'fuck', 'fuckass', 'fuckbag', 'fuckboy', 'fuckbrain', 'fuckbutt', 'fuckbutter', 'fucked', 'fucker', 'fuckersucker', 'fuckface', 'fuckhead', 'fuckhole', 'fuckin', 'fucking', 'fucknut', 'fucknutt', 'fuckoff', 'fucks', 'fuckstick', 'fucktard', 'fucktart', 'fuckup', 'fuckwad', 'fuckwit', 'fuckwitt', 'fudgepacker', 'gay', 'gayass', 'gaybob', 'gaydo', 'gayfuck', 'gayfuckist', 'gaylord', 'gaytard', 'gaywad', 'goddamn', 'goddamnit', 'gooch', 'gook', 'gringo', 'guido', 'handjob', 'heeb', 'hell', 'ho', 'hoe', 'homo', 'homodumbshit', 'honkey', 'humping', 'jackass', 'jagoff', 'jap', 'jerkass', 'jigaboo', 'jizz', 'junglebunny', 'kike', 'kooch', 'kootch', 'kraut', 'kunt', 'kyke', 'lameass', 'lardass', 'lesbian', 'lesbo', 'lezzie', 'mcfagget', 'mick', 'minge', 'mothafucka', 'mothafuckin', 'motherfucker', 'motherfucking', 'muff', 'muffdiver', 'munging', 'negro', 'nigaboo', 'nigga', 'nigger', 'niggers', 'niglet', 'nutsack', 'paki', 'panooch', 'pecker', 'peckerhead', 'penis', 'penisbanger', 'penisfucker', 'penispuffer', 'piss', 'pissed', 'pissflaps', 'polesmoker', 'pollock', 'poon', 'poonani', 'poonany', 'poontang', 'porchmonkey', 'prick', 'punanny', 'punta', 'pussies', 'pussy', 'pussylicking', 'puto', 'queef', 'queer', 'queerbait', 'queerhole', 'renob', 'rimjob', 'ruski', 'sandnigger', 'schlong', 'scrote', 'shit', 'shitass', 'shitbag', 'shitbagger', 'shitbrains', 'shitbreath', 'shitcanned', 'shitcunt', 'shitdick', 'shitface', 'shitfaced', 'shithead', 'shithole', 'shithouse', 'shitspitter', 'shitstain', 'shitter', 'shittiest', 'shitting', 'shitty', 'shiz', 'shiznit', 'skank', 'skeet', 'skullfuck', 'slut', 'slutbag', 'smeg', 'snatch', 'spic', 'spick', 'splooge', 'spook', 'suckass', 'tard', 'testicle', 'thundercunt', 'tit', 'titfuck', 'tits', 'tittyfuck', 'twat', 'twatlips', 'twats', 'twatwaffle', 'unclefucker', 'vajj', 'vag', 'vagina', 'vajayjay', 'vjayjay', 'wank', 'wankjob', 'wetback', 'whore', 'whorebag', 'whoreface', 'wop'),
+    'word_match_exact' => TRUE,
+    'response' => array("That's no way to talk to a baby. If you want me to go away, I will, just text AWAY.", "You kiss your mother with that mouth? If you want me to go away, I will, just text AWAY.", "Woah, that's too much for my baby ears to handle. If you want me to go away, I will, just text AWAY."),
+  ),
+  array(
+    'phrase_match' => array('Calm down'),
+    'AND_match' => array(array('calm', 'down')),
+    'response' => array("I'm trying, I swear!"),
+  ),
+  array(
+    'exact_match' => array('wait'),
+    'response' => array("I don't control these things. "),
+  ),
+  array(
+    'phrase_match' => array('Potty trained', ' potty train', ' use the toilet'),
+    'response' => array("I won't be potty trained for at least another year, buckle up!"),
+  ),
+  array(
+    'phrase_match' => array('Shake baby'),
+    'response' => array("OW", "I'm not a doll! That hurts!"),
+  ),
+  array(
+    'exact_match' => array('change yourself'),
+    'phrase_match' => array('change yourself'),
+    'response' => array("I can't hold onto anything bigger than a pinky, how do you expect me to change my own diaper?", "Give me about 2 years and I totally will"),
+  ),
+  array(
+    'phrase_match' => array('Changed your diaper', 'youre all clean', 'Ill change you', 'changing you', 'clean now', 'diaper changed', 'change you', 'smelling good', 'changes diaper'),
+    'word_match' => array('change', 'wash', 'clean'),
+    'response' => array("So fresh and so clean clean", "Thanks!", "Thanks! When you smell better, you feel better"),
+  ),
+  array(
+    'exact_match' => array('ok', 'okay', 'done'),
+    'phrase_match' => array('all done', 'I did it', 'I will', 'I am', 'I did', 'Im done'),
+    'response' => array("You're the best!", "Thanks!", "Thank you!", "Phew, so much better"),
+  ),
+  array(
+    'phrase_match' => array('youre the best'),
+    'response' => array("No you're the best."),
+  ),
+  array(
+    'phrase_match' => array('I cant right now', 'not now', 'Ill do it later'),
+    'response' => array("Mkay, I'll be here waiting.", "Just don't forget about me!"),
+  ),
+  array(
+    'phrase_match' => array('I already changed you'),
+    'AND_match' => array(array('change', 'already')),
+    'response' => array("Well, I poop a lot.", "Call me Sir Poops A Lot"),
+  ),
+  array(
+    'phrase_match' => array('Are you hungry', 'Do you need food', 'Do you need a bottle', 'Something to eat'),
+    'response' => array("Yes please, I'm always hungry", "I could always eat", "A little snack sounds good"),
+  ),
+  array(
+    'phrase_match' => array('Do you need to be changed', 'Diaper change', 'Check diaper', ' change diaper'),
+    'response' => array("I pretty much always need my diaper changed", "Yeah, I think there might be a situation downtown"),
+  ),
+  array(
+    'phrase_match' => array('Sit in your soiled clothes', 'sit in your dirty diaper', 'stay dirty'),
+    'response' => array("Well that's just gross, imagine it for a second. Go ahead."),
+  ),
+  array(
+    'phrase_match' => array('Are you sleepy', 'Are you tired', 'are you sleep', 'are you asleep'),
+    'response' => array("I'm a little sleepy"),
+  ),
+  array(
+    'phrase_match' => array('Im sleeping', 'Im asleep'),
+    'response' => array("Not anymore!"),
+  ),
+  array(
+    'phrase_match' => array('Please dont cry'),
+    'AND_match' => array(array('dont', 'cry')),
+    'response' => array("I'm a baby, it's what I do!"),
+  ),
+  array(
+    'phrase_match' => array('Chill out'),
+    'AND_match' => array(array('chill', 'out')),
+    'response' => array("This is me chilled out"),
+  ),
+  array(
+    'AND_match' => array(array('stay', 'still'), array('hold', 'still')),
+    'response' => array("BUT I. DONT. WANNAAAAAA", "This is about as still as I get."),
+  ),
+  array(
+    'phrase_match' => array('Im coming', 'Im here', 'here I come', 'coming', 'here', 'im home'),
+    'response' => array("Can't wait to see you!", "YAY!"),
+  ),
+  array(
+    'phrase_match' => array('on my way'),
+    'word_match' => array('omw'),
+    'response' => array("Woohoo! See you soon!", "Yay! See you in a little.", "Good :)"),
+  ),
+  array(
+    'phrase_match' => array('Youre ugly', 'youre not cute'),
+    'response' => array("Well they tell me I look like my parents...", "Where do you think I get my looks from?", "I'm lookin at you.."),
+  ),
+  array(
+    'exact_match' => array('No it doesnt', 'No youre not'),
+    'response' => array("Hey, don't argue with a baby.", "I'm the baby, I'm always right", "There's no arguing with a baby-\"I'm a baby\" is the ultimate trump card."),
+  ),
+  array(
+    'phrase_match' => array('Goo goo gaga', 'goo goo ga ga'),
+    'AND_match' => array(array('goo', 'ga'), array('goo', 'gaga')),
+    'response' => array("Aw, look at you trying to talk in my language. That's so cute."),
+  ),
+  array(
+    'phrase_match' => array('Im at work', 'Im at school'),
+    'response' => array("Okay, I'll try to be quiet til you're done"),
+  ),
+  array(
+    'phrase_match' => array('driving me crazy', 'drive me crazy'),
+    'response' => array("But the cuteness makes up for it :)"),
+  ),
+  array(
+    'phrase_match' => array('get adopted', 'putting you up for adoption'),
+    'response' => array("You don't mean that. If you really want me to go away though, I will, just text AWAY :("),
+  ),
+  array(
+    'phrase_match' => array('snack time'),
+    'response' => array("Nom nom nom nom"),
+  ),
+  array(
+    'phrase_match' => array('There was no school today', 'school is already out', 'school has been out', 'Its the weekend', 'Its Saturday', 'Its Sunday'),
+    'response' => array("I'm just a baby, I don't even know what day of the week it is. "),
+  ),
+  array(
+    'phrase_match' => array('Yes I have to study'),
+  ),
+  array(
+    'phrase_match' => array('I dont have to study'),
+    'response' => array("Perfect! Then we can play allll night"),
+  ),
+  array(
+    'phrase_match' => array('I dont take algebra', 'I already took algebra'),
+    'response' => array("I can't even say my name yet, I don't know the difference between school subjects"),
+  ),
+  array(
+    'phrase_match' => array('I cant sing', 'I dont know any lullabies', 'I dont know a lullaby'),
+    'response' => array("I'm sure whatever you sing will be perfect."),
+  ),
+  array(
+    'phrase_match' => array('cant send a photo', 'cant send a picture', 'cant send a pic', 'Do I have to send a picture', 'Do I have to send a photo'),
+    'response' => array("You don't have to send me a picture. You just take so many of me, I thought it would be nice to have one of you!"),
+  ),
+  array(
+    'phrase_match' => array('I dont want to sing'),
+    'response' => array("But it'll make me go to sleep"),
+  ),
+  array(
+    'phrase_match' => array('You do it'),
+    'response' => array("I can't even say my own name yet, how am I supposed to do it?"),
+  ),
+  array(
+    'phrase_match' => array('Whats your name?'),
+    'response' => array("That's your job! Just don't go all celeb on me and name me Flamingo or something."),
+  ),
+  array(
+    'phrase_match' => array('Dont go', 'Dont go away', 'Dont leave', 'No dont leave baby'),
+    'response' => array("Ok fine I won't go, I would miss you too much anyway."),
+  ),
+  array(
+    'phrase_match' => array('i miss you', 'i missed you'),
+    'response' => array("Daww :)"),
+  ),
+  array(
+    'exact_match' => array('boo'),
+    'phrase_match' => array('peek a boo'),
+    'response' => array("Ah! You scared me."),
+  ),
+  array(
+    'phrase_match' => array('What do you want to play'),
+    'response' => array("Peek-a-boo! Duh."),
+  ),
+  array(
+    'phrase_match' => array('passing you off', 'pass you off'),
+    'response' => array("You can't just pass me off, I'm here to stay!"),
+  ),
+  array(
+    'exact_match' => array('tell me'),
+    'phrase_match' => array('Tell me what you need', 'Tell me what you want'),
+    'response' => array("I wish I could!", "I'm trying but I can't!"),
+  ),
+  array(
+    'phrase_match' => array('Try harder', 'Youre not trying'),
+    'response' => array("I really am trying. Things will be so much easier when I learn how to talk out loud. "),
+  ),
+  array(
+    'word_match' => array('/\bha[ha]*\b/', 'LOL', 'LMAO'),
+    'response' => array("Glad you find me funny :)", "I'm just a regular comedian. ", "I'm glad you think I'm as funny as I do!"),
+  ),
+  array(
+    'word_match' => array('tickle', 'tickling'),
+    'response' => array("Hehehe I'm ticklish!", "Heheh!", "Ahh I'm ticklish! I can't breathe I'm laughing so hard!"),
+  ),
+);
+
+$activity = $workflow->newActivity('end');
+$activity->name = 'end';
+$activity->inputs = array('out_of_flow_responder');
+
+$workflows[$workflow->name] = $workflow;

--- a/modules/dosomething/dosomething_sms/workflows/test.keywords.inc
+++ b/modules/dosomething/dosomething_sms/workflows/test.keywords.inc
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @file
+ * Array of endpoints ("keywords") and the names of the workflow they are each
+ * associated with. Keyword/workflow pairs here are for testing only.
+ */
+$keywords['dosomething-sms-test'] = 'dosomething_sms_test';

--- a/modules/dosomething/dosomething_sms/workflows/test.workflows.inc
+++ b/modules/dosomething/dosomething_sms/workflows/test.workflows.inc
@@ -5,6 +5,8 @@
  * ConductorWorkflow definitions for test endpoints.
  */
 
+require_once drupal_get_path('module', 'dosomething_sms') . '/sms_flow_game_constants.inc';
+
 $workflow = new ConductorWorkflow();
 $workflow->wid = 'new';
 $workflow->name = 'dosomething_sms_test';

--- a/modules/dosomething/dosomething_sms/workflows/test.workflows.inc
+++ b/modules/dosomething/dosomething_sms/workflows/test.workflows.inc
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * ConductorWorkflow definitions for test endpoints.
+ */
+
+$workflow = new ConductorWorkflow();
+$workflow->wid = 'new';
+$workflow->name = 'dosomething_sms_test';
+$workflow->api_version = '1.0';
+
+$activity = $workflow->newActivity('start');
+$activity->name = 'start';
+$activity->outputs = array('prompt');
+
+$activity = $workflow->newActivity('sms_prompt');
+$activity->name = 'prompt';
+$activity->inputs = array('start');
+$activity->outputs = array('end');
+$activity->question = 'this is a test.';
+
+$activity = $workflow->newActivity('end');
+$activity->name = 'end';
+$activity->inputs = array('prompt');
+
+$workflows[$workflow->name] = $workflow;


### PR DESCRIPTION
- Previously both dosomething_sms and sms_flow modules were used as homes to SMS code. This is all now consolidated again in the dosomething_sms module alone.
- Previous methods also relied on the sms_mobile_commons and smsframework modules. Those dependencies have been removed and we're just using the mobilecommons module in conjunction with the mobilecommons-php library to make our calls to - you guessed it - Mobile Commons.
  - Using the mobilecommons module also solves how we'll set private authentication credentials.
- I also started the process of bringing over some of our ConductorActivity plugins - everything under dosomething_sms/plugins/activity/misc. I only brought over the ones so far that rely on Mobile Commons API calls.

Resolves #90, #91
