### PR TITLE
Save Reportback sub-functions + documentation

### DIFF
--- a/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -332,7 +332,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
   foreach ($values['field_image_user_reportback'][LANGUAGE_NONE] as $delta => $file) {
     // Exclude the "add another" field (which has fid value 0).
     if ($file['fid'] != 0) {
-      $values['files'][] = $file;
+      $values['files'][] = $file['fid'];
     }
   }
   // @todo: Sort $files array by the weight field, to allow for re-ordering.
@@ -405,10 +405,16 @@ function dosomething_reportback_delete_form_submit($form, &$form_state) {
 }
 
 /**
- * Inserts a reportback entity.
+ * Inserts a reportback entity with given $values.
  *
  * @param array $values
- *   An array of expected reportback values.
+ *   Associative array of values to save to new reportback, with keys:
+ *   - uid: The user uid who is reporting back.
+ *   - nid: The node nid that user is reporting back for.
+ *   - files: An array of File fid's to store with the reportback.
+ *   - quantity: Number of nouns verbed.
+ *   - why_participated: Why user participated.
+ *   - num_participants: Number of participants (if applicable).
  *
  * @return mixed
  *   Newly inserted reportback rbid if success, or FALSE if error.
@@ -419,10 +425,13 @@ function dosomething_reportback_insert_reportback($values) {
 }
 
 /**
- * Updates a reportback entity.
+ * Updates a reportback entity with given $values.
  *
+ * @param int $rbid
+ *   The reportback rbid of the reportback to update.
  * @param array $values
- *   An array of expected reportback values.
+ *   An array of expected reportback values.  
+ *   See @dosomething_reportback_insert_reportback().
  *
  * @return mixed
  *   The updated reportback rbid if success, or FALSE if error.
@@ -492,9 +501,9 @@ function dosomething_reportback_save($entity, $values) {
     // Load metadata wrapper for easier set methods.
     $wrapper = entity_metadata_wrapper('reportback', $entity);
     // Set entity properties.
-    dosomething_reportback_set_properties(&$wrapper, $values);
+    dosomething_reportback_set_properties($wrapper, $values);
     // Set entity files.
-    dosomething_reportback_set_files(&$wrapper, $values);
+    dosomething_reportback_set_files($wrapper, $values);
     // Save the entity.
     $wrapper->save();
     // Return reportback rbid.
@@ -512,7 +521,7 @@ function dosomething_reportback_save($entity, $values) {
  * @param object $wrapper
  *   The reportback entity wrapper to set properties for.
  * @param array $values
- *   Array of property values to set, indexed by the property name.
+ *   Associative of property values to set, with property name as keys.
  */
 function dosomething_reportback_set_properties(&$wrapper, $values) {
   // List all possible entity properties to write.
@@ -533,15 +542,16 @@ function dosomething_reportback_set_properties(&$wrapper, $values) {
  * @param object $wrapper
  *   The reportback entity wrapper to set properties for.
  * @param array $values
- *   Multi-dimensional array of files to set.
+ *   An array of file fid's to set.
  */
 function dosomething_reportback_set_files(&$wrapper, $values) {
   // Get total count of images present on entity.
   $num_images = count($wrapper->field_image_user_reportback);
   $i = 0;
   // Loop through all files provided in $values.
-  foreach ($values['files'] as $delta => $file) {
-    $wrapper->field_image_user_reportback[$i] = array('fid' => (int) $file['fid']);
+  foreach ($values['files'] as $fid) {
+    // Image field is stored as array of Files arrays.
+    $wrapper->field_image_user_reportback[$i] = array('fid' => $fid);
     $i++;
   }
   // Are there existing images in entity field not present in $values['files']?

--- a/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -477,48 +477,27 @@ function dosomething_reportback_exists($nid, $uid = NULL) {
 }
 
 /**
- * Saves a reportback entity.
+ * Saves a reportback entity with given values.
  *
- * @param array $values
- *   The reportback entity values to save.
  * @param object $entity
  *   The reportback entity to save (may be a blank entity if insert).
- *
+ * @param array $values
+ *   The reportback entity values to save.
  *
  * @return mixed
  *   The reportback entity rbid if success, or FALSE if error.
  */
 function dosomething_reportback_save($entity, $values) {
   try {
+    // Load metadata wrapper for easier set methods.
     $wrapper = entity_metadata_wrapper('reportback', $entity);
-    // List all possible entity properties to write.
-    $properties = array('uid', 'nid', 'quantity', 'why_participated', 'num_participants');
-    // For each of them:
-    foreach ($properties as $property) {
-      // If we have a value set for this property.
-      if (isset($values[$property])) {
-        // Set property value in wrapper.
-        $wrapper->{$property}->set($values[$property]);
-      }
-    }
-    // Handle Image User Reportback Field.
-    // Get total count of images present on entity.
-    $num_images = count($wrapper->field_image_user_reportback);
-    $i = 0;
-    // Loop through all files provided in $values.
-    foreach ($values['files'] as $delta => $file) {
-      $wrapper->field_image_user_reportback[$i] = array('fid' => (int) $file['fid']);
-      $i++;
-    }
-    // Are there existing images in entity field not present in $values['files']?
-    if (isset($wrapper->field_image_user_reportback[$i])) {
-      // Loop through remaining image values in the entity field.
-      for ($i=$i; $i<$num_images; $i++) {
-        // It means they were removed, so unset them.
-        unset($wrapper->field_image_user_reportback[$i]);
-      }
-    }
+    // Set entity properties.
+    dosomething_reportback_set_properties(&$wrapper, $values);
+    // Set entity files.
+    dosomething_reportback_set_files(&$wrapper, $values);
+    // Save the entity.
     $wrapper->save();
+    // Return reportback rbid.
     return $wrapper->rbid->value();
   }
   catch (Exception $e) {
@@ -527,3 +506,50 @@ function dosomething_reportback_save($entity, $values) {
   }
 }
 
+/**
+ * Sets a reportback entity's properties via entity metadata wrapper.
+ *
+ * @param object $wrapper
+ *   The reportback entity wrapper to set properties for.
+ * @param array $values
+ *   Array of property values to set, indexed by the property name.
+ */
+function dosomething_reportback_set_properties(&$wrapper, $values) {
+  // List all possible entity properties to write.
+  $properties = array('uid', 'nid', 'quantity', 'why_participated', 'num_participants');
+  // For each of them:
+  foreach ($properties as $property) {
+    // If we have a value set for this property.
+    if (isset($values[$property])) {
+      // Set property value in wrapper.
+      $wrapper->{$property}->set($values[$property]);
+    }
+  }
+}
+
+/**
+ * Sets a reportback entity's files via entity metadata wrapper.
+ *
+ * @param object $wrapper
+ *   The reportback entity wrapper to set properties for.
+ * @param array $values
+ *   Multi-dimensional array of files to set.
+ */
+function dosomething_reportback_set_files(&$wrapper, $values) {
+  // Get total count of images present on entity.
+  $num_images = count($wrapper->field_image_user_reportback);
+  $i = 0;
+  // Loop through all files provided in $values.
+  foreach ($values['files'] as $delta => $file) {
+    $wrapper->field_image_user_reportback[$i] = array('fid' => (int) $file['fid']);
+    $i++;
+  }
+  // Are there existing images in entity field not present in $values['files']?
+  if (isset($wrapper->field_image_user_reportback[$i])) {
+    // Loop through remaining image values in the entity field.
+    for ($i=$i; $i<$num_images; $i++) {
+      // It means they were removed, so unset them.
+      unset($wrapper->field_image_user_reportback[$i]);
+    }
+  }
+}

--- a/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -498,16 +498,14 @@ function dosomething_reportback_exists($nid, $uid = NULL) {
  */
 function dosomething_reportback_save($entity, $values) {
   try {
-    // Load metadata wrapper for easier set methods.
-    $wrapper = entity_metadata_wrapper('reportback', $entity);
     // Set entity properties.
-    dosomething_reportback_set_properties($wrapper, $values);
+    dosomething_reportback_set_properties($entity, $values);
     // Set entity files.
-    dosomething_reportback_set_files($wrapper, $values);
+    dosomething_reportback_set_files($entity, $values);
     // Save the entity.
-    $wrapper->save();
+    $entity->save();
     // Return reportback rbid.
-    return $wrapper->rbid->value();
+    return $entity->rbid;
   }
   catch (Exception $e) {
     watchdog('dosomething_reportback', $e, array(), WATCHDOG_ERROR);
@@ -516,14 +514,14 @@ function dosomething_reportback_save($entity, $values) {
 }
 
 /**
- * Sets a reportback entity's properties via entity metadata wrapper.
+ * Sets a reportback entity's properties.
  *
- * @param object $wrapper
- *   The reportback entity wrapper to set properties for.
+ * @param object $entity
+ *   The reportback entity to set properties for.
  * @param array $values
  *   Associative of property values to set, with property name as keys.
  */
-function dosomething_reportback_set_properties(&$wrapper, $values) {
+function dosomething_reportback_set_properties(&$entity, $values) {
   // List all possible entity properties to write.
   $properties = array('uid', 'nid', 'quantity', 'why_participated', 'num_participants');
   // For each of them:
@@ -531,35 +529,25 @@ function dosomething_reportback_set_properties(&$wrapper, $values) {
     // If we have a value set for this property.
     if (isset($values[$property])) {
       // Set property value in wrapper.
-      $wrapper->{$property}->set($values[$property]);
+      $entity->{$property} = $values[$property];
     }
   }
 }
 
 /**
- * Sets a reportback entity's files via entity metadata wrapper.
+ * Sets a reportback entity's files.
  *
- * @param object $wrapper
- *   The reportback entity wrapper to set properties for.
+ * @param object $entity
+ *   The reportback entity to set properties for.
  * @param array $values
  *   An array of file fid's to set.
  */
-function dosomething_reportback_set_files(&$wrapper, $values) {
-  // Get total count of images present on entity.
-  $num_images = count($wrapper->field_image_user_reportback);
-  $i = 0;
+function dosomething_reportback_set_files(&$entity, $values) {
+  // Unset current image field values.
+  $entity->field_image_user_reportback = array();
   // Loop through all files provided in $values.
   foreach ($values['files'] as $fid) {
     // Image field is stored as array of Files arrays.
-    $wrapper->field_image_user_reportback[$i] = array('fid' => $fid);
-    $i++;
-  }
-  // Are there existing images in entity field not present in $values['files']?
-  if (isset($wrapper->field_image_user_reportback[$i])) {
-    // Loop through remaining image values in the entity field.
-    for ($i=$i; $i<$num_images; $i++) {
-      // It means they were removed, so unset them.
-      unset($wrapper->field_image_user_reportback[$i]);
-    }
+    $entity->field_image_user_reportback[LANGUAGE_NONE][] = array('fid' => $fid);
   }
 }

--- a/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -323,8 +323,6 @@ function dosomething_reportback_form($form, &$form_state, $wrapper, $entity = NU
  */
 function dosomething_reportback_form_submit($form, &$form_state) {
   global $user;
-  // @todo: Check that $form_state['values']['nid'] == arg(1), 
-  // If we can assume this form is always rendered on campaign.
   $values = $form_state['values'];
   $values['uid'] = $user->uid;
   $values['files'] = array();
@@ -335,23 +333,19 @@ function dosomething_reportback_form_submit($form, &$form_state) {
       $values['files'][] = $file['fid'];
     }
   }
-  // @todo: Sort $files array by the weight field, to allow for re-ordering.
-  if ($values['rbid'] == 0) {
-    $entity = entity_create('reportback', array());
-    $rbid = dosomething_reportback_insert_reportback($values);
-    if ($rbid) {
-      // Load node to get reportback message confirmation.
-      $node_wrapper = entity_metadata_wrapper('node', $values['nid']);
-      drupal_set_message($node_wrapper->field_reportback_confirm_msg->value());
-      return;
-    }
+  // @todo: Sort $files array by the weight field, to support re-ordering.
+
+  // If no rbid, we need to insert. If insert is success:
+  if ($values['rbid'] == 0 && dosomething_reportback_insert_reportback($values)) {
+    // Load node to get reportback message confirmation.
+    $node_wrapper = entity_metadata_wrapper('node', $values['nid']);
+    drupal_set_message($node_wrapper->field_reportback_confirm_msg->value());
+    return;
   }
-  else {
-    $rbid = dosomething_reportback_update_reportback($values['rbid'], $values);
-    if ($rbid) {
-      drupal_set_message(t("Your submission has been updated."));
-      return;
-    }
+  // Else we are updating the entity:
+  elseif (dosomething_reportback_update_reportback($values['rbid'], $values)) {
+    drupal_set_message(t("Your submission has been updated."));
+    return;
   }
   // If we didn't break out of function by now, insert/update didn't work.
   drupal_set_message(t("An error has occurred."), 'error');


### PR DESCRIPTION
Fixes #482
- Documents expected `$values` array for dosomething_reportback insert/update reportback functions
- Simplifies `$values['files]` to expect a single array of File fid's
- Splits out `dosomething_reportback_save` into smaller, testable functions.
