### PR TITLE
Mobilecommons Opt-In

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -225,7 +225,7 @@ function dosomething_signup_views_data() {
 /**
  * Implements hook_user_view().
  */
-function dosomething_user_user_view($account, $view_mode, $langcode) {
+function dosomething_signup_user_view($account, $view_mode, $langcode) {
   // Output user signups.
   $account->content['campaigns'] = array(
     '#type' => 'user_profile_item',

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -233,3 +233,37 @@ function dosomething_signup_user_view($account, $view_mode, $langcode) {
     '#markup' => views_embed_view('user_signups', 'block', $account->uid),
   );
 }
+
+/**
+ * Sends a Mobilecommons API request to sign up given user for campaigns opt-i
+ */
+function dosomething_signup_mobilecommons_opt_in() {
+  // Make sure mobilecommons module is enabled.
+  if (!module_exists('mobilecommons')) { return; }
+
+  // If user doesn't have mobile number, exit function.
+  $mobile = dosomething_user_get_mobile();
+  if (!$mobile) { return; }
+
+  try {
+    // @todo: Move this all into a new function in the mobilecommons.module.
+    libraries_load('mobilecommons-php');
+    $config = array(
+      'username' => variable_get('mobilecommons_api_auth_email'),
+      'password' => variable_get('mobilecommons_api_auth_password'),
+    );
+    $MobileCommons = new MobileCommons($config);
+    // Next get prepare the opt-in request.
+    $args = array(
+      // All campaigns use this opt-in path for now.
+      'opt_in_path' => variable_get('dosomething_signup_mobilecommons_opt_in', 164453),
+      'person[phone]' => $mobile,
+      //@todo: Pass campaign name as param for as 'person[campaign_name]'.
+    );
+    $response = $MobileCommons->opt_in($args);
+  }
+  catch (Exception $e) {
+    // Log the error.
+    watchdog('dosomething_signup', $e, array(), WATCHDOG_ERROR);
+  }
+}

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -264,3 +264,16 @@ function dosomething_user_get_field($field_name, $account = NULL) {
   $wrapper = entity_metadata_wrapper('user', $account);
   return $wrapper->{$field_name}->value();
 }
+
+/**
+ * Returns given user's mobile number.
+ *
+ * @param object $account
+ *   The account to return value for. If NULL, uses global $user.
+ *
+ * @return mixed
+ *   Returns NULL if not set, otherwise string.
+ */
+function dosomething_user_get_mobile($account = NULL) {
+  return dosomething_user_get_field('field_mobile', $account);
+}

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -245,4 +245,22 @@ function dosomething_user_clean_cell_number($number) {
   return FALSE;
 }
 
-
+/**
+ * Returns value for given field on given user.
+ * 
+ * @param string $field_name
+ *   The machine name of the field that stores value to return.
+ * @param object $account
+ *   The account to return value for. If NULL, uses global $user.
+ *
+ * @return mixed
+ *   Returns NULL if not set, otherwise whatever type of data the field stores.
+ */
+function dosomething_user_get_field($field_name, $account = NULL) {
+  if ($account == NULL) {
+    global $user;
+    $account = $user;
+  }
+  $wrapper = entity_metadata_wrapper('user', $account);
+  return $wrapper->{$field_name}->value();
+}

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -172,8 +172,8 @@ projects[paraneue][options][working-copy] = TRUE
 ; LIBRARIES
 
 ; Mobile Commons PHP
-libraries[mobilecommons_php][download][type] = "git"
-libraries[mobilecommons_php][download][url] = "https://github.com/DoSomething/mobilecommons-php.git"
+libraries[mobilecommons-php][download][type] = "git"
+libraries[mobilecommons-php][download][url] = "https://github.com/DoSomething/mobilecommons-php.git"
 
 ; DSAPI PHP Library
 ;libraries[dsapi][download][type] = "git"


### PR DESCRIPTION
Creates a function in `dosomething_signup` to opt-in a user into a mobilecommons path as specified by #450.

This looks like the request is successful (you need to enable mobilecommons module and add credentials to test) but it doesn't seem like the opt-in path is actually set up, because I'm not receiving any texts.  Not closing out #450 yet as we'll still need to alter this to pass through a campaign nid/name into the opt-in request as well.
