### PR TITLE
Drush make local

### DIFF
--- a/build-dosomething.make
+++ b/build-dosomething.make
@@ -6,5 +6,5 @@ includes[] = drupal-org-core.make
 
 ; Dosomething Profile
 projects[dosomething][type] = profile
-projects[dosomething][download][type] = git
-projects[dosomething][download][url] = "git@github.com:DoSomething/dosomething.git"
+projects[dosomething][download][type] = local
+projects[dosomething][download][source] = '.'

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -158,6 +158,7 @@ projects[paraneue][type] = "theme"
 projects[paraneue][download][type] = "git"
 projects[paraneue][download][url] = "git@github.com:DoSomething/paraneue.git"
 projects[paraneue][subdir] = "dosomething"
+projects[paraneue][options][working-copy] = TRUE
 
 ; LIBRARIES
 

--- a/salt/roots/salt/drush-ext.sls
+++ b/salt/roots/salt/drush-ext.sls
@@ -11,5 +11,11 @@ update-terminus:
     - watch:
       - cmd: get-terminus
 
+drush-make-local:
+  cmd.wait:
+    - name: 'drush dl make_local-6.x-1.0'
+    - user: vagrant
+    - watch:
+      - cmd: get-terminus
 
 {% endif %}

--- a/salt/roots/salt/top.sls
+++ b/salt/roots/salt/top.sls
@@ -6,4 +6,4 @@ base:
     - selenium
     - install
     - composer
-    - terminus
+    - drush-ext


### PR DESCRIPTION
This merge installs the make_local drush command via a salt step.  It also updates the build make file to point to the local location of the profile.

I also renamed the terminus sls to drush-ext (extensions) for organizational purposes.

This will require a provision of your vagrant image  OR you can run `drush dl make_local-6.x-1.0` from within your VM.

Fixes #513
