### PR TITLE
Condintionally Prints Scholarship Variable

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -212,8 +212,11 @@ function dosomething_campaign_preprocess_node(&$vars) {
     $node = menu_get_object();
     $wrapper = entity_metadata_wrapper('node', $node);
 
-    // Vars needed for both the pitch & action page.
-    $vars['scholarship'] = '$' . $wrapper->field_scholarship_amount->value() . ' Scholarship';
+    $scholarship = $wrapper->field_scholarship_amount->value();
+    if (isset($scholarship)) {
+      $vars['scholarship'] = '$' . $scholarship . ' Scholarship';
+    }
+
     $vars['cta'] = $wrapper->field_call_to_action->value();
 
     // Timing.


### PR DESCRIPTION
On the pitch page, only print the scholarship variable and hand-drawn arrow if a scholarship was set on the campaign.

Fixes #824
