### PR TITLE
Fixes #1064 - missing email value in payload

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -133,6 +133,8 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
     break;
 
     case 'user_pass':
+      // Get account object by email address submitted for reset
+      $account = user_load_by_mail($form_state['input']['name']);
       // Send external message request
       $params = array(
         'email' => $account->mail,
@@ -154,6 +156,8 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
 function dosomething_user_new_user($form, &$form_state) {
   // Should we sign this kid up for messages?
   if (!dosomething_user_is_under_thirteen()) {
+    global $user;
+    $account = $user;
     // Send external message request
     $params = array(
       'email' => $account->mail,


### PR DESCRIPTION
Fixes #1064

The payload value for email was missing in both the new user registration and the password reset. The email value is required to build the related message to be sent my Mandrilll.
