### PR TITLE
Pitch page for anon user

### DIFF
--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -82,12 +82,17 @@ function dosomething_campaign_entity_info_alter(&$entity_info) {
 function dosomething_campaign_entity_view_mode_alter(&$view_mode, $context) {
   // Is this a campaign node?
   if ($context['entity_type'] == 'node' && $context['entity']->type == 'campaign' && $view_mode == 'full') {
+    // If anonymous user:
+    if (!user_is_logged_in()) {
+      // Display pitch view mode.
+      $view_mode = 'pitch';
+      return;
+    }
     $node = $context['entity'];
-    // If the current user is not on staff, and not signed up for the campaign, show the pitch page.
-    if (!dosomething_user_is_staff()) {
-      if (!dosomething_signup_exists($node->nid)) {
-        $view_mode = 'pitch';
-      }
+    // Otherwise, if auth user not signed up for the campaign:
+    if (!dosomething_signup_exists($node->nid)) {
+      // Display pitch view mode.
+      $view_mode = 'pitch';
     }
   }
 }
@@ -227,7 +232,21 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
  */
 function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
   $vars['scholarship'] = '$' . $wrapper->field_scholarship_amount->value() . ' Scholarship';
-  $vars['signup_form'] = drupal_get_form('dosomething_signup_form', $vars['nid']);
+  // Define label for signup button.
+  $label = t("Sign Up");
+  // If user is logged in:
+  if (user_is_logged_in()) {
+    // Render button as sign up form.
+    $vars['signup_button'] = drupal_get_form('dosomething_signup_form', $vars['nid'], $label); 
+  }
+  // Otherwise, for anonymous user:
+  else {
+    // Render button as link to open up the login modal.
+    $vars['signup_button'] = array(
+      // @todo: Add relevant class to open up modal.
+      '#markup' => '<a href="#" class="btn">' . $label . '</a>',
+    );
+  }
 }
 
 /**

--- a/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -89,10 +89,11 @@ function dosomething_campaign_entity_view_mode_alter(&$view_mode, $context) {
       return;
     }
     $node = $context['entity'];
-    // Otherwise, if auth user not signed up for the campaign:
-    if (!dosomething_signup_exists($node->nid)) {
-      // Display pitch view mode.
-      $view_mode = 'pitch';
+    // If the current user is not on staff, and not signed up for the campaign, show the pitch page.
+    if (!dosomething_user_is_staff()) {
+      if (!dosomething_signup_exists($node->nid)) {
+        $view_mode = 'pitch';
+      }
     }
   }
 }

--- a/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -102,17 +102,21 @@ function dosomething_signup_exists($nid, $uid = NULL) {
 /**
  * Form constructor for user signup form.
  *
+ * Displayed for an authenticated user to signup for a node.
+ *
  * @param int $nid
  *   The node nid to signup for.
+ * @param string $label
+ *   The label to display on the form submit button.
  */
-function dosomething_signup_form($form, &$form_state, $nid) {
+function dosomething_signup_form($form, &$form_state, $nid, $label) {
   $form['nid'] = array(
     '#type' => 'hidden',
     '#default_value' => $nid,
   );
   $form['submit'] = array(
     '#type' => 'submit',
-    '#value' => t("Sign Up"),
+    '#value' => $label,
   );
   return $form;
 }
@@ -123,15 +127,15 @@ function dosomething_signup_form($form, &$form_state, $nid) {
  * @see dosomething_signup_form()
  */
 function dosomething_signup_form_submit($form, &$form_state) {
-  global $user;
-  if (!$user->uid) {
-    drupal_set_message("Please sign in first");
+  // Shouldn't be able to submit form as anonymous user, but check.
+  if (!user_is_logged_in()) {
+    drupal_set_message("Please sign in first.");
+    return;
   }
-  else {
-    $sid = dosomething_signup_insert($form_state['values']['nid']);
-    if (is_numeric($sid)) {
-      drupal_set_message(t("You're signed up!"));
-    }
+  $nid = $form_state['values']['nid'];
+  // Signup shouldn't exist already, but check. 
+  if (!dosomething_signup_exists($nid) && dosomething_signup_insert($nid)) {
+    drupal_set_message(t("You're signed up!"));
   }
 }
 

--- a/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -1,5 +1,5 @@
 <div class="content clearfix <?php print $classes; ?>">
   <?php print $cta; ?>
   <?php print $scholarship; ?>
-  <?php print render($signup_form); ?>
+  <?php print render($signup_button); ?>
 </div>


### PR DESCRIPTION
- Displays pitch page for anonymous user, and renders signup_button as a link instead of the signup form.
- Passes new param $label into dosomething_signup_form to declare the submit label value once within `dosomething_campaign_preprocess_pitch_page`.
