### PR TITLE
Unset empty 'active hours' option in campagin form

### DIFF
--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -18,4 +18,6 @@ function dosomething_campaign_form_campaign_node_form_alter(&$form, &$form_state
   $add_link_div = '<div id="add-fact-status"></div><div>' . l(t('Add new fact'), $add_fact_link, array('attributes' => array('class' => 'ctools-use-modal'))) . '</div>';
 
   $form['field_fact_problem']['#prefix'] = $add_link_div;
+
+  unset($form['field_active_hours'][LANGUAGE_NONE]['#options']['_none']);
 }


### PR DESCRIPTION
Fixes #327

Conflicts:

```
modules/dosomething/dosomething_campaign/dosomething_campaign.module
```
