### PR TITLE
Initial pass at dosomething_sms module

### DIFF
--- a/lib/modules/dosomething/dosomething_sms/dosomething_sms.info
+++ b/lib/modules/dosomething/dosomething_sms/dosomething_sms.info
@@ -1,0 +1,6 @@
+name = DoSomething SMS
+description = Provides SMS integration for DoSomething.org
+core = 7.x
+dependencies[] = conductor_sms
+package = DoSomething
+configure = admin/config/dosomething/dosomething_sms

--- a/lib/modules/dosomething/dosomething_sms/dosomething_sms.install
+++ b/lib/modules/dosomething/dosomething_sms/dosomething_sms.install
@@ -40,55 +40,5 @@ function dosomething_sms_schema() {
     ),
   );
 
-  $schema['dosomething_sms_invite_records'] = array(
-    'description' => 'Stores alphas and betas who go through the SMS flow.',
-    'primary key' => array('sid'),
-    'fields' => array(
-      'sid' => array(
-        'description' => 'The id of the record.',
-        'type' => 'serial',
-        'unsigned' => true,
-        'not null' => true,
-      ),
-      'alpha' => array(
-        'description' => 'The alpha\'s phone number.',
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => true,
-      ),
-      'beta' => array(
-        'description' => 'The beta\'s phone number.',
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => true,
-      ),
-      'type' => array(
-        'description' => 'The type of object that the beta has been invited to.',
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => true
-      ),
-      'nid' => array(
-        'description' => 'The ID of the page / whatever that the person was invited to.',
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'not null' => TRUE
-      ),
-      'accepted_invite' => array(
-        'description' => 'Whether or not the user accepted the invitation.',
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'default' => 0,
-        'not null' => TRUE,
-      ),
-      'timestamp' => array(
-        'description' => 'The time that it all began...',
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'not null' => TRUE
-      )
-    ),
-  );
-
   return $schema;
 }

--- a/lib/modules/dosomething/dosomething_sms/dosomething_sms.install
+++ b/lib/modules/dosomething/dosomething_sms/dosomething_sms.install
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * Install/Update/Uninstall functions for dosomething_sms module
+ * Installation and schema hooks for dosomething_sms.module.
  */
 
 /**

--- a/lib/modules/dosomething/dosomething_sms/dosomething_sms.install
+++ b/lib/modules/dosomething/dosomething_sms/dosomething_sms.install
@@ -1,0 +1,94 @@
+<?php
+/**
+ * @file
+ * Install/Update/Uninstall functions for dosomething_sms module
+ */
+
+/**
+ * Define the table schemas used for this module.
+ */
+function dosomething_sms_schema() {
+  $schema = array();
+
+  $schema['dosomething_sms_game'] = array(
+    'description' => 'Stores details to SMS games relative to a user / unique phone number.',
+    'fields' => array(
+      'game_id' => array(
+        'description' => 'Unique identifier for the game/quiz.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE
+      ),
+      'phone' => array(
+        'description' => 'Phone number',
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => true
+      ),
+      'started_paths' => array(
+        'description' => 'Serialized array of opt-in paths that the user has been sent to.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => true
+      ),
+      'answers' => array(
+        'description' => 'Serialized struct of answers given by the user {optin-path: {array of answers}}',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => true
+      ),
+    ),
+  );
+
+  $schema['dosomething_sms_invite_records'] = array(
+    'description' => 'Stores alphas and betas who go through the SMS flow.',
+    'primary key' => array('sid'),
+    'fields' => array(
+      'sid' => array(
+        'description' => 'The id of the record.',
+        'type' => 'serial',
+        'unsigned' => true,
+        'not null' => true,
+      ),
+      'alpha' => array(
+        'description' => 'The alpha\'s phone number.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => true,
+      ),
+      'beta' => array(
+        'description' => 'The beta\'s phone number.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => true,
+      ),
+      'type' => array(
+        'description' => 'The type of object that the beta has been invited to.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => true
+      ),
+      'nid' => array(
+        'description' => 'The ID of the page / whatever that the person was invited to.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE
+      ),
+      'accepted_invite' => array(
+        'description' => 'Whether or not the user accepted the invitation.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'default' => 0,
+        'not null' => TRUE,
+      ),
+      'timestamp' => array(
+        'description' => 'The time that it all began...',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE
+      )
+    ),
+  );
+
+  return $schema;
+}

--- a/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
+++ b/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
@@ -151,19 +151,8 @@ function dosomething_sms_incoming_callback($path) {
   $output = '';
   conductor_sms_response($output, $context);
 
-  // If an output is given, reply in the xml format expected from Mobile Commons
-  if (!empty($output)) {
-    $output =
-    '<?xml version="1.0" encoding="UTF-8"?>
-    <response>
-     <reply>
-      <text>
-       <![CDATA[' . $output . ']]>
-      </text>
-     </reply>
-    </response>';
-    print $output;
-  }
+  // Reply with output back to Mobile Commons. If empty, Mobile Commons will ignore it.
+  print $output;
 
   return NULL;
 }

--- a/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
+++ b/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
@@ -142,7 +142,6 @@ function dosomething_sms_incoming_callback($path) {
  * Filter to ensure incoming texts are coming from Mobile Commons' IP.
  */
 function dosomething_sms_incoming_check() {
-return TRUE;
   // Valid IP range as specified by Mobile Commons is: 64.22.127.0/24.
   // This translates to any IP 64.22.127.0 - 64.22.127.255
   $ip = ip_address();

--- a/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
+++ b/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
@@ -5,6 +5,54 @@
  */
 
 /**
+ * Implements hook_menu().
+ */
+function dosomething_sms_menu() {
+  $items = array();
+
+  $items['dosomething_sms/%'] = array(
+    'title' => 'SMS Receiver for Mobile Commons mData Requests',
+    'page callback' => 'dosomething_sms_incoming_callback',
+    'access callback' => 'dosomething_sms_incoming_check',
+    'page arguments' => array(1),
+    'type' => MENU_CALLBACK,
+  );
+
+  return $items;
+}
+
+/**
+ * Implements hook_permission().
+ */
+function dosomething_sms_permission() {
+  return array(
+    'administer dosomething_sms' => array(
+      'title' => t('Administer dosomething_sms module'),
+      'description' => t('Administer access to everything in module'),
+      'restrict access' => TRUE,
+    ),
+  );
+}
+
+/**
+ * Implements hook_ctools_plugin_api().
+ */
+function dosomething_sms_ctools_plugin_api($owner, $api) {
+  if ($owner == 'conductor') {
+    return array('version' => 1.0);
+  }
+}
+
+/**
+ * Implements hook_ctools_plugin_directory().
+ */
+function dosomething_sms_ctools_plugin_directory($owner, $plugin_type) {
+  if ($owner == 'conductor') {
+    return "plugins/$plugin_type";
+  }
+}
+
+/**
  * Implements hook_conductor_sms_keywords().
  *
  * Specifies conductor workflows that should trigger for a given endpoint
@@ -67,24 +115,6 @@ function _dosomething_sms_list_files_by_extension($dir, $file_ext, &$matching_fi
         $matching_files[] = $path;
       }
     }
-  }
-}
-
-/**
- * Implements hook_ctools_plugin_api().
- */
-function dosomething_sms_ctools_plugin_api($owner, $api) {
-  if ($owner == 'conductor') {
-    return array('version' => 1.0);
-  }
-}
-
-/**
- * Implements hook_ctools_plugin_directory().
- */
-function dosomething_sms_ctools_plugin_directory($owner, $plugin_type) {
-  if ($owner == 'conductor') {
-    return "plugins/$plugin_type";
   }
 }
 
@@ -162,36 +192,6 @@ function dosomething_sms_incoming_check() {
 }
 
 /**
- * Implements hook_menu().
- */
-function dosomething_sms_menu() {
-  $items = array();
-
-  $items['dosomething_sms/%'] = array(
-    'title' => 'SMS Receiver for Mobile Commons mData Requests',
-    'page callback' => 'dosomething_sms_incoming_callback',
-    'access callback' => 'dosomething_sms_incoming_check',
-    'page arguments' => array(1),
-    'type' => MENU_CALLBACK,
-  );
-
-  return $items;
-}
-
-/**
- * Implements hook_permission().
- */
-function dosomething_sms_permission() {
-  return array(
-    'administer dosomething_sms' => array(
-      'title' => t('Administer dosomething_sms module'),
-      'description' => t('Administer access to everything in module'),
-      'restrict access' => TRUE,
-    ),
-  );
-}
-
-/**
  * Create record in dosomething_sms_game table.
  *
  * @param string $phone
@@ -233,14 +233,11 @@ function dosomething_sms_game_get_paths($phone, $game_id) {
   $phone = preg_replace('#[^0-9]#i', '', $phone);
   $phone = substr($phone, -10);
 
-  $select = db_query("
-    SELECT started_paths
-    FROM dosomething_sms_game
-    WHERE
-       phone = '" . $phone . "'
-       AND game_id = '" . $game_id . "'
-    LIMIT 1
-  ");
+  $select = db_select('dosomething_sms_game', 'g')
+    ->condition('phone', $phone)
+    ->condition('game_id', $game_id)
+    ->fields('g', array('started_paths'))
+    ->execute();
 
   $record = current($select->fetchAll());
 
@@ -294,16 +291,13 @@ function dosomething_sms_game_get_answers($phone, $game_id) {
   $phone = preg_replace('#[^0-9]#i', '', $phone);
   $phone = substr($phone, -10);
 
-  $select = db_query("
-    SELECT answers
-    FROM dosomething_sms_game
-    WHERE
-      phone = '" . $phone . "'
-      AND game_id = '" . $game_id . "'
-    LIMIT 1
-  ");
+  $select = db_select('dosomething_sms_game', 'g')
+    ->condition('phone', $phone)
+    ->condition('game_id', $game_id)
+    ->fields('g', array('answers'))
+    ->execute();
 
-  $record = current($select ->fetchAll());
+  $record = current($select->fetchAll());
 
   if ($record && !empty($record->answers)) {
     $return = json_decode($record->answers, TRUE);

--- a/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
+++ b/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
@@ -329,7 +329,7 @@ function dosomething_sms_game_set_answers($phone, $game_id, $answers) {
  * @param array $args
  *   Additional arguments.
  */
-function dosomething_sms_mobile_commons_opt_in($phone, $opt_in_path, $args = array()) {
+function dosomething_sms_mobilecommons_opt_in($phone, $opt_in_path, $args = array()) {
   $content = array(
     'opt_in_path[]' => $opt_in_path,
     'person' => array(
@@ -354,7 +354,7 @@ function dosomething_sms_mobile_commons_opt_in($phone, $opt_in_path, $args = arr
  * @param int $campaign
  *   A single campaign ID to opt out of.
  */
-function dosomething_sms_mobile_commons_opt_out($phone, $campaign) {
+function dosomething_sms_mobilecommons_opt_out($phone, $campaign) {
   $content = array(
     'person' => array(
       'phone' => $phone,

--- a/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
+++ b/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
@@ -1,0 +1,385 @@
+<?php
+/**
+ * @file
+ * Provides Do Something-specific SMS functionality.
+ */
+
+/**
+ * Implements hook_conductor_sms_keywords().
+ *
+ * Specifies conductor workflows that should trigger for a given endpoint
+ *   [endpoint] => [conductor workflow]
+ */
+function dosomething_sms_conductor_sms_keywords() {
+  $keywords = array();
+
+  // Find files in this directory tree with the .keywords.inc extension and
+  // include them to populate the keywords array.
+  $files = array();
+  _dosomething_sms_list_files_by_extension(dirname(__FILE__), '.keywords.inc', $files);
+
+  foreach ($files as $file) {
+    include $file;
+  }
+
+  return $keywords;
+}
+
+/**
+ * Implements hook_default_conductor_workflows().
+ * Searches for local .workflows.inc files for instantiated ConductorWorkflows to add to array.
+ */
+function dosomething_sms_default_conductor_workflows() {
+  $workflows = array();
+
+  // Find files in this directory tree with the .workflows.inc extension and
+  // include them to populate the workflows array.
+  $files = array();
+  _dosomething_sms_list_files_by_extension(dirname(__FILE__), '.workflows.inc', $files);
+
+  foreach ($files as $file) {
+    include $file;
+  }
+
+  return $workflows;
+}
+
+/**
+ * Helper function to find all files within a directory that end with the given extension.
+ *
+ * @param string $dir
+ *   Directory to search for files.
+ * @param string $file_ext
+ *   File extension of files to search for.
+ * @param array $matching_files
+ *   The files that match the $file_ext being searched for.
+ */
+function _dosomething_sms_list_files_by_extension($dir, $file_ext, &$matching_files) {
+  $files = scandir($dir);
+  foreach ($files as $file) {
+    if ($file != '.' && $file != '..') {
+      $path = $dir . '/' . $file;
+
+      if (is_dir($path)) {
+        _dosomething_sms_list_files_by_extension($path, $file_ext, $matching_files);
+      }
+      elseif (preg_match('/'  . $file_ext . '$/', $path) === 1) {
+        $matching_files[] = $path;
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_ctools_plugin_api().
+ */
+function dosomething_sms_ctools_plugin_api($owner, $api) {
+  if ($owner == 'conductor') {
+    return array('version' => 1.0);
+  }
+}
+
+/**
+ * Implements hook_ctools_plugin_directory().
+ */
+function dosomething_sms_ctools_plugin_directory($owner, $plugin_type) {
+  if ($owner == 'conductor') {
+    return "plugins/$plugin_type";
+  }
+}
+
+/**
+ * Callback for Mobile Commons mData requests. Allows for different endpoints
+ * to trigger different keyword paths.
+ *
+ * @param string $path
+ *   @TODO
+ */
+function dosomething_sms_incoming_callback($path) {
+  // Direct correlation between path endpoint and keyword used. If the path doesn't
+  // match any keyword specified in the array of keywords, then error out.
+  $keyword = $path;
+  $keyword_map = module_invoke_all('conductor_sms_keywords');
+  if (!array_key_exists($path, $keyword_map)) {
+    watchdog('dosomething_sms', "Received message at unsupported path: /dosomething_sms/$path");
+    return NULL;
+  }
+
+  // Build context for the conductor workflow
+  $message = isset($_REQUEST['args']) ? $_REQUEST['args'] : FALSE;
+  $carrier = isset($_REQUEST['carrier']) ? $_REQUEST['carrier'] : FALSE;
+  $sender = isset($_REQUEST['phone']) ? $_REQUEST['phone'] : FALSE;
+
+  $context = array(
+    'message' => $message,
+    'keyword' => $keyword,
+    'carrier' => $carrier,
+    'sender' => $sender,
+  );
+
+  // Pass message on to Conductor to handle and generate a response
+  $output = '';
+  conductor_sms_response($output, $context);
+
+  // If an output is given, reply in the xml format expected from Mobile Commons
+  if (!empty($output)) {
+    $output =
+    '<?xml version="1.0" encoding="UTF-8"?>
+    <response>
+     <reply>
+      <text>
+       <![CDATA[' . $output . ']]>
+      </text>
+     </reply>
+    </response>';
+    print $output;
+  }
+
+  return NULL;
+}
+
+/**
+ * Filter to ensure incoming texts are coming from Mobile Commons' IP.
+ */
+function dosomething_sms_incoming_check() {
+return TRUE;
+  // Valid IP range as specified by Mobile Commons is: 64.22.127.0/24.
+  // This translates to any IP 64.22.127.0 - 64.22.127.255
+  $ip = ip_address();
+  $valid = FALSE;
+  if (strpos($ip, '64.22.127') === 0) {
+    if ((int) substr($ip, 9, 3) >= 0 && (int) substr($ip, 10, 3) <= 255) {
+      $valid = TRUE;
+    }
+  }
+
+  // Also check the Mobile Commons backup data center IP: 67.214.223.81 - .94
+  else if (strpos($ip, '67.214.213') === 0) {
+    if ((int) substr($ip, 11, 3) >= 81 && (int) substr($ip, 11, 3) <= 94) {
+      $valid = TRUE;
+    }
+  }
+  return $valid;
+}
+
+/**
+ * Implements hook_menu().
+ */
+function dosomething_sms_menu() {
+  $items = array();
+
+  $items['dosomething_sms/%'] = array(
+    'title' => 'SMS Receiver for Mobile Commons mData Requests',
+    'page callback' => 'dosomething_sms_incoming_callback',
+    'access callback' => 'dosomething_sms_incoming_check',
+    'page arguments' => array(1),
+    'type' => MENU_CALLBACK,
+  );
+
+  return $items;
+}
+
+/**
+ * Implements hook_permission().
+ */
+function dosomething_sms_permission() {
+  return array(
+    'administer dosomething_sms' => array(
+      'title' => t('Administer dosomething_sms module'),
+      'description' => t('Administer access to everything in module'),
+      'restrict access' => TRUE,
+    ),
+  );
+}
+
+/**
+ * Create record in dosomething_sms_game table.
+ *
+ * @param string $phone
+ *   Phone number to add to the table.
+ * @param int $game_id
+ *   The game ID for this record.
+ *   @see dosomething_sms_game_constants.inc
+ *
+ * @return
+ *   If the record insert or update failed, returns FALSE. If it succeeded,
+ *   returns SAVED_NEW or SAVED_UPDATED, depending on the operation performed.
+ */
+function dosomething_sms_game_create_record($phone, $game_id) {
+  $phone = substr($phone, -10);
+
+  $record = array(
+    'phone' => $phone,
+    'game_id' => $game_id,
+    'started_paths' => '',
+    'answers' => '',
+  );
+
+  $ret = drupal_write_record('dosomething_sms_game', $record);
+}
+
+/**
+ * Retrieve the opt-in paths a user has been sent to.
+ *
+ * @param string $phone
+ *   Phone number of the user to lookup.
+ * @param int $game_id
+ *   The game ID to query for.
+ *   @see dosomething_sms_game_constants.inc
+ *
+ * @return array
+ *   The paths a user has been opted-in to.
+ */
+function dosomething_sms_game_get_paths($phone, $game_id) {
+  $phone = preg_replace('#[^0-9]#i', '', $phone);
+  $phone = substr($phone, -10);
+
+  $select = db_query("
+    SELECT started_paths
+    FROM dosomething_sms_game
+    WHERE
+       phone = '" . $phone . "'
+       AND game_id = '" . $game_id . "'
+    LIMIT 1
+  ");
+
+  $record = current($select->fetchAll());
+
+  if ($record && !empty($record->started_paths)) {
+    // Deserialize string into array
+    $return = explode(',', $record->started_paths);
+  }
+
+  return !empty($return) ? $return : array();
+}
+
+/**
+ * Save the opt-in paths a user has been sent to to the dosomething_sms_game table.
+ *
+ * @param string $phone
+ *   Phone number of the user.
+ * @param int $game_id
+ *   The game ID the paths are associated with.
+ *   @see dosomething_sms_game_constants.inc
+ * @param array $paths
+ *   The opt-in paths a user has been sent to.
+ */
+function dosomething_sms_game_set_paths($phone, $game_id, $paths) {
+  $phone = substr($phone, -10);
+
+  // Serialize array before writing it to the database
+  $serialized_paths = implode(',', $paths);
+
+  db_update('dosomething_sms_game')
+    ->fields(array(
+      'started_paths' => $serialized_paths
+    ))
+    ->condition('phone', $phone)
+    ->condition('game_id', $game_id)
+    ->execute();
+}
+
+/**
+ * Return answers from dosomething_sms_game.
+ *
+ * @param string $phone
+ *   Phone number of the user.
+ * @param int $game_id
+ *   Game ID to get the answers for.
+ *   @see dosomething_sms_game_constants.inc
+ *
+ * @return
+ *   Associative array of the user's answers to the given game. Otherwise, NULL.
+ */
+function dosomething_sms_game_get_answers($phone, $game_id) {
+  $phone = preg_replace('#[^0-9]#i', '', $phone);
+  $phone = substr($phone, -10);
+
+  $select = db_query("
+    SELECT answers
+    FROM dosomething_sms_game
+    WHERE
+      phone = '" . $phone . "'
+      AND game_id = '" . $game_id . "'
+    LIMIT 1
+  ");
+
+  $record = current($select ->fetchAll());
+
+  if ($record && !empty($record->answers)) {
+    $return = json_decode($record->answers, TRUE);
+  }
+
+  return !empty($return) ? $return : NULL;
+}
+
+/**
+ * Convert answers from associative array to json string and save to dosomething_sms_game.
+ *
+ * @param string $phone
+ *   Phone number of the user.
+ * @param int $game_id
+ *   Game ID the answers are associated with.
+ *   @see dosomething_sms_game_constants.inc
+ * @param array $answers
+ *   The answers to convert and save.
+ */
+function dosomething_sms_game_set_answers($phone, $game_id, $answers) {
+  $phone = substr($phone, -10);
+  $serialized_answers = json_encode($answers);
+
+  db_update('dosomething_sms_game')
+    ->fields(array(
+      'answers' => $serialized_answers
+    ))
+    ->condition('phone', $phone)
+    ->condition('game_id', $game_id)
+    ->execute();
+}
+
+/**
+ * Subscribe to a Mobile Commons opt-in path.
+ *
+ * @param string $phone
+ *   Phone number of the user.
+ * @param int $opt_in_path
+ *   Mobile Commons opt-in path id.
+ * @param array $args
+ *   Additional arguments.
+ */
+function dosomething_sms_mobile_commons_opt_in($phone, $opt_in_path, $args = array()) {
+  $content = array(
+    'opt_in_path[]' => $opt_in_path,
+    'person' => array(
+      'phone' => $phone,
+    ),
+  );
+
+  if (!empty($args)) {
+    foreach ($args as $key => $val) {
+      $content[$key] = urlencode($val);
+    }
+  }
+
+  mobilecommons_request('opt_in', $content);
+}
+
+/**
+ * Unsubscribe the user from a Mobile Commons campaign.
+ *
+ * @param string $phone
+ *   Phone number of the user.
+ * @param int $campaign
+ *   A single campaign ID to opt out of.
+ */
+function dosomething_sms_mobile_commons_opt_out($phone, $campaign) {
+  $content = array(
+    'person' => array(
+      'phone' => $phone,
+    ),
+  );
+
+  $content['campaign'] = $campaign;
+
+  mobilecommons_request('opt_out', $content);
+}

--- a/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
+++ b/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
@@ -93,7 +93,7 @@ function dosomething_sms_ctools_plugin_directory($owner, $plugin_type) {
  * to trigger different keyword paths.
  *
  * @param string $path
- *   @TODO
+ *   Keyword associated with a ConductorWorkflow that the request will be handled by.
  */
 function dosomething_sms_incoming_callback($path) {
   // Direct correlation between path endpoint and keyword used. If the path doesn't

--- a/lib/modules/dosomething/dosomething_sms/dosomething_sms_game_constants.inc
+++ b/lib/modules/dosomething/dosomething_sms/dosomething_sms_game_constants.inc
@@ -2,11 +2,11 @@
 
 /**
  * @file
- * Class of constants to be used for sms_flow_game game_id's.
+ * Class of constants to be used for dosomething_sms_game game_id's.
  *
  * Constants shouldn't be removed from this and repurposed for other SMS flows
  * unless you know what you're getting yourself into.
  */
-class SmsFlowGameConstants {
+class DoSomethingSmsGameConstants {
   const COMEBACKCLOTHES_TIPS = 1;
 }

--- a/lib/modules/dosomething/dosomething_sms/dosomething_sms_game_constants.inc
+++ b/lib/modules/dosomething/dosomething_sms/dosomething_sms_game_constants.inc
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @file
+ * Class of constants to be used for sms_flow_game game_id's.
+ *
+ * Constants shouldn't be removed from this and repurposed for other SMS flows
+ * unless you know what you're getting yourself into.
+ */
+class SmsFlowGameConstants {
+  const COMEBACKCLOTHES_TIPS = 1;
+}

--- a/lib/modules/dosomething/dosomething_sms/plugins/activity/gateways/start_campaign/ConductorActivityStartCampaignGateway.class.php
+++ b/lib/modules/dosomething/dosomething_sms/plugins/activity/gateways/start_campaign/ConductorActivityStartCampaignGateway.class.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Through an mData trigger, users are opted out of a Mobile Commons transactional
+ * campaign and opted in to a path in the campaign actual.
+ */
+class ConductorActivityStartCampaignGateway extends ConductorActivity {
+
+  /**
+   * Map of incoming requests from an mData ID and the campaign id to opt-out of
+   * along with the path id to opt-in to.
+   *
+   * @var array
+   */
+  public $routes = array();
+
+  public function run() {
+    $state = $this->getState();
+    $mobile = $state->getContext('sms_number');
+    $mdataID = intval($_REQUEST['mdata_id']);
+
+    // Find the routing info for replies through this mdata id
+    if (array_key_exists($mdataID, $this->routes)) {
+      $route = $this->routes[$mdataID];
+
+      // Opt the user out of the transactional campaign
+      dosomething_sms_mobile_commons_opt_out($mobile, $route['out_campaign_id']);
+
+      // Opt the user into a path in the actual campaign
+      dosomething_sms_mobile_commons_opt_in($mobile, $route['opt_in_path_id']);
+    }
+
+    $state->setContext('ignore_no_response_error', TRUE);
+    $state->markCompleted();
+  }
+}

--- a/lib/modules/dosomething/dosomething_sms/plugins/activity/gateways/start_campaign/ConductorActivityStartCampaignGateway.class.php
+++ b/lib/modules/dosomething/dosomething_sms/plugins/activity/gateways/start_campaign/ConductorActivityStartCampaignGateway.class.php
@@ -24,10 +24,10 @@ class ConductorActivityStartCampaignGateway extends ConductorActivity {
       $route = $this->routes[$mdataID];
 
       // Opt the user out of the transactional campaign
-      dosomething_sms_mobile_commons_opt_out($mobile, $route['out_campaign_id']);
+      dosomething_sms_mobilecommons_opt_out($mobile, $route['out_campaign_id']);
 
       // Opt the user into a path in the actual campaign
-      dosomething_sms_mobile_commons_opt_in($mobile, $route['opt_in_path_id']);
+      dosomething_sms_mobilecommons_opt_in($mobile, $route['opt_in_path_id']);
     }
 
     $state->setContext('ignore_no_response_error', TRUE);

--- a/lib/modules/dosomething/dosomething_sms/plugins/activity/gateways/start_campaign/start_campaign.inc
+++ b/lib/modules/dosomething/dosomething_sms/plugins/activity/gateways/start_campaign/start_campaign.inc
@@ -1,0 +1,9 @@
+<?php
+
+$plugin = array(
+  'title' => t('Start Campaign Gateway'),
+  'description' => t('Transitions user from transactional Mobile Commons campaign to the actual campaign.'),
+  'handler' => array(
+    'class' => 'ConductorActivityStartCampaignGateway',
+  ),
+);

--- a/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.keywords.inc
+++ b/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.keywords.inc
@@ -5,4 +5,4 @@
  * Array of endpoints ("keywords") and the name of the workflows they are each
  * associated with.
  */
-$keywords['start-campaign-transition'] = 'sms_flow_start_campaign_transition';
+$keywords['start-campaign-transition'] = 'dosomething_sms_start_campaign_transition';

--- a/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.keywords.inc
+++ b/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.keywords.inc
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @file
+ * Array of endpoints ("keywords") and the name of the workflows they are each
+ * associated with.
+ */
+$keywords['start-campaign-transition'] = 'sms_flow_start_campaign_transition';

--- a/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.workflows.inc
+++ b/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.workflows.inc
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * ConductorWorkflow definitions for DoSomething SMS endpoints.
+ */
+
+/**
+ * Gateway from transactional Mobile Commons campaign to starting the actual
+ * campaign SMS experience.
+ */
+$workflow = new ConductorWorkflow();
+$workflow->wid = 'new';
+$workflow->name = 'sms_flow_start_campaign_transition';
+$workflow->title = 'Start Campaign Transition';
+$workflow->api_version = '1.0';
+
+$activity = $workflow->newActivity('start');
+$activity->name = 'start';
+$activity->outputs = array('start_campaign');
+
+$activity = $workflow->newActivity('start_campaign');
+$activity->name = 'start_campaign';
+$activity->inputs = array('start');
+$activity->outputs = array('end');
+$activity->routes = array(
+  '10851' => array(                // mData id with the campaign start keyword.
+    'out_campaign_id' => '124251', // Starting campaign id to opt-out of.
+    'opt_in_path_id' => '164793',  // In-progress campaign opt-in path id to opt-in to.
+  ),
+);
+
+$activity = $workflow->newActivity('end');
+$activity->name = 'end';
+$activity->inputs = array('start_campaign');
+
+$workflows[$workflow->name] = $workflow;

--- a/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.workflows.inc
+++ b/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.workflows.inc
@@ -11,7 +11,7 @@
  */
 $workflow = new ConductorWorkflow();
 $workflow->wid = 'new';
-$workflow->name = 'sms_flow_start_campaign_transition';
+$workflow->name = 'dosomething_sms_start_campaign_transition';
 $workflow->title = 'Start Campaign Transition';
 $workflow->api_version = '1.0';
 


### PR DESCRIPTION
For Issue #894

The `dosomething_sms` module here only takes pieces from the old world `dosomething_sms` and old world `sms_flow` modules that are currently needed for the Comeback Clothes campaign.

Highlights:
- All things related to `dosomething_sms_start_campaign_transition` are for the new world SMS UX plan where users are transitioned from one Mobile Commons campaign to another.
- `dosomething_sms_game` will be used for tracking a user's progress through SMS tips. Not yet included because I have no content. This was previously handled by the `sms_flow_game` table.
- The module has `dosomething_sms_mobile_commons_opt_in()` and `dosomething_sms_mobile_commons_opt_out()` methods. Not sure if you want to use these or continue to do like what was done in the `dosomething_signup` module. And/or if this implementation should include checks on whether necessary modules and libraries exist.
- The implementation here depends on the 7.x-1.1 version of the `mobilecommons` module.

cc: @aaronschachter 
