### PR TITLE
Administrator role

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.info
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.info
@@ -71,6 +71,7 @@ features[user_permission][] = view revisions
 features[user_permission][] = view the administration theme
 features[user_role][] = administrator
 features[user_role][] = editor
+features[variable][] = user_admin_role
 features[variable][] = user_email_verification
 features[variable][] = user_mail_cancel_confirm_notify
 features[variable][] = user_mail_password_reset_notify

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.strongarm.inc
@@ -13,6 +13,13 @@ function dosomething_user_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'user_admin_role';
+  $strongarm->value = '3';
+  $export['user_admin_role'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'user_email_verification';
   $strongarm->value = 0;
   $export['user_email_verification'] = $strongarm;


### PR DESCRIPTION
Makes the "administrator" role the "administrator" role forreals.

Per help text on "admin/config/people/accounts":
- This role will be automatically assigned new permissions whenever a module is enabled. Changing this setting will not affect existing permissions.
