### PR TITLE
action (prove it) – gallery updates

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/_campaign.scss
@@ -81,7 +81,7 @@
     background-size: cover;
 
     background-image: url(https://trello-attachments.s3.amazonaws.com/52de9089aa3032b85e9b0962/52e1724e23eeb26f4e9fc427/7bbfd71b19c829a2b0feb38073cdb205/campaign-hero.jpg) !important;
-    // TODO - Remove this
+    // @TODO - Remove this
 
     @include media( $tablet ) {
       padding: 450px 0 100px;
@@ -257,6 +257,7 @@
   .step.prove {
     overflow: hidden;
     background-image: url(https://trello-attachments.s3.amazonaws.com/52efb2a8c56de7320e6ffc06/52e1724e23eeb26f4e9fc427/6e777d666be111dec7badaecb9bf18ac/polaroid-pattern.jpg);
+    // @TODO Remove this
 
     h2.title, div.copy {
       color: #fff;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/_port-to-neue.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/_port-to-neue.scss
@@ -115,23 +115,38 @@ header.header {
   .next-button {
     position: relative;
     top: 33.3333%;
-    height: 25px;
-    width: 25px;
-    color: $purple;
-    font-size: 20px;
-    line-height: 10px;
+    height: 0;
+    width: 0;
     border: 25px solid #fff;
     border-radius: 25px;
 
     @include user-select;
+
+    .arrow {
+      font-size: 40px;
+      line-height: 10px;
+      color: $purple;
+      position: absolute;
+      top: -18px;
+
+      @include icomoon-icon;
+    }
   }
 
   .prev-button {
     left: 0;
+
+    .arrow {
+      left: -22px;
+    }
   }
 
   .next-button {
     right: 0;
+
+    .arrow {
+      right: -24px;
+    }
   }
 
   .slide {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/_port-to-neue.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/_port-to-neue.scss
@@ -41,6 +41,7 @@ header.header {
     background-size: 170px 30px;
     background-position: 50% 50%;
     background-image: url("https://trello-attachments.s3.amazonaws.com/52de9089aa3032b85e9b0962/52e1724e23eeb26f4e9fc427/10fb3a32f6c9eef369c955ca7f3ef74f/highlight.png");
+    // @TODO - Remove this
 
     @include transform( rotate(-2deg) );
   }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -9,6 +9,7 @@
       <?php print render($signup_button); ?>
 
       <?php if (isset($scholarship)): ?>
+      <?php //@TODO: Remove Trello-hosted placeholder ?>
       <img class="arrow" src="https://trello-attachments.s3.amazonaws.com/52de9089aa3032b85e9b0962/52e1724e23eeb26f4e9fc427/7e9e3ef8974d815230449b9829e98ac0/arrow.png" alt="Click the button!" />
       <p class="scholarship"><span class="highlight"><?php print $scholarship; ?></span></p>
       <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -16,195 +16,193 @@
     </div>
   </header>
 
-  <div class="content">
-    <nav id="nav" class="navigation">
-      <ul>
-        <li><a class="plain js-jump-scroll" href="#know">know</a></li>
-        <li><a class="plain js-jump-scroll" href="#do">do</a></li>
-        <li><a class="plain js-jump-scroll" href="#plan">plan</a></li>
-        <li><a class="primary js-jump-scroll" href="#prove">prove it</a></li>
-      </ul>
-    </nav>
+  <nav id="nav" class="navigation">
+    <ul>
+      <li><a class="plain js-jump-scroll" href="#know">know</a></li>
+      <li><a class="plain js-jump-scroll" href="#do">do</a></li>
+      <li><a class="plain js-jump-scroll" href="#plan">plan</a></li>
+      <li><a class="primary js-jump-scroll" href="#prove">prove it</a></li>
+    </ul>
+  </nav>
 
-    <h2 id="know" class="step-header"><span class="shift">Know It</span></h2>
-    <section class="know step">
-      <div class="col first">
-        <h4>The Problem</h4>
-        <?php if (isset($fact_problem)): ?>
-        <p><?php print $fact_problem['fact']; ?></p>
-        <?php foreach ($fact_problem['sources'] as $source): ?>
-          <p class="legal">Source: <?php print $source; ?></p>
-        <?php endforeach; ?>
-        <?php endif; ?>
-
-        <?php if (isset($psa)): ?>
-          <?php print $psa; ?>
-        <?php endif; ?>
-      </div>
-
-      <div class="col second">
-        <h4>The Solution</h4>
-        <?php if (isset($fact_solution)): ?>
-        <p><?php print $fact_solution['fact']; ?></p>
-        <?php foreach ($fact_solution['sources'] as $source): ?>
-          <p class="legal">Source: <?php print $source; ?></p>
-        <?php endforeach; ?>
-        <?php endif; ?>
-
-        <?php if (isset($solution_copy)): ?>
-        <div class="solution-copy"><?php print $solution_copy['safe_value']; ?></div>
-        <?php endif; ?>
-
-        <?php if (isset($solution_support)): ?>
-        <div class="solution-supporting-copy"><?php print $solution_support['safe_value']; ?></div>
-        <?php endif; ?>
-
-        <?php if (isset($more_facts)): ?>
-        <?php foreach ($more_facts as $fact): ?>
-          <div>
-            <p><?php print $fact['fact']; ?></p>
-            <?php foreach ($fact['sources'] as $source): ?>
-              <p class="legal">Source: <?php print $source; ?></p>
-            <?php endforeach; ?>
-          </div>
-        <?php endforeach; ?>
-        <?php endif; ?>
-      </div>
-
-      <aside class="cached-modal">
-        <?php if (isset($faq)): ?>
-        <h4>FAQ</h4>
-        <?php foreach ($faq as $item): ?>
-        <h4 class="faq-header"><?php print $item['header']; ?></h4>
-        <div class="faq-copy"><?php print $item['copy'] ?></div>
-        <?php endforeach; ?>
-        <?php endif; ?>
-      </aside>
-    </section>
-
-    <h2 id="plan" class="step-header"><span class="shift">Plan It</span></h2>
-    <section class="plan step">
-      <?php if (isset($starter)) : ?>
-        <div class="intro"><?php print $starter['safe_value']; ?></div>
-      <?php endif; ?>
-
-      <div class="col first">
-        <?php if (isset($items_needed)) : ?>
-          <h4>Stuff You Need</h4>
-          <div><?php print $items_needed['safe_value']; ?></div>
-        <?php endif; ?>
-
-        <?php if (isset($action_guides)) : ?>
-          <ul>
-          <?php foreach ($action_guides as $action_guide): ?>
-            <li><?php print $action_guide; ?></li>
-          <?php endforeach; ?>
-          </ul>
-        <?php endif; ?>
-
-        <?php if (isset($time)) : ?>
-          <h4>Time and Place</h4>
-          <div><?php print $time['safe_value']; ?></div>
-        <?php endif; ?>
-      </div>
-
-      <div class="col second">
-        <?php if (isset($hype)) : ?>
-          <h4>Hype</h4>
-          <div><?php print $hype['safe_value']; ?></div>
-        <?php endif; ?>
-
-        <?php if (isset($vips)) : ?>
-          <h4>VIPs</h4>
-          <div><?php print $vips['safe_value']; ?></div>
-        <?php endif; ?>
-      </div>
-
-      <?php if (isset($location_finder_url)) : ?>
-        <div class="location-finder">
-          <h4>Find a Location</h4>
-          <div class="border">
-            <?php if (isset($location_finder_copy)) : ?>
-              <div><?php print $location_finder_copy['safe_value']; ?></div>
-            <?php endif; ?>
-
-            <a class="btn secondary" href="<?php print $location_finder_url['url']; ?>" target="_blank">Locate</a>
-          </div>
-        </div>
-      <?php endif; ?>
-    </section>
-
-    <h2 id="do" class="step-header"><span class="shift">Do It</span></h2>
-    <section class="do step">
-      <h3><?php print $pre_step_header; ?></h3>
-      <div><?php print $pre_step_copy['safe_value']; ?></div>
-
-      <?php if (isset($step_pre)) : ?>
-      <div class="tip-header-wrapper">
-      <?php foreach ($step_pre as $key=>$item): ?>
-        <a href="#tip<?php print $key; ?>" class="js-show-tip tip-header <?php $key == 0 ? print ' active' : '' ?>"><?php print $item['header']; ?></a><span class="bullet">&#149;&nbsp;</span>
+  <h2 id="know" class="step-header"><span class="shift">Know It</span></h2>
+  <section class="know step">
+    <div class="col first">
+      <h4>The Problem</h4>
+      <?php if (isset($fact_problem)): ?>
+      <p><?php print $fact_problem['fact']; ?></p>
+      <?php foreach ($fact_problem['sources'] as $source): ?>
+        <p class="legal">Source: <?php print $source; ?></p>
       <?php endforeach; ?>
-      </div>
-
-      <div class="tip-body-wrapper">
-      <?php foreach ($step_pre as $key=>$item): ?>
-        <div class="tip-body tip<?php print $key; ?>"><?php print $item['copy'] ?></div>
-      <?php endforeach; ?>
-      </div>
       <?php endif; ?>
 
-      <h3>Snap a Pic</h3>
-      <?php print $pic_step['safe_value']; ?>
-      <h4><?php print $post_step_header; ?></h4>
-      <div><?php print $post_step_copy; ?></div>
-
-      <!-- MODAL -->
-      <?php if (isset($step_post)) : ?>
-      <div class="cached-modal">
-      <?php foreach ($step_post as $item): ?>
-      <h3><?php print $item['header']; ?></h3>
-      <div><?php print $item['copy'] ?></div>
-      <?php endforeach; ?>
-      </div>
+      <?php if (isset($psa)): ?>
+        <?php print $psa; ?>
       <?php endif; ?>
-    </section>
+    </div>
 
-    <h2 id="prove" class="step-header"><span class="shift">Prove It</span></h2>
-    <section class="prove step">
-      <div class="content">
-        <h2 class="title">Pics or It Didn't Happen</h2>
-        <div class="copy"><?php print $reportback_copy; ?></div>
+    <div class="col second">
+      <h4>The Solution</h4>
+      <?php if (isset($fact_solution)): ?>
+      <p><?php print $fact_solution['fact']; ?></p>
+      <?php foreach ($fact_solution['sources'] as $source): ?>
+        <p class="legal">Source: <?php print $source; ?></p>
+      <?php endforeach; ?>
+      <?php endif; ?>
 
-        <a href="#modal-report-back" class="js-modal-link btn large"><?php print $reportback_link_label; ?></a>
-        <div id="modal-report-back" class="cached-modal"><?php print render($reportback_form); ?></div>
-      </div>
+      <?php if (isset($solution_copy)): ?>
+      <div class="solution-copy"><?php print $solution_copy['safe_value']; ?></div>
+      <?php endif; ?>
 
-      <div class="js-carousel gallery">
-      <?php if (isset($reportback_image)): ?>
-        <div id="prev" class="prev-wrapper">
-          <div class="prev-button">&lt;</div>
-        </div>
+      <?php if (isset($solution_support)): ?>
+      <div class="solution-supporting-copy"><?php print $solution_support['safe_value']; ?></div>
+      <?php endif; ?>
 
-        <div class="slide-wrapper">
-          <?php foreach ($reportback_image as $key=>$image): ?>
-          <figure id="slide<?php print $key ?>" class="slide"><img src="<?php print $image ?>" /></figure>
+      <?php if (isset($more_facts)): ?>
+      <?php foreach ($more_facts as $fact): ?>
+        <div>
+          <p><?php print $fact['fact']; ?></p>
+          <?php foreach ($fact['sources'] as $source): ?>
+            <p class="legal">Source: <?php print $source; ?></p>
           <?php endforeach; ?>
         </div>
-
-        <div id="next" class="next-wrapper">
-          <div class="next-button">&gt;</div>
-        </div>
-      <?php else: ?>
-      <div class="slide-wrapper">
-        <figure class="slide visible"><img src="https://trello-attachments.s3.amazonaws.com/53037337ba957ad54dc80486/53063914418de170762c28c0/62291511fcc8d763184a04a99db007b7/placeholder.jpg" alt="This could be you!" /></figure>
-        </div>
+      <?php endforeach; ?>
       <?php endif; ?>
-      </div>
-    </section>
+    </div>
 
-    <?php if (isset($zendesk_form)): ?>
-    <?php //@todo: Modalize and link to me. ?>
-    <?php print render($zendesk_form); ?>
+    <aside class="cached-modal">
+      <?php if (isset($faq)): ?>
+      <h4>FAQ</h4>
+      <?php foreach ($faq as $item): ?>
+      <h4 class="faq-header"><?php print $item['header']; ?></h4>
+      <div class="faq-copy"><?php print $item['copy'] ?></div>
+      <?php endforeach; ?>
+      <?php endif; ?>
+    </aside>
+  </section>
+
+  <h2 id="plan" class="step-header"><span class="shift">Plan It</span></h2>
+  <section class="plan step">
+    <?php if (isset($starter)) : ?>
+      <div class="intro"><?php print $starter['safe_value']; ?></div>
     <?php endif; ?>
-  </div>
+
+    <div class="col first">
+      <?php if (isset($items_needed)) : ?>
+        <h4>Stuff You Need</h4>
+        <div><?php print $items_needed['safe_value']; ?></div>
+      <?php endif; ?>
+
+      <?php if (isset($action_guides)) : ?>
+        <ul>
+        <?php foreach ($action_guides as $action_guide): ?>
+          <li><?php print $action_guide; ?></li>
+        <?php endforeach; ?>
+        </ul>
+      <?php endif; ?>
+
+      <?php if (isset($time)) : ?>
+        <h4>Time and Place</h4>
+        <div><?php print $time['safe_value']; ?></div>
+      <?php endif; ?>
+    </div>
+
+    <div class="col second">
+      <?php if (isset($hype)) : ?>
+        <h4>Hype</h4>
+        <div><?php print $hype['safe_value']; ?></div>
+      <?php endif; ?>
+
+      <?php if (isset($vips)) : ?>
+        <h4>VIPs</h4>
+        <div><?php print $vips['safe_value']; ?></div>
+      <?php endif; ?>
+    </div>
+
+    <?php if (isset($location_finder_url)) : ?>
+      <div class="location-finder">
+        <h4>Find a Location</h4>
+        <div class="border">
+          <?php if (isset($location_finder_copy)) : ?>
+            <div><?php print $location_finder_copy['safe_value']; ?></div>
+          <?php endif; ?>
+
+          <a class="btn secondary" href="<?php print $location_finder_url['url']; ?>" target="_blank">Locate</a>
+        </div>
+      </div>
+    <?php endif; ?>
+  </section>
+
+  <h2 id="do" class="step-header"><span class="shift">Do It</span></h2>
+  <section class="do step">
+    <h3><?php print $pre_step_header; ?></h3>
+    <div><?php print $pre_step_copy['safe_value']; ?></div>
+
+    <?php if (isset($step_pre)) : ?>
+    <div class="tip-header-wrapper">
+    <?php foreach ($step_pre as $key=>$item): ?>
+      <a href="#tip<?php print $key; ?>" class="js-show-tip tip-header <?php $key == 0 ? print ' active' : '' ?>"><?php print $item['header']; ?></a><span class="bullet">&#149;&nbsp;</span>
+    <?php endforeach; ?>
+    </div>
+
+    <div class="tip-body-wrapper">
+    <?php foreach ($step_pre as $key=>$item): ?>
+      <div class="tip-body tip<?php print $key; ?>"><?php print $item['copy'] ?></div>
+    <?php endforeach; ?>
+    </div>
+    <?php endif; ?>
+
+    <h3>Snap a Pic</h3>
+    <?php print $pic_step['safe_value']; ?>
+    <h4><?php print $post_step_header; ?></h4>
+    <div><?php print $post_step_copy; ?></div>
+
+    <!-- MODAL -->
+    <?php if (isset($step_post)) : ?>
+    <div class="cached-modal">
+    <?php foreach ($step_post as $item): ?>
+    <h3><?php print $item['header']; ?></h3>
+    <div><?php print $item['copy'] ?></div>
+    <?php endforeach; ?>
+    </div>
+    <?php endif; ?>
+  </section>
+
+  <h2 id="prove" class="step-header"><span class="shift">Prove It</span></h2>
+  <section class="prove step">
+    <div class="content">
+      <h2 class="title">Pics or It Didn't Happen</h2>
+      <div class="copy"><?php print $reportback_copy; ?></div>
+
+      <a href="#modal-report-back" class="js-modal-link btn large"><?php print $reportback_link_label; ?></a>
+      <div id="modal-report-back" class="cached-modal"><?php print render($reportback_form); ?></div>
+    </div>
+
+    <div class="js-carousel gallery">
+    <?php if (isset($reportback_image)): ?>
+      <div id="prev" class="prev-wrapper">
+        <div class="prev-button">&lt;</div>
+      </div>
+
+      <div class="slide-wrapper">
+        <?php foreach ($reportback_image as $key=>$image): ?>
+        <figure id="slide<?php print $key ?>" class="slide"><img src="<?php print $image ?>" /></figure>
+        <?php endforeach; ?>
+      </div>
+
+      <div id="next" class="next-wrapper">
+        <div class="next-button">&gt;</div>
+      </div>
+    <?php else: ?>
+    <div class="slide-wrapper">
+      <figure class="slide visible"><img src="https://trello-attachments.s3.amazonaws.com/53037337ba957ad54dc80486/53063914418de170762c28c0/62291511fcc8d763184a04a99db007b7/placeholder.jpg" alt="This could be you!" /></figure>
+      </div>
+    <?php endif; ?>
+    </div>
+  </section>
+
+  <?php if (isset($zendesk_form)): ?>
+  <?php //@todo: Modalize and link to me. ?>
+  <?php print render($zendesk_form); ?>
+  <?php endif; ?>
 </section>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -179,8 +179,8 @@
         <div id="modal-report-back" class="cached-modal"><?php print render($reportback_form); ?></div>
       </div>
 
-      <?php if (isset($reportback_image)): ?>
       <div class="js-carousel gallery">
+      <?php if (isset($reportback_image)): ?>
         <div id="prev" class="prev-wrapper">
           <div class="prev-button">&lt;</div>
         </div>
@@ -194,14 +194,17 @@
         <div id="next" class="next-wrapper">
           <div class="next-button">&gt;</div>
         </div>
-      </div>
+      <?php else: ?>
+      <div class="slide-wrapper">
+        <figure class="slide visible"><img src="https://trello-attachments.s3.amazonaws.com/53037337ba957ad54dc80486/53063914418de170762c28c0/62291511fcc8d763184a04a99db007b7/placeholder.jpg" alt="This could be you!" /></figure>
+        </div>
       <?php endif; ?>
+      </div>
     </section>
 
     <?php if (isset($zendesk_form)): ?>
     <?php //@todo: Modalize and link to me. ?>
     <?php print render($zendesk_form); ?>
     <?php endif; ?>
-
   </div>
 </section>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -181,7 +181,7 @@
     <div class="js-carousel gallery">
     <?php if (isset($reportback_image)): ?>
       <div id="prev" class="prev-wrapper">
-        <div class="prev-button">&lt;</div>
+        <div class="prev-button"><span class="arrow">&#xe605;</span></div>
       </div>
 
       <div class="slide-wrapper">
@@ -191,7 +191,7 @@
       </div>
 
       <div id="next" class="next-wrapper">
-        <div class="next-button">&gt;</div>
+        <div class="next-button"><span class="arrow">&#xe60a;</span></div>
       </div>
     <?php else: ?>
     <div class="slide-wrapper">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -195,6 +195,7 @@
       </div>
     <?php else: ?>
     <div class="slide-wrapper">
+      <?php //@TODO: Remove Trello-hosted placeholder ?>
       <figure class="slide visible"><img src="https://trello-attachments.s3.amazonaws.com/53037337ba957ad54dc80486/53063914418de170762c28c0/62291511fcc8d763184a04a99db007b7/placeholder.jpg" alt="This could be you!" /></figure>
       </div>
     <?php endif; ?>


### PR DESCRIPTION
1. If the campaign does not have any report back images associated with it, a single fallback image without pagination is displayed.
   ![default](https://f.cloud.github.com/assets/1479130/2261398/71f532f8-9e4e-11e3-9f69-78fa15223ed8.png)
2. Pagination icons are now pulled in using our icon font.
   ![pagination](https://f.cloud.github.com/assets/1479130/2261399/71f62c6c-9e4e-11e3-800b-5910f5d7435f.png)
3. Markup cleaned up.

Closes #828 
Closes #829
