### PR TITLE
Signup form

### DIFF
--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.info
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.info
@@ -8,6 +8,7 @@ dependencies[] = ctools
 dependencies[] = date
 dependencies[] = dosomething_fact
 dependencies[] = dosomething_image
+dependencies[] = dosomething_signup
 dependencies[] = dosomething_taxonomy
 dependencies[] = entity
 dependencies[] = entityreference

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -95,6 +95,7 @@ function dosomething_campaign_preprocess_node(&$vars) {
  */
 function dosomething_campaign_preprocess_pitch_page(&$vars) {
   // Prepare vars for pitch page.
+  $vars['signup_form'] = drupal_get_form('dosomething_signup_form', $vars['nid']);
 }
 
 /**

--- a/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -96,3 +96,33 @@ function dosomething_signup_exists($nid, $uid = NULL) {
   // Otherwise return FALSE.
   return FALSE;
 }
+
+/**
+ * Form constructor for user signup form.
+ *
+ * @param int $nid
+ *   The node nid to signup for.
+ */
+function dosomething_signup_form($form, &$form_state, $nid) {
+  $form['nid'] = array(
+    '#type' => 'hidden',
+    '#default_value' => $nid,
+  );
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t("Sign Up"),
+  );
+  return $form;
+}
+
+/**
+ * Form submission handler for dosomething_signup_form().
+ *
+ * @see dosomething_signup_form().
+ */
+function dosomething_signup_form_submit($form, &$form_state) {
+  $sid = dosomething_signup_insert($form_state['values']['nid']);
+  if (is_numeric($sid)) {
+    drupal_set_message(t("You're signed up!"));
+  }
+}

--- a/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -118,7 +118,7 @@ function dosomething_signup_form($form, &$form_state, $nid) {
 /**
  * Form submission handler for dosomething_signup_form().
  *
- * @see dosomething_signup_form().
+ * @see dosomething_signup_form()
  */
 function dosomething_signup_form_submit($form, &$form_state) {
   $sid = dosomething_signup_insert($form_state['values']['nid']);

--- a/modules/dosomething/dosomething_user/dosomething_user.test
+++ b/modules/dosomething/dosomething_user/dosomething_user.test
@@ -99,6 +99,16 @@ class DosomethingUserWebTestCase extends DrupalWebTestCase {
       'manage features',
       'view the administration theme',
     );
+    $this->editor_perms = array(
+      'access administration menu',
+      'access administration pages',
+      'access content overview',
+      'revert revisions',
+      'view any unpublished content',
+      'view own unpublished content',
+      'view revisions',
+      'view the administration theme',
+    );
   }
 
   /**
@@ -134,13 +144,12 @@ class DosomethingUserWebTestCase extends DrupalWebTestCase {
    * @return object
    *  A newly created user object with the "authenticated user" and "administrator" roles.
    */
-  public function createAdminUser() {
-    $role_name = 'administrator';
+  public function createUserByRoleName($role_name) {
     $role = user_role_load_by_name($role_name);
     $timestamp = time();
     $fields = array(
-      'name' => 'Administrator ' . $timestamp,
-      'mail' => 'admin.' . $timestamp . '@example.com',
+      'name' => $role_name . ' ' . $timestamp,
+      'mail' => $role_name . ' ' . $timestamp . '@example.com',
       'pass' => 'password',
       'status' => 1,
       'init' => 'email address',
@@ -150,10 +159,10 @@ class DosomethingUserWebTestCase extends DrupalWebTestCase {
       ),
     );
     // First param is blank so a new user is created:
-    $admin = user_save('', $fields);
-    $this->assertTrue(is_numeric($admin->uid), "Admin user uid " . $admin->uid . " is numeric.");
-    $this->assertTrue(in_array($role_name, $admin->roles), "Admin user uid " . $admin->uid . " has 'administrator' role.");
-    return $admin;
+    $user = user_save('', $fields);
+    $this->assertTrue(is_numeric($user->uid), $role_name . " user uid " . $user->uid . " is numeric.");
+    $this->assertTrue(in_array($role_name, $user->roles), $role_name . " user uid " . $user->uid . " has '" . $role_name . "' role.");
+    return $user;
   }
 
   /**
@@ -161,7 +170,7 @@ class DosomethingUserWebTestCase extends DrupalWebTestCase {
    */
   function testAdministratorPerms() {
     // Create an administrator user:  
-    $admin = $this->createAdminUser();
+    $admin = $this->createUserByRoleName('administrator');
     // Loop through admin perms and test that $admin user has them granted.
     foreach ($this->administrator_perms as $key => $perm) {
       $this->subTestUserAccess($perm, $admin);

--- a/modules/dosomething/dosomething_user/dosomething_user.test
+++ b/modules/dosomething/dosomething_user/dosomething_user.test
@@ -109,6 +109,9 @@ class DosomethingUserWebTestCase extends DrupalWebTestCase {
       'view revisions',
       'view the administration theme',
     );
+    $this->authenticated_perms = array(
+      'access content',
+    );
   }
 
   /**
@@ -200,6 +203,10 @@ class DosomethingUserWebTestCase extends DrupalWebTestCase {
   function testAuthUserAdminPerms() {
     // Create an authenticated user:
     $auth = $this->drupalCreateUser();
+    // Loop through authenticated perms and test that $auth user has them.
+    foreach ($this->authenticated_perms as $perm) {
+      $this->subTestUserAccess($perm, $auth);
+    }
     // Loop through admin perms and test that $auth user does not have them.
     foreach ($this->administrator_perms as $perm) {
       $this->subTestUserAccess($perm, $auth, FALSE);

--- a/modules/dosomething/dosomething_user/dosomething_user.test
+++ b/modules/dosomething/dosomething_user/dosomething_user.test
@@ -21,7 +21,7 @@ class DosomethingUserUnitTestCase extends DrupalUnitTestCase {
     parent::setUp();
   }
 
-  function testValidCell() {
+  public function testValidCell() {
     $good = '718-224-9982';
     $country = '1-718-224-9982';
     $stuff = '1 (718) 224.9982';
@@ -120,11 +120,12 @@ class DosomethingUserWebTestCase extends DrupalWebTestCase {
    * Executes assertFalse and assertTrue tests based on boolean $granted value.
    *
    * @param string $permission
-   *  The permission to check for, e.g. "administer nodes".
+   *   The permission to check for, e.g. "administer nodes".
    * @param object $user
-   *  The loaded user to check permissions of.
-   * @param boolean $granted
-   *  The access to check: If $granted == FALSE, check that the permission doesn't exist for given $user.
+   *   The loaded user to check permissions of.
+   * @param bool $granted
+   *   If $granted == FALSE, test that permission is denied for given $user.
+   *   Else test that the permission us grabted for the given $user.
    */
   public function subTestUserAccess($permission, $user, $granted = TRUE) {
     $has_access = user_access($permission, $user);
@@ -140,12 +141,13 @@ class DosomethingUserWebTestCase extends DrupalWebTestCase {
    * Creates and returns a user with "administrator" role.
    *
    * Because drupalCreateUser will actually just create a new role based
-   * on the permissions you pass it, that doesn't help us here, because we're 
-   * testing the actual administrator role as defined by dosomething_user.
-   * We need to create an actual "real" user in the users table to grant it the permission.
+   * on the permissions you pass it, that doesn't help us here, since we're 
+   * testing the actual roles defined by dosomething_user.
+   *
+   * We need to create an actual user in the users table to test the role.
    *
    * @return object
-   *  A newly created user object with the "authenticated user" and "administrator" roles.
+   *   A newly created user object with the "authenticated user" and given role.
    */
   public function createUserByRoleName($role_name) {
     $role = user_role_load_by_name($role_name);
@@ -169,10 +171,10 @@ class DosomethingUserWebTestCase extends DrupalWebTestCase {
   }
 
   /**
-   * Tests that an administrator has all the expected admin permissions.
+   * Test that an administrator has all the expected admin permissions.
    */
-  function testAdministratorPerms() {
-    // Create an administrator user:  
+  public function testAdministratorPerms() {
+    // Create an administrator user:
     $admin = $this->createUserByRoleName('administrator');
     // Loop through admin perms and test that $admin user has them granted.
     foreach ($this->administrator_perms as $perm) {
@@ -181,10 +183,10 @@ class DosomethingUserWebTestCase extends DrupalWebTestCase {
   }
 
   /**
-   * Tests that an editor has all the expected editor permissions.
+   * Test that an editor has all the expected editor permissions.
    */
-  function testEditorPerms() {
-    // Create an editor user:  
+  public function testEditorPerms() {
+    // Create an editor user:
     $editor = $this->createUserByRoleName('editor');
     // Loop through editor perms and test that $editor user has them granted.
     foreach ($this->editor_perms as $perm) {
@@ -198,9 +200,9 @@ class DosomethingUserWebTestCase extends DrupalWebTestCase {
   }
 
   /**
-   * Tests that an authenticated user has none of the expected admin permissions.
+   * Test that an authenticated user has none of the expected admin permissions.
    */
-  function testAuthUserAdminPerms() {
+  public function testAuthUserAdminPerms() {
     // Create an authenticated user:
     $auth = $this->drupalCreateUser();
     // Loop through authenticated perms and test that $auth user has them.

--- a/modules/dosomething/dosomething_user/dosomething_user.test
+++ b/modules/dosomething/dosomething_user/dosomething_user.test
@@ -172,8 +172,25 @@ class DosomethingUserWebTestCase extends DrupalWebTestCase {
     // Create an administrator user:  
     $admin = $this->createUserByRoleName('administrator');
     // Loop through admin perms and test that $admin user has them granted.
-    foreach ($this->administrator_perms as $key => $perm) {
+    foreach ($this->administrator_perms as $perm) {
       $this->subTestUserAccess($perm, $admin);
+    }
+  }
+
+  /**
+   * Tests that an editor has all the expected editor permissions.
+   */
+  function testEditorPerms() {
+    // Create an editor user:  
+    $editor = $this->createUserByRoleName('editor');
+    // Loop through editor perms and test that $editor user has them granted.
+    foreach ($this->editor_perms as $perm) {
+      $this->subTestUserAccess($perm, $editor);
+    }
+    // Find the administrator permissions an editor should not have.
+    $admin_only = array_diff($this->administrator_perms, $this->editor_perms);
+    foreach ($admin_only as $perm) {
+      $this->subTestUserAccess($perm, $editor, FALSE);
     }
   }
 
@@ -184,7 +201,11 @@ class DosomethingUserWebTestCase extends DrupalWebTestCase {
     // Create an authenticated user:
     $auth = $this->drupalCreateUser();
     // Loop through admin perms and test that $auth user does not have them.
-    foreach ($this->administrator_perms as $key => $perm) {
+    foreach ($this->administrator_perms as $perm) {
+      $this->subTestUserAccess($perm, $auth, FALSE);
+    }
+    // Loop through editor perms and test that $auth user does not have them.
+    foreach ($this->editor_perms as $perm) {
       $this->subTestUserAccess($perm, $auth, FALSE);
     }
   }

--- a/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -1,11 +1,3 @@
 <div class="content clearfix <?php print $classes; ?>">
-	<img src="<?php print $cover_image['src']; ?>" alt="<?php print $cover_image['alt']; ?>" />
-	<?php print render($content['signup_form']); ?>
-	<?php if (!empty($gallery)): ?>
-  <div id="gallery">
-  <?php foreach ($gallery as $gallery_image): ?>
-    <img src="<?php print $gallery_image['src']; ?>" alt="<?php print $gallery_image['alt']; ?>" />
-  <?php endforeach; ?>
-  </div>
-  <?php endif; ?>
+  <?php print render($signup_form); ?>
 </div>


### PR DESCRIPTION
This PR should merged after #394 to avoid any potential merge conflicts.  I must have created this branch from the `editor_test` branch instead of `dev`, as you'll see it contains the same 4 commits that #394 does. :\

This PR resolves #345
- Creates a simple signup form, which will be used when an authenticated user visits a pitch page to sign up.
- Also renders the signup form in the theme's pitch template.
