### PR TITLE
Fact Footnotes

### DIFF
--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -39,29 +39,39 @@ function dosomething_fact_node_view($node, $view_mode, $langcode) {
  * @param object $fact_field_wrapper
  *   A Fact entityreference field as returned by entity_metadata_wrapper.
  *   e.g. dosomething_fact_get_fact_wrapper_values($wrapper->field_fact_problem)
+ * @param int $source_index
+ *   The array key from which the return sources should begin counting.
  *
  * @return mixed
- *   Array of fact values, or NULL if not a valid wrapper property.
- *
+ *   Multi-dimensional array of facts and their sources.
  */
-function dosomething_fact_get_fact_field_wrapper_values($fact_field_wrapper) {
+function dosomething_fact_get_fact_field_wrapper_values($fact_field_wrapper, $source_index = 0) {
   // Make sure $fact_field_wrapper is an object.
-  if (is_object($fact_field_wrapper)) {
-    // If EntityDrupalWrapper, it's a single value field:
-    if (get_class($fact_field_wrapper) == 'EntityDrupalWrapper') {
-      return dosomething_fact_get_fact_wrapper_values($fact_field_wrapper);
-    }
-    // If EntityListWrapper, it's a multi-value field:
-    if (get_class($fact_field_wrapper) == 'EntityListWrapper') {
-      $values = array();
-      foreach ($fact_field_wrapper->getIterator() as $delta => $fact) {
-        $values[] = dosomething_fact_get_fact_wrapper_values($fact);
-      }
-      return $values;
-    }
+  if (!is_object($fact_field_wrapper)) { return NULL; }
+
+  $field_class = get_class($fact_field_wrapper);
+
+  // If EntityDrupalWrapper, single value field:
+  if ($field_class == 'EntityDrupalWrapper') {
+    return dosomething_fact_get_fact_wrapper_values($fact_field_wrapper, $source_index);
   }
-  // Return NULL as default.
-  return NULL;
+  // If EntityListWrapper, multi-value field:
+  if ($field_class == 'EntityListWrapper') {
+    $values = array();
+    $i = 0;
+    foreach ($fact_field_wrapper->getIterator() as $delta => $fact) {
+      // Gather fact vars.
+      $fact = dosomething_fact_get_fact_wrapper_values($fact, $i);
+      // Add into return array.
+      $values['facts'][] = $fact;
+      // Append sources.
+      foreach ($fact['sources'] as $key => $source) {
+        $values['sources'][$key] = $source;
+        $i++;
+      }
+    }
+    return $values;
+  }
 }
 
 /**
@@ -69,19 +79,31 @@ function dosomething_fact_get_fact_field_wrapper_values($fact_field_wrapper) {
  *
  * @param object $fact_wrapper
  *   A Fact node entity_metadata_wrapper.
+ * @param int $source_index
+ *   The array key from which the return sources should begin counting.
  *
  * @return array
- *   Multi-dimensional of fact markdown values.
- *
+ *   Array of a fact with keys:
+ *   - copy: The fact copy.
+ *   - footnotes: string of footnote numbers corresponding to fact sources
+ *   - sources: an array which beings indexing from given $source_index.
  */
-function dosomething_fact_get_fact_wrapper_values($fact_wrapper) {
+function dosomething_fact_get_fact_wrapper_values($fact_wrapper, $source_index = 0) {
+  // Initialize sources and footnotes return arrays.
+  $footnotes = array();
   $sources = array();
-  // Loop through sources multi-value field:
+  // Loop through field_source_copy multi-values:
   foreach ($fact_wrapper->field_source_copy->value() as $delta => $source) {
-    $sources[] = $source['safe_value'];
+    // Store source safe_value for index $source_index.
+    $sources[$source_index] = $source['safe_value'];
+    // Add 1 to footnote display because $source_index is zero based.
+    $footnotes[] = $source_index + 1;
+    // Increment to count the next source.
+    $source_index++;
   }
   return array(
     'fact' => $fact_wrapper->title->value(),
+    'footnotes' => implode(' ', $footnotes),
     'sources' => $sources,
   );
 }

--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
@@ -50,7 +50,8 @@ function dosomething_fact_page_preprocess_node(&$vars) {
     if ($node->field_video->value()) {
       $vars['intro_video'] = theme('dosomething_video_embed', array('field' => $node->field_video->value()));
     }
-
-    $vars['facts'] = dosomething_fact_get_fact_field_wrapper_values($node->field_facts);
+    $values = dosomething_fact_get_fact_field_wrapper_values($node->field_facts);
+    $vars['facts'] = $values['facts'];
+    $vars['sources'] = $values['sources'];
   }
 }

--- a/lib/modules/dosomething/dosomething_fact_page/node--fact_page.tpl.php
+++ b/lib/modules/dosomething/dosomething_fact_page/node--fact_page.tpl.php
@@ -18,21 +18,26 @@
   <?php if (isset($intro_image)): ?>
     <?php print $intro_image; ?>
   <?php elseif ($intro_video): ?>
-    <?php print $intro_video; ?>
+    <?php //print $intro_video; ?>
   <?php endif; ?>
   <br/>
+
   <?php if (isset($facts)): ?>
     <?php foreach ($facts as $key => $fact): ?>
-      <?php print '#' . ($key + 1) . ' ' . $fact['fact']; ?>
-      <?php if (is_array($fact['sources'])): ?>
-        <?php foreach ($fact['sources'] as $source): ?>
-          <p class="legal">Source: <?php print $source; ?></p>
-        <?php endforeach; ?>
-      <?php elseif (isset($fact['source'])): ?>
-         <p class="legal">Source: <?php print $fact['source']; ?></p>
-      <?php endif; ?>
+      <p>
+        <?php print ($key + 1) . '. ' . $fact['fact']; ?>
+        <sup><?php print $fact['footnotes']; ?></sup>
+      </p>
     <?php endforeach; ?>
   <?php endif; ?>
+
+  <?php if (isset($sources)): ?>
+    <h4>Sources</h4>
+    <?php foreach ($sources as $key => $source): ?>
+      <p><sup><?php print ($key + 1); ?></sup> <?php print $source; ?></p>
+    <?php endforeach; ?>
+  <?php endif; ?>
+
 
   <?php if (isset($call_to_action)): ?>
     <div class="cta">


### PR DESCRIPTION
Fixes #918

![footnotes](http://genre-x.com/wp-content/uploads/2011/09/kevin-bacon_380_1332094a.jpg)

Makes changes to get_fact_values functions to return an array of footnotes, along with the fact and a corresponding array of the fact's sources.  Changes:

`dosomething_fact_get_fact_wrapper_values`
- Adds a `$source_index` argument, to specify what number to start counting sources
- Returns an additional `footnotes` array with a given fact, starting from `$source_index`
- Indexes `sources` array starting from `$source_index`

`dosomething_fact_get_fact_field_wrapper_values`
- Adds the `$source_index` argument
- Returns a multi-dimensional array
  - `facts` = an array of facts. each fact: `array('fact' => 'This is the title', 'footnotes' => '2 3 4')`
  - `sources` = an array of sources.

This allows printing the sources on the bottom of a page, with the indexing matching the values in the footnotes values for each fact.

Updates the Fact Page to output fact footnotes and sources at the bottom of the page.
