### PR TITLE
Include custom modules & themes via make

### DIFF
--- a/lib/profiles/dosomething/dosomething.make
+++ b/lib/profiles/dosomething/dosomething.make
@@ -1,0 +1,92 @@
+; Dosomething custom modules and themes
+api = 2
+core = 7.x
+
+includes[] = drupal-org.make
+
+; MODULES
+
+; Dosomething Action Guide
+projects[dosomething_action_guide][type] = "module"
+projects[dosomething_action_guide][download][type] = local
+projects[dosomething_action_guide][download][source] = './lib/modules/dosomething/dosomething_action_guide'
+projects[dosomething_action_guide][subdir] = "dosomething"
+
+; Dosomething Campaign
+projects[dosomething_campaign][type] = "module"
+projects[dosomething_campaign][download][type] = local
+projects[dosomething_campaign][download][source] = './lib/modules/dosomething/dosomething_campaign'
+projects[dosomething_campaign][subdir] = "dosomething"
+
+; Dosomething Fact
+projects[dosomething_fact][type] = "module"
+projects[dosomething_fact][download][type] = local
+projects[dosomething_fact][download][source] = './lib/modules/dosomething/dosomething_fact'
+projects[dosomething_fact][subdir] = "dosomething"
+
+; Dosomething Fact Page
+projects[dosomething_fact_page][type] = "module"
+projects[dosomething_fact_page][download][type] = local
+projects[dosomething_fact_page][download][source] = './lib/modules/dosomething/dosomething_fact_page'
+projects[dosomething_fact_page][subdir] = "dosomething"
+
+; Dosomething Helpers
+projects[dosomething_helpers][type] = "module"
+projects[dosomething_helpers][download][type] = local
+projects[dosomething_helpers][download][source] = './lib/modules/dosomething/dosomething_helpers'
+projects[dosomething_helpers][subdir] = "dosomething"
+
+; Dosomething Image
+projects[dosomething_image][type] = "module"
+projects[dosomething_image][download][type] = local
+projects[dosomething_image][download][source] = './lib/modules/dosomething/dosomething_image'
+projects[dosomething_image][subdir] = "dosomething"
+
+; Dosomething Reportback
+projects[dosomething_reportback][type] = "module"
+projects[dosomething_reportback][download][type] = local
+projects[dosomething_reportback][download][source] = './lib/modules/dosomething/dosomething_reportback'
+projects[dosomething_reportback][subdir] = "dosomething"
+
+; Dosomething Search
+projects[dosomething_search][type] = "module"
+projects[dosomething_search][download][type] = local
+projects[dosomething_search][download][source] = './lib/modules/dosomething/dosomething_search'
+projects[dosomething_search][subdir] = "dosomething"
+
+; Dosomething Settings
+projects[dosomething_settings][type] = "module"
+projects[dosomething_settings][download][type] = local
+projects[dosomething_settings][download][source] = './lib/modules/dosomething/dosomething_settings'
+projects[dosomething_settings][subdir] = "dosomething"
+
+; Dosomething Signup
+projects[dosomething_signup][type] = "module"
+projects[dosomething_signup][download][type] = local
+projects[dosomething_signup][download][source] = './lib/modules/dosomething/dosomething_signup'
+projects[dosomething_signup][subdir] = "dosomething"
+
+; Dosomething Static Content
+projects[dosomething_static_content][type] = "module"
+projects[dosomething_static_content][download][type] = local
+projects[dosomething_static_content][download][source] = './lib/modules/dosomething/dosomething_static_content'
+projects[dosomething_static_content][subdir] = "dosomething"
+
+; Dosomething Taxonomy
+projects[dosomething_taxonomy][type] = "module"
+projects[dosomething_taxonomy][download][type] = local
+projects[dosomething_taxonomy][download][source] = './lib/modules/dosomething/dosomething_taxonomy'
+projects[dosomething_taxonomy][subdir] = "dosomething"
+
+; Dosomething User
+projects[dosomething_user][type] = "module"
+projects[dosomething_user][download][type] = local
+projects[dosomething_user][download][source] = './lib/modules/dosomething/dosomething_user'
+projects[dosomething_user][subdir] = "dosomething"
+
+; THEMES
+; Dosomething User
+projects[paraneue_dosomething][type] = "theme"
+projects[paraneue_dosomething][download][type] = local
+projects[paraneue_dosomething][download][source] = './lib/themes/dosomething/paraneue_dosomething'
+projects[paraneue_dosomething][subdir] = "dosomething"

--- a/lib/profiles/dosomething/dosomething.make
+++ b/lib/profiles/dosomething/dosomething.make
@@ -85,7 +85,7 @@ projects[dosomething_user][download][source] = './lib/modules/dosomething/dosome
 projects[dosomething_user][subdir] = "dosomething"
 
 ; THEMES
-; Dosomething User
+; Paraneue Dosomething
 projects[paraneue_dosomething][type] = "theme"
 projects[paraneue_dosomething][download][type] = local
 projects[paraneue_dosomething][download][source] = './lib/themes/dosomething/paraneue_dosomething'

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -131,7 +131,6 @@ projects[view_unpublished][patch][] = "https://drupal.org/files/view_unpublished
 projects[views] = "3.7"
 projects[views][subdir] = "contrib"
 
-
 ; GIT PROJECTS
 
 ; Conductor


### PR DESCRIPTION
**Why would I want to do something like this?**
Because it makes the project easier to package and deploy.  Currently, we would have to symlink the modules and themes directories every time we deploy or package up a dist.  This way, all of our custom modules and themes are included by default.

**Thats confusing, and annoying.**
No, its not.

**Yes it is**
Nope, I gave you a nice dosomething.make file in the profile directory.  This is where need to include the custom modules and themes.  Yes, it adds another step when creating new modules, but this should not happen very often

**But, I like how things work now.**
Well, thats too bad, plus everything should be business as usual.

Thoughts/Issues folks?
