### PR TITLE
Signup message

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -307,10 +307,15 @@ function dosomething_signup_user_signup($nid, $account = NULL) {
  * Sets Drupal message for a signup for given $title.
  *
  * @param string $title
- *   Title to display within the Drupal message.
+ *   Optional - Title of whatever user has signed up for.
  */
-function dosomething_signup_set_signup_message($title) {
-  $message = t("You're signed up for") . ' <em>' . $title . '</em>! ';
+function dosomething_signup_set_signup_message($title = NULL) {
+  // If title exists:
+  if ($title) {
+    // Prepare it for the message.
+    $title = ' ' . t("for") . ' <em>' . $title . '</em>';
+  }
+  $message = t("You're signed up") . $title . '! ';
   $message .=  t("Get started below.");
   drupal_set_message($message);
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -299,10 +299,20 @@ function dosomething_signup_user_signup($nid, $account = NULL) {
     );
     dosomething_user_send_message_request('campaign_signup', $params);
     // Set success message.
-    $message = t("You're signed up!") . '<br />';
-    $message .= t("Get started with") . ' ' . $node->title . '  ' . t("below!");
-    drupal_set_message($message);
+    dosomething_signup_set_signup_message($node->title);
   }
+}
+
+/**
+ * Sets Drupal message for a signup for given $title.
+ *
+ * @param string $title
+ *   Title to display within the Drupal message.
+ */
+function dosomething_signup_set_signup_message($title) {
+  $message = t("You're signed up for") . ' <em>' . $title . '</em>! ';
+  $message .=  t("Get started below.");
+  drupal_set_message($message);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -408,6 +408,8 @@ function dosomething_user_clean_cell_number($number) {
  *    - impact_noun
  */
 function dosomething_user_send_message_request($origin, $params = NULL) {
+  if (!module_exists('message_broker_producer')) return FALSE;
+
   $payload = array(
     'activity' => $origin,
     'email' => $params['email'],
@@ -446,8 +448,13 @@ function dosomething_user_send_message_request($origin, $params = NULL) {
       );
       break;
   }
-  if (module_exists('message_broker_producer')) {
-    message_broker_producer_request('produceTransactional', $payload);
+
+  try {
+    return message_broker_producer_request('produceTransactional', $payload);
+  }
+  catch (Exception $e){
+    watchdog('dosomething_user', $e, array(), WATCHDOG_ERROR);
+    return FALSE;
   }
 }
 


### PR DESCRIPTION
Refs #980 

Adds a `dosomething_signup_set_signup_message` to configure the campaign signup message.

Also error checks for any exceptions thrown from `message_broker_producer_request`.
