### PR TITLE
Campaign Admin UI Test

### DIFF
--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -142,8 +142,8 @@ function dosomething_campaign_admin_settings_form($form, &$form_state) {
   $elements = array(
     'cta_text',
     'know',
-    'season_high_low',
     'season_high_start',
+    'season_high_end',
     'season_low_start',
     'season_low_end',
     'stat_problem',

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.info
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.info
@@ -3,4 +3,5 @@ description = Provides a custom Campaign Entity and its functionality.
 core = 7.x
 package = DoSomething
 dependencies[] = entity
+files[] = dosomething_campaign.test
 files[] = includes/dosomething_campaign.inc

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.test
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.test
@@ -7,7 +7,7 @@
 
 
 /**
- * Base class for all dosomething_user web test cases.
+ * Base class for all dosomething_campaign web test cases.
  */
 class DosomethingCampaignWebTestCase extends DrupalWebTestCase {
   // Required to test inside the DoSomething profile:
@@ -33,15 +33,17 @@ class DosomethingCampaignWebTestCase extends DrupalWebTestCase {
     $this->drupalLogin($this->auth_user);
     $uid = $this->auth_user->uid;
     // Store test values for each column:
-    $values = array(
+    $col_values = array(
     	'title' => 'Title',
     	'cta_text' => 'CTA Text',
+    	'season_high_start' => '01/01',
+    	'season_high_end' => '03/01',
+    	'is_season_high_end_displayed' => TRUE,
+    	'season_low_start' => '01/01',
+    	'season_low_end' => '03/01',
     );
-    // Create campaign to submit.
-    $edit = array();
-    $edit['title'] = $values['title'];
-    $edit['cta_text'] = $values['cta_text'];
-    $this->drupalPost('admin/campaign/add', $edit, t('Save Campaign'));
+    // Submit $col_values as a new campaign:
+    $this->drupalPost('admin/campaign/add', $col_values, t('Save Campaign'));
     // Fetch last inserted campaign record:
     $result = db_select('dosomething_campaign', 'c')
       ->fields('c')
@@ -50,7 +52,10 @@ class DosomethingCampaignWebTestCase extends DrupalWebTestCase {
 	    ->execute()
 	    ->fetchAssoc();
 	  $this->assertIdentical($this->auth_user->uid, $result['uid'], '"uid" value is equal.');
-	  $this->assertIdentical($values['title'], $result['title'], '"title" value is equal.');
-	  $this->assertIdentical($values['cta_text'], $result['cta_text'], '"cta_text" value is equal.');
+	  // Loop through column values:
+	  foreach ($col_values as $col_name => $value) {
+	  	// Test if value is equal to query result:
+		  $this->assertEqual($col_values[$col_name], $result[$col_name], $col_name . ': ' . $col_values[$col_name] . ' == ' . $result[$col_name]);
+	  }
   }
 }

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.test
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.test
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @file
+ * Tests for the dosomething_campaign module.
+ */
+
+
+/**
+ * Base class for all dosomething_user web test cases.
+ */
+class DosomethingCampaignWebTestCase extends DrupalWebTestCase {
+  // Required to test inside the DoSomething profile:
+  protected $profile = 'dosomething';
+
+  public static function getInfo() {
+    return array(
+      'name' => 'DoSomething Campaign Web Test',
+      'description' => 'Web tests for DoSomething Campaign',
+      'group' => 'DoSomething',
+    );
+  }
+
+  public function setUp() {
+    parent::setUp(array('dosomething_campaign'));
+    $this->auth_user = $this->drupalCreateUser();
+  }
+
+  /**
+   * Tests values are saved into the dosomething_campaign table.
+   */
+  function testCampaignForm() {
+    $this->drupalLogin($this->auth_user);
+    $uid = $this->auth_user->uid;
+    // Store test values for each column:
+    $values = array(
+    	'title' => 'Title',
+    	'cta_text' => 'CTA Text',
+    );
+    // Create campaign to submit.
+    $edit = array();
+    $edit['title'] = $values['title'];
+    $edit['cta_text'] = $values['cta_text'];
+    $this->drupalPost('admin/campaign/add', $edit, t('Save Campaign'));
+    // Fetch last inserted campaign record:
+    $result = db_select('dosomething_campaign', 'c')
+      ->fields('c')
+	    ->orderBy('id', 'DESC')
+	    ->range(0,1)
+	    ->execute()
+	    ->fetchAssoc();
+	  $this->assertIdentical($this->auth_user->uid, $result['uid'], '"uid" value is equal.');
+	  $this->assertIdentical($values['title'], $result['title'], '"title" value is equal.');
+	  $this->assertIdentical($values['cta_text'], $result['cta_text'], '"cta_text" value is equal.');
+  }
+}


### PR DESCRIPTION
- Adds a SimpleTest to test Campaign entity form.  Submits campaign at `/admin/campaign/new`, and queries dosomething_campaign table to verify expected columns / values.
  - Fixes misspelled form key in `dosomething_campaign_admin_settings_form`

Resolves #174
