### PR TITLE
Bower stuff

### DIFF
--- a/themes/dosomething/paraneue_dosomething/bower.json
+++ b/themes/dosomething/paraneue_dosomething/bower.json
@@ -17,9 +17,7 @@
     "tests"
   ],
   "dependencies": {
-    "pattern-library": "git@github.com:DoSomething/ds-neue.git#~3.0.0",
     "underscore": "~1.5.2",
-    "jquery": "~1.11.0",
     "mailcheck": "~1.0.3"
   },
   "resolutions": {

--- a/themes/dosomething/paraneue_dosomething/package.json
+++ b/themes/dosomething/paraneue_dosomething/package.json
@@ -18,6 +18,7 @@
     "jshint-stylish": "~0.1.4",
     "grunt-shell": "~0.6.1",
     "grunt-contrib-imagemin": "~0.5.0",
-    "grunt-contrib-copy": "~0.5.0"
+    "grunt-contrib-copy": "~0.5.0",
+    "grunt-browserify": "~1.3.0"
   }
 }

--- a/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -10,7 +10,9 @@
 //
 //                                                                                
 
-@import "../bower_components/pattern-library/scss/helpers";
+// import paraneue's bower installation of Neue
+@import "../../../../html/profiles/dosomething/themes/dosomething/paraneue/paraneue/bower_components/pattern-library/scss/helpers"; 
+
 
 // features
 @import "feature/auth";


### PR DESCRIPTION
Fixes missing Grunt plugin dependency. Also we're no longer pulling Neue into both Paraneue and Paraneue_DoSomething so that the code isn't duplicated (and therefore potentially having the version numbers differ). Fixes dosomething/paraneue#19.

:chicken: 
