### PR TITLE
Restores wercker build steps and disables ds-api library pull for now

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -137,8 +137,8 @@ libraries[mobilecommons_php][download][type] = "git"
 libraries[mobilecommons_php][download][url] = "https://github.com/DoSomething/mobilecommons-php.git"
 
 ; DSAPI PHP Library
-libraries[dsapi][download][type] = "git"
-libraries[dsapi][download][url] = "git@github.com:DoSomething/dsapi-php.git"
+;libraries[dsapi][download][type] = "git"
+;libraries[dsapi][download][url] = "git@github.com:DoSomething/dsapi-php.git"
 
 ; NEUE
 libraries[neue][download][type] = "git"

--- a/wercker.yml
+++ b/wercker.yml
@@ -3,4 +3,10 @@ services:
     - wercker/mysql
 build:
     steps:
+        - add-ssh-key:
+            keyname: DOSOMETHING
         - desmondmorris/drush@0.0.2
+        - script:
+            name: Run make file
+            code: |-
+                drush make --prepare-install --no-gitinfofile --no-cache build-dosomething.make html


### PR DESCRIPTION
Disabling the ds-api library for now.  Since the make file clones multiple private repos, it is necessary to add ssh keys to the build pipeline for the both.  Currently the add-ssh-key build step does not accommodate this properly. 
