### PR TITLE
Campaign footnotes

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -276,15 +276,21 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $vars['solution_support'] = $wrapper->field_solution_support->value();
   $vars['issue'] = $wrapper->field_issue->value()->name;
 
-  // Collect fact values as tpl variables.
-  $fact_problem = $wrapper->field_fact_problem->value();
-  if (isset($fact_problem)) {
-    $vars['fact_problem'] = dosomething_fact_get_fact_field_vars($wrapper->field_fact_problem);
+  // Collect multiple fact fields values as fact and sources variables.
+  $fact_fields = array('field_fact_problem', 'field_fact_solution');
+  $fact_vars = dosomething_fact_get_mutiple_fact_field_vars($wrapper->nid->value(), $fact_fields);
+  if (!empty($fact_vars)) {
+    if (isset($fact_vars['facts']['field_fact_problem'])) {
+      $vars['fact_problem'] = $fact_vars['facts']['field_fact_problem'];
+    }
+    if (isset($fact_vars['facts']['field_fact_solution'])) {
+      $vars['fact_solution'] = $fact_vars['facts']['field_fact_solution'];
+    }
+    // Store all sources from fields as a sources array.
+    $vars['fact_sources'] = $fact_vars['sources'];
   }
-  $fact_solution = $wrapper->field_fact_solution->value();
-  if (isset($fact_solution)) {
-    $vars['fact_solution'] = dosomething_fact_get_fact_field_vars($wrapper->field_fact_solution);
-  }
+
+  // Check for additional facts in field_facts.
   if ($wrapper->field_facts->count() > 0) {
     $vars['more_facts'] = dosomething_fact_get_fact_field_vars($wrapper->field_facts);
   }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -279,14 +279,14 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   // Collect fact values as tpl variables.
   $fact_problem = $wrapper->field_fact_problem->value();
   if (isset($fact_problem)) {
-    $vars['fact_problem'] = dosomething_fact_get_fact_wrapper_values($wrapper->field_fact_problem);
+    $vars['fact_problem'] = dosomething_fact_get_fact_field_vars($wrapper->field_fact_problem);
   }
   $fact_solution = $wrapper->field_fact_solution->value();
   if (isset($fact_solution)) {
-    $vars['fact_solution'] = dosomething_fact_get_fact_wrapper_values($wrapper->field_fact_solution);
+    $vars['fact_solution'] = dosomething_fact_get_fact_field_vars($wrapper->field_fact_solution);
   }
   if ($wrapper->field_facts->count() > 0) {
-    $vars['more_facts'] = dosomething_fact_get_fact_field_wrapper_values($wrapper->field_facts);
+    $vars['more_facts'] = dosomething_fact_get_fact_field_vars($wrapper->field_facts);
   }
 
   // Collect all field_collection values as vars.

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -24,6 +24,10 @@ function dosomething_fact_node_view($node, $view_mode, $langcode) {
 
   // If viewing a fact node:
   if ($node->type == 'fact' && $view_mode == 'full') {
+    $node->content['fact'] = array(
+      '#markup' => '<h1>' . $node->title . '</h1>',
+      '#weight' => -10,
+    );
     $entityref_fields = array(
       'field_facts',
       'field_fact_problem',
@@ -31,6 +35,40 @@ function dosomething_fact_node_view($node, $view_mode, $langcode) {
     );
     dosomething_helpers_add_entityref_links($node, $entityref_fields);
   }
+}
+
+/**
+ * Returns variables for multiple given Fact Entityreference fields.
+ *
+ * @param object|int $node
+ *   The nid or loaded node to return fact field values from.
+ * @param array $field_names
+ *   Array of field machine names to return values from.
+ *
+ * @return array
+ *   Multi-dimensional array with keys:
+ *   - facts: Array of fact values, indexed by keys of $field_names.
+ *   -   @see dosomething_fact_get_fact_vars()
+ *   - sources: Sequential array of all sources found in all $field_names.
+ */
+function dosomething_fact_get_mutiple_fact_field_vars($node, $field_names) {
+  // Initalize return array.
+  $vars = array(
+    'facts' => array(),
+    'sources' => array(),
+  );
+  $wrapper = entity_metadata_wrapper('node', $node);
+
+  foreach ($field_names as $field_name) {
+    $field_wrapper = $wrapper->{$field_name};
+    $i = count($vars['sources']);
+    $fact = dosomething_fact_get_fact_field_vars($field_wrapper, $i);
+    // Index fact by $field_name to reference $field_name's facts.
+    $vars['facts'][$field_name] = $fact;
+    // Append sources to composite $sources array.
+    $vars['sources'] = array_merge($vars['sources'], $fact['sources']);
+  }
+  return $vars;
 }
 
 /**
@@ -103,6 +141,7 @@ function dosomething_fact_get_fact_wrapper_values($fact_wrapper, $source_index =
   }
   return array(
     'fact' => $fact_wrapper->title->value(),
+    'nid' => $fact_wrapper->nid->value(),
     'footnotes' => implode(' ', $footnotes),
     'sources' => $sources,
   );

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -45,7 +45,7 @@ function dosomething_fact_node_view($node, $view_mode, $langcode) {
  * @return mixed
  *   Multi-dimensional array of facts and their sources.
  */
-function dosomething_fact_get_fact_field_wrapper_values($fact_field_wrapper, $source_index = 0) {
+function dosomething_fact_get_fact_field_vars($fact_field_wrapper, $source_index = 0) {
   // Make sure $fact_field_wrapper is an object.
   if (!is_object($fact_field_wrapper)) { return NULL; }
 
@@ -61,7 +61,7 @@ function dosomething_fact_get_fact_field_wrapper_values($fact_field_wrapper, $so
     $i = 0;
     foreach ($fact_field_wrapper->getIterator() as $delta => $fact) {
       // Gather fact vars.
-      $fact = dosomething_fact_get_fact_wrapper_values($fact, $i);
+      $fact = dosomething_fact_get_fact_field_vars($fact, $i);
       // Add into return array.
       $values['facts'][] = $fact;
       // Append sources.

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -137,7 +137,7 @@ function dosomething_fact_get_fact_wrapper_values($fact_wrapper, $source_index =
   // Loop through field_source_copy multi-values:
   foreach ($fact_wrapper->field_source_copy->value() as $delta => $source) {
     // Store source safe_value for index $source_index.
-    $sources[$source_index] = $source['safe_value'];;
+    $sources[$source_index] = $source['safe_value'];
     // Add 1 to footnote display because $source_index is zero based.
     $footnotes[] = $source_index + 1;
     // Increment to count the next source.

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -95,7 +95,7 @@ function dosomething_fact_get_fact_field_vars($fact_field_wrapper, $source_index
 
   // If EntityDrupalWrapper, single value field:
   if ($field_class == 'EntityDrupalWrapper') {
-    return dosomething_fact_get_fact_wrapper_values($fact_field_wrapper, $source_index);
+    return dosomething_fact_get_fact_vars($fact_field_wrapper, $source_index);
   }
   // If EntityListWrapper, multi-value field:
   if ($field_class == 'EntityListWrapper') {
@@ -119,7 +119,7 @@ function dosomething_fact_get_fact_field_vars($fact_field_wrapper, $source_index
 /**
  * Returns array of values of a Fact node.
  *
- * @param object $fact_wrapper
+ * @param object $fact
  *   A Fact node entity_metadata_wrapper.
  * @param int $source_index
  *   The array key from which the return sources should begin counting.
@@ -130,12 +130,12 @@ function dosomething_fact_get_fact_field_vars($fact_field_wrapper, $source_index
  *   - footnotes: string of footnote numbers corresponding to fact sources
  *   - sources: an array which beings indexing from given $source_index.
  */
-function dosomething_fact_get_fact_wrapper_values($fact_wrapper, $source_index = 0) {
+function dosomething_fact_get_fact_vars($fact, $source_index = 0) {
   // Initialize sources and footnotes return arrays.
   $footnotes = array();
   $sources = array();
   // Loop through field_source_copy multi-values:
-  foreach ($fact_wrapper->field_source_copy->value() as $delta => $source) {
+  foreach ($fact->field_source_copy->value() as $delta => $source) {
     // Store source safe_value for index $source_index.
     $sources[$source_index] = $source['safe_value'];
     // Add 1 to footnote display because $source_index is zero based.
@@ -144,8 +144,8 @@ function dosomething_fact_get_fact_wrapper_values($fact_wrapper, $source_index =
     $source_index++;
   }
   return array(
-    'fact' => $fact_wrapper->title->value(),
-    'nid' => $fact_wrapper->nid->value(),
+    'fact' => $fact->title->value(),
+    'nid' => $fact->nid->value(),
     'footnotes' => implode(' ', $footnotes),
     'sources' => $sources,
   );

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -62,11 +62,15 @@ function dosomething_fact_get_mutiple_fact_field_vars($node, $field_names) {
   foreach ($field_names as $field_name) {
     $field_wrapper = $wrapper->{$field_name};
     $i = count($vars['sources']);
-    $fact = dosomething_fact_get_fact_field_vars($field_wrapper, $i);
-    // Index fact by $field_name to reference $field_name's facts.
-    $vars['facts'][$field_name] = $fact;
-    // Append sources to composite $sources array.
-    $vars['sources'] = array_merge($vars['sources'], $fact['sources']);
+    // If values exist in this field:
+    if ($field_wrapper->value()) {
+      // Gather the field's fact vars.
+      $fact = dosomething_fact_get_fact_field_vars($field_wrapper, $i);
+      // Index vars by $field_name to reference $field_name specific facts.
+      $vars['facts'][$field_name] = $fact;
+      // Append sources to composite $sources array.
+      $vars['sources'] = array_merge($vars['sources'], $fact['sources']);
+    }
   }
   return $vars;
 }
@@ -133,7 +137,8 @@ function dosomething_fact_get_fact_wrapper_values($fact_wrapper, $source_index =
   // Loop through field_source_copy multi-values:
   foreach ($fact_wrapper->field_source_copy->value() as $delta => $source) {
     // Store source safe_value for index $source_index.
-    $sources[$source_index] = $source['safe_value'];
+    $source_value = dosomething_helpers_strip_enclosing_ptags($source['safe_value']);
+    $sources[$source_index] = $source_value;
     // Add 1 to footnote display because $source_index is zero based.
     $footnotes[] = $source_index + 1;
     // Increment to count the next source.

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -137,8 +137,7 @@ function dosomething_fact_get_fact_wrapper_values($fact_wrapper, $source_index =
   // Loop through field_source_copy multi-values:
   foreach ($fact_wrapper->field_source_copy->value() as $delta => $source) {
     // Store source safe_value for index $source_index.
-    $source_value = dosomething_helpers_strip_enclosing_ptags($source['safe_value']);
-    $sources[$source_index] = $source_value;
+    $sources[$source_index] = $source['safe_value'];;
     // Add 1 to footnote display because $source_index is zero based.
     $footnotes[] = $source_index + 1;
     // Increment to count the next source.

--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
@@ -50,7 +50,7 @@ function dosomething_fact_page_preprocess_node(&$vars) {
     if ($node->field_video->value()) {
       $vars['intro_video'] = theme('dosomething_video_embed', array('field' => $node->field_video->value()));
     }
-    $values = dosomething_fact_get_fact_field_wrapper_values($node->field_facts);
+    $values = dosomething_fact_get_fact_field_vars($node->field_facts);
     $vars['facts'] = $values['facts'];
     $vars['sources'] = $values['sources'];
   }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -98,7 +98,7 @@ function dosomething_helpers_add_entityref_links(&$node, $fields) {
 }
 
 /**
- * Implements hook_preprocess_html(). 
+ * Implements hook_preprocess_html().
  */
 function dosomething_helpers_preprocess_html(&$vars) {
   $dmoz_meta_tag = array(
@@ -111,4 +111,13 @@ function dosomething_helpers_preprocess_html(&$vars) {
   );
 
   drupal_add_html_head($dmoz_meta_tag, 'dmoz_meta_tag');
+}
+
+/**
+ * Returns given $string without eclosing <p> and </p> tags.
+ *
+ * Useful for stripping from Markdown values.
+ */
+function dosomething_helpers_strip_enclosing_ptags($string) {
+  return preg_replace('/<p[^>]*>(.*)<\/p[^>]*>/i', '$1', $string);
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -112,12 +112,3 @@ function dosomething_helpers_preprocess_html(&$vars) {
 
   drupal_add_html_head($dmoz_meta_tag, 'dmoz_meta_tag');
 }
-
-/**
- * Returns given $string without eclosing <p> and </p> tags.
- *
- * Useful for stripping from Markdown values.
- */
-function dosomething_helpers_strip_enclosing_ptags($string) {
-  return preg_replace('/<p[^>]*>(.*)<\/p[^>]*>/i', '$1', $string);
-}

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -34,7 +34,9 @@
       <h4>The Problem</h4>
 
       <?php if (isset($fact_problem)): ?>
-      <div class="fact-problem"><?php print $fact_problem['fact']; ?><sup>1</sup></div>
+      <div class="fact-problem">
+        <?php print $fact_problem['fact']; ?><sup><?php print $fact_problem['footnotes']; ?></sup>
+      </div>
       <?php endif; ?>
 
       <?php if (isset($faq)): ?>
@@ -85,13 +87,12 @@
     <div class="col second">
       <h4>The Solution</h4>
 
-      <?php // @TODO - Print only one of these ?>
       <?php if (isset($fact_solution)): ?>
-      <div class="fact-solution"><?php print $fact_solution['fact']; ?></div>
-      <?php endif; ?>
-
-      <?php if (isset($solution_copy)): ?>
-      <div class="solution-copy"><?php print $solution_copy['safe_value']; ?><sup>2</sup></div>
+        <div class="fact-solution">
+          <?php print $fact_solution['fact']; ?><sup><?php print $fact_solution['footnotes']; ?></sup>
+        </div>
+      <?php elseif (isset($solution_copy)): ?>
+        <div class="solution-copy"><?php print $solution_copy['safe_value']; ?></div>
       <?php endif; ?>
 
       <?php if (isset($solution_support)): ?>
@@ -100,13 +101,11 @@
     </div>
 
     <div class="col sources">
-      <?php if (isset($fact_problem)): ?>
+      <?php if (isset($fact_sources)): ?>
       <div class="legal">
         <strong>Sources:</strong>
-        <sup>1</sup>
-
-        <?php foreach ($fact_problem['sources'] as $source): ?>
-        <?php print $source; ?>
+        <?php foreach ($fact_sources as $key => $source): ?>
+          <div><sup><?php print ($key + 1); ?></sup> <?php print $source; ?></div>
         <?php endforeach; ?>
       </div>
       <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -96,7 +96,7 @@
       <?php endif; ?>
 
       <?php if (isset($solution_support)): ?>
-      <div class="solution-supporting-copy"><?php print $solution_support['safe_value']; ?></div>
+      <div class="solution-supporting-copy"><?php print $solution_support; ?></div>
       <?php endif; ?>
     </div>
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -34,9 +34,7 @@
       <h4>The Problem</h4>
 
       <?php if (isset($fact_problem)): ?>
-      <div class="fact-problem">
-        <?php print $fact_problem['fact']; ?><sup><?php print $fact_problem['footnotes']; ?></sup>
-      </div>
+      <div class="fact-problem"><?php print $fact_problem['fact']; ?><sup><?php print $fact_problem['footnotes']; ?></sup></div>
       <?php endif; ?>
 
       <?php if (isset($faq)): ?>
@@ -86,9 +84,7 @@
       <h4>The Solution</h4>
 
       <?php if (isset($fact_solution)): ?>
-        <div class="fact-solution">
-          <?php print $fact_solution['fact']; ?><sup><?php print $fact_solution['footnotes']; ?></sup>
-        </div>
+        <div class="fact-solution"><?php print $fact_solution['fact']; ?><sup><?php print $fact_solution['footnotes']; ?></sup></div>
       <?php elseif (isset($solution_copy)): ?>
         <div class="solution-copy"><?php print $solution_copy['safe_value']; ?></div>
       <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -103,16 +103,6 @@
         <?php endforeach; ?>
       </div>
       <?php endif; ?>
-
-      <?php if (isset($fact_solution)): ?>
-      <div class="legal">
-        <sup>2</sup>
-
-        <?php foreach ($fact_solution['sources'] as $source): ?>
-        <?php print $source; ?>
-        <?php endforeach; ?>
-      </div>
-      <?php endif; ?>
     </div>
   </section>
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -58,14 +58,12 @@
       </ul>
       <script id="modal-facts" type="text/cached-modal">
         <a href="#" class="js-close-modal modal-close-button">×</a>
-        <?php foreach ($more_facts as $fact): ?>
-          <div class="fact-more">
-            <div class="fact-more"><?php print $fact['fact']; ?></div>
-            <?php // @TODO: Output sources separately.  ?>
-            <?php foreach ($fact['sources'] as $source): ?>
-              <div class="legal"><p>Source:</p><?php print $source; ?></div>
-            <?php endforeach; ?>
-          </div>
+        <?php foreach ($more_facts['facts'] as $key => $fact): ?>
+          <div class="fact-more"><?php print $fact['fact']; ?><sup><?php print $fact['footnotes']; ?></sup></div>
+        <?php endforeach; ?>
+        Sources:
+        <?php foreach ($more_facts['sources'] as $key => $source): ?>
+          <div class="legal"><sup><?php print ($key + 1); ?></sup><?php print $source; ?></div>
         <?php endforeach; ?>
       </script>
       <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -70,9 +70,9 @@
 
       <?php if (isset($partner_info)): ?>
       <?php foreach ($partner_info as $delta => $partner): ?>
-        <a href="#modal-partner-<?php print $delta; ?>" class="js-modal-link">
-          Why we &lt;3 <?php print $partner['name']; ?>
-        </a>
+        <ul>
+          <li><a href="#modal-partner-<?php print $delta; ?>" class="js-modal-link">Why we &lt;3 <?php print $partner['name']; ?></a>
+        </ul>
         <script id="modal-partner-<?php print $delta; ?>" type="text/cached-modal">
           <a href="#" class="js-close-modal modal-close-button">×</a>
           <?php print $partner['copy']; ?>


### PR DESCRIPTION
Fixes #855

Adds footnotes with corresponding sources into Campaign Actoin Page by way of a new  `dosomething_fact_get_mutiple_fact_field_vars($field_names)` function:

-- @param $field_names: an array of fact entityreference fields

-- @return: array of facts/footnotes and sources for all facts, indexed sequentially.
