### PR TITLE
Adds a .jshintrc and syncs with Neue

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/.jshintrc
+++ b/lib/themes/dosomething/paraneue_dosomething/.jshintrc
@@ -1,0 +1,26 @@
+{
+    "browser": true,
+    "bitwise": true,
+    "camelcase": true,
+    "curly": true,
+    "eqeqeq": true,
+    "immed": true,
+    "indent": 2,
+    "latedef": true,
+    "newcap": true,
+    "noarg": true,
+    "quotmark": "double",
+    "regexp": true,
+    "undef": true,
+    "unused": true,
+    "strict": true,
+    "trailing": true,
+    "smarttabs": true,
+    "expr": true,
+    "predef": [
+      "_",
+      "$",
+      "jQuery",
+      "Modernizr"
+    ]
+}


### PR DESCRIPTION
This creates a `.jshintrc` file to configure JSHint and adds an option to suppress `expr` warnings so that I may continue using ternary operators to my heart's content.

Fixes #818
