### PR TITLE
Campaign Tags auto-complete

### DIFF
--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -14,12 +14,6 @@ function campaign_form($form, &$form_state, $campaign, $op = 'edit') {
   // Prefix for Entity column description variables:
   $desc_prefix = DOSOMETHING_CAMPAIGN_FORM_DESC_PREFIX;
 
-  // Initialize $fields_form and $fields_form_state to store the Entity's Field API form:
-  $fields_form = array();
-  $fields_form_state = array();
-  // Attach the entity's Field API data into $fields_form to use for later in our actual $form:
-  field_attach_form('campaign', $campaign, $fields_form, $fields_form_state);
-
   // Basic info:
   $form['title'] = array(
     '#title' => t('Title'),
@@ -190,8 +184,14 @@ function campaign_form($form, &$form_state, $campaign, $op = 'edit') {
     '#collapsed' => TRUE,
     '#description' => variable_get($desc_prefix . 'taxonomy', ''),
   );
-  $form['taxonomy']['field_cause'] = $fields_form['field_cause'];
-  $form['taxonomy']['field_action_type'] = $fields_form['field_action_type'];
+  // Attach field_cause.
+  field_attach_form('campaign', $campaign, $form['taxonomy'], $form_state, NULL, array(
+    'field_name' => 'field_cause',
+  ));
+  // Attach field_action_type.
+  field_attach_form('campaign', $campaign, $form['taxonomy'], $form_state, NULL, array(
+    'field_name' => 'field_action_type',
+  ));
   $form['taxonomy']['hours'] = array(
     '#title' => t('Active Hours'),
     '#type' => 'radios',

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -214,6 +214,10 @@ function campaign_form($form, &$form_state, $campaign, $op = 'edit') {
     '#description' => variable_get($desc_prefix . 'is_staff_pick', ''),
     '#weight' => 300,
   );
+  // Attach field_tags.
+  field_attach_form('campaign', $campaign, $form['taxonomy'], $form_state, NULL, array(
+    'field_name' => 'field_tags',
+  ));
 
   // Reportback:
   $form['reportback'] = array(

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
@@ -72,10 +72,45 @@ function dosomething_campaign_field_default_field_instances() {
     ),
   );
 
+  // Exported field_instance: 'campaign-campaign-field_tags'
+  $field_instances['campaign-campaign-field_tags'] = array(
+    'bundle' => 'campaign',
+    'default_value' => NULL,
+    'deleted' => 0,
+    'description' => '',
+    'display' => array(
+      'default' => array(
+        'label' => 'above',
+        'module' => 'taxonomy',
+        'settings' => array(),
+        'type' => 'taxonomy_term_reference_link',
+        'weight' => 2,
+      ),
+    ),
+    'entity_type' => 'campaign',
+    'field_name' => 'field_tags',
+    'label' => 'Tags',
+    'required' => 0,
+    'settings' => array(
+      'user_register_form' => FALSE,
+    ),
+    'widget' => array(
+      'active' => 0,
+      'module' => 'taxonomy',
+      'settings' => array(
+        'autocomplete_path' => 'taxonomy/autocomplete',
+        'size' => 60,
+      ),
+      'type' => 'taxonomy_autocomplete',
+      'weight' => 3,
+    ),
+  );
+
   // Translatables
   // Included for use with string extractors like potx.
   t('Action Type');
   t('Cause');
+  t('Tags');
 
   return $field_instances;
 }

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.info
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.info
@@ -10,5 +10,6 @@ dependencies[] = taxonomy
 features[features_api][] = api:2
 features[field_instance][] = campaign-campaign-field_action_type
 features[field_instance][] = campaign-campaign-field_cause
+features[field_instance][] = campaign-campaign-field_tags
 files[] = dosomething_campaign.test
 files[] = includes/dosomething_campaign.inc

--- a/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.features.field_base.inc
+++ b/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.features.field_base.inc
@@ -78,5 +78,39 @@ function dosomething_taxonomy_field_default_field_bases() {
     'type' => 'taxonomy_term_reference',
   );
 
+  // Exported field_base: 'field_tags'
+  $field_bases['field_tags'] = array(
+    'active' => 1,
+    'cardinality' => -1,
+    'deleted' => 0,
+    'entity_types' => array(),
+    'field_name' => 'field_tags',
+    'foreign keys' => array(
+      'tid' => array(
+        'columns' => array(
+          'tid' => 'tid',
+        ),
+        'table' => 'taxonomy_term_data',
+      ),
+    ),
+    'indexes' => array(
+      'tid' => array(
+        0 => 'tid',
+      ),
+    ),
+    'locked' => 0,
+    'module' => 'taxonomy',
+    'settings' => array(
+      'allowed_values' => array(
+        0 => array(
+          'vocabulary' => 'tags',
+          'parent' => 0,
+        ),
+      ),
+    ),
+    'translatable' => 0,
+    'type' => 'taxonomy_term_reference',
+  );
+
   return $field_bases;
 }

--- a/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.info
+++ b/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.info
@@ -10,6 +10,7 @@ dependencies[] = uuid_features
 features[features_api][] = api:2
 features[field_base][] = field_action_type
 features[field_base][] = field_cause
+features[field_base][] = field_tags
 features[taxonomy][] = action_type
 features[taxonomy][] = cause
 features[taxonomy][] = tags


### PR DESCRIPTION
Resolves #211

Creates a field_tags field on the campaign entity, and adds an auto-complete widget to the campaign form.

This also cleans up code committed for #214 - the easier way seems to be to use field_attach_form for the current `$form` variable instead of creating the duplicate, and just using the $options parameter to specify the field to attach.
