### PR TITLE
Campaign View Modes for Pitch and Action

### DIFF
--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -123,7 +123,7 @@ function dosomething_campaign_view_entity($campaign, $view_mode = 'action') {
 function dosomething_campaign_signup_form($form, &$form_state) {
   $form['submit'] = array(
     '#type' => 'submit',
-    '#value' => 'Do This',
+    '#value' => t('Do This'),
   );
   return $form;
 }

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -20,24 +20,36 @@ function dosomething_campaign_entity_info() {
     'uri callback' => 'entity_class_uri',
     'controller class' => 'CampaignEntityController',
     'admin ui' => array(
-       'path' => 'admin/campaign',
-       'controller class' => 'CampaignEntityUIController',
-       'menu wildcard' => '%campaign',
-       'file' => 'dosomething_campaign.admin.inc',
-     ),
-     'module' => 'dosomething_campaign',
+      'path' => 'admin/campaign',
+      'controller class' => 'CampaignEntityUIController',
+      'menu wildcard' => '%campaign',
+      'file' => 'dosomething_campaign.admin.inc',
+    ),
+    'module' => 'dosomething_campaign',
      // Controls who can access entity CRUD.
-     'access callback' => 'dosomething_campaign_access',
-     'fieldable' => TRUE,
-     'bundles' => array(
-        'campaign' => array(
-          'label' => t('Video'),
-          'admin' => array(
-            'path' => 'admin/campaign',
-            'access arguments' => array(1),
-            ),
-          ),
+    'access callback' => 'dosomething_campaign_access',
+    // Inform Field API that we can add Fields to this entity.
+    'fieldable' => TRUE,
+    'bundles' => array(
+      'campaign' => array(
+        'label' => t('Video'),
+        'admin' => array(
+          'path' => 'admin/campaign',
+          'access arguments' => array(1),
+        ),
       ),
+    ),
+    // Custom view modes.
+    'view modes' => array(
+      'pitch' => array(
+        'label' => t('Pitch'),
+        'custom settings' => FALSE,
+      ),
+      'action' => array(
+        'label' => t('Action'),
+        'custom settings' => FALSE,
+      ),
+    ),
   );
   return $info;
 }
@@ -51,7 +63,7 @@ function dosomething_campaign_menu() {
     'title callback' => 'dosomething_campaign_page_title',
     'title arguments' => array(1),
     'page callback' => 'dosomething_campaign_view_entity',
-    'page arguments' => array(1),
+    'page arguments' => array(1, 2),
     'access callback' => TRUE,
   );
   $items['admin/config/dosomething/dosomething_campaign'] = array(
@@ -64,6 +76,7 @@ function dosomething_campaign_menu() {
   );
   return $items;
 }
+
 
 /**
  * Title callback: Returns the title of the campaign.
@@ -98,8 +111,19 @@ function campaign_load($id) {
 /**
  * Callback for /campaign/ID page.
  *
- * Just a place to render a complete campaign entity.
+ * Passing view_mode as an argument is temporary until signups are functional.
  */
-function dosomething_campaign_view_entity($campaign) {
-  return entity_view('campaign', array($campaign->id => $campaign));
+function dosomething_campaign_view_entity($campaign, $view_mode = 'action') {
+  return entity_view('campaign', array($campaign->id => $campaign), $view_mode);
+}
+
+/**
+ * Form constructor for the Campaign Signup form.
+ */
+function dosomething_campaign_signup_form($form, &$form_state) {
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => 'Do This',
+  );
+  return $form;
 }

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -127,3 +127,14 @@ function dosomething_campaign_signup_form($form, &$form_state) {
   );
   return $form;
 }
+
+/**
+ * Process variables for entity.tpl.php.
+ *
+ * @see template_preprocess_entity in Entity API module.
+ */
+function dosomething_campaign_preprocess_entity(&$variables) {
+  $entity_type = $variables['elements']['#entity_type'];
+  // Enables ENTITY--VIEW_MODE.tpl.php naming suggestion.
+  $variables['theme_hook_suggestions'][] = $entity_type . '__' . $variables['view_mode'];
+}

--- a/modules/dosomething/dosomething_campaign/includes/dosomething_campaign.inc
+++ b/modules/dosomething/dosomething_campaign/includes/dosomething_campaign.inc
@@ -33,14 +33,22 @@ class CampaignEntityController extends EntityAPIController {
    */
   public function buildContent($entity, $view_mode = 'full', $langcode = NULL, $content = array()) {
     $build = parent::buildContent($entity, $view_mode, $langcode, $content);
-    foreach ($entity as $key => $value) {
+
+    // Get the columns defined in the dosomething_campaign table:
+    module_load_install('dosomething_campaign');
+    $schema = dosomething_campaign_schema();
+ 
+    // Add them into the render array:
+    foreach ($schema['dosomething_campaign']['fields'] as $key => $value) {
       $build[$key] = array(
         '#type' => 'markup',
-        '#markup' => $value,
+        '#markup' => $entity->{$key},
         '#prefix' => '<div>' . $key . ': ',
         '#suffix' => '</div>',
       );      
     }
+
+    // @todo: If pitch page, add the signup button:
     return $build;
   }
 

--- a/modules/dosomething/dosomething_campaign/includes/dosomething_campaign.inc
+++ b/modules/dosomething/dosomething_campaign/includes/dosomething_campaign.inc
@@ -43,7 +43,7 @@ class CampaignEntityController extends EntityAPIController {
       $build[$key] = array(
         '#type' => 'markup',
         '#markup' => $entity->{$key},
-        '#prefix' => '<div>' . $key . ': ',
+        '#prefix' => '<div class="' . drupal_html_class($key) . '">',
         '#suffix' => '</div>',
       );
     }

--- a/modules/dosomething/dosomething_campaign/includes/dosomething_campaign.inc
+++ b/modules/dosomething/dosomething_campaign/includes/dosomething_campaign.inc
@@ -31,7 +31,7 @@ class CampaignEntityController extends EntityAPIController {
    *
    * Adds campaign column values into campaign entity's render.
    */
-  public function buildContent($entity, $view_mode = 'full', $langcode = NULL, $content = array()) {
+  public function buildContent($entity, $view_mode = 'action', $langcode = NULL, $content = array()) {
     $build = parent::buildContent($entity, $view_mode, $langcode, $content);
 
     // Get the columns defined in the dosomething_campaign table:
@@ -45,10 +45,15 @@ class CampaignEntityController extends EntityAPIController {
         '#markup' => $entity->{$key},
         '#prefix' => '<div>' . $key . ': ',
         '#suffix' => '</div>',
-      );      
+      );
     }
 
-    // @todo: If pitch page, add the signup button:
+    // Add signup form if viewing the pitch.
+    if ($view_mode == 'pitch') {
+      $build['signup_form'] = drupal_get_form('dosomething_campaign_signup_form');
+      $build['signup_form']['#weight'] = 200;
+    }
+
     return $build;
   }
 


### PR DESCRIPTION
Creates two custom view modes for the Campaign Entity: "Pitch" and "Action", and adds a Signup "Do This") Form into the Pitch view mode (form submit is not functional yet).

The action page can be viewed at campaign/[id], and the pitch page can be viewed by navigating to campaign/[id]/pitch.  This page callback will be updated to display the view_mode based on user signup status once signups are functional.

Also implements hook_preprocess_entity in order to allow for naming convention: campaign--pitch.tpl.php and campaign--action.tpl.php.

Works towards #173 -- all we need to do is actually create the tpl files in order to close it.
