### PR TITLE
Mobilecommons signup

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -244,8 +244,12 @@ function dosomething_signup_user_signup($nid, $uid = NULL) {
 
   // Insert signup.
   if ($sid = dosomething_signup_insert($nid, $uid)) {
+    $node = node_load($nid);
+    // Opt-in to mobilecommons.
+    dosomething_signup_mobilecommons_opt_in($node->title);
     // Set success message.
-    $message = t("You're signed up!");
+    $message = t("You're signed up!") . '<br />';
+    $message .= t("Get started with") . ' ' . $node->title .'  ' . t("below!");
     drupal_set_message($message);
   }
 }
@@ -254,7 +258,7 @@ function dosomething_signup_user_signup($nid, $uid = NULL) {
 /**
  * Sends a Mobilecommons API request to sign up given user for campaigns opt-i
  */
-function dosomething_signup_mobilecommons_opt_in() {
+function dosomething_signup_mobilecommons_opt_in($campaign_title) {
   // Make sure mobilecommons module is enabled.
   if (!module_exists('mobilecommons')) { return; }
 
@@ -275,7 +279,7 @@ function dosomething_signup_mobilecommons_opt_in() {
       // All campaigns use this opt-in path for now.
       'opt_in_path' => variable_get('dosomething_signup_mobilecommons_opt_in', 164453),
       'person[phone]' => $mobile,
-      //@todo: Pass campaign name as param for as 'person[campaign_name]'.
+      'person[campaign_name]' => $campaign_title,
     );
     $response = $MobileCommons->opt_in($args);
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -233,20 +233,26 @@ function dosomething_signup_user_view($account, $view_mode, $langcode) {
 
 /**
  * Signup a user $uid for a given node $nid.
+ *
+ * @param int $nid
+ *   The node nid the user is signing up for.
+ * @param int $uid
+ *   Optional - the user uid to sign up.
+ *   If not provided, uses global $user->uid.
  */
-function dosomething_signup_user_signup($nid, $uid = NULL) {
-  if ($uid == NULL) {
+function dosomething_signup_user_signup($nid, $account = NULL) {
+  if ($account == NULL) {
     global $user;
-    $uid = $user->uid;
+    $account = $user;
   }
   // If a signup already exists, exit.
-  if (dosomething_signup_exists($nid, $uid)) { return; }
+  if (dosomething_signup_exists($nid, $account->uid)) { return; }
 
   // Insert signup.
-  if ($sid = dosomething_signup_insert($nid, $uid)) {
+  if ($sid = dosomething_signup_insert($nid, $account->uid)) {
     $node = node_load($nid);
     // Opt-in to mobilecommons.
-    dosomething_signup_mobilecommons_opt_in($node->title);
+    dosomething_signup_mobilecommons_opt_in($account, $node->title);
     // Set success message.
     $message = t("You're signed up!") . '<br />';
     $message .= t("Get started with") . ' ' . $node->title .'  ' . t("below!");
@@ -256,14 +262,19 @@ function dosomething_signup_user_signup($nid, $uid = NULL) {
 
 
 /**
- * Sends a Mobilecommons API request to sign up given user for campaigns opt-i
+ * Sends a Mobilecommons API request to opt-in user with given campaign title.
+ *
+ * @param object $account
+ *   The user object of user to opt-in.
+ * @param string $title
+ *   The campaign title the user has signed up for.
  */
-function dosomething_signup_mobilecommons_opt_in($campaign_title) {
+function dosomething_signup_mobilecommons_opt_in($account, $title) {
   // Make sure mobilecommons module is enabled.
   if (!module_exists('mobilecommons')) { return; }
 
   // If user doesn't have mobile number, exit function.
-  $mobile = dosomething_user_get_mobile();
+  $mobile = dosomething_user_get_mobile($account);
   if (!$mobile) { return; }
 
   try {
@@ -279,7 +290,7 @@ function dosomething_signup_mobilecommons_opt_in($campaign_title) {
       // All campaigns use this opt-in path for now.
       'opt_in_path' => variable_get('dosomething_signup_mobilecommons_opt_in', 164453),
       'person[phone]' => $mobile,
-      'person[campaign_name]' => $campaign_title,
+      'person[campaign_name]' => $title,
     );
     $response = $MobileCommons->opt_in($args);
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -236,9 +236,9 @@ function dosomething_signup_user_view($account, $view_mode, $langcode) {
  *
  * @param int $nid
  *   The node nid the user is signing up for.
- * @param int $uid
- *   Optional - the user uid to sign up.
- *   If not provided, uses global $user->uid.
+ * @param object account
+ *   Optional - the user object to sign up.
+ *   If not provided, uses global $user.
  */
 function dosomething_signup_user_signup($nid, $account = NULL) {
   if ($account == NULL) {
@@ -308,7 +308,6 @@ function dosomething_signup_mobilecommons_opt_in($account, $title) {
  *
  * @return array
  *   Array of node nid's.
- *
  */
 function dosomething_signup_get_signup_nids_by_uid($uid) {
   $query = db_select('dosomething_signup', 's');

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -139,10 +139,7 @@ function dosomething_signup_form_submit($form, &$form_state) {
     return;
   }
   $nid = $form_state['values']['nid'];
-  // Signup shouldn't exist already, but check.
-  if (!dosomething_signup_exists($nid) && dosomething_signup_insert($nid)) {
-    drupal_set_message(t("You're signed up!"));
-  }
+  dosomething_signup_user_signup($nid);
 }
 
 /**
@@ -233,6 +230,26 @@ function dosomething_signup_user_view($account, $view_mode, $langcode) {
     '#markup' => views_embed_view('user_signups', 'block', $account->uid),
   );
 }
+
+/**
+ * Signup a user $uid for a given node $nid.
+ */
+function dosomething_signup_user_signup($nid, $uid = NULL) {
+  if ($uid == NULL) {
+    global $user;
+    $uid = $user->uid;
+  }
+  // If a signup already exists, exit.
+  if (dosomething_signup_exists($nid, $uid)) { return; }
+
+  // Insert signup.
+  if ($sid = dosomething_signup_insert($nid, $uid)) {
+    // Set success message.
+    $message = t("You're signed up!");
+    drupal_set_message($message);
+  }
+}
+
 
 /**
  * Sends a Mobilecommons API request to sign up given user for campaigns opt-i

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -135,22 +135,32 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
 
   }
 }
+
 /**
  * Custom login submission handler.
  *
  * If there's a hidden nid, sign the user up for a campaign.
+ *
+ * This function will only work upon registration if account variables
+ * are set to the following:
+ * -- A visitor can register for the site without admin approval
+ * -- Email verification is not required when user creates account.
+ *
+ * Otherwise, the global $user upon account creation is set with uid 0
+ * and signup will fail.
+ *
+ * @see dosomething_user_strongarm()
  */
 function dosomething_user_login_submit($form, &$form_state) {
-   // If nid is not present, nothing to sign up for.  Exit.
-   if (!isset($form_state['input']['nid'])) { return; };
-   $nid = $form_state['input']['nid'];
-   // Redirect to node (this is needed for user_register form).
-   $form_state['redirect'] = 'node/' . $nid;
-   // If a signup does not exist:
-   if (!dosomething_signup_exists($nid)) {
-     // Signup for the node.
-     dosomething_signup_insert($nid);
-   }
+  // If nid is not present, nothing to sign up for.  Exit.
+  if (!isset($form_state['input']['nid'])) { return; }
+  $nid = $form_state['input']['nid'];
+  // Redirect to node (this is needed for user_register form).
+  $form_state['redirect'] = 'node/' . $nid;
+  // Signup global user for node $nid.
+  if (module_exists('dosomething_signup')) {
+    dosomething_signup_user_signup($nid);
+  }
 }
 
 /**
@@ -194,7 +204,7 @@ function dosomething_user_register_after_build($form, &$form_state) {
 /**
  * Add hidden campaign nid to signup/registration form.
  *
- * @param array - $form
+ * @param array $form
  *  A drupal form.
  */
 function _dosomething_user_add_campaign_data(&$form) {
@@ -227,7 +237,7 @@ function _dosomething_user_login_shared_helper_text(&$form) {
 /**
  * Registration helper text.
  *
- * @param array = $form
+ * @param array $form
  *  A drupal form.
  */
 function _dosomething_user_register_helper_text(&$form) {
@@ -241,6 +251,7 @@ function _dosomething_user_register_helper_text(&$form) {
   $form['account']['mail']['#title'] = t('Email');
   $form['account']['mail']['#attributes']['placeholder'] = t('your_email@example.com');
 }
+
 /**
  * Custom login validation.
  *
@@ -282,30 +293,6 @@ function dosomething_user_register_validate($form, &$form_state) {
       // Store only the numbers.
       form_set_value($form['field_mobile'], array(LANGUAGE_NONE => array(0 => array('value' => $mobile_clean))), $form_state);
     }
-  }
-}
-
-
-/**
- * Additional callback to sign user up for campaign.
- *
- * Signs up global $user for a node $nid if $nid isset in the $form_state.
- * This function will only work upon registration if account variables
- * are set to the following:
- * -- A visitor can register for the site without admin approval
- * -- Email verification is not required when user creates account.
- *
- * Otherwise, the global $user upon account creation is set with uid 0
- * and signup will fail.
- *
- * @see dosomething_user_strongarm()
- */
-function dosomething_user_signup($form, &$form_state, $obj) {
-
-  // If a signup does not exist:
-  if (!dosomething_signup_exists($nid)) {
-    // Signup for the node.
-    dosomething_signup_insert($nid);
   }
 }
 


### PR DESCRIPTION
Closes #450

Creates a `dosomething_signup_user_signup` function which handles inserting a signup record and the API request to opt-in to Mobilecommons.

Uses this new function to replace  manual `dosomething_signup_insert` calls in `dosomething_user_login_submit` and `dosomething_signup_form_submit`.
