### PR TITLE
Pitch Page Modals

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -246,8 +246,7 @@ function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
   else {
     // Render button as link to open up the login modal.
     $vars['signup_button'] = array(
-      // @todo: Add relevant class to open up modal.
-      '#markup' => '<a href="#" class="btn">' . $label . '</a>',
+      '#markup' => '<a href="#modal-login" class="js-modal-link btn medium">' . $label . '</a>',
     );
   }
 }


### PR DESCRIPTION
# Pitch Auth

Calls the log in authentication modal when unauthenticated users attempt to sign up on the campaign pitch page.
## NOTE

:warning: You must either delete or comment out the **user.js** file packaged with Drupal's User module in order for this to work. Desmond is looking into removing the file permanently.

Fixes #715
