### PR TITLE
Reportback Form fix

### DIFF
--- a/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -264,6 +264,7 @@ function dosomething_reportback_form($form, &$form_state, $wrapper, $entity = NU
       'rbid' => 0,
       'quantity' => '',
       'why_participated' => NULL,
+      'num_participants' => NULL,
     ));
     $submit_label = t("Submit");
   }


### PR DESCRIPTION
Gets rid of PHP notice by populating $entity->num_participants with NULL if form is in create mode.
