### PR TITLE
Browserify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ doxy.sh
 Doxyfile
 node_modules
 themes/dosomething/paraneue_dosomething/dist/
-themes/dosomething/paraneue_dosomething/vendor/
+themes/dosomething/paraneue_dosomething/bower_components/

--- a/themes/README.md
+++ b/themes/README.md
@@ -1,3 +1,9 @@
 DoSomething specific custom themes live here.
 
 We need this directory in order to make symlinking during development easier.
+
+## Theming Stack Overview
+
+ - `Neue` has CSS and JS for basic layout. Exports a SCSS helper file with mixins and variables for app dev. It is imported into `Paraneue` and `Paraneue_DoSomething` using a `bower.json` file in each respective directory.
+ - `Paraneue` pulls in Neue's CSS and JS, and jQuery. It themes Drupal base features and nothing more. Paraneue does **not** include its own app-level CSS or JS.
+ - `Paraneue_DoSomething` has app-level templates, SCSS, and JS (i.e. styles and scripts for pitch/action page) and a build system to keep that up to date.

--- a/themes/dosomething/paraneue_dosomething/.bowerrc
+++ b/themes/dosomething/paraneue_dosomething/.bowerrc
@@ -1,3 +1,0 @@
-{
-  "directory" : "vendor"
-}

--- a/themes/dosomething/paraneue_dosomething/Gruntfile.js
+++ b/themes/dosomething/paraneue_dosomething/Gruntfile.js
@@ -83,13 +83,24 @@ module.exports = function(grunt) {
       all: ["tests/*.html"]
     },
 
+
+    browserify: {
+      dist: {
+        src: ['js/app.js'],
+        dest: 'dist/app.js',
+        options: {
+          transform: ['debowerify']
+        }
+      }
+    },
+
     uglify: {
       prod: {
         options: {
           report: "gzip"
         },
         files: {
-          "dist/app.js": ["js/**/*.js", "!js/polyfills/**/*.js"],
+          "dist/app.js": ["dist/app.js"],
         }
       },
       dev: {
@@ -99,7 +110,7 @@ module.exports = function(grunt) {
           beautify: true
         },
         files: {
-          "dist/app.js": ["js/**/*.js", "!js/polyfills/**/*.js"],
+          "dist/app.js": ["dist/app.js"],
         }
       }
     },
@@ -140,8 +151,8 @@ module.exports = function(grunt) {
   grunt.registerTask("test:js", ["qunit"]);
 
   // build
-  grunt.registerTask("build", ["lint", "sass:compile", "imagemin", "uglify:dev", "copy:main"]);
-  grunt.registerTask("prod", ["shell:clean", "sass:compile", "cssmin:minify", "copy:main", "imagemin", "uglify:prod"]); // used when preparing code for distribution
+  grunt.registerTask("build", ["lint", "sass:compile", "imagemin", "browserify:dist", "uglify:dev", "copy:main"]);
+  grunt.registerTask("prod", ["shell:clean", "sass:compile", "cssmin:minify", "copy:main", "imagemin", "browserify:dist", "uglify:prod"]); // used when preparing code for distribution
 
 
   grunt.loadNpmTasks("grunt-sass");
@@ -150,6 +161,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks("grunt-contrib-copy");
   grunt.loadNpmTasks("grunt-contrib-jshint");
   grunt.loadNpmTasks("grunt-contrib-qunit");
+  grunt.loadNpmTasks('grunt-browserify');
   grunt.loadNpmTasks("grunt-contrib-uglify");
   grunt.loadNpmTasks("grunt-contrib-watch");
   grunt.loadNpmTasks("grunt-docco2");

--- a/themes/dosomething/paraneue_dosomething/js/App.js
+++ b/themes/dosomething/paraneue_dosomething/js/App.js
@@ -4,10 +4,13 @@
 //
 //
 
-var DS = DS || {};
+// global variables
+var DS;
 
 (function() {
   "use strict";
+
+  var _ = require('underscore');
 
   // We configure Underscore templating to use brackets (Mustache-style) syntax.
   _.templateSettings = {
@@ -15,5 +18,6 @@ var DS = DS || {};
     interpolate: /\{\{[^#\{]([\s\S]+?)[^\}]\}\}/g,  // {{ title }}
     escape:      /\{\{\{([\s\S]+?)\}\}\}/g,         // {{{ title }}}
   };
+
 
 })();

--- a/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
+++ b/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
@@ -14,5 +14,4 @@ features[] = main_menu
 features[] = secondary_menu
 
 stylesheets[all][] = dist/app.css
-stylesheets[all][] = vendor/pattern-library/neue.css
 scripts[] = dist/app.js

--- a/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -10,7 +10,7 @@
 //
 //                                                                                
 
-@import "../vendor/pattern-library/scss/helpers";
+@import "../bower_components/pattern-library/scss/helpers";
 
 // features
 @import "feature/auth";


### PR DESCRIPTION
Fixes #462 after dosomething/paraneue#17 gets merged in.

Current order of things in the front-end world:
- Neue has CSS and JS for basic layout. Exports a SCSS helper file with mixins and variables for app dev.
- Paraneue pulls in Neue's CSS and JS, and jQuery. It themes Drupal base features and nothing more. Paraneue does **not** include its own app-level CSS or JS.
- Paraneue_DoSomething has app-level SCSS and JS (i.e. styles and scripts for pitch/action page) and a build system to keep that up to date.

Awkward bits:
- There are two separate Bower installations to install dependencies to Paraneue and Paraneue_DoSomething. Since jQuery and Neue are pulled in during Paraneue's build process, changing dependencies on Paraneue_Dosomething won't affect anything.
- We can't build JS with dependencies in Paraneue, since the Browserify build process in Paraneue_DoSomething won't know that the dependencies were already included in Paraneue, and so if they're referenced in both places then it will be included in both files.
