### PR TITLE
Sponsors vars - Part 2

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -238,8 +238,12 @@ function dosomething_campaign_preprocess_node(&$vars) {
     }
 
     if (isset($vars['field_partners'])) {
-      // Temp fix until we preprocess the field_partners field collection.
-      $vars['sponsors'] = array();
+      // Returns partners, sponsors, and partner_info arrays.
+      $partners_vars = dosomething_taxonomy_get_partners_vars($vars['nid']);
+      // Gather any returned arrays.
+      foreach ($partners_vars as $key => $values) {
+        $vars[$key] = $values;
+      }
     }
 
     if ($vars['view_mode'] == 'pitch') {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -241,8 +241,12 @@ function dosomething_campaign_preprocess_node(&$vars) {
     }
 
     if (isset($vars['field_partners'])) {
-      // Temp fix until we preprocess the field_partners field collection.
-      $vars['sponsors'] = array();
+      // Returns partners, sponsors, and partner_info arrays.
+      $partners_vars = dosomething_taxonomy_get_partners_vars($vars['nid']);
+      // Gather any returned arrays.
+      foreach ($partners_vars as $key => $values) {
+        $vars[$key] = $values;
+      }
     }
 
     if ($vars['view_mode'] == 'pitch') {

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -11,20 +11,53 @@
  *   An entity_metadata_wrapper object.
  *
  * @return mixed
- *   Multi-dimensional array of sponsor data or NULL if empty.
+ *   Multi-dimensional array of partners/sponsors, or NULL if empty.
  *
  */
-function dosomething_taxonomy_get_sponsors($sponsor_field_wrapper) {
+function dosomething_taxonomy_get_partners_vars($nid) {
+  $wrapper = entity_metadata_wrapper('node', $nid);
+
+  // Intialize return arrays.
+  $partners = array();
   $sponsors = array();
-  foreach ($sponsor_field_wrapper->getIterator() as $delta => $term_wrapper) {
-    $sponsors[$delta]['name']  = $term_wrapper->name->value();
-    if (property_exists($term_wrapper->field_image_sponsor_logo, 'nid')) {
-      $sponsor_img_nid =  $term_wrapper->field_image_sponsor_logo->value()->nid;
-      $sponsors[$delta]['img'] = dosomething_image_get_themed_image($sponsor_img_nid, 'sq', '310x310');
+  $partner_info = array();
+  $info_count = 0;
+
+  // Loop through field collection items.
+  foreach ($wrapper->field_partners->value() as $delta => $item) {
+    $fc_item = entity_metadata_wrapper('field_collection_item', $item);
+
+    // Store partner term data.
+    $term = taxonomy_term_load($fc_item->field_partner->value()->tid);
+    $term_wrapper = entity_metadata_wrapper('taxonomy_term', $term);
+    $partners[$delta]['tid'] = $term_wrapper->getIdentifier();
+    $partners[$delta]['name'] = $term_wrapper->label();
+    if ($logo = $term_wrapper->field_partner_logo->value()) {
+      $partners[$delta]['logo'] = $logo['fid'];
     }
+
+    // If partner is a sponsor, add into sponsors array.
+    if ($fc_item->field_is_sponsor->value()) {
+      $sponsors[] = $partners[$delta];
+    }
+
+    // If copy exists, add it and relevant image/video into the partner_info array.
+    if ($copy = $fc_item->field_partner_copy->value()) {
+      $partner_info[$info_count] = $partners[$delta];
+      $partner_info[$info_count]['copy'] = $copy['safe_value'];
+      $partner_info[$info_count]['image'] = $fc_item->field_image_partner->value();
+      $partner_info[$info_count]['video'] = $fc_item->field_video->value();
+      $info_count++;
+    }
+
+
   }
-  if (!empty($sponsors)) {
-    return $sponsors;
+  if (!empty($partners)) {
+    return array(
+      'partners' => $partners,
+      'sponsors' => $sponsors,
+      'partner_info' => $partner_info,
+    );
   }
   return NULL;
 }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -7,6 +7,7 @@
 
       <?php if (isset($sponsors)): ?>
       <div class="sponsor">
+        Powered by
         <?php foreach ($sponsors as $key => $sponsor) :?>
           <?php print $sponsor['name']; ?>
           <?php // print $sponsor['img']; ?>
@@ -62,6 +63,17 @@
         </div>
       <?php endforeach; ?>
       </div>
+      <?php endif; ?>
+
+      <?php if (isset($partner_info)): ?>
+      <?php foreach ($partner_info as $delta => $partner): ?>
+        <a href="#modal-partner-<?php print $delta; ?>" class="js-modal-link">
+          Why we <3 <?php print $partner['name']; ?>
+        </a>
+        <div id="modal-partner-<?php print $delta; ?>" class="cached-modal">
+          <?php print $partner['copy']; ?>
+        </div>
+      <?php endforeach; ?>
       <?php endif; ?>
 
     </div>
@@ -238,6 +250,15 @@
       </div>
     <?php endif; ?>
     </div>
+
+    <?php if (isset($sponsors)): ?>
+    <div class="sponsor">
+      In partnership with
+      <?php foreach ($partners as $key => $partner) :?>
+        <?php print $partner['name']; ?>
+      <?php endforeach; ?>
+    </div>
+    <?php endif; ?>
 
     <footer class="help">
       <!-- @TODO - This is a placeholder. Remove once Zen Desk is working. -->

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -7,6 +7,7 @@
 
       <?php if (isset($sponsors)): ?>
       <div class="sponsor">
+        Powered by
         <?php foreach ($sponsors as $key => $sponsor) :?>
           <?php print $sponsor['name']; ?>
           <?php // print $sponsor['img']; ?>
@@ -58,6 +59,17 @@
         </div>
       <?php endforeach; ?>
       </div>
+      <?php endif; ?>
+
+      <?php if (isset($partner_info)): ?>
+      <?php foreach ($partner_info as $delta => $partner): ?>
+        <a href="#modal-partner-<?php print $delta; ?>" class="js-modal-link">
+          Why we <3 <?php print $partner['name']; ?>
+        </a>
+        <div id="modal-partner-<?php print $delta; ?>" class="cached-modal">
+          <?php print $partner['copy']; ?>
+        </div>
+      <?php endforeach; ?>
       <?php endif; ?>
 
     </div>
@@ -226,6 +238,15 @@
     <?php endif; ?>
     </div>
   </section>
+
+  <?php if (isset($sponsors)): ?>
+  <div class="sponsor">
+    In partnership with
+    <?php foreach ($partners as $key => $partner) :?>
+      <?php print $partner['name']; ?>
+    <?php endforeach; ?>
+  </div>
+  <?php endif; ?>
 
   <?php if (isset($zendesk_form)): ?>
   <?php //@todo: Modalize and link to me. ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -41,6 +41,7 @@
         <li><a href="#modal-faq" class="js-modal-link">Check out our FAQs</a></li>
       </ul>
       <div id="modal-faq" class="cached-modal">
+        <a href="#" class="js-close-modal modal-close-button">×</a>
         <?php foreach ($faq as $item): ?>
           <h4 class="faq-header"><?php print $item['header']; ?></h4>
           <div class="faq-copy"><?php print $item['copy'] ?></div>
@@ -53,15 +54,16 @@
         <li><a href="#modal-facts" class="js-modal-link">Learn more about <?php print $issue; ?></a></li>
       </ul>
       <div id="modal-facts" class="cached-modal">
-      <?php foreach ($more_facts as $fact): ?>
-        <div class="fact-more">
-          <div class="fact-more"><?php print $fact['fact']; ?></div>
-          <?php // @TODO: Output sources separately.  ?>
-          <?php foreach ($fact['sources'] as $source): ?>
-            <div class="legal"><p>Source:</p><?php print $source; ?></div>
-          <?php endforeach; ?>
-        </div>
-      <?php endforeach; ?>
+        <a href="#" class="js-close-modal modal-close-button">×</a>
+        <?php foreach ($more_facts as $fact): ?>
+          <div class="fact-more">
+            <div class="fact-more"><?php print $fact['fact']; ?></div>
+            <?php // @TODO: Output sources separately.  ?>
+            <?php foreach ($fact['sources'] as $source): ?>
+              <div class="legal"><p>Source:</p><?php print $source; ?></div>
+            <?php endforeach; ?>
+          </div>
+        <?php endforeach; ?>
       </div>
       <?php endif; ?>
 
@@ -71,6 +73,7 @@
           Why we <3 <?php print $partner['name']; ?>
         </a>
         <div id="modal-partner-<?php print $delta; ?>" class="cached-modal">
+          <a href="#" class="js-close-modal modal-close-button">×</a>
           <?php print $partner['copy']; ?>
         </div>
       <?php endforeach; ?>
@@ -225,7 +228,10 @@
       <div class="copy"><?php print $reportback_copy; ?></div>
 
       <a href="#modal-report-back" class="js-modal-link btn large"><?php print $reportback_link_label; ?></a>
-      <div id="modal-report-back" class="cached-modal"><?php print render($reportback_form); ?></div>
+      <div id="modal-report-back" class="cached-modal">
+        <a href="#" class="js-close-modal modal-close-button">×</a>
+        <?php print render($reportback_form); ?>
+      </div>
     </div>
 
     <div class="js-carousel gallery">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -39,6 +39,7 @@
       <?php if (isset($faq)): ?>
       <a href="#modal-faq" class="js-modal-link">Check out our FAQs</a>
       <div id="modal-faq" class="cached-modal">
+        <a href="#" class="js-close-modal modal-close-button">×</a>
         <?php foreach ($faq as $item): ?>
           <h4 class="faq-header"><?php print $item['header']; ?></h4>
           <div class="faq-copy"><?php print $item['copy'] ?></div>
@@ -49,15 +50,16 @@
       <?php if (isset($more_facts)): ?>
       <a href="#modal-facts" class="js-modal-link">Learn more about <?php print $issue; ?></a>
       <div id="modal-facts" class="cached-modal">
-      <?php foreach ($more_facts as $fact): ?>
-        <div class="fact-more">
-          <div class="fact-more"><?php print $fact['fact']; ?></div>
-          <?php // @TODO: Output sources separately.  ?>
-          <?php foreach ($fact['sources'] as $source): ?>
-            <div class="legal"><p>Source:</p><?php print $source; ?></div>
-          <?php endforeach; ?>
-        </div>
-      <?php endforeach; ?>
+        <a href="#" class="js-close-modal modal-close-button">×</a>
+        <?php foreach ($more_facts as $fact): ?>
+          <div class="fact-more">
+            <div class="fact-more"><?php print $fact['fact']; ?></div>
+            <?php // @TODO: Output sources separately.  ?>
+            <?php foreach ($fact['sources'] as $source): ?>
+              <div class="legal"><p>Source:</p><?php print $source; ?></div>
+            <?php endforeach; ?>
+          </div>
+        <?php endforeach; ?>
       </div>
       <?php endif; ?>
 
@@ -67,6 +69,7 @@
           Why we <3 <?php print $partner['name']; ?>
         </a>
         <div id="modal-partner-<?php print $delta; ?>" class="cached-modal">
+          <a href="#" class="js-close-modal modal-close-button">×</a>
           <?php print $partner['copy']; ?>
         </div>
       <?php endforeach; ?>
@@ -212,7 +215,10 @@
       <div class="copy"><?php print $reportback_copy; ?></div>
 
       <a href="#modal-report-back" class="js-modal-link btn large"><?php print $reportback_link_label; ?></a>
-      <div id="modal-report-back" class="cached-modal"><?php print render($reportback_form); ?></div>
+      <div id="modal-report-back" class="cached-modal">
+        <a href="#" class="js-close-modal modal-close-button">×</a>
+        <?php print render($reportback_form); ?>
+      </div>
     </div>
 
     <div class="js-carousel gallery">


### PR DESCRIPTION
New PR to avoid merge conflict hell.

Refs #768

Fixes #755

Adds dosomething_taxonomy_get_partners_vars to preprocess the field_partners field collection. This function returns three arrays:

partners: All partner terms associated with a node
sponsors: All partner terms associated with a node as Sponsors
partner_info: Variables for each partner/sponsor modal
Outputs each array into the campaign template.

TODO: Preprocess the sponsor logos, and modal image/video fields.
