### PR TITLE
Adds hosts and black angus alias files via salt state.  Related to #675

### DIFF
--- a/provision/salt/roots/salt/dosomething.sls
+++ b/provision/salt/roots/salt/dosomething.sls
@@ -1,0 +1,13 @@
+{% if grains['os'] == 'Ubuntu' %}
+
+ds-hosts:
+  file.managed:
+    - name: /etc/hosts
+    - source: salt://dosomething/hosts
+
+ds-aliases:
+  file.managed:
+    - name: /home/vagrant/.drush/blackangus.aliases.drushrc.php
+    - source: salt://dosomething/blackangus.aliases.drushrc.php
+
+{% endif %}

--- a/provision/salt/roots/salt/dosomething/blackangus.aliases.drushrc.php
+++ b/provision/salt/roots/salt/dosomething/blackangus.aliases.drushrc.php
@@ -1,0 +1,6 @@
+<?php
+
+$aliases['stage'] = array(
+  'db-url' => 'mysql://blackangus.dosomething.org:3306/ds_stage',
+  'db-allows-remote' => TRUE,
+);

--- a/provision/salt/roots/salt/dosomething/hosts
+++ b/provision/salt/roots/salt/dosomething/hosts
@@ -1,0 +1,2 @@
+127.0.0.1       localhost
+10.11.12.169    blackangus.dosomething.org

--- a/provision/salt/roots/salt/top.sls
+++ b/provision/salt/roots/salt/top.sls
@@ -8,3 +8,4 @@ base:
     - composer
     - node
     - drush-ext
+    - dosomething


### PR DESCRIPTION
This merge allows us to safely pull down the staging db via the drush `sql-sync` command.  This is all possible by using drush aliases.  The following command will pull down the ds_stage db and import it into the dosomething db within your vm:

```
drush sql-sync @blackangus.stage @self
```

**Important**
1.  You must be on the DS network for this to work.  So if you are remote, you must be connecting to the VPN.
2.  Currently, you must add the proper mysql credentials to the alias file for this to work.  You can find the full db string (here)[https://gist.github.com/desmondmorris/66ed52d15d6b3486235a].  You will need to replace the db string in /home/vagrant/.drush/blackangus.aliases.drushrc.php with the one in that link I provided.  I think we may be able to get around this by configuring the mysql db on stage to accept read only pulls from any request within our network (VPN). @mshmsh5000 thoughts on that?
3.  You must be with a working drupal webroot for the self alias to work.  So make sure you cd into /vagrant/html first.

**Coming soon**
With aliases we will also be able to easily rsync the files directory down and run drush commands against the staging server.
