### PR TITLE
Paraneue working copy 

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -158,6 +158,7 @@ projects[paraneue][type] = "theme"
 projects[paraneue][download][type] = "git"
 projects[paraneue][download][url] = "git@github.com:DoSomething/paraneue.git"
 projects[paraneue][subdir] = "dosomething"
+projects[paraneue][options][working-copy] = TRUE
 
 ; LIBRARIES
 


### PR DESCRIPTION
This merge contains:
- Added working copy option to paraneue project in drupal-org.make file - Fixes #512
