### PR TITLE
Campaign automatic revisions

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.strongarm.inc
@@ -37,7 +37,9 @@ function dosomething_campaign_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'node_options_campaign';
-  $strongarm->value = array();
+  $strongarm->value = array(
+    0 => 'revision',
+  );
   $export['node_options_campaign'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
Creates new revision every time a campaign is updated.  This change has already been made into the staging database.
