### PR TITLE
View reportback images

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -39,7 +39,6 @@ function dosomething_reportback_entity_property_info() {
     'type' => 'integer',
     'schema field' => 'rbid',
     'entity views field' => TRUE,
-    'setter callback' => 'entity_property_verbatim_set',
   );
   $properties['nid'] = array(
     'label' => t('Node nid'),
@@ -577,4 +576,53 @@ function dosomething_reportback_mbp_request($entity) {
     );
     dosomething_user_mbp_request('campaign_reportback', $params);
   }
+}
+
+/**
+ * Implements hook_views_data().
+ */
+function dosomething_reportback_views_data() {
+  $data['dosomething_reportback_file']['table']['group'] = t('Reportback');
+  $data['dosomething_reportback_file']['table']['base'] = array(
+    'field' => 'rbid', // This is the identifier field for the view.
+    'title' => t('Reportback images'),
+    'help' => t('Image uploads for reportbacks.'),
+    'weight' => -10,
+  );
+  $data['dosomething_reportback_file']['table']['join'] = array(
+    'dosomething_reportback' => array(
+      'left_field' => 'rbid',
+      'field' => 'rbid',
+    ),
+    'file_managed' => array(
+      'left_field' => 'fid',
+      'field' => 'fid',
+    ),
+  );
+  $data['dosomething_reportback_file']['rbid'] = array(
+    'title' => t('Reportback file rbid'),
+    'help' => t('Reportback file rid that references a reportback.'),
+    'relationship' => array(
+      'base' => 'dosomething_reportback',
+      'base field' => 'rbid',
+      'handler' => 'views_handler_relationship',
+      'label' => t('Reportback rbid'),
+      'title' => t('Reportback rbid'),
+      'help' => t('The Reportback rbid the File belongs to.'),
+    ),
+  );
+  $data['dosomething_reportback_file']['fid'] = array(
+    'title' => t('Reportback image fid'),
+    'help' => t('The fid of the Reportback image file.'),
+    'field' => array(
+      'handler' => 'views_handler_field_file',
+      'click sortable' => TRUE,
+    ),
+    'relationship' => array(
+      'base' => 'file_managed',
+      'handler' => 'views_handler_relationship',
+      'label' => t('Reportback image'),
+    ),
+  );
+  return $data;
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
@@ -85,6 +85,11 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['empty']['area']['empty'] = TRUE;
   $handler->display->display_options['empty']['area']['content'] = 'No reportbacks found.';
   $handler->display->display_options['empty']['area']['format'] = 'markdown';
+  /* Relationship: Reportback: User uid */
+  $handler->display->display_options['relationships']['uid']['id'] = 'uid';
+  $handler->display->display_options['relationships']['uid']['table'] = 'dosomething_reportback';
+  $handler->display->display_options['relationships']['uid']['field'] = 'uid';
+  $handler->display->display_options['relationships']['uid']['required'] = TRUE;
   /* Field: Reportback: Reportback rbid */
   $handler->display->display_options['fields']['rbid']['id'] = 'rbid';
   $handler->display->display_options['fields']['rbid']['table'] = 'views_entity_reportback';
@@ -92,29 +97,26 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['fields']['rbid']['label'] = 'Rbid';
   $handler->display->display_options['fields']['rbid']['separator'] = '';
   $handler->display->display_options['fields']['rbid']['link_to_entity'] = 1;
-  /* Field: Reportback: User uid */
-  $handler->display->display_options['fields']['uid']['id'] = 'uid';
-  $handler->display->display_options['fields']['uid']['table'] = 'views_entity_reportback';
-  $handler->display->display_options['fields']['uid']['field'] = 'uid';
-  $handler->display->display_options['fields']['uid']['label'] = 'User';
-  $handler->display->display_options['fields']['uid']['link_to_entity'] = 1;
-  $handler->display->display_options['fields']['uid']['view_mode'] = 'full';
-  $handler->display->display_options['fields']['uid']['bypass_access'] = 0;
-  /* Field: Reportback: User uid */
-  $handler->display->display_options['fields']['uid_1']['id'] = 'uid_1';
-  $handler->display->display_options['fields']['uid_1']['table'] = 'views_entity_reportback';
-  $handler->display->display_options['fields']['uid_1']['field'] = 'uid';
-  $handler->display->display_options['fields']['uid_1']['label'] = 'Uid';
-  $handler->display->display_options['fields']['uid_1']['link_to_entity'] = 1;
-  $handler->display->display_options['fields']['uid_1']['display'] = 'id';
-  $handler->display->display_options['fields']['uid_1']['view_mode'] = 'full';
-  $handler->display->display_options['fields']['uid_1']['bypass_access'] = 0;
   /* Field: Reportback: Created Date */
   $handler->display->display_options['fields']['created']['id'] = 'created';
   $handler->display->display_options['fields']['created']['table'] = 'dosomething_reportback';
   $handler->display->display_options['fields']['created']['field'] = 'created';
   $handler->display->display_options['fields']['created']['label'] = 'Date';
   $handler->display->display_options['fields']['created']['date_format'] = 'short';
+  /* Field: Reportback: User uid */
+  $handler->display->display_options['fields']['uid']['id'] = 'uid';
+  $handler->display->display_options['fields']['uid']['table'] = 'views_entity_reportback';
+  $handler->display->display_options['fields']['uid']['field'] = 'uid';
+  $handler->display->display_options['fields']['uid']['label'] = 'UId';
+  $handler->display->display_options['fields']['uid']['link_to_entity'] = 1;
+  $handler->display->display_options['fields']['uid']['display'] = 'id';
+  $handler->display->display_options['fields']['uid']['view_mode'] = 'full';
+  $handler->display->display_options['fields']['uid']['bypass_access'] = 0;
+  /* Field: User: E-mail */
+  $handler->display->display_options['fields']['mail']['id'] = 'mail';
+  $handler->display->display_options['fields']['mail']['table'] = 'users';
+  $handler->display->display_options['fields']['mail']['field'] = 'mail';
+  $handler->display->display_options['fields']['mail']['relationship'] = 'uid';
   /* Field: Reportback: Quantity */
   $handler->display->display_options['fields']['quantity']['id'] = 'quantity';
   $handler->display->display_options['fields']['quantity']['table'] = 'dosomething_reportback';
@@ -186,15 +188,17 @@ function dosomething_reportback_views_default_views() {
     t('last »'),
     t('Copy'),
     t('No reportbacks found.'),
+    t('User'),
     t('Rbid'),
     t('.'),
-    t('User'),
-    t('Uid'),
     t('Date'),
+    t('UId'),
+    t('E-mail'),
     t('Quantity'),
     t(','),
     t('All'),
     t('Reportbacks: %1'),
+    t('Uid'),
     t('Page'),
   );
   $export['node_reportbacks'] = $view;

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
@@ -123,7 +123,7 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['fields']['updated']['label'] = 'Updated';
   $handler->display->display_options['fields']['updated']['alter']['make_link'] = TRUE;
   $handler->display->display_options['fields']['updated']['alter']['path'] = 'reportback/[rbid]';
-  $handler->display->display_options['fields']['updated']['date_format'] = 'raw time ago';
+  $handler->display->display_options['fields']['updated']['date_format'] = 'short';
   /* Field: Reportback: User uid */
   $handler->display->display_options['fields']['uid']['id'] = 'uid';
   $handler->display->display_options['fields']['uid']['table'] = 'views_entity_reportback';
@@ -155,7 +155,7 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['fields']['uri']['relationship'] = 'fid';
   $handler->display->display_options['fields']['uri']['label'] = 'Pic';
   $handler->display->display_options['fields']['uri']['alter']['alter_text'] = TRUE;
-  $handler->display->display_options['fields']['uri']['alter']['text'] = '<img src="[uri]" width="200" height="200" />';
+  $handler->display->display_options['fields']['uri']['alter']['text'] = '<img src="[uri]" width="200" height="200"/>';
   $handler->display->display_options['fields']['uri']['alter']['make_link'] = TRUE;
   $handler->display->display_options['fields']['uri']['alter']['path'] = 'reportback/[rbid]';
   $handler->display->display_options['fields']['uri']['file_download_path'] = TRUE;
@@ -244,7 +244,7 @@ function dosomething_reportback_views_default_views() {
     t('Quantity'),
     t(','),
     t('Pic'),
-    t('<img src="[uri]" />'),
+    t('<img src="[uri]" width="200" height="200"/>'),
     t('Fid'),
     t('All'),
     t('Reportbacks: %1'),

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
@@ -34,24 +34,16 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['style_plugin'] = 'table';
   $handler->display->display_options['style_options']['columns'] = array(
     'rbid' => 'rbid',
-    'uid' => 'uid',
-    'uid_1' => 'uid_1',
     'created' => 'created',
+    'uid' => 'uid',
+    'mail' => 'mail',
     'quantity' => 'quantity',
+    'fid' => 'fid',
+    'updated' => 'updated',
   );
-  $handler->display->display_options['style_options']['default'] = 'created';
+  $handler->display->display_options['style_options']['default'] = 'updated';
   $handler->display->display_options['style_options']['info'] = array(
     'rbid' => array(
-      'align' => '',
-      'separator' => '',
-      'empty_column' => 0,
-    ),
-    'uid' => array(
-      'align' => '',
-      'separator' => '',
-      'empty_column' => 0,
-    ),
-    'uid_1' => array(
       'align' => '',
       'separator' => '',
       'empty_column' => 0,
@@ -63,12 +55,33 @@ function dosomething_reportback_views_default_views() {
       'separator' => '',
       'empty_column' => 0,
     ),
-    'field_image_user_reportback' => array(
+    'uid' => array(
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'mail' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
       'align' => '',
       'separator' => '',
       'empty_column' => 0,
     ),
     'quantity' => array(
+      'sortable' => 1,
+      'default_sort_order' => 'desc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'fid' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'updated' => array(
       'sortable' => 1,
       'default_sort_order' => 'desc',
       'align' => '',
@@ -90,6 +103,11 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['relationships']['uid']['table'] = 'dosomething_reportback';
   $handler->display->display_options['relationships']['uid']['field'] = 'uid';
   $handler->display->display_options['relationships']['uid']['required'] = TRUE;
+  /* Relationship: Reportback: Reportback image fid */
+  $handler->display->display_options['relationships']['fid']['id'] = 'fid';
+  $handler->display->display_options['relationships']['fid']['table'] = 'dosomething_reportback_file';
+  $handler->display->display_options['relationships']['fid']['field'] = 'fid';
+  $handler->display->display_options['relationships']['fid']['label'] = 'Image';
   /* Field: Reportback: Reportback rbid */
   $handler->display->display_options['fields']['rbid']['id'] = 'rbid';
   $handler->display->display_options['fields']['rbid']['table'] = 'views_entity_reportback';
@@ -97,17 +115,17 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['fields']['rbid']['label'] = 'Rbid';
   $handler->display->display_options['fields']['rbid']['separator'] = '';
   $handler->display->display_options['fields']['rbid']['link_to_entity'] = 1;
-  /* Field: Reportback: Created Date */
-  $handler->display->display_options['fields']['created']['id'] = 'created';
-  $handler->display->display_options['fields']['created']['table'] = 'dosomething_reportback';
-  $handler->display->display_options['fields']['created']['field'] = 'created';
-  $handler->display->display_options['fields']['created']['label'] = 'Date';
-  $handler->display->display_options['fields']['created']['date_format'] = 'short';
+  /* Field: Reportback: Last Updated */
+  $handler->display->display_options['fields']['updated']['id'] = 'updated';
+  $handler->display->display_options['fields']['updated']['table'] = 'dosomething_reportback';
+  $handler->display->display_options['fields']['updated']['field'] = 'updated';
+  $handler->display->display_options['fields']['updated']['label'] = 'Updated';
+  $handler->display->display_options['fields']['updated']['date_format'] = 'raw time ago';
   /* Field: Reportback: User uid */
   $handler->display->display_options['fields']['uid']['id'] = 'uid';
   $handler->display->display_options['fields']['uid']['table'] = 'views_entity_reportback';
   $handler->display->display_options['fields']['uid']['field'] = 'uid';
-  $handler->display->display_options['fields']['uid']['label'] = 'UId';
+  $handler->display->display_options['fields']['uid']['label'] = 'Uid';
   $handler->display->display_options['fields']['uid']['link_to_entity'] = 1;
   $handler->display->display_options['fields']['uid']['display'] = 'id';
   $handler->display->display_options['fields']['uid']['view_mode'] = 'full';
@@ -117,6 +135,19 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['fields']['mail']['table'] = 'users';
   $handler->display->display_options['fields']['mail']['field'] = 'mail';
   $handler->display->display_options['fields']['mail']['relationship'] = 'uid';
+  /* Field: File: File ID */
+  $handler->display->display_options['fields']['fid']['id'] = 'fid';
+  $handler->display->display_options['fields']['fid']['table'] = 'file_managed';
+  $handler->display->display_options['fields']['fid']['field'] = 'fid';
+  $handler->display->display_options['fields']['fid']['relationship'] = 'fid';
+  $handler->display->display_options['fields']['fid']['label'] = 'Fid';
+  $handler->display->display_options['fields']['fid']['link_to_file'] = TRUE;
+  /* Field: Reportback: Created Date */
+  $handler->display->display_options['fields']['created']['id'] = 'created';
+  $handler->display->display_options['fields']['created']['table'] = 'dosomething_reportback';
+  $handler->display->display_options['fields']['created']['field'] = 'created';
+  $handler->display->display_options['fields']['created']['label'] = 'Created';
+  $handler->display->display_options['fields']['created']['date_format'] = 'short';
   /* Field: Reportback: Quantity */
   $handler->display->display_options['fields']['quantity']['id'] = 'quantity';
   $handler->display->display_options['fields']['quantity']['table'] = 'dosomething_reportback';
@@ -189,16 +220,18 @@ function dosomething_reportback_views_default_views() {
     t('Copy'),
     t('No reportbacks found.'),
     t('User'),
+    t('Image'),
     t('Rbid'),
     t('.'),
-    t('Date'),
-    t('UId'),
+    t('Updated'),
+    t('Uid'),
     t('E-mail'),
+    t('Fid'),
+    t('Created'),
     t('Quantity'),
     t(','),
     t('All'),
     t('Reportbacks: %1'),
-    t('Uid'),
     t('Page'),
   );
   $export['node_reportbacks'] = $view;

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
@@ -113,6 +113,7 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['fields']['rbid']['table'] = 'views_entity_reportback';
   $handler->display->display_options['fields']['rbid']['field'] = 'rbid';
   $handler->display->display_options['fields']['rbid']['label'] = 'Rbid';
+  $handler->display->display_options['fields']['rbid']['exclude'] = TRUE;
   $handler->display->display_options['fields']['rbid']['separator'] = '';
   $handler->display->display_options['fields']['rbid']['link_to_entity'] = 1;
   /* Field: Reportback: Last Updated */
@@ -120,6 +121,8 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['fields']['updated']['table'] = 'dosomething_reportback';
   $handler->display->display_options['fields']['updated']['field'] = 'updated';
   $handler->display->display_options['fields']['updated']['label'] = 'Updated';
+  $handler->display->display_options['fields']['updated']['alter']['make_link'] = TRUE;
+  $handler->display->display_options['fields']['updated']['alter']['path'] = 'reportback/[rbid]';
   $handler->display->display_options['fields']['updated']['date_format'] = 'raw time ago';
   /* Field: Reportback: User uid */
   $handler->display->display_options['fields']['uid']['id'] = 'uid';
@@ -135,13 +138,6 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['fields']['mail']['table'] = 'users';
   $handler->display->display_options['fields']['mail']['field'] = 'mail';
   $handler->display->display_options['fields']['mail']['relationship'] = 'uid';
-  /* Field: File: File ID */
-  $handler->display->display_options['fields']['fid']['id'] = 'fid';
-  $handler->display->display_options['fields']['fid']['table'] = 'file_managed';
-  $handler->display->display_options['fields']['fid']['field'] = 'fid';
-  $handler->display->display_options['fields']['fid']['relationship'] = 'fid';
-  $handler->display->display_options['fields']['fid']['label'] = 'Fid';
-  $handler->display->display_options['fields']['fid']['link_to_file'] = TRUE;
   /* Field: Reportback: Created Date */
   $handler->display->display_options['fields']['created']['id'] = 'created';
   $handler->display->display_options['fields']['created']['table'] = 'dosomething_reportback';
@@ -152,6 +148,24 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['fields']['quantity']['id'] = 'quantity';
   $handler->display->display_options['fields']['quantity']['table'] = 'dosomething_reportback';
   $handler->display->display_options['fields']['quantity']['field'] = 'quantity';
+  /* Field: File: Path */
+  $handler->display->display_options['fields']['uri']['id'] = 'uri';
+  $handler->display->display_options['fields']['uri']['table'] = 'file_managed';
+  $handler->display->display_options['fields']['uri']['field'] = 'uri';
+  $handler->display->display_options['fields']['uri']['relationship'] = 'fid';
+  $handler->display->display_options['fields']['uri']['label'] = 'Pic';
+  $handler->display->display_options['fields']['uri']['alter']['alter_text'] = TRUE;
+  $handler->display->display_options['fields']['uri']['alter']['text'] = '<img src="[uri]" width="200" height="200" />';
+  $handler->display->display_options['fields']['uri']['alter']['make_link'] = TRUE;
+  $handler->display->display_options['fields']['uri']['alter']['path'] = 'reportback/[rbid]';
+  $handler->display->display_options['fields']['uri']['file_download_path'] = TRUE;
+  /* Field: File: File ID */
+  $handler->display->display_options['fields']['fid']['id'] = 'fid';
+  $handler->display->display_options['fields']['fid']['table'] = 'file_managed';
+  $handler->display->display_options['fields']['fid']['field'] = 'fid';
+  $handler->display->display_options['fields']['fid']['relationship'] = 'fid';
+  $handler->display->display_options['fields']['fid']['label'] = 'Fid';
+  $handler->display->display_options['fields']['fid']['link_to_file'] = TRUE;
   /* Sort criterion: Reportback: Created Date */
   $handler->display->display_options['sorts']['created']['id'] = 'created';
   $handler->display->display_options['sorts']['created']['table'] = 'dosomething_reportback';
@@ -226,10 +240,12 @@ function dosomething_reportback_views_default_views() {
     t('Updated'),
     t('Uid'),
     t('E-mail'),
-    t('Fid'),
     t('Created'),
     t('Quantity'),
     t(','),
+    t('Pic'),
+    t('<img src="[uri]" />'),
+    t('Fid'),
     t('All'),
     t('Reportbacks: %1'),
     t('Page'),

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -119,10 +119,17 @@ class ReportbackEntityController extends EntityAPIController {
       '#type' => 'markup',
       '#markup' => l($account->name, 'user/' . $account->uid),
     );
+
     $build['node_title'] = array(
       '#type' => 'markup',
       '#markup' => l($node_wrapper->title->value(), 'node/' . $entity->nid),
     );
+    foreach ($entity->getThemedImages('300x300') as $delta => $image) {
+      $build['file_' . $delta] = array(
+        '#type' => 'markup',
+        '#markup' => $image,
+      );
+    }
     $build['quantity_count'] = array(
       '#type' => 'markup',
       '#markup' => $entity->quantity,


### PR DESCRIPTION
Refs #974 

Uses `hook_views_data` to expose the `dosomething_reportback_file` db table to views.

Updates `node/*/reportbacks` view to display uploaded images.

Displays uploaded images in the reportback entity view, `reportback/[rbid]`.  This entity view is staff only.
