### PR TITLE
Replaces robots.txt during staging deployment

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -12,6 +12,9 @@ namespace :deploy do
 
       execute "cd '#{release_path}/html/sites/default'; sudo rm -rf files 2> /dev/null; sudo ln -s #{shared_path}/files files"
       execute "sudo ln -s #{shared_path}/settings.staging.php #{release_path}/html/sites/default/settings.staging.php"
+
+      # Prevent the robots
+      execute "printf 'User-agent: *\nDisallow: /' > #{release_path}/html/robots.txt"
     end
   end
 


### PR DESCRIPTION
To prevent unwanted robots and crawlers on the public facing staging instance we must update the robots file in the webroot with: 

```
User-agent: *
Disallow: /
```

This is executed after deployments
