### PR TITLE
Hotfix for reportback upload directory

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -554,7 +554,9 @@ function dosomething_reportback_entity_insert($entity, $type) {
  * Returns the path to write a reportback file for given node $nid.
  */
 function dosomething_reportback_get_file_dir($nid) {
-  return 'public://reportbacks/' . $nid;
+  return 'public://';
+  // @todo: Make me work. @see Issue #1054.
+  // return 'public://reportbacks/' . $nid;
 }
 
 /**


### PR DESCRIPTION
This is a hotfix to get reportback uploads working on staging for today's deployment.

Tough to troubleshoot this on my work machine because when the upload directory is set to `reportbacks/[nid]`, it works.  However I can replicate #1054 from my personal machine, so I'll continue to investigate. 
