### PR TITLE
Prove It image fix

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -587,9 +587,10 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $vars['official_rules_src'] = file_create_url($official_rules['uri']);
 
   // Reportback gallery.
-  foreach ($vars['field_image_reportback_gallery'] as $key => $rb_image) {
-    $rb_image['nid'] = $rb_image['entity']->nid;
-    $vars['reportback_image'][$key] = dosomething_image_get_themed_image_url($rb_image['nid'], 'landscape', '720x310');
+  if ($reportback_gallery = $wrapper->field_image_reportback_gallery->value()) {
+    foreach ($reportback_gallery as $key => $rb_image) {
+      $vars['reportback_image'][$key] = dosomething_image_get_themed_image_url($rb_image->nid, 'landscape', '720x310');
+    }
   }
 
   // Reportback form.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -597,7 +597,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   // Reportback gallery.
   if ($reportback_gallery = $wrapper->field_image_reportback_gallery->value()) {
     foreach ($reportback_gallery as $key => $rb_image) {
-      $vars['reportback_image'][$key] = dosomething_image_get_themed_image_url($rb_image->nid, 'landscape', '720x310');
+      $vars['reportback_image'][$key] = dosomething_image_get_themed_image_url($rb_image->nid, 'landscape', '740x480');
     }
   }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -578,8 +578,16 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $vars['pic_step'] = $wrapper->field_photo_step->value();
   $vars['post_step_header'] = $wrapper->field_post_step_header->value();
   $vars['post_step_copy'] = $wrapper->field_post_step_copy->value();
-  $vars['step_image_square'] = dosomething_image_get_themed_image($step_image['entity']->nid, 'square', '310x310');
-  $vars['step_image_landscape'] = dosomething_image_get_themed_image($step_image['entity']->nid, 'landscape', '720x310');
+  // Step gallery.
+  if ($step_gallery = $wrapper->field_image_step_gallery->value()) {
+    $step_images = array();
+    foreach ($step_gallery as $key => $step_image) {
+      $step_images[$key]['nid'] = $step_image->nid;
+    }
+    // We only need one image for tpl for now, so get the image for key 0.
+    $vars['step_image_square'] = dosomething_image_get_themed_image($step_images[0]['nid'], 'square', '310x310');
+    $vars['step_image_landscape'] = dosomething_image_get_themed_image($step_images[0]['nid'], 'landscape', '720x310');
+  }
 
   // Prove.
   $vars['reportback_copy'] = $wrapper->field_reportback_copy->value();


### PR DESCRIPTION
Not sure why this was happening but could definitely replicate that the image was not appearing for an authenticated user, and would appear for an admin.

Using preprocess values from the `entity_metadata_wrapper` instead of the `$vars` array seems to do the trick.  Will update the issue with findings of why that is once we get some breathing room.
