### PR TITLE
Redis ground work

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -1,4 +1,13 @@
 <?php
+
+/**
+ * Lets do something about globals
+ */
+define('DS_PROFILE_PATH', 'profiles/dosomething');
+define('DS_MODULES_PATH', DS_PROFILE_PATH . '/modules');
+define('DS_THEMES_PATH', DS_PROFILE_PATH . 'themes');
+define('DS_LIBRARIES_PATH', DS_PROFILE_PATH . '/libraries');
+
 /**
  * Database settings:
  */
@@ -51,6 +60,29 @@ $conf['varnish_control_key'] = '00c9203c65874ca5b4c359e19f00bf56';
 // Drupal 7 does not cache pages when we invoke hooks during bootstrap.
 // This needs to be disabled.
 $conf['page_cache_invoke_hooks'] = FALSE;
+
+require_once DS_MODULES_PATH . '/contrib/redis/redis.autoload.inc';
+
+// Predis autoloader not working. Declare here instead.
+spl_autoload_register(function($classname) {
+  if (0 === strpos($classname, 'Predis\\')) {
+    $filename = DS_LIBRARIES_PATH . '/predis/lib/';
+    $filename .= str_replace('\\', '/', $classname) . '.php';
+    return (bool)require_once $filename;
+  }
+  return false;
+});
+
+$conf['cache_backends'][] = DS_MODULES_PATH . '/contrib/redis/redis.autoload.inc';
+$conf['redis_client_interface'] = 'Predis';
+$conf['redis_client_host'] = getenv('DS_REDIS_HOST') ?: '127.0.0.1';
+$conf['redis_client_port'] = getenv('DS_REDIS_PORT') ?: '6379';
+$conf['cache_class_cache'] = 'Redis_Cache';
+$conf['cache_class_cache_menu'] = 'Redis_Cache';
+$conf['cache_class_cache_bootstrap'] = 'Redis_Cache';
+
+$conf['cache_class_cache_form'] = 'DrupalDatabaseCache';
+$conf['lock_inc'] = DS_MODULES_PATH . '/contrib/redis/redis.lock.inc';
 
 /**
  * Salt hash:

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -41,6 +41,7 @@ dependencies[] = metatag
 dependencies[] = mobilecommons
 dependencies[] = module_filter
 dependencies[] = pathauto
+dependencies[] = redis
 dependencies[] = search
 dependencies[] = strongarm
 dependencies[] = uuid

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -97,6 +97,10 @@ projects[optimizely][subdir] = "contrib"
 projects[pathauto] = "1.2"
 projects[pathauto][subdir] = "contrib"
 
+; Redis
+projects[redis] = "2.6"
+projects[redis][subdir] = "contrib"
+
 ; Secure Pages
 projects[securepages] = "1.0-beta2"
 projects[securepages][subdir] "contrib"

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -191,18 +191,22 @@ projects[paraneue][options][working-copy] = TRUE
 
 ; LIBRARIES
 
-; Mobile Commons PHP
-libraries[mobilecommons-php][download][type] = "git"
-libraries[mobilecommons-php][download][url] = "https://github.com/DoSomething/mobilecommons-php.git"
-
 ; DSAPI PHP Library
 ;libraries[dsapi][download][type] = "git"
 ;libraries[dsapi][download][url] = "git@github.com:DoSomething/dsapi-php.git"
 
-; Zendesk PHP
-libraries[zendesk][download][type] = "git"
-libraries[zendesk][download][url] = "https://github.com/zendesk/zendesk_api_client_php"
-
 ; Message Broker PHP Library
 libraries[messagebroker-phplib][download][type] = "git"
 libraries[messagebroker-phplib][download][url] = "https://github.com/DoSomething/messagebroker-phplib.git"
+
+; Mobile Commons PHP
+libraries[mobilecommons-php][download][type] = "git"
+libraries[mobilecommons-php][download][url] = "https://github.com/DoSomething/mobilecommons-php.git"
+
+; Predis
+libraries[predis][download][type] = "git"
+libraries[predis][download][url] = "git@github.com:nrk/predis.git"
+
+; Zendesk PHP
+libraries[zendesk][download][type] = "git"
+libraries[zendesk][download][url] = "https://github.com/zendesk/zendesk_api_client_php"

--- a/provision/salt/roots/salt/redis.sls
+++ b/provision/salt/roots/salt/redis.sls
@@ -1,0 +1,7 @@
+{% if grains['os'] == 'Ubuntu' %}
+
+redis-server:
+  pkg:
+    - installed
+
+{% endif %}

--- a/provision/salt/roots/salt/top.sls
+++ b/provision/salt/roots/salt/top.sls
@@ -7,5 +7,6 @@ base:
     - install
     - composer
     - node
+    - redis
     - dosomething
     - drush-ext


### PR DESCRIPTION
This merge installs redis server into our VM and adds and enables the Drupal redis module.  It also pulls down the predis library.

This does not include any of the default settings that are necessary to wire this up.  These will come in a future merge.
