### PR TITLE
Fixes #1069 - Move to mbp naming convention

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -546,7 +546,7 @@ function dosomething_reportback_set_files(&$entity, $values) {
  */
 function dosomething_reportback_entity_insert($entity, $type) {
   if ($type == 'reportback') {
-    dosomething_reportback_message_broker($entity);
+    dosomething_reportback_mbp_request($entity);
   }
 }
 
@@ -562,7 +562,7 @@ function dosomething_reportback_get_file_dir($nid) {
 /**
  * Sends exernal message request for a reportback.
  */
-function dosomething_reportback_message_broker($entity) {
+function dosomething_reportback_mbp_request($entity) {
   // Send external message request
   if (module_exists('dosomething_user')) {
     $account = user_load($entity->uid);
@@ -575,6 +575,6 @@ function dosomething_reportback_message_broker($entity) {
       'impact_number' => '??',
       'impact_noun' => '??',
     );
-    dosomething_user_send_message_request('campaign_reportback', $params);
+    dosomething_user_mbp_request('campaign_reportback', $params);
   }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -297,7 +297,7 @@ function dosomething_signup_user_signup($nid, $account = NULL) {
       'step_two' => '??',
       'step_three' => '??',
     );
-    dosomething_user_send_message_request('campaign_signup', $params);
+    dosomething_user_mbp_request('campaign_signup', $params);
     // Set success message.
     dosomething_signup_set_signup_message($node->title);
   }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -140,7 +140,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
         'first_name' => dosomething_user_get_field('field_first_name', $account),
         'reset_link' => user_pass_reset_url($account),
       );
-      dosomething_user_send_message_request('user_password', $params);
+      dosomething_user_mbp_request('user_password', $params);
     break;
 
   }
@@ -160,7 +160,7 @@ function dosomething_user_new_user($form, &$form_state) {
       'uid' => $account->uid,
       'first_name' => dosomething_user_get_field('field_first_name', $account),
     );
-    dosomething_user_send_message_request('user_register', $params);
+    dosomething_user_mbp_request('user_register', $params);
     // Sign user up for mobile commons
     if (module_exists('dosomething_signup')) {
       $opt_in = variable_get('dosomething_mobilecommons_general');
@@ -409,7 +409,7 @@ function dosomething_user_clean_cell_number($number) {
  *    - impact_number
  *    - impact_noun
  */
-function dosomething_user_send_message_request($origin, $params = NULL) {
+function dosomething_user_mbp_request($origin, $params = NULL) {
   if (!module_exists('message_broker_producer')) return FALSE;
 
   $payload = array(


### PR DESCRIPTION
Fixes #1069

Removes the word "message" with mbp. "Message" is used to reference messages being displayed to the user via drupal_set_message()
