### PR TITLE
Allow editors publish/unpublish

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.features.user_permission.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.features.user_permission.inc
@@ -163,6 +163,7 @@ function dosomething_user_user_default_permissions() {
     'name' => 'administer nodes',
     'roles' => array(
       'administrator' => 'administrator',
+      'editor' => 'editor',
     ),
     'module' => 'node',
   );


### PR DESCRIPTION
The "administer nodes" permission will allow editors to publish and unpublish.

It also allows them to do things like change authoring information, "promoted" and "sticky" .. but we could always just hide this stuff if it's too much.
