### PR TITLE
Mobilecommons update

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
@@ -54,11 +54,15 @@ function dosomething_signup_get_mobilecommons_vars($account, $lid, $title = NULL
   $args = array(
     'opt_in_path[]' => $lid,
     'person[phone]' => $mobile,
-    // Expected format is YYYY-MM-DD.
-    'person[date_of_birth]' => dosomething_user_get_birthdate('Y-m-d', $account),
-    'person[first_name]' => dosomething_user_get_field('field_first_name', $account),
     'person[email]' => $account->mail,
   );
+  if ($first_name = dosomething_user_get_field('field_first_name', $account)) {
+    $args['person[first_name]'] = $first_name;
+  }
+  // Expected DOB format is YYYY-MM-DD.
+  if ($dob = dosomething_user_get_birthdate('Y-m-d', $account)) {
+    $args['person[date_of_birth]'] = $dob;
+  }
   if (isset($title)) {
     $args['person[campaign_name]'] = $title;
   }

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
@@ -17,6 +17,12 @@ function dosomething_signup_mobilecommons_opt_in($account, $lid, $title = NULL) 
   // Make sure mobilecommons module is enabled.
   if (!module_exists('mobilecommons')) { return; }
 
+   // If user doesn't have mobile number, exit function.
+  $mobile = dosomething_user_get_mobile($account);
+  if (!$mobile) {
+    return FALSE;
+  }
+
   try {
     // If valid args for given $user:
     if ($args = dosomething_signup_get_mobilecommons_vars($account, $lid, $title)) {
@@ -45,15 +51,9 @@ function dosomething_signup_mobilecommons_opt_in($account, $lid, $title = NULL) 
  *   Array of arguments to pass to a Mobilecommons request, or FALSE if no mobile.
  */
 function dosomething_signup_get_mobilecommons_vars($account, $lid, $title = NULL) {
-   // If user doesn't have mobile number, exit function.
-  $mobile = dosomething_user_get_mobile($account);
-  if (!$mobile) {
-    return FALSE;
-  }
-
   $args = array(
     'opt_in_path[]' => $lid,
-    'person[phone]' => $mobile,
+    'person[phone]' => dosomething_user_get_mobile($account),
     'person[email]' => $account->mail,
   );
   if ($first_name = dosomething_user_get_field('field_first_name', $account)) {

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
@@ -5,8 +5,10 @@
  *
  * @param object $account
  *   The user object of user to opt-in.
+ * @param int $lid
+ *   The opt-in path to use for opt-in.
  * @param string $title
- *   The campaign title the user has signed up for.
+ *   Optional The campaign title the user has signed up for.
  */
 function dosomething_signup_mobilecommons_opt_in($account, $lid, $title = NULL) {
   // Make sure mobilecommons module is enabled.
@@ -17,20 +19,7 @@ function dosomething_signup_mobilecommons_opt_in($account, $lid, $title = NULL) 
   if (!$mobile) { return; }
 
   try {
-    // @todo: Move $config / new MobileCommons($config) code
-    // into a new function in the contrib mobilecommons.module.
-    $library = libraries_load('mobilecommons-php');
-    if (empty($library['loaded'])) {
-      return FALSE;
-    }
-    $config = array(
-      'username' => variable_get('mobilecommons_api_auth_email'),
-      'password' => variable_get('mobilecommons_api_auth_password'),
-    );
-    $MobileCommons = new MobileCommons($config);
-    // Next get prepare the opt-in request.
     $args = array(
-      // All campaigns use this opt-in path for now.
       'opt_in_path' => $lid,
       'person[phone]' => $mobile,
       'person[campaign_name]' => $title,
@@ -39,7 +28,7 @@ function dosomething_signup_mobilecommons_opt_in($account, $lid, $title = NULL) 
       'person[first_name]' => dosomething_user_get_field('field_first_name', $account),
       'person[email]' => $account->mail,
     );
-    return $MobileCommons->opt_in($args);
+    return mobilecommons_request('opt_in', $args);
   }
   catch (Exception $e) {
     // Log the error.

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
@@ -8,31 +8,59 @@
  * @param int $lid
  *   The opt-in path to use for opt-in.
  * @param string $title
- *   Optional The campaign title the user has signed up for.
+ *   Optional -- The campaign title the user has signed up for.
+ *
+ * @return mixed
+ *   A Mobilecommons object, or FALSE if error.
  */
 function dosomething_signup_mobilecommons_opt_in($account, $lid, $title = NULL) {
   // Make sure mobilecommons module is enabled.
   if (!module_exists('mobilecommons')) { return; }
 
-  // If user doesn't have mobile number, exit function.
-  $mobile = dosomething_user_get_mobile($account);
-  if (!$mobile) { return; }
-
   try {
-    $args = array(
-      'opt_in_path' => $lid,
-      'person[phone]' => $mobile,
-      'person[campaign_name]' => $title,
-      // Expected format is YYYY-MM-DD.
-      'person[date_of_birth]' => dosomething_user_get_birthdate('Y-m-d', $account),
-      'person[first_name]' => dosomething_user_get_field('field_first_name', $account),
-      'person[email]' => $account->mail,
-    );
-    return mobilecommons_request('opt_in', $args);
+    // If valid args for given $user:
+    if ($args = dosomething_signup_get_mobilecommons_vars($account, $lid, $title)) {
+      // Submit Mobilecommons request.
+      return mobilecommons_request('opt_in', $args);
+    }
   }
   catch (Exception $e) {
     // Log the error.
     watchdog('dosomething_signup', $e, array(), WATCHDOG_ERROR);
   }
   return FALSE;
+}
+
+/**
+ * Prepares array of arguments to pass to a Mobilecommons opt-in request.
+ *
+ * @param object $account
+ *   The user object of user to opt-in.
+ * @param int $lid
+ *   The opt-in path to use for opt-in.
+ * @param string $title
+ *   Optional -- The campaign title the user has signed up for.
+ *
+ * @return mixed
+ *   Array of arguments to pass to a Mobilecommons request, or FALSE if no mobile.
+ */
+function dosomething_signup_get_mobilecommons_vars($account, $lid, $title = NULL) {
+   // If user doesn't have mobile number, exit function.
+  $mobile = dosomething_user_get_mobile($account);
+  if (!$mobile) {
+    return FALSE;
+  }
+
+  $args = array(
+    'opt_in_path[]' => $lid,
+    'person[phone]' => $mobile,
+    // Expected format is YYYY-MM-DD.
+    'person[date_of_birth]' => dosomething_user_get_birthdate('Y-m-d', $account),
+    'person[first_name]' => dosomething_user_get_field('field_first_name', $account),
+    'person[email]' => $account->mail,
+  );
+  if (isset($title)) {
+    $args['person[campaign_name]'] = $title;
+  }
+  return $args;
 }

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -82,7 +82,7 @@ projects[metatag] = "1.0-beta9"
 projects[metatag][subdir] = "contrib"
 
 ; Mobile Commons
-projects[mobilecommons] = "1.0"
+projects[mobilecommons] = "1.1"
 projects[mobilecommons][subdir] = "contrib"
 
 ; Module Filter


### PR DESCRIPTION
Fixes #882

If you're testing any campaign signup stuff, run a `ds build` to grab the latest mobilecommons contrib module.  Or download and replace in your relevant local html/profiles/dosomething/modules/contrib/mobilecommons.
