### PR TITLE
Reportback form validation

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -284,11 +284,14 @@ function dosomething_campaign_node_view($node, $view_mode, $langcode) {
       $reportback = NULL;
       if ($rbid = dosomething_reportback_exists($node->nid)) {
         // Load existing reportback entity to pass through to reportback form.
-        $reportback = entity_load_single('reportback', $rbid);
+        $reportback = reportback_load($rbid);
       }
       $wrapper = entity_metadata_wrapper('node', $node->nid);
       // Set Reportback Form variable in node content for rendering in theme layer.
       $node->content['reportback_form'] = drupal_get_form('dosomething_reportback_form', $wrapper, $reportback);
+    }
+    if (module_exists('dosomething_zendesk')) {
+      $node->content['zendesk_form'] = drupal_get_form('dosomething_zendesk_form');
     }
   }
 }
@@ -539,8 +542,8 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $vars['reportback_form'] = $vars['content']['reportback_form'];
 
   // Zendesk Support Ticket form.
-  if (module_exists('dosomething_zendesk')) {
-    $vars['zendesk_form'] = drupal_get_form('dosomething_zendesk_form');
+  if (isset($vars['content']['reportback_form'])) {
+    $vars['zendesk_form'] = $vars['content']['zendesk_form'];
   }
 }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -275,6 +275,25 @@ function dosomething_campaign_theme($existing, $type, $theme, $path) {
 }
 
 /**
+ * Implements hook_node_view().
+ */
+function dosomething_campaign_node_view($node, $view_mode, $langcode) {
+  if ($node->type == 'campaign' && $view_mode == 'full') {
+    if (module_exists('dosomething_reportback')) {
+      // Initalize reportback to NULL.
+      $reportback = NULL;
+      if ($rbid = dosomething_reportback_exists($node->nid)) {
+        // Load existing reportback entity to pass through to reportback form.
+        $reportback = entity_load_single('reportback', $rbid);
+      }
+      $wrapper = entity_metadata_wrapper('node', $node->nid);
+      // Set Reportback Form variable in node content for rendering in theme layer.
+      $node->content['reportback_form'] = drupal_get_form('dosomething_reportback_form', $wrapper, $reportback);
+    }
+  }
+}
+
+/**
  * Implements hook_entity_info_alter().
  */
 function dosomething_campaign_entity_info_alter(&$entity_info) {
@@ -512,16 +531,12 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   }
 
   // Reportback form.
-  // Intialize reportback entity to NULL.
-  $reportback = NULL;
   $vars['reportback_link_label'] = t("Submit Your Pic");
   // If logged in user's reportback exists for this node,
   if ($rbid = dosomething_reportback_exists($vars['nid'])) {
-    // Load existing reportback entity to pass through to reportback form.
-    $reportback = entity_load_single('reportback', $rbid);
     $vars['reportback_link_label'] = t("Update Submission");
   }
-  $vars['reportback_form'] = drupal_get_form('dosomething_reportback_form', $wrapper, $reportback);
+  $vars['reportback_form'] = $vars['content']['reportback_form'];
 
   // Zendesk Support Ticket form.
   if (module_exists('dosomething_zendesk')) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -286,6 +286,7 @@ function dosomething_reportback_form($form, &$form_state, $wrapper, $entity = NU
     '#attributes' => array(
       'placeholder' => t("Enter # here"),
     ),
+    '#element_validate' => array('element_validate_integer_positive'),
     '#title' => t("Total # of @noun @verb", array(
         '@noun' => $wrapper->field_reportback_noun->value(),
         '@verb' => $wrapper->field_reportback_verb->value(),

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -333,9 +333,10 @@ function dosomething_reportback_form_submit($form, &$form_state) {
   $values['uid'] = $user->uid;
 
   // Save uploaded file.
-  $file = dosomething_reportback_form_save_file($form_state);
-  // Store new file's fid into values.
-  $values['fid'] = $file->fid;
+  if ($file = dosomething_reportback_form_save_file($form_state)) {
+    // Store new file's fid into values.
+    $values['fid'] = $file->fid;
+  }
   // Save values into reportback.
   dosomething_reportback_save($values);
 
@@ -364,8 +365,9 @@ function dosomething_reportback_form_validate_file($form, &$form_state) {
       form_set_error('reportback_file', t('There was an error. Please try again.'));
     }
   }
-  else {
-    form_set_error('reportback_file', t('No file was uploaded.'));
+  // If this is a new reportback form, file is mandatory.
+  elseif ($form_state['values']['rbid'] == 0) {
+    form_set_error('reportback_file', t('Please upload an image.'));
   }
 }
 
@@ -373,6 +375,10 @@ function dosomething_reportback_form_validate_file($form, &$form_state) {
  * Saves file from form into file_managed with permanent status.
  */
 function dosomething_reportback_form_save_file(&$form_state) {
+  // If nothing set in storage, exit.
+  if (!isset($form_state['storage']['file'])) return;
+
+  // Retrieve file from storage.
   $file = $form_state['storage']['file'];
   // We are done with the file, remove it from storage.
   unset($form_state['storage']['file']);
@@ -536,7 +542,7 @@ function dosomething_reportback_set_properties(&$entity, $values) {
  *   An array of file fid's to set.
  */
 function dosomething_reportback_set_files(&$entity, $values) {
-  if (isset($values['fid'])) {
+  if (isset($values['fid']) && !empty($values['fid'])) {
     $entity->fid = $values['fid'];
   }
 }


### PR DESCRIPTION
Fixes #1087
- Checks that quantity is a non zero integer with handy Drupal core shiz `'#element_validate' => array('element_validate_integer_positive'),`
- Image upload is only mandatory upon reportback creation (not update)

Moves rendering of `reportback_form` into `hook_node_view` instead of `hook_preprocess_node` to get drupal messages to appear correctly after submitting (before this change, they wouldn't appear until refreshing the page after submit -- see http://pixeljets.com/blog/be-careful-drupalgetform-theme-layer)

Additionally, makes same change for `zendesk_form`.
