### PR TITLE
drush aliases, ssh configs and ds binary update commands

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -348,3 +348,23 @@ if [[ $1 == "grunt" ]]
 then
   grunt $2
 fi
+
+#----------------------------------------------------------------------
+# update-files
+#----------------------------------------------------------------------
+if [[ $1 == "update-files" ]]
+then
+  echo "Pulling down files from staging"
+  cd $WEB_PATH
+  drush rsync @ds.staging @self -y
+fi
+
+#----------------------------------------------------------------------
+# update-db
+#----------------------------------------------------------------------
+if [[ $1 == "update-db" ]]
+then
+  echo "Pulling down db from staging"
+  cd $WEB_PATH
+  drush sql-sync @ds.staging @self -y
+fi

--- a/provision/salt/roots/salt/dosomething.sls
+++ b/provision/salt/roots/salt/dosomething.sls
@@ -5,4 +5,11 @@ drush-aliases:
     - name: /home/vagrant/.drush/ds.aliases.drushrc.php
     - source: salt://dosomething/ds.aliases.drushrc.php
 
+ssh-host-access:
+  file.managed:
+    - name: /home/vagrant/.ssh/config
+    - source: salt://ssh/config
+    - user: vagrant
+    - group: vagrant
+
 {% endif %}

--- a/provision/salt/roots/salt/dosomething.sls
+++ b/provision/salt/roots/salt/dosomething.sls
@@ -5,6 +5,11 @@ drush-aliases:
     - name: /home/vagrant/.drush/ds.aliases.drushrc.php
     - source: salt://dosomething/ds.aliases.drushrc.php
 
+drush-policy:
+  file.managed:
+    - name: /home/vagrant/.drush/policy.drush.inc
+    - source: salt://dosomething/policy.drush.inc
+
 ssh-host-access:
   file.managed:
     - name: /home/vagrant/.ssh/config

--- a/provision/salt/roots/salt/dosomething.sls
+++ b/provision/salt/roots/salt/dosomething.sls
@@ -1,0 +1,8 @@
+{% if grains['os'] == 'Ubuntu' %}
+
+drush-aliases:
+  file.managed:
+    - name: /home/vagrant/.drush/ds.aliases.drushrc.php
+    - source: salt://dosomething/ds.aliases.drushrc.php
+
+{% endif %}

--- a/provision/salt/roots/salt/dosomething/ds.aliases.drushrc.php
+++ b/provision/salt/roots/salt/dosomething/ds.aliases.drushrc.php
@@ -1,0 +1,11 @@
+<?php
+
+$aliases['staging'] = array(
+ 'uri' => 'staging.beta.dosomething.org',
+ 'root' => '/var/www/beta.dosomething.org/current/html',
+ 'remote-host' => 'staging.beta.dosomething.org',
+ 'remote-user' => 'dosomething',
+ 'path-aliases' => array(
+   '%files' => '/var/www/beta.dosomething.org/shared/files',
+ ),
+);

--- a/provision/salt/roots/salt/dosomething/policy.drush.inc
+++ b/provision/salt/roots/salt/dosomething/policy.drush.inc
@@ -1,0 +1,13 @@
+<?php
+
+function drush_policy_sql_sync_validate($source = NULL, $destination = NULL) {
+  if ($destination == '@ds.staging') {
+    return drush_set_error('POLICY_DENY', dt('You cannot overwrite the staging db from here'));
+  }
+}
+
+function drush_policy_core_rsync_validate($source, $destination, $additional_options = array()) {
+  if ($destination == '@ds.staging') {
+    return drush_set_error('POLICY_DENY', dt('You cannot overwrite the staging files from here'));
+  }
+}

--- a/provision/salt/roots/salt/install.sls
+++ b/provision/salt/roots/salt/install.sls
@@ -4,6 +4,8 @@ github-access:
   file.managed:
     - name: /home/vagrant/.ssh/known_hosts
     - source: salt://ssh/known_hosts
+    - user: vagrant
+    - group: vagrant
     - require:
       - pkg: apache2
 

--- a/provision/salt/roots/salt/ssh/config
+++ b/provision/salt/roots/salt/ssh/config
@@ -1,0 +1,2 @@
+Host *.dosomething.org
+    StrictHostKeyChecking no

--- a/provision/salt/roots/salt/top.sls
+++ b/provision/salt/roots/salt/top.sls
@@ -7,4 +7,5 @@ base:
     - install
     - composer
     - node
+    - dosomething
     - drush-ext


### PR DESCRIPTION
tldr; `ds update-db` will pull down the staging db and `ds update-files` will pull down the staging files

This merge introduces the managed drush alias file in the vagrant VM.  It gives us access to the app at the new staging environment (staging.beta).  To make this work, file ownership of the known_hosts fie needed to be granted to the vagrant user.  I also added a ssh to avoid strict host checking when ssh-ing into the staging instance.  This allows us to run drush commands against the staging instance directly from or VM.

```
drush @ds.staging cc all
drush @ds.staging fra
```

This also allows us to run rsync and sql-sync commands to quickly grab files and db from the staging instance. 

This rsync's the files from the staging instance down to the current environment.

```
drush rsync @ds.staging @self -y 
```

This pulls the db from the staging instance down to the current environment.

```
drush sql-sync @ds.staging @self -y
```

Both of these must be run from within a working drupal webroot, so /vagrant/html.

**WARNING** - These commands can be dangerous if you are not careful.  The first alias always represents the env you would like to pull from.  If you switch these up, you will bork the staging site.  So I created two convienience functions in the ds binary: `update-db` and `update-files`

**UPDATE**\* - I was able to add a drush policy file (go figure), to restrict the sync commands from overwriting the staging db and files

Do not disappoint dries
![dries-buytaert_pan_23415](https://f.cloud.github.com/assets/129360/2274082/a25d3d18-9f17-11e3-91c6-b069a3281845.jpg)

Related to: #675
