### PR TITLE
Confirmation Page

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -104,7 +104,11 @@ function dosomething_campaign_reportback_confirmation_page($node) {
   );
   // Link back to current node.
   $campaign_link_title = t('Back to @title', array('@title' => $node->title));
-  $back_to_campaign_link = l($campaign_link_title, 'node/' . $node->nid);
+  $back_to_campaign_link = l($campaign_link_title, 'node/' . $node->nid, array(
+    'attributes' => array('class' =>
+      array('btn', 'secondary', 'small')
+    ))
+  );
   // Store current node's primary cause tid.
   $tid = $wrapper->field_primary_cause->getIdentifier();
   // Get recommended campaign nids for term $tid and current user.
@@ -139,14 +143,13 @@ function dosomething_campaign_get_recommended_campaign_vars($nid) {
   $image_link = NULL;
   $image_nid = $wrapper->field_image_campaign_cover->getIdentifier();
   if ($image_nid) {
-    $image = dosomething_image_get_themed_image($image_nid, 'landscape', '740x480');
-    $image_link = l($image, $path, array('html' => TRUE));
+    $image = dosomething_image_get_themed_image_url($image_nid, 'landscape', '740x480');
   }
   return array(
     'nid' => $wrapper->getIdentifier(),
     'title' => l($wrapper->label(), $path),
     'call_to_action' => $wrapper->field_call_to_action->value(),
-    'image' => $image_link,
+    'image' => $image,
   );
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -26,6 +26,7 @@
 @import "feature/campaign";
 @import "feature/pitch";
 @import "feature/action";
+@import "feature/confirmation";
 
 // Content Pages
 @import "feature/content";

--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/_confirmation.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/_confirmation.scss
@@ -1,0 +1,65 @@
+.confirmation--wrapper {
+
+  // --------
+  //  Layout
+  // --------
+
+  header.header,
+  section.campaigns {
+    overflow: auto;
+
+    .content {
+      @include media($tablet) {
+        @include span-columns(12);
+        @include shift(2);
+      }
+    }
+
+    .btn {
+      float: left;
+    }
+
+    .btn.secondary {
+      margin: 1.5rem 0 0 0;
+
+      a {
+        text-decoration: none;
+        color: #555;
+        display: block;
+      }
+    }
+  }
+
+
+  // ----------
+  //  Sections
+  // ----------
+
+  header.header {
+    padding: 144px 0 96px;
+    background: $purple;
+
+    h1, p {
+      color: #fff;
+    }
+  }
+
+  section.campaigns {
+    padding: 96px 0;
+
+    h3.title a {
+      text-decoration: none;
+    }
+  }
+
+  div.campaign {
+    @include media($tablet) {
+      @include span-columns(4 of 12);
+    }
+
+    img {
+      width: 100%;
+    }
+  }
+
+}

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
@@ -1,19 +1,24 @@
-<h1>You Did It!</h1>
+<section class="confirmation--wrapper">
+  <header class="header">
+    <div class="content">
+      <h1>You Did It!</h1>
+      <p><?php print $copy; ?></p>
+      <?php print $more_campaigns_link; ?>
+      <?php print $back_to_campaign_link; ?>
+    </div>
+  </header>
 
-<p><?php print $copy; ?></p>
-
-<?php print $more_campaigns_link; ?>
-
-<?php print $back_to_campaign_link; ?>
-
-<div class="row">
-<?php foreach ($recommended as $rec): ?>
-  <div class="column span_4">
-    <?php if (isset($rec['image'])): ?>
-      <?php print $rec['image']; ?>
-    <?php endif; ?>
-    <h3><?php print $rec['title']; ?></h3>
-    <p><?php print $rec['call_to_action']; ?></p>
-  </div>
-<?php endforeach; ?>
-</div>
+  <section class="campaigns">
+    <div class="content">
+    <?php foreach ($recommended as $rec): ?>
+      <div class="campaign">
+        <h3 class="title"><?php print $rec['title']; ?></h3>
+        <?php if (isset($rec['image'])): ?>
+        <figure class="image"><img src="<?php print $rec['image']; ?>" alt="Campaign Image" /></figure>
+        <?php endif; ?>
+        <p><?php print $rec['call_to_action']; ?></p>
+      </div>
+    <?php endforeach; ?>
+    </div>
+  </section>
+</section>


### PR DESCRIPTION
First pass at the confirmation page. Kept this quick and dirty for the initial version. Mobile styles to come.

![confirmation](https://f.cloud.github.com/assets/1479130/2286824/da309784-9fe5-11e3-8346-c07eb7d77d71.png)

Resolves #863
Resolves #862
