### PR TITLE
Fixes #1094

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -64,7 +64,7 @@ class ReportbackEntity extends Entity {
       $timestamp = $this->updated;
     }
     try {
-      $fids = $this->fids;
+      $fids = $this->getFids();
       // Log the entity values into the log table.
       $id = db_insert($this->log_table)
         ->fields(array(


### PR DESCRIPTION
Fixes #1094

Changes the `Reportback.insertLog` method to query the `dosomething_reportback_file` table at the time of `insertLog`, instead of checking the `fids` property (which wont be up to date unless we loaded the entity again, after the insert into files table).
