### PR TITLE
Campaign custom variables

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -120,8 +120,11 @@ function dosomething_campaign_get_custom_var_prefix($nid) {
 /**
  * Implements hook_node_delete().
  */
-function dosomething_campaign_node_delete() {
-  // @todo: Delete any custom variables associated with node.
+function dosomething_campaign_node_delete($node) {
+  // Delete any custom variables associated with node.
+  foreach (dosomething_campaign_get_custom_varnames($node->nid) as $name) {
+    variable_del($name);
+  }
 }
 
 /*

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -375,13 +375,13 @@ function dosomething_campaign_preprocess_custom_vars(&$vars) {
   $prefix = dosomething_campaign_get_custom_var_prefix($vars['nid']);
   // Check for custom alt color.
   $alt_color = variable_get($prefix . 'alt_color');
-  if (isset($alt_color) && !empty($alt_color)) {
+  if (!empty($alt_color)) {
     // Sanitize value for sanity's sake.
     $vars['alt_color'] = strip_tags($alt_color);
   }
   // Check for alt background File fid.
   $fid = variable_get($prefix . 'alt_bg_fid');
-  if (isset($fid) && !empty($fid)) {
+  if (!empty($fid)) {
     $file = file_load($fid);
     $vars['alt_bg_src'] = file_create_url($file->uri);
   }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -64,11 +64,13 @@ function _dosomething_campaign_form_extras(&$form, &$form_state) {
     '#size' => 6,
   );
   // Alt bg pattern variable.
-  $alt_bg_pattern = $prefix . 'alt_bg_pattern';
-  $form['custom'][$alt_bg_pattern] = array(
+  $alt_bg_fid = $prefix . 'alt_bg_fid';
+  $form['custom'][$alt_bg_fid] = array(
     '#type' => 'managed_file',
-    '#title' => t('Alt bg pattern'),
-    '#default_value' => variable_get($alt_bg_pattern),
+    '#title' => t('Alt background pattern'),
+    '#default_value' => variable_get($alt_bg_fid),
+    //@todo: /campaigns/[nid] directory?
+    '#upload_location' => 'public://',
   );
   $form['#submit'][] = 'dosomething_campaign_save_custom_vars';
 }
@@ -80,13 +82,26 @@ function dosomething_campaign_save_custom_vars(&$form, &$form_state) {
   $values = $form_state['values'];
   $nid = $values['nid'];
   // Gather all possible custom variable names for $nid.
+  $prefix = dosomething_campaign_get_custom_var_prefix($nid);
   $varnames = dosomething_campaign_get_custom_varnames($nid);
+  // Store variable name for alt_bg_fid.
+  $alt_bg_fid = $prefix . 'alt_bg_fid';
   // Foreach possible custom variable:
-  foreach ($varnames as $custom_var) {
+  foreach ($varnames as $varname) {
     // If a value is set, or if a value exists already (in case of removal):
-    if (!empty($values[$custom_var]) || variable_get($custom_var)) {
+    if (!empty($values[$varname]) || variable_get($varname)) {
       // Set variable value.
-      variable_set($custom_var, $values[$custom_var]);
+      variable_set($varname, $values[$varname]);
+      // If this is the alt bg file, and we have a value present.
+      if ($varname == $alt_bg_fid && !empty($values[$varname])) {
+        // Load the file.
+        $file = file_load($values[$varname]);
+        // If not permanent, make it permanent.
+        if ($file->status != FILE_STATUS_PERMANENT) {
+          $file->status = FILE_STATUS_PERMANENT;
+          file_save($file);
+        }
+      }
     }
   }
 }
@@ -96,7 +111,7 @@ function dosomething_campaign_save_custom_vars(&$form, &$form_state) {
  */
 function dosomething_campaign_get_custom_varnames($nid) {
   $names = array(
-    'alt_bg_pattern',
+    'alt_bg_fid',
     'alt_color',
   );
   // Initialize return array.
@@ -333,6 +348,9 @@ function dosomething_campaign_preprocess_node(&$vars) {
       dosomething_campaign_preprocess_partners_vars($vars);
     }
 
+    // Preprocess any custom campaign variables.
+    dosomething_campaign_preprocess_custom_vars($vars);
+
     if ($vars['view_mode'] == 'pitch') {
       // Use the pitch page template to theme.
       $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'] . '__pitch';
@@ -344,6 +362,29 @@ function dosomething_campaign_preprocess_node(&$vars) {
       dosomething_campaign_preprocess_action_page($vars, $wrapper);
     }
   }
+}
+
+/**
+ * Preprocesses variables for any custom settings.
+ *
+ * @param array $vars
+ *   Node variables, passed from preprocess_node.
+ */
+function dosomething_campaign_preprocess_custom_vars(&$vars) {
+  // Get prefix to check for custom campaign variables.
+  $prefix = dosomething_campaign_get_custom_var_prefix($vars['nid']);
+  // Check for custom alt color.
+  $alt_color = variable_get($prefix . 'alt_color');
+  if (isset($alt_color) && !empty($alt_color)) {
+    // Sanitize value for sanity's sake.
+    $vars['alt_color'] = strip_tags($alt_color);
+  }
+  // Check for alt background image.
+  $fid = variable_get($prefix . 'alt_bg_fid');
+  if (isset($fid) && !empty($fid)) {
+    $vars['alt_bg_image'] = dosomething_image_get_image_url_by_fid($fid, '50x50');
+  }
+  dsm($vars);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -404,7 +404,7 @@ function dosomething_campaign_preprocess_partners_vars(&$vars) {
   if (isset($vars['sponsors'])) {
     foreach ($vars['sponsors'] as $delta => $sponsor) {
       if (isset($sponsor['fid'])) {
-        $img = dosomething_image_get_image_url_by_fid($sponsor['fid'], '50x50');
+        $img = dosomething_image_get_themed_image_by_fid($sponsor['fid'], '50x50');
         $vars['sponsors'][$delta]['img'] = $img;
       }
     }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -379,12 +379,12 @@ function dosomething_campaign_preprocess_custom_vars(&$vars) {
     // Sanitize value for sanity's sake.
     $vars['alt_color'] = strip_tags($alt_color);
   }
-  // Check for alt background image.
+  // Check for alt background File fid.
   $fid = variable_get($prefix . 'alt_bg_fid');
   if (isset($fid) && !empty($fid)) {
-    $vars['alt_bg_image'] = dosomething_image_get_image_url_by_fid($fid, '50x50');
+    $file = file_load($fid);
+    $vars['alt_bg_src'] = file_create_url($file->uri);
   }
-  dsm($vars);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -12,6 +12,10 @@ include_once 'dosomething_campaign.features.inc';
 function dosomething_campaign_form_campaign_node_form_alter(&$form, &$form_state, $form_id) {
   unset($form['field_active_hours'][LANGUAGE_NONE]['#options']['_none']);
   $form['title']['#description'] = t('Title - i.e. "Protect your Pills", "Birthday Mail", or "Teens for Jeans" <br/><strong> Limit: 20 characters. </strong>');
+  // If we're updating an existing node, add the custom settings fieldset.
+  if (isset($form['nid']['#value'])) {
+    _dosomething_campaign_form_extras($form, $form_state);
+  }
 }
 
 /**
@@ -37,6 +41,87 @@ function dosomething_campaign_menu() {
     'access arguments' => array(1),
   );
   return $items;
+}
+
+/**
+ * Adds form elements for custom campaign variables.
+ */
+function _dosomething_campaign_form_extras(&$form, &$form_state) {
+  $prefix = dosomething_campaign_get_custom_var_prefix($form['nid']['#value']);
+  $form['custom'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Custom settings'),
+    '#weight' => 60,
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $alt_color = $prefix . 'alt_color';
+  $form['custom'][$alt_color] = array(
+    '#type' => 'textfield',
+    '#title' => t('Alt color'),
+    '#default_value' => variable_get($alt_color),
+    '#field_prefix' => '#',
+    '#size' => 6,
+  );
+  // Alt bg pattern variable.
+  $alt_bg_pattern = $prefix . 'alt_bg_pattern';
+  $form['custom'][$alt_bg_pattern] = array(
+    '#type' => 'managed_file',
+    '#title' => t('Alt bg pattern'),
+    '#default_value' => variable_get($alt_bg_pattern),
+  );
+  $form['#submit'][] = 'dosomething_campaign_save_custom_vars';
+}
+
+/**
+ * Saves custom campaign variables.
+ */
+function dosomething_campaign_save_custom_vars(&$form, &$form_state) {
+  $values = $form_state['values'];
+  $nid = $values['nid'];
+  // Gather all possible custom variable names for $nid.
+  $varnames = dosomething_campaign_get_custom_varnames($nid);
+  // Foreach possible custom variable:
+  foreach ($varnames as $custom_var) {
+    // If a value is set, or if a value exists already (in case of removal):
+    if (!empty($values[$custom_var]) || variable_get($custom_var)) {
+      // Set variable value.
+      variable_set($custom_var, $values[$custom_var]);
+    }
+  }
+}
+
+/**
+ * Returns list of possible custom variable names for a given $nid.
+ */
+function dosomething_campaign_get_custom_varnames($nid) {
+  $names = array(
+    'alt_bg_pattern',
+    'alt_color',
+  );
+  // Initialize return array.
+  $vars = array();
+  // For each custom variable:
+  foreach ($names as $name) {
+    // Generate the variable name for this $nid and append to return array.
+    $vars[] = dosomething_campaign_get_custom_var_prefix($nid) . $name;
+  }
+  return $vars;
+}
+
+/**
+ * Returns string of prefix used to identify a campaign's custom variables.
+ */
+function dosomething_campaign_get_custom_var_prefix($nid) {
+  return 'dosomething_campaign_nid_' . $nid . '_';
+}
+
+
+/**
+ * Implements hook_node_delete().
+ */
+function dosomething_campaign_node_delete() {
+  // @todo: Delete any custom variables associated with node.
 }
 
 /*

--- a/lib/modules/dosomething/dosomething_image/dosomething_image.module
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.module
@@ -132,7 +132,7 @@ function dosomething_image_node_view($node, $view_mode, $langcode) {
  * @return array
  *  A themed image tag with no set height/width.
  */
-function dosomething_image_get_image_url_by_fid($fid, $style, $alt = '') {
+function dosomething_image_get_themed_image_by_fid($fid, $style, $alt = '') {
   $file = file_load($fid);
   $image = image_load($file->uri);
   $content = array(

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -92,7 +92,7 @@ class ReportbackEntity extends Entity {
     if (!module_exists('dosomething_image')) return $images();
 
     foreach ($this->fids as $fid) {
-      $images[] = dosomething_image_get_image_url_by_fid($fid, $style);
+      $images[] = dosomething_image_get_themed_image_by_fid($fid, $style);
     }
     return $images;
   }


### PR DESCRIPTION
Fixes #895

Adds a fieldset for on an existing campaign node's edit form, where we can set a custom alt color and custom alt background image.

The variables in the template are named `alt_color` and `alt_bg_src`.

The values are stored as Drupal variables instead of fields, because only a small number of campaigns will actually need these values.  

The list of available variables are defined within a function called `dosomething_campaign_get_custom_varnames`, so it's easier to add, update, and maintain custom variables in the future.  Looking into possibly using this storage method for scholarships as well, since few campaigns have them.

Also renames incorrectly named `dosomething_image_get_image_url_by_fid` function as `dosomething_image_get_themed_image_by_fid`.
