### PR TITLE
Reportback form images

### DIFF
--- a/lib/modules/dosomething/dosomething_image/dosomething_image.module
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.module
@@ -114,3 +114,30 @@ function dosomething_image_node_view($node, $view_mode, $langcode) {
     dosomething_helpers_add_entityref_links($node, $entityref_fields);
   }
 }
+
+/**
+ * Returns a themed image for a given File $fid.
+ *
+ * @param int $fid
+ *  The File fid.
+ * @param string $style
+ *  The image style preset/size to return the image.
+ * @param string $alt
+ *  Optional - image alt text.
+ *
+ * @return array
+ *  A themed image tag with no set height/width.
+ */
+function dosomething_image_get_image_url_by_fid($fid, $style, $alt = '') {
+  $file = file_load($fid);
+  $image = image_load($file->uri);
+  $content = array(
+    'file' => array(
+      '#theme' => 'image_style',
+      '#style_name' => $style,
+      '#path' => $image->source,
+      '#alt' => $alt,
+    ),
+  );
+  return drupal_render($content);
+}

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -126,6 +126,22 @@ function dosomething_reportback_menu() {
 }
 
 /**
+ * Implements hook_theme().
+ */
+function dosomething_reportback_theme($existing, $type, $theme, $path) {
+  return array(
+    'reportback_form_images' => array(
+      'template' => 'reportback-form-images',
+      'path' => drupal_get_path('module', 'dosomething_reportback') . '/theme',
+      'variables' => array(
+        'updated' => NULL,
+        'images' => NULL,
+      ),
+    ),
+  );
+}
+
+/**
  * Implements hook_admin_paths().
  */
 function dosomething_reportback_admin_paths() {
@@ -244,12 +260,13 @@ function dosomething_reportback_form($form, &$form_state, $wrapper, $entity = NU
     ));
     $submit_label = t("Submit your pic");
   }
-  // Else, it's update form.  Display updated date.
+  // Else, it's update form.
   else {
-    //@todo: Display uploaded reportback files here.
-    $form['header'] = array(
-      '#markup' => '<p class="legal">Last updated ' . format_date($entity->updated, 'short') . '</p>',
-    );
+    // Output reportback images with date last updated.
+    $form['header']['#markup'] =theme('reportback_form_images', array(
+      'updated' => format_date($entity->updated, 'short'),
+      'images' => $entity->getThemedImages('300x300'),
+    ));
     $submit_label = t("Update submission");
   }
   $form['rbid'] = array(

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -84,6 +84,19 @@ class ReportbackEntity extends Entity {
     }
   }
 
+  /**
+   * Returns array of themed images for this Reportback.
+   */
+  public function getThemedImages($style) {
+    $images = array();
+    if (!module_exists('dosomething_image')) return $images();
+
+    foreach ($this->fids as $fid) {
+      $images[] = dosomething_image_get_image_url_by_fid($fid, $style);
+    }
+    return $images;
+  }
+
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/theme/reportback-form-images.tpl.php
+++ b/lib/modules/dosomething/dosomething_reportback/theme/reportback-form-images.tpl.php
@@ -1,0 +1,4 @@
+<p class="legal">Last updated: <?php print $updated; ?></p>
+<?php foreach ($images as $image): ?>
+  <?php print $image; ?>
+<?php endforeach; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/README.md
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/README.md
@@ -7,7 +7,12 @@ Place tpl files inside this directory if you need to override them.
 Campaign
 --------
 
-The campaign directory is for Campaign entity specific files.  The campaign.tpl.php file 
-is used for the "action" view mode, which is the default view mode for viewing a campaign.
-The campaign--pitch.tpl.php file is used for the "pitch" view mode.  Both of these tpl files
-have been copied from the entity.tpl.php file, in the Entity contrib module. 
+* `node--campaign.tpl.php` - Full node view of a campaign, a.k.a the Action Page
+* `node--campaign--pitch.tpl.php` - Pitch view mode of a campaign
+* `reportback-confirmation.tpl.php` - Displayed after a user submits the campaign's reportback form.
+
+
+Reportback
+----------
+* `reportback.tpl.php` - Staff only view of a reportback entity. e.g. /reportback/[id]
+* `reportback-form-images.tpl.php` - Displays a reportback's images, and last updated. @see `dosomething_reportback_form()`

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-form-images.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-form-images.tpl.php
@@ -1,0 +1,4 @@
+<p class="legal">Last updated: <?php print $updated; ?></p>
+<?php foreach ($images as $image): ?>
+  <?php print $image; ?>
+<?php endforeach; ?>


### PR DESCRIPTION
Closes #1016, Refs #974 

Displays the reportback images a user has uploaded within the form.

Adds a `dosomething_image_get_image_url_by_fid` function to do that.

@DFurnes -- Check out `paraneue_dosomething/templates/reportback/reportback-form-images.tpl.php`
