### PR TITLE
README for generating Facts/Campaigns

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -1,1 +1,3 @@
-DoSomething specific custom modules will live here
+DoSomething specific custom modules live here.
+
+We need this directory in order to keep the contrib and our custom modules separated nicely and to make symlinking during development easier

--- a/modules/dosomething/README.md
+++ b/modules/dosomething/README.md
@@ -1,3 +1,0 @@
-DoSomething specific custom modules will live here
-
-We need this directory in order to keep the contrib and our custom modules separated nicely and to make symlinking during development easier

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign_devel/README.md
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign_devel/README.md
@@ -1,0 +1,6 @@
+This module generates Dummy DS Campaign entities for development.
+
+Make sure to generate DS Fact entites via the DS Fact Devel module 
+first, before generating dummy campaigns.
+
+Then, generate campaigns at admin/config/development/generate/campaign.

--- a/modules/dosomething/dosomething_fact/dosomething_fact_devel/README.md
+++ b/modules/dosomething/dosomething_fact/dosomething_fact_devel/README.md
@@ -1,0 +1,3 @@
+This module generates Dummy DS Fact entities for development.
+
+Enable the module and generate facts at admin/config/development/generate/fact.

--- a/themes/README.md
+++ b/themes/README.md
@@ -1,1 +1,3 @@
-DoSomething specific custom themes will live here
+DoSomething specific custom themes live here.
+
+We need this directory in order to make symlinking during development easier.

--- a/themes/dosomething/README.md
+++ b/themes/dosomething/README.md
@@ -1,3 +1,0 @@
-DoSomething specific custom themes will live here
-
-We need this directory in order to make symlinking during development easier


### PR DESCRIPTION
Adds README files for the DS Fact and DS Campaign Devel submodules.

Cleans up README's in the /modules and /themes directories by removing the 2nd READMEs in the modules/dosomething and themes/dosomething directories.
