### PR TITLE
Updating default solr settings

### DIFF
--- a/config/default.settings.local.php
+++ b/config/default.settings.local.php
@@ -52,3 +52,9 @@ $conf['varnish_control_key'] = '00c9203c65874ca5b4c359e19f00bf56';
 // Drupal 7 does not cache pages when we invoke hooks during bootstrap.
 // This needs to be disabled.
 $conf['page_cache_invoke_hooks'] = FALSE;
+
+// These settings 
+$conf['apachesolr_host'] = '192.168.1.169';
+$conf['apachesolr_port'] = '8008';
+$conf['apachesolr_path'] = '/solr/collection1';
+$conf['apachesolr_read_only'] = 1;

--- a/config/default.settings.local.php
+++ b/config/default.settings.local.php
@@ -53,7 +53,7 @@ $conf['varnish_control_key'] = '00c9203c65874ca5b4c359e19f00bf56';
 // This needs to be disabled.
 $conf['page_cache_invoke_hooks'] = FALSE;
 
-// These settings 
+// These settings point to the solr instance on staging.
 $conf['apachesolr_host'] = '192.168.1.169';
 $conf['apachesolr_port'] = '8008';
 $conf['apachesolr_path'] = '/solr/collection1';

--- a/lib/modules/dosomething/dosomething_search/dosomething_search.apachesolr_environments.inc
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.apachesolr_environments.inc
@@ -10,9 +10,9 @@
 function dosomething_search_apachesolr_environments() {
   $export = array();
 
-  $host = variable_get('apachesolr_host', '10.179.104.149');
-  $port = variable_get('apachesolr_port', '8000');
-  $path = variable_get('apachesolr_path', '\\/sorl');
+  $host = variable_get('apachesolr_host', '192.168.1.169');
+  $port = variable_get('apachesolr_port', '8080');
+  $path = variable_get('apachesolr_path', 'solr/collection1');
 
   $environment = new stdClass();
   $environment->api_version = 1;


### PR DESCRIPTION
- Adding default solr settings that point to the staging
  solr instance to avoid drush/solr errors when building in
  dev environments.

Fixes #794
