### PR TITLE
Zendesk lib

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -70,6 +70,9 @@ ds build [--install]
   --install
     Runs "drush site-install" to actually install the Drupal instance.
 
+ds composer
+  Installs libraries via Composer within the Drupal libraries directory.
+
 ds grunt [--watch]
   Installs Bower dependencies & compiles front-end assets (SCSS/JS) using Grunt.
 
@@ -115,6 +118,9 @@ function build {
   echo 'Linking themes'
   rm -rf "$WEB_PATH/profiles/dosomething/themes/dosomething/paraneue_dosomething"
   ln -s "$LIB_PATH/themes/dosomething/paraneue_dosomething" "$WEB_PATH/profiles/dosomething/themes/dosomething/paraneue_dosomething"
+
+  echo 'Install composer dependencies'
+  composer
 
   echo 'Install bower dependencies'
   bower
@@ -238,6 +244,23 @@ function deploy {
 }
 
 #=== FUNCTION ==================================================================
+# NAME: composer
+# DESCRIPTION: Installs/Updates comopser dependencies
+#===============================================================================
+function composer {
+  if hash composer 2>/dev/null;
+  then
+    cd $WEB_PATH/profiles/dosomething/libraries/zendesk
+    echo -e "\e[4mInstalling composer dependencies for Zendesk...\e[0m"
+    eval "/usr/local/bin/composer install"
+
+    cd $BASE_PATH
+
+  fi
+}
+
+
+#=== FUNCTION ==================================================================
 # NAME: bower
 # DESCRIPTION: Installs/Updates bower dependencies
 #===============================================================================
@@ -331,6 +354,14 @@ fi
 if [[ $1 == "deploy" ]]
 then
   deploy
+fi
+
+#----------------------------------------------------------------------
+# composer
+#----------------------------------------------------------------------
+if [[ $1 == "composer" ]]
+then
+  composer
 fi
 
 #----------------------------------------------------------------------

--- a/bin/ds
+++ b/bin/ds
@@ -245,7 +245,7 @@ function deploy {
 
 #=== FUNCTION ==================================================================
 # NAME: composer
-# DESCRIPTION: Installs/Updates comopser dependencies
+# DESCRIPTION: Installs/Updates composer dependencies
 #===============================================================================
 function composer {
   if hash composer 2>/dev/null;

--- a/lib/modules/dosomething/dosomething_zendesk/README.md
+++ b/lib/modules/dosomething/dosomething_zendesk/README.md
@@ -1,0 +1,22 @@
+# DoSomething Zendesk
+
+A module to interact with the Zendesk PHP API Client Library:
+
+https://github.com/zendesk/zendesk_api_client_php
+
+## Installation
+
+Composer must be installed in order install the PHP library.
+
+The repository https://github.com/zendesk/zendesk_api_client_php should be
+cloned into the Drupal libraries directory with directory name "zendesk".
+
+Within the libraries/zendesk directory, run `composer install` to install the
+Zendesk PHP API library.  This will generate a vendor/autoload.php file, which
+`dosomething_zendesk_libraries_info` references to load the Zendesk PHP API
+Client Library.
+
+## Usage
+
+The `dosomething_zendesk_form` will create a new Zendesk ticket, setting the
+ticket requester as the currently logged in user.

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.info
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.info
@@ -2,3 +2,5 @@ name = DoSomething Zendesk
 description = Functionality for Zendesk integration.
 core = 7.x
 package = DoSomething
+configure = admin/config/services/dosomething_zendesk
+files[] = dosomething_zendesk.test

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -138,12 +138,12 @@ function dosomething_zendesk_get_ticket_array($values) {
   $keys = array('email', 'subject', 'body');
   // Loop through $values to make sure all keys are present.
   foreach ($keys as $key) {
-    if (!isset($values['key'])) {
+    if (!isset($values[$key])) {
       // Return FALSE if key is not present.
       return FALSE;
     }
   }
-  // Return
+  // Return expected format for Ticket creation.
   return array(
     'requester' => array(
       'email' => $values['email'],

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -4,11 +4,6 @@
  * Code for the DoSomething Zendesk module.
  */
 
-// @todo: Figure this out so we don't need to declare this.
-// This will break everything if the library is not installed.
-// Namespace to allow use of ZendeskAPI class.
-use Zendesk\API\Client as ZendeskAPI;
-
 /**
  * Implements hook_menu().
  */
@@ -53,7 +48,7 @@ function dosomething_zendesk_get_client() {
   $subdomain = variable_get('dosomething_zendesk_subdomain');
   $username = variable_get('dosomething_zendesk_username');
   $token = variable_get('dosomething_zendesk_token');
-  $client = new ZendeskAPI($subdomain, $username);
+  $client = new Zendesk\API\Client($subdomain, $username);
   $client->setAuth('token', $token);
   return $client;
 }

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -102,9 +102,9 @@ function dosomething_zendesk_form_submit($form, &$form_state) {
  *   Whether or not API request was successful.
  */
 function dosomething_zendesk_create_ticket($values) {
-  if ($client = dosomething_zendesk_get_client()) {
-    // Get expected format for a create Ticket request.
-    $ticket = dosomething_zendesk_get_ticket_array($values);
+  // Get expected format for a create Ticket request.
+  $ticket = dosomething_zendesk_get_ticket_array($values);
+  if ($ticket && $client = dosomething_zendesk_get_client()) {
     // Submit API request to create ticket.
     try {
       $client->tickets()->create($ticket);
@@ -128,10 +128,22 @@ function dosomething_zendesk_create_ticket($values) {
  *     - subject: Subject of the ticket.
  *     - body: Body of the ticket.
  *
- * @return array
- *   An array with expected keys and values for the Zendesk Tickets API.
+ * @return mixed
+ *   FALSE if an expected key is not persent, otherwise an array with
+ *   expected keys and values for submitting to Zendesk Tickets API.
+ *
  */
 function dosomething_zendesk_get_ticket_array($values) {
+  // List expected array keys.
+  $keys = array('email', 'subject', 'body');
+  // Loop through $values to make sure all keys are present.
+  foreach ($keys as $key) {
+    if (!isset($values['key'])) {
+      // Return FALSE if key is not present.
+      return FALSE;
+    }
+  }
+  // Return
   return array(
     'requester' => array(
       'email' => $values['email'],

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -4,6 +4,8 @@
  * Code for the DoSomething Zendesk module.
  */
 
+// @todo: Figure this out so we don't need to declare this.
+// This will break everything if the library is not installed.
 // Namespace to allow use of ZendeskAPI class.
 use Zendesk\API\Client as ZendeskAPI;
 
@@ -29,10 +31,10 @@ function dosomething_zendesk_menu() {
 function dosomething_zendesk_libraries_info() {
   $libraries['zendesk'] = array(
     'name' => 'Zendesk',
-    'path' => 'lib',
+    'path' => 'vendor',
     'files' => array(
       'php' => array(
-        'ZenDesk.php'
+        'autoload.php'
       ),
     ),
     'version' => 1

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.test
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.test
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @file
+ * Tests for dosomething_zendesk.module.
+ */
+
+class DoSomethingZendeskUnitTestCase extends DrupalUnitTestCase {
+  // Required to test inside the DoSomething profile:
+  protected $profile = 'dosomething';
+
+  public static function getInfo() {
+    return array(
+      'name' => 'DoSomething Zendesk Unit Tests',
+      'description' => 'Unit tests for dosomething_zendesk module.',
+      'group' => 'DoSomething',
+    );
+  }
+
+  /**
+   * Test for dosomething_zendesk_get_ticket_array().
+   */
+  public function testGetTicketArray() {
+    // Initialize test values.
+    $values = array(
+      'email' => 'dosomething@example.com',
+      'subject' => 'Question about Batman',
+      'body' => "Hi, I was wondering why Batman is so awesome.",
+    );
+    $ticket = dosomething_zendesk_get_ticket_array($values);
+    $this->assertTrue(is_array($ticket), "An array was returned.");
+    $this->assertEqual($ticket['requester']['email'], $values['email']);
+    $this->assertEqual($ticket['subject'], $values['email']);
+    $this->assertEqual($ticket['comment']['body'], $values['body']);
+  }
+
+}

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -67,3 +67,5 @@ dependencies[] = dosomething_signup
 dependencies[] = dosomething_static_content
 dependencies[] = dosomething_taxonomy
 dependencies[] = dosomething_user
+dependencies[] = dosomething_zendesk
+

--- a/lib/profiles/dosomething/dosomething.make
+++ b/lib/profiles/dosomething/dosomething.make
@@ -84,6 +84,12 @@ projects[dosomething_user][download][type] = local
 projects[dosomething_user][download][source] = './lib/modules/dosomething/dosomething_user'
 projects[dosomething_user][subdir] = "dosomething"
 
+; Dosomething Zendesk
+projects[dosomething_zendesk][type] = "module"
+projects[dosomething_zendesk][download][type] = local
+projects[dosomething_zendesk][download][source] = './lib/modules/dosomething/dosomething_zendesk'
+projects[dosomething_zendesk][subdir] = "dosomething"
+
 ; THEMES
 ; Paraneue Dosomething
 projects[paraneue_dosomething][type] = "theme"

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -188,3 +188,7 @@ libraries[mobilecommons-php][download][url] = "https://github.com/DoSomething/mo
 ; DSAPI PHP Library
 ;libraries[dsapi][download][type] = "git"
 ;libraries[dsapi][download][url] = "git@github.com:DoSomething/dsapi-php.git"
+
+; Zendesk PHP
+libraries[zendesk][download][type] = "git"
+libraries[zendesk][download][url] = "https://github.com/zendesk/zendesk_api_client_php"


### PR DESCRIPTION
Adds the Zendesk library into the Dosomething profile's libraries directory. 
- You'll need to run a new `ds build` in order to install the library and make use of the `dosomething_zendesk` module.

Fixes #796 with a `ds composer` method and wiki docs: https://github.com/DoSomething/dosomething/wiki/DoSomething-modules#wiki-libraries

Fixes #797 by changing `dosomething_zendesk_libraries_info` to relevant `vendor/autoload.php`

Closes #770 with fully functional Zendesk ticket form (upon enabling dosomething_zendesk and configuring the auth variables)
