### PR TITLE
Local Drupal settings FTW

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vagrant
 html/
+settings.local.php
 build/
 config/deploy_vars.yml
 docs

--- a/bin/ds
+++ b/bin/ds
@@ -125,6 +125,15 @@ function build {
 
   echo 'Replacing settings.php file...'
   rm -f $WEB_PATH/sites/default/settings.php && ln -s $BASE_PATH/settings.php $WEB_PATH/sites/default/settings.php
+  
+  if [ ! -e "$BASE_PATH/settings.local.php" ]
+  then
+    echo 'Creating local settings file...'
+    cp $BASE_PATH/default.settings.local.php $BASE_PATH/settings.local.php
+  fi
+  
+  echo 'Linking local settings file...'
+  ln -s $BASE_PATH/settings.local.php $WEB_PATH/sites/default/settings.local.php
 
   echo 'Adding role to admin user...'
   drush user-add-role 'administrator' 1

--- a/default.settings.local.php
+++ b/default.settings.local.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @file
+ * Drupal instance-specific configuration file. This is included at the end of
+ * the distributed settings.php, so use this to set everything related to
+ * your local instance.
+ *
+ * Example settings below. See the original settings.php for full
+ * documentation.
+ *
+ * TO USE: Copy to html/sites/default/settings.local.php and edit. Your local
+ * copy will be ignored by Git.
+ */
+
+// Database settings.
+$databases = array (
+  'default' =>
+    array (
+      'default' =>
+        array (
+          'database' => 'dosomething',
+          'username' => 'root',
+          'password' => '',
+          'host' => 'localhost',
+          'port' => '',
+          'driver' => 'mysql',
+          'prefix' => '',
+        ),
+    ),
+);
+
+// Salt for one-time login links and cancel links, form tokens, etc.
+$drupal_hash_salt = '3i_SZ1VTl_8FBxXeZhTEvf6LkeVNypM0EV90tNuHs5k';
+
+// Base URL (optional). This should make correspond to the securepages_basepath
+// setting, below.
+$base_url = 'http://dev.dosomething.org:8888';  // NO trailing slash!
+
+// Secure Pages integration.
+$conf['https'] = TRUE;
+$conf['securepages_basepath'] = 'http://dev.dosomething.org:8888';
+$conf['securepages_basepath_ssl'] = 'https://dev.dosomething.org:8889';
+
+// Add Varnish as the page cache handler.
+$conf['varnish_version'] = '3';
+$conf['varnish_control_key'] = 'fc0a087c-abd3-4abf-a6aa-51a7c0bcda92';
+$conf['cache_backends'] = array('profiles/dosomething/modules/contrib/varnish/varnish.cache.inc');
+$conf['cache_class_cache_page'] = 'VarnishCache';
+
+// Drupal 7 does not cache pages when we invoke hooks during bootstrap.
+// This needs to be disabled.
+$conf['page_cache_invoke_hooks'] = FALSE;
+
+

--- a/settings.php
+++ b/settings.php
@@ -211,9 +211,9 @@
  * @endcode
  */
 $databases = array (
-  'default' => 
+  'default' =>
   array (
-    'default' => 
+    'default' =>
     array (
       'database' => 'dosomething',
       'username' => 'root',
@@ -566,34 +566,11 @@ $conf['404_fast_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN"
  */
 # $conf['allow_authorize_operations'] = FALSE;
 
-// Required for Secure Pages integration.
-$conf['https'] = TRUE;
-
 // Environment settings
 $env = getenv('ENVIRONMENT');
 define('ENVIRONMENT', $env ? $env: 'DEVELOPMENT');
 
-switch(ENVIRONMENT) {
-  default:
-  case 'DEVELOPMENT':
-    $base_url = 'http://dev.dosomething.org:8888';
-
-    // Add Varnish as the page cache handler.
-    $conf['varnish_version'] = '3';
-    $conf['varnish_control_key'] = 'fc0a087c-abd3-4abf-a6aa-51a7c0bcda92';
-    $conf['cache_backends'] = array('profiles/dosomething/modules/contrib/varnish/varnish.cache.inc');
-    $conf['cache_class_cache_page'] = 'VarnishCache';
-    // Drupal 7 does not cache pages when we invoke hooks during bootstrap.
-    // This needs to be disabled.
-    $conf['page_cache_invoke_hooks'] = FALSE;
-
-    // Set securepages paths
-    $conf['securepages_basepath'] = 'http://dev.dosomething.org:8888';
-    $conf['securepages_basepath_ssl'] = 'https://dev.dosomething.org:8889';
-    break;
-  case 'TEST':
-  case 'STAGING':
-  case 'PRODUCTION':
-    break;
+// Include local settings file if it exists.
+if (is_readable('sites/default/settings.local.php')) {
+  include_once('sites/default/settings.local.php');
 }
-


### PR DESCRIPTION
This ships with a template for local settings: `default.settings.local.php`.

On the initial build, this will get copied to the non-versioned `settings.local.php`.  `bin/ds` will make sure this is symlinked to `sites/default/settings.local.php`. The main `settings.php` will find and include this.

This is now where you can store all instance-specific settings.
