### PR TITLE
Reportback Activity log

### DIFF
--- a/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -87,6 +87,12 @@ function dosomething_reportback_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'op' => array(
+        'description' => 'Operation performed on the reportback.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => FALSE,
+      ),
       'timestamp' => array(
         'description' => 'The Unix timestamp of the update.',
         'type' => 'int',

--- a/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -66,5 +66,65 @@ function dosomething_reportback_schema() {
       'uid' => array('uid'),
     ),
   );
+  $schema['dosomething_reportback_log'] = array(
+    'description' => 'Table of reportback update activity.',
+    'fields' => array(
+      'id' => array(
+        'description' => 'Primary key of log table.',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'rbid' => array(
+        'description' => 'Reportback rbid updated.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'uid' => array(
+        'description' => 'The {users}.uid that updated.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'timestamp' => array(
+        'description' => 'The Unix timestamp of the update.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'quantity' => array(
+        'description' => 'The quantity of reportback_nouns reportback_verbed.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'why_participated' => array(
+        'description' => 'Why the user participated.',
+        'type' => 'text',
+        'length' => '2048',
+        'not null' => FALSE,
+      ),
+      'num_participants' => array(
+        'description' => 'The number of participants (if applicable).',
+        'type' => 'int',
+        'not null' => FALSE,
+        'default' => NULL,
+      ),
+      'files' => array(
+        'description' => 'Comma separated list of file fids attached to reportback.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => FALSE,
+      ),
+      'num_files' => array(
+        'description' => 'The number of files attached to reportback.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+    ),
+    'primary key' => array('id'),
+  );
   return $schema;
 }

--- a/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -50,8 +50,8 @@ function dosomething_reportback_schema() {
       ),
       'why_participated' => array(
         'description' => 'Why the user participated.',
-        'type' => 'varchar',
-        'length' => '255',
+        'type' => 'text',
+        'length' => '2048',
         'not null' => FALSE,
       ),
       'num_participants' => array(

--- a/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -546,3 +546,77 @@ function dosomething_reportback_set_files(&$entity, $values) {
     $entity->field_image_user_reportback[LANGUAGE_NONE][] = array('fid' => $fid);
   }
 }
+
+/**
+ * Inserts a record into the reportback log table for a given reportback.
+ *
+ * Called from various hook_entity_[operation] functions.
+ * @see dosomething_reportback_entity_insert().
+ *
+ * @param string $op
+ *   The operation performed, e.g. "insert", "update", "delete".
+ * @param object $entity
+ *   The reportback entity to log an update for.
+ */
+function dosomething_reportback_log_insert($op, $entity) {
+  global $user;
+  $fids = array();
+  // Loop through all files in field_image_user_reportback to store fids.
+  foreach ($entity->field_image_user_reportback[LANGUAGE_NONE] as $file) {
+    $fids[] = $file['fid'];
+  }
+  // If deleting, store current time.
+  if ($op == 'delete') {
+    $timestamp = REQUEST_TIME;
+  }
+  // Else use the entity's updated property.
+  else {
+    $timestamp = $entity->updated;
+  }
+  try {
+    // Log the entity values into the log table.
+    $id = db_insert('dosomething_reportback_log')
+      ->fields(array(
+        'rbid' => $entity->rbid,
+        'uid' => $user->uid,
+        'op' => $op,
+        'timestamp' => $timestamp,
+        'quantity' => $entity->quantity,
+        'why_participated' => $entity->why_participated,
+        'num_participants' => $entity->num_participants,
+        'files' => implode(',', $fids),
+        'num_files' => count($fids),
+      ))
+      ->execute();
+  }
+  catch (Exception $e) {
+    watchdog('dosomething_reportback', $e, array(), WATCHDOG_ERROR);
+  }
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function dosomething_reportback_entity_insert($entity, $type) {
+  if ($type == 'reportback') {
+    dosomething_reportback_log_insert('insert', $entity);
+  }
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function dosomething_reportback_entity_update($entity, $type) {
+  if ($type == 'reportback') {
+    dosomething_reportback_log_insert('update', $entity);
+  }
+}
+
+/**
+ * Implements hook_entity_delete().
+ */
+function dosomething_reportback_entity_delete($entity, $type) {
+  if ($type == 'reportback') {
+    dosomething_reportback_log_insert('delete', $entity);
+  }
+}


### PR DESCRIPTION
Need to either rebuild or uninstall / reinstall dosomething_reportback module if testing any reportback stuff.

This PR creates a dosomething_reportback_log table, to track all reportback insert, update, and delete transactions.  This has been requested by data team since we're no longer allowing users to submit multiple reportbacks, but instead giving them the ability to update one reportback per campaign they've signed up for.
