### PR TITLE
Removing ds_search from make file to prevent build breakage

### DIFF
--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -50,7 +50,6 @@ dependencies[] = dosomething_fact
 dependencies[] = dosomething_image
 dependencies[] = dosomething_helpers
 dependencies[] = dosomething_reportback
-dependencies[] = dosomething_search
 dependencies[] = dosomething_settings
 dependencies[] = dosomething_signup
 dependencies[] = dosomething_static_content


### PR DESCRIPTION
- The ds_search module contains features that should create a
  new server, but this isn't working properly
