### PR TITLE
Enable modules in dosomething.info on ds build.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -156,6 +156,10 @@ function build {
   echo 'Updating database...'
   drush updb -y
 
+  # Enable modules in info file
+  echo 'Enabling modules in dosomething.info'
+  drush --script-path=../bin/ php-script enable_modules.php
+
   echo 'Clearing caches...'
   drush cc all
 

--- a/bin/enable_modules.php
+++ b/bin/enable_modules.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Script to run after deployments.
+ * Checks the dosomething.info file to determine if new modules need to be enabled.
+ *
+ * to run: drush --script-path=../bin/ php-script enable_modules.php
+ *
+ */
+
+// Parse the data in the info file.
+$info = drupal_parse_info_file('../lib/profiles/dosomething/dosomething.info');
+$modules = $info['dependencies'];
+
+// Enable modules
+enable_modules_if_needed($modules);
+
+/**
+ * Enable modules if disabled.
+ *
+ * @param array $modules
+ *  An array of modules
+ */
+function enable_modules_if_needed($modules) {
+  foreach ($modules as $module) {
+    // Check if modules are disabled.
+    $result = db_select('system', 's')
+            ->fields('s', array('status'))
+            ->condition('name', $module, '=')
+            ->condition('status', 0, '=')
+            ->execute();
+    if ($result->fetchAssoc()) {
+      // Create an array of modules to enable.
+      $to_enable[] = $module;
+    }
+  }
+  if ($to_enable) {
+    module_enable($to_enable);
+    echo "Enabled new modules";
+  }
+  else {
+    echo "No new modules to enable";
+  }
+}


### PR DESCRIPTION
On `ds build` this will check the `dosomething.info` file and enable any modules that are not already enabled.

If we no longer need `securepages` module we should remove that from the info file before this is merged in.

Refs #934
