### PR TITLE
Adds helper functions to display entityref parents

### DIFF
--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -7,21 +7,6 @@
 include_once 'dosomething_fact.features.inc';
 
 /**
- * Implements hook_node_access().
- */
-function dosomething_fact_node_access($node, $op, $account) {
-  // If viewing a fact:
-  if ($node->type == 'fact' && $op == 'view') {
-    // If staff user, able to view the Fact node.
-    if (module_exists('dosomething_user') && dosomething_user_is_staff($account)) {
-      return NODE_ACCESS_ALLOW;
-    }
-    // Otherwise, no facts for you.
-    return NODE_ACCESS_DENY;
-  }
-}
-
-/**
  * Implements hook_node_view().
  */
 function dosomething_fact_node_view($node, $view_mode, $langcode) {

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -22,6 +22,24 @@ function dosomething_fact_node_access($node, $op, $account) {
 }
 
 /**
+ * Implements hook_node_view().
+ */
+function dosomething_fact_node_view($node, $view_mode, $langcode) {
+  // Make sure dosomething_helpers is enabled.
+  if (!module_exists('dosomething_helpers')) { return; }
+
+  // If viewing a fact node:
+  if ($node->type == 'fact' && $view_mode == 'full') {
+    $entityref_fields = array(
+      'field_facts',
+      'field_fact_problem',
+      'field_fact_solution',
+    );
+    dosomething_helpers_add_entityref_links($node, $entityref_fields);
+  }
+}
+
+/**
  * Returns array of values of a Fact entityreference field.
  *
  * @param object $fact_field_wrapper

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -23,3 +23,76 @@ function dosomething_helpers_form_alter(&$form, &$form_state, $form_id) {
     drupal_add_js(drupal_get_path('module', 'dosomething_helpers') . '/dosomething_helpers_nodeform.js');
   }
 }
+
+/**
+ * Gets node nid's that reference the given $nid in a given $field_name.
+ *
+ * @param int $nid
+ *  The node nid value stored as the given field's target_id.
+ * @param string $field_name
+ *  The machine name of the entityreference field to look for parents.
+ *
+ * @return mixed
+ *  Array of entity objects (not loaded).  FALSE if no parents found.
+ */
+function dosomething_helpers_get_entityref_parents($nid, $field_name) {
+  $query = new EntityFieldQuery;
+  $result = $query->entityCondition('entity_type', 'node')
+    ->fieldCondition($field_name, 'target_id', $nid)
+    ->execute();
+  if (isset($result['node'])) {
+    return $result['node'];
+  }
+  return NULL;
+}
+
+/**
+ * Returns links to nodes that reference a given $nid with given $field_name.
+ *
+ * @param int $nid
+ *  The node nid value stored as the given field's target_id.
+ * @param string $field_name
+ *  The machine name of the entityreference field to look for parents.
+ *
+ * @return string
+ *   Markup of results.
+ */
+function dosomething_helpers_get_entityref_parent_list($nid, $field_name) {
+  if ($parents = dosomething_helpers_get_entityref_parents($nid, $field_name)) {
+    $header = array('Title', 'Type', 'Published', 'Created');
+    foreach ($parents as $parent) {
+      $node = node_load($parent->nid);
+      $rows[] = array(
+        l($node->title, 'node/' . $parent->nid),
+        $node->type,
+        $node->status,
+        format_date($node->created, 'short'),
+      );
+    }
+    return theme('table', array('header' => $header, 'rows' => $rows));
+  }
+  else {
+    return t("Not referenced in @field.", array('@field' => $field_name));
+  }
+}
+
+/**
+ * Adds links to a node's content displaying instances in $field_name.
+ *
+ * @param object $node
+ *  The node, passed from a hook_node_view.
+ * @param array $fields
+ *  Array of machine name of fields to check for.
+ */
+function dosomething_helpers_add_entityref_links(&$node, $fields) {
+  $i = 30;
+  foreach ($fields as $fld) {
+    $node->content[$fld] = array(
+      '#prefix' => '<div><h3>' . $fld .'</h3>',
+      '#suffix' => '</div>',
+      '#markup' => dosomething_helpers_get_entityref_parent_list($node->nid, $fld),
+      '#weight' => $i,
+    );
+    $i = $i + 10;
+  }
+}

--- a/lib/modules/dosomething/dosomething_image/dosomething_image.module
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.module
@@ -76,3 +76,26 @@ function dosomething_image_get_themed_image_url($nid, $ratio, $style) {
   $base_path = dosomething_image_get_image_url($nid, $ratio);
   return image_style_url($style, $base_path);
 }
+
+/**
+ * Implements hook_node_view().
+ */
+function dosomething_image_node_view($node, $view_mode, $langcode) {
+  // Make sure dosomething_helpers is enabled.
+  if (!module_exists('dosomething_helpers')) { return; }
+
+  // If viewing an image node:
+  if ($node->type == 'image' && $view_mode == 'full') {
+    $entityref_fields = array(
+      'field_gallery_image',
+      'field_hero_image',
+      'field_image_campaign_cover',
+      'field_image_psa_replacement',
+      'field_image_reportback_gallery',
+      'field_image_sponsor_logo',
+      'field_image_step_gallery',
+      'field_intro_image',
+    );
+    dosomething_helpers_add_entityref_links($node, $entityref_fields);
+  }
+}

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -7,9 +7,21 @@
 include_once 'dosomething_user.features.inc';
 
 /**
- * @file
- * Functionality for users on DoSomething.
+ * Implements hook_node_access().
  */
+function dosomething_user_node_access($node, $op, $account) {
+  // Internal content types to be viewed by staff only:
+  $staff_types = array('fact', 'image');
+  // If viewing an internal staff type:
+  if (in_array($node->type, $staff_types) && $op == 'view') {
+    // If staff user, able to view the Fact node.
+    if (dosomething_user_is_staff($account)) {
+      return NODE_ACCESS_ALLOW;
+    }
+    // Otherwise, no facts for you.
+    return NODE_ACCESS_DENY;
+  }
+}
 
  /**
   * Confirms that a specific cell phone number is valid.  A valid phone number


### PR DESCRIPTION
Fixes last item left in #606
- Adds helper functions which query entityreference fields to see where a given node is referenced.
- Moves `hook_node_access` check into `dosomething_user` to have one place to deny access to view content types that only staff should have view access to (facts, images).
- Displays three sections on a Fact node (which is an internal view only staff can see):
  - parent nodes which reference the Fact via field_facts (this will include campaigns and fact_page)
  - parent nodes which reference the Fact via field_fact_problem
  - parent nodes which reference the Fact via field_fact_solution
- Similarly displays parent nodes which reference a given image node on the image node's node_view (which again, only staff can see
