### PR TITLE
Smart settings and cap deploy to pc staging server

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -10,7 +10,7 @@ set :repo_url, 'git@github.com:DoSomething/dosomething.git'
 set :branch, "dev"
 
 # Default deploy_to directory is /var/www/my_app
-set :deploy_to, '/home/ubuntu/app'
+# set :deploy_to, '/var/www/my_app'
 
 # Default value for :scm is :git
 set :scm, :git
@@ -60,9 +60,15 @@ namespace :deploy do
 
   after :deploy, :drush_make do
     on roles(:app) do |host|
-      execute "cd '#{release_path}'; sudo drush make build-dosomething.make dist"
+      execute "cd '#{release_path}'; ds build"
+      execute "cd '#{release_path}/lib/themes/dosomething/paraneue_dosomething'; grunt prod"
 
-      execute "sudo ln -nfs #{release_path}/config/settings.php #{release_path}/dist/sites/default/settings.php"
+      # The next two lines are temp until we get the "smart" settings reviewed and tested.
+      execute "sudo rm -rf #{release_path}/html/sites/default/settings.php"
+      execute "sudo rm -rf #{release_path}/html/sites/default/settings.local.php"
+
+      # Also temporary.
+      execute "ln -s #{release_path}/config/smart-settings.php #{release_path}/html/sites/default/settings.php"
     end
   end
 

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -4,9 +4,10 @@
 # server in each group is considered to be the first
 # unless any hosts have the primary property set.
 # Don't declare `role :all`, it's a meta role
-role :app, %w{deploy@example.com}
-role :web, %w{deploy@example.com}
-role :db,  %w{deploy@example.com}
+
+set :deploy_to, "/home/ubuntu/app"
+
+role :app, %w{ubuntu@98.129.111.165}
 
 # Extended Server Syntax
 # ======================
@@ -14,7 +15,7 @@ role :db,  %w{deploy@example.com}
 # definition into the server list. The second argument
 # something that quacks like a hash can be used to set
 # extended properties on the server.
-server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
+server '98.129.111.165', user: 'ubuntu', roles: %w{app}
 
 # you can set custom ssh options
 # it's possible to pass any option but you need to keep in mind that net/ssh understand limited list of options

--- a/config/smart-settings.php
+++ b/config/smart-settings.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Database settings:
+ */
+$databases['default']['default'] = array(
+  'database' => getenv('DS_DB_MASTER_NAME') ?: 'dosomething',
+  'username' => getenv('DS_DB_MASTER_USER') ?: 'root',
+  'password' => getenv('DS_DB_MASTER_PASS') ?: '',
+  'host' => getenv('DS_DB_MASTER_HOST') ?: 'localhost',
+  'port' => getenv('DS_DB_MASTER_PORT') ?: '3306',
+  'driver' => getenv('DS_DB_MASTER_DRIVER') ?: 'mysql',
+  'prefix' => getenv('DS_DB_MASTER_PREFIX') ?: '',
+);
+
+/**
+ * Hosts & urls
+ */
+$hostname = getenv('DS_HOSTNAME') ?: 'dev.dosomething.org';
+
+$insecure_port = getenv('DS_INSECURE_PORT') ?: 8888;
+$secure_port = getenv('DS_SECURE_PORT') ?: 8889;
+
+if (!empty($insecure_port)) {
+  $base_url = 'http://' . $hostname . ':' . $insecure_port;
+}
+else {
+  $base_url = 'http://' . $hostname;
+}
+
+$conf['https'] = TRUE;
+$conf['securepages_basepath'] = $base_url;
+
+if (!empty($secure_port)) {
+  $conf['securepages_basepath_ssl'] = 'https://' . $hostname . ':' . $secure_port;
+}
+else {
+  $conf['securepages_basepath_ssl'] = 'https://' . $hostname;
+}
+
+/**
+ * Caching
+ */
+// Add Varnish as the page cache handler.
+$conf['varnish_version'] = '3';
+$conf['cache_backends'] = array('profiles/dosomething/modules/contrib/varnish/varnish.cache.inc');
+$conf['cache_class_cache_page'] = 'VarnishCache';
+
+// This is managed from salt://varnishd/secret
+$conf['varnish_control_key'] = '00c9203c65874ca5b4c359e19f00bf56';
+
+// Drupal 7 does not cache pages when we invoke hooks during bootstrap.
+// This needs to be disabled.
+$conf['page_cache_invoke_hooks'] = FALSE;
+
+/**
+ * Salt hash:
+ */
+$drupal_hash_salt = '3i_SZ1VTl_8FBxXeZhTEvf6LkeVNypM0EV90tNuHs5k';
+
+/**
+ * PHP Configuration overrides:
+ */
+ini_set('session.gc_probability', 1);
+ini_set('session.gc_divisor', 100);
+ini_set('session.gc_maxlifetime', 200000);
+ini_set('session.cookie_lifetime', 2000000);
+
+/**
+ * Fast 404 pages:
+ */
+$conf['404_fast_paths_exclude'] = '/\/(?:styles)\//';
+$conf['404_fast_paths'] = '/\.(?:txt|png|gif|jpe?g|css|js|ico|swf|flv|cgi|bat|pl|dll|exe|asp)$/i';
+$conf['404_fast_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>';
+
+
+/**
+ * Load environment aware settings override files
+ */
+$environment = getenv('DS_ENVIRONMENT') ?: 'local';
+
+// Include local settings file if it exists.
+if (is_readable('sites/default/settings.'. $environment .'.php')) {
+  include_once('sites/default/settings.'. $environment .'.php');
+}

--- a/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
+++ b/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
@@ -164,6 +164,5 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-browserify');
   grunt.loadNpmTasks("grunt-contrib-uglify");
   grunt.loadNpmTasks("grunt-contrib-watch");
-  grunt.loadNpmTasks("grunt-docco2");
   grunt.loadNpmTasks("grunt-shell");
 };

--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -12,7 +12,6 @@
     "grunt-contrib-cssmin": "~0.7.0",
     "grunt-contrib-coffee": "~0.7.0",
     "grunt-contrib-uglify": "~0.2.4",
-    "grunt-docco2": "~0.1.5",
     "grunt-contrib-jshint": "~0.7.1",
     "grunt-contrib-qunit": "~0.3.0",
     "jshint-stylish": "~0.1.4",


### PR DESCRIPTION
This merge introduces a deployment task that ships code to a staging VM present in our PC environment.  The DNS is still resolving, but this will eventually point to staging.beta.dosomething.org.  You will need ssh keys on that machine to deploy and we will most likely set this deployment as a job that can be trigger in jenkins.

This also introduces a "smart" settings file that needs to be tested a bit more before replacing the existing settings files in our config folder.  Currently this file looks for environment variables to set the db and hostname values in settings.php.  It also looks for a environment specific settings file based on the current environment set.  This defaults to local.  This is only being used in the deployment currently.  Once this gets more local testing, I propose replacing settings.php and settings.local with this file.

Here is the list of currently support env vars:

```
DS_DB_MASTER_NAME
DS_DB_MASTER_USER
DS_DB_MASTER_PASS
DS_DB_MASTER_HOST
DS_DB_MASTER_PORT
DS_DB_MASTER_DRIVER
DS_DB_MASTER_PREFIX
DS_HOSTNAME
DS_INSECURE_PORT
DS_SECURE_PORT
```

Varnish salt & drupal salt should be included here eventually as well.  We can also use these to set the redis and storage paths.  By default, this should work without envvars in the local environment
