### PR TITLE
Action guide preprocess / template file

### DIFF
--- a/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.module
+++ b/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.module
@@ -5,3 +5,32 @@
  */
 
 include_once 'dosomething_action_guide.features.inc';
+
+/**
+ * Implements hook_preprocess_node().
+ */
+function dosomething_action_guide_preprocess_node(&$vars) {
+  if ($vars['type'] != 'action_guide') { return; }
+
+  if ($vars['view_mode'] == 'full') {
+    $node = menu_get_object();
+    $wrapper = entity_metadata_wrapper('node', $node);
+    $text_vars = array(
+      'subtitle',
+      'intro_title',
+      'intro',
+      'additional_text_title',
+      'additional_text',
+    );
+    foreach ($text_vars as $label) {
+      $field = "field_" . $label;
+      $vars[$label] = $wrapper->{$field}->value();
+    }
+    $intro_image = $wrapper->field_intro_image->getIdentifier();
+    if ($intro_image) {
+      $vars['intro_image'] = dosomething_image_get_themed_image($intro_image, 'landscape', '550x330');
+    }
+    // Preprocess gallery variables.
+    dosomething_static_content_preprocess_gallery_vars($vars);
+  }
+}

--- a/lib/modules/dosomething/dosomething_action_guide/node--action_guide.tpl.php
+++ b/lib/modules/dosomething/dosomething_action_guide/node--action_guide.tpl.php
@@ -1,0 +1,41 @@
+<article id="node-<?php print $node->nid; ?>" class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
+
+  <div>
+    <h1><?php print $title; ?></h1>
+    <?php if (isset($subtitle)): ?>
+      <h2><?php print $subtitle; ?></h2>
+    <?php endif; ?>
+  </div>
+
+  <?php if (isset($intro_title)): ?>
+    <h2><?php print $intro_title; ?></h2>
+  <?php endif; ?>
+
+  <?php if (isset($intro)): ?>
+    <div><?php print $intro['safe_value']; ?></div>
+  <?php endif; ?>
+
+  <?php if (isset($intro_image)): ?>
+    <?php print $intro_image; ?>
+  <?php endif; ?>
+
+  <?php if (isset($galleries)): ?>
+    <?php foreach ($galleries as $gallery): ?>
+      <?php print $gallery['image']; ?>
+      <?php if ($gallery['image_title']): ?>
+        <h3><?php print $gallery['image_title']; ?></h3>
+      <?php endif; ?>
+      <?php if ($gallery['image_description']): ?>
+        <p><?php print $gallery['image_description']; ?></p>
+      <?php endif; ?>
+    <?php endforeach; ?>
+  <? endif; ?>
+
+  <?php if (isset($additional_text_title)): ?>
+    <h2><?php print $additional_text_title; ?></h2>
+  <?php endif; ?>
+  <?php if (isset($additional_text)): ?>
+    <?php print $additional_text['safe_value']; ?>
+  <?php endif; ?>
+
+</article>

--- a/lib/modules/dosomething/dosomething_helpers/README.md
+++ b/lib/modules/dosomething/dosomething_helpers/README.md
@@ -1,0 +1,28 @@
+# DoSomething Helpers
+
+General cross-module helper functions go here.
+
+## Content Type Theme Registry
+
+The 'dosomething_helpers_theme_registry_alter' in the theme.inc alters the theme
+registry to check for the existence of a content type's node--[NAME].tpl.php
+file within the module's directory.  This allows for a base template file in
+the module directory, to serve as a guide for theming.
+
+The registry alter will not work for a content type unless it is added into the
+`dosomething_helpers_modules` variable, which is defined in the
+`dosomething_helpers_strongarm` file.
+
+## Get EntityReference Parents
+
+The `dosomething_helpers.module` file contains functions used to query specified
+entityreference fields for a given node nid, and return the parent nodes that
+reference it.
+
+These functions are used on the full view mode of nodes like Facts and Images, to
+display all nodes that reference them.
+
+## Node Form Enhancements
+
+This module is responsible for adding all of those character counters in the
+node edit forms.

--- a/lib/modules/dosomething/dosomething_helpers/README.txt
+++ b/lib/modules/dosomething/dosomething_helpers/README.txt
@@ -1,4 +1,0 @@
-Dosomething helpers
-===================
-
-TODO: write some documentation.

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.strongarm.inc
@@ -18,6 +18,7 @@ function dosomething_helpers_strongarm() {
   $strongarm->value = array(
     'static_content',
     'fact_page',
+    'action_guide',
   );
   $export['dosomething_helpers_modules'] = $strongarm;
 

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
@@ -53,23 +53,37 @@ function dosomething_static_content_preprocess_node(&$vars) {
       $vars['intro_video'] = theme('dosomething_video_embed', array('field' => $node->field_video->value()));
     }
 
-    $gallery_count = count($content['field_gallery']['#items']);
-    $vars['galleries'] = array();
-    // Loop through the galleries.
-    for ($i=0; $i<$gallery_count;$i++) {
-      $collection_item = reset($content['field_gallery'][$i]['entity']['field_collection_item']);
-      $collection_item = $collection_item['field_gallery_item'];
+    // Preprocess gallery variables.
+    dosomething_static_content_preprocess_gallery_vars($vars);
+  }
+}
 
-      $gallery_item_count = count($collection_item['#items']);
-      $vars['galleries'][$i] = array();
-      for ($a=0; $a<$gallery_item_count;$a++) {
-        $gallery_item = reset($collection_item[$a]['entity']['field_collection_item']);
-        $vars['galleries'][$a]['image'] = dosomething_image_get_themed_image($gallery_item['field_gallery_image']['#items'][0]['target_id'], 'sq', 'gallery_large');
+/**
+ * Preprocesses variables for the field_gallery field collection.
+ *
+ * @param array $vars
+ *   Variable array as passed from a hook_preprocess_node.
+ *
+ * @see dosomething_static_content_preprocess_node().
+ */
+function dosomething_static_content_preprocess_gallery_vars(&$vars) {
+  $content = $vars['content'];
+  $gallery_count = count($content['field_gallery']['#items']);
+  $vars['galleries'] = array();
+  // Loop through the galleries.
+  for ($i = 0; $i < $gallery_count; $i++) {
+    $collection_item = reset($content['field_gallery'][$i]['entity']['field_collection_item']);
+    $collection_item = $collection_item['field_gallery_item'];
 
-        $link_field = $gallery_item['field_image_title'][0]['#element'];
-        $vars['galleries'][$a]['image_title'] = $link_field['url'] ? l(t($link_field['title']), $link_field['url'], array('target' => '_blank')) : $link_field['title'];
-        $vars['galleries'][$a]['image_description'] = $gallery_item['field_image_description'][0]['#markup'];
-      }
+    $gallery_item_count = count($collection_item['#items']);
+    $vars['galleries'][$i] = array();
+    for ($a = 0; $a < $gallery_item_count; $a++) {
+      $gallery_item = reset($collection_item[$a]['entity']['field_collection_item']);
+      $vars['galleries'][$a]['image'] = dosomething_image_get_themed_image($gallery_item['field_gallery_image']['#items'][0]['target_id'], 'sq', 'gallery_large');
+
+      $link_field = $gallery_item['field_image_title'][0]['#element'];
+      $vars['galleries'][$a]['image_title'] = $link_field['url'] ? l(t($link_field['title']), $link_field['url'], array('target' => '_blank')) : $link_field['title'];
+      $vars['galleries'][$a]['image_description'] = $gallery_item['field_image_description'][0]['#markup'];
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
@@ -6,6 +6,9 @@
 
 include_once 'dosomething_static_content.features.inc';
 
+/**
+ * Implements hook_preprocess_node().
+ */
 function dosomething_static_content_preprocess_node(&$vars) {
   if ($vars['type'] == 'static_content') {
     $content = $vars['content'];


### PR DESCRIPTION
- Creates a base tpl file for the Action Guide content type and places it into the module directory.
- Updates `dosomething_helpers_modules` variable to include action guide.
- Documentation!

FYI @blisteringherb  - There seems like there may be variables missing from the original preprocess gallery functions, like the Gallery Title.  We'll need to tweak both content types' preprocess and template files as we fix any bugs.
