### PR TITLE
Comeback Clothes SMS report backs

### DIFF
--- a/lib/modules/dosomething/dosomething_sms/plugins/activity/prompts/mms_prompt/ConductorActivityMMSPrompt.class.php
+++ b/lib/modules/dosomething/dosomething_sms/plugins/activity/prompts/mms_prompt/ConductorActivityMMSPrompt.class.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Extends ConductorActivitySMSPrompt. Asks user a question and expects an MMS
+ * image in return.
+ */
+class ConductorActivityMMSPrompt extends ConductorActivitySMSPrompt {
+
+  /**
+   * If no mms image is found, opt user into this Mobile Commons path.
+   *
+   * @var int
+   */
+  public $noMmsResponse;
+
+  public function run() {
+    $state = $this->getState();
+
+    // Process user's response, expecting any mms to be in $_REQUEST['mms_image_url'].
+    // If none is set, jump to the end of the workflow.
+    $mms_image_url = $_REQUEST['mms_image_url'];
+    if (!empty($mms_image_url)) {
+      $state->setContext($this->name . ':mms', $mms_image_url);
+    }
+    elseif (!empty($this->noMmsResponse)) {
+      // Send user a response for no MMS being sent.
+      $mobile = $state->getContext('sms_number');
+      dosomething_sms_mobilecommons_opt_in($mobile, $this->noMmsResponse);
+
+      // Bypass conductor_sms error thrown when no text response is given.
+      $state->setContext('ignore_no_response_error', TRUE);
+
+      // Send user to the end of the workflow.
+      self::useOutput('end');
+    }
+
+    $state->markCompleted();
+  }
+
+  /**
+   * Removes all outputs from this activity except for the one specified in the param
+   *
+   * @param string $activityName
+   *   Name of activity in outputs array to keep
+   */
+  private function useOutput($activityName) {
+    foreach($this->outputs as $key => $val) {
+      if ($val != $activityName) {
+        unset($this->outputs[$key]);
+      }
+    }
+  }
+
+}

--- a/lib/modules/dosomething/dosomething_sms/plugins/activity/prompts/mms_prompt/mms_prompt.inc
+++ b/lib/modules/dosomething/dosomething_sms/plugins/activity/prompts/mms_prompt/mms_prompt.inc
@@ -1,0 +1,7 @@
+<?php
+
+$plugin = array(
+  'title' => t('MMS Prompt'),
+  'description' => t('Prompt for and expect to receive an MMS in return'),
+  'handler' => array('class' => 'ConductorActivityMMSPrompt'),
+);

--- a/lib/modules/dosomething/dosomething_sms/plugins/activity/prompts/mobilecommons_opt_in_prompt/ConductorActivityMobileCommonsOptInPrompt.class.php
+++ b/lib/modules/dosomething/dosomething_sms/plugins/activity/prompts/mobilecommons_opt_in_prompt/ConductorActivityMobileCommonsOptInPrompt.class.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Extends ConductorActivitySMSPrompt. Opts the user into a Mobile Commons
+ * opt-in path and suspends the workflow until a response is received.
+ */
+class ConductorActivityMobileCommonsOptInPrompt extends ConductorActivitySMSPrompt {
+
+  /**
+   * The Mobile Commons opt-in path to join the user into.
+   *
+   * @var int
+   */
+  public $optInPathId;
+
+  public function run() {
+    $state = $this->getState();
+
+    if ($state->getContext($this->name . ':message') === FALSE && !empty($this->optInPathId)) {
+      // Opt user into a Mobile Commons path.
+      $mobile = $state->getContext('sms_number');
+      dosomething_sms_mobilecommons_opt_in($mobile, $this->optInPathId);
+
+      // Bypass conductor_sms error thrown when no text response is given.
+      $state->setContext('ignore_no_response_error', TRUE);
+
+      // Wait for user response before going to next activity in workflow.
+      $state->markSuspended();
+      return;
+    }
+
+    parent::run();
+  }
+
+}

--- a/lib/modules/dosomething/dosomething_sms/plugins/activity/prompts/mobilecommons_opt_in_prompt/mobilecommons_opt_in_prompt.inc
+++ b/lib/modules/dosomething/dosomething_sms/plugins/activity/prompts/mobilecommons_opt_in_prompt/mobilecommons_opt_in_prompt.inc
@@ -1,0 +1,9 @@
+<?php
+
+$plugin = array(
+  'title' => t('Mobile Commons Opt-In Prompt'),
+  'description' => t('Opt the user into a specified Mobile Commons opt-in path, and suspend the workflow until a response is received.'),
+  'handler' => array(
+    'class' => 'ConductorActivityMobileCommonsOptInPrompt',
+  ),
+);

--- a/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/ConductorActivitySmsReportBack.class.php
+++ b/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/ConductorActivitySmsReportBack.class.php
@@ -58,6 +58,9 @@ class ConductorActivitySmsReportBack extends ConductorActivity {
     $state = $this->getState();
     $mobile = $state->getContext('sms_number');
 
+    // Mobile Commons sends the international code in its payload. Remove it.
+    $mobile = substr($mobile, -10);
+
     // Get user by cell number if it exists. Otherwise create it.
     $user = dosomething_user_get_user_by_cell($mobile);
     if (!$user) {

--- a/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/ConductorActivitySmsReportBack.class.php
+++ b/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/ConductorActivitySmsReportBack.class.php
@@ -64,8 +64,12 @@ class ConductorActivitySmsReportBack extends ConductorActivity {
       $user = dosomething_user_create_user_by_mobile($mobile);
     }
 
-    // Check for an rbid indicating that the user's submitted a report back previously.
-    $values = array();
+    // Initialize reportback values, defaulting to create a new reportback.
+    $values = array(
+      'rbid' => 0,
+    );
+
+    // Check for a previously submitted reportback to update instead.
     if ($rbid = dosomething_reportback_exists($this->nid, $user->uid)) {
       $values['rbid'] = $rbid;
     }

--- a/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/ConductorActivitySmsReportBack.class.php
+++ b/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/ConductorActivitySmsReportBack.class.php
@@ -61,7 +61,7 @@ class ConductorActivitySmsReportBack extends ConductorActivity {
     // Get user by cell number if it exists. Otherwise create it.
     $user = dosomething_user_get_user_by_cell($mobile);
     if (!$user) {
-      $user = dosomething_user_create_user_by_cell($mobile);
+      $user = dosomething_user_create_user_by_mobile($mobile);
     }
 
     // Check for an rbid indicating that the user's submitted a report back previously.

--- a/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/ConductorActivitySmsReportBack.class.php
+++ b/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/ConductorActivitySmsReportBack.class.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Submit report back with data received through a ConductorWorkflow.
+ */
+class ConductorActivitySmsReportBack extends ConductorActivity {
+
+  /**
+   * Context in which the submitted MMS URL can be found.
+   *
+   * @var string
+   */
+  public $mmsContext;
+
+  /**
+   * Node ID to submit the report back to.
+   *
+   * @var int
+   */
+  public $nid;
+
+  /**
+   * Maps report back submission properties to the context names their values
+   * should be pulled from.
+   *
+   * @var array
+   */
+  public $propertyToContextMap;
+
+  /**
+   * Mobile Commons opt-in path ID to send user to after submission.
+   *
+   * @var int
+   */
+  public $optInPathId;
+
+  /**
+   * Mobile Commons campaign ID to opt the user out of after submission.
+   *
+   * @var int
+   */
+  public $optOutCampaignId;
+
+  /**
+   * The Mobile Commons campaign Id that $this->optInPathId resides in. This
+   * helps on the Mobile Commons end to determine if this report back is the
+   * first campaign completed on SMS by this user.
+   *
+   * @var int
+   */
+  public $mobileCommonsCompletedCampaignId;
+
+  /**
+   * Called when this activity gets activated and run by the containing
+   * ConductorWorkflow's controller.
+   */
+  public function run() {
+    $state = $this->getState();
+    $mobile = $state->getContext('sms_number');
+
+    // Get user by cell number if it exists. Otherwise create it.
+    $user = dosomething_user_get_user_by_cell($mobile);
+    if (!$user) {
+      $user = dosomething_user_create_user_by_cell($mobile);
+    }
+
+    // Check for an rbid indicating that the user's submitted a report back previously.
+    $values = array();
+    if ($rbid = dosomething_reportback_exists($this->nid, $user->uid)) {
+      $values['rbid'] = $rbid;
+    }
+
+    // Get the MMS URL from the provided context.
+    $pictureUrl = $state->getContext($this->mmsContext);
+
+    // Download, save, and move the file to proper directory.
+    $pictureContents = file_get_contents($pictureUrl);
+    $file = file_save_data($pictureContents, $pictureFilename);
+    $file = file_move($file, dosomething_reportback_get_file_dir($this->nid));
+
+    // Save UID and permanent status.
+    $file->uid = $user->uid;
+    $file->status = FILE_STATUS_PERMANENT;
+    file_save($file);
+
+    // Get the fid to submit with the report back.
+    $values['fid'] = $file->fid;
+
+    // Get answers from context and set them to their appropriate properties.
+    foreach ($this->propertyToContextMap as $property => $context) {
+      $values[$property] = $state->getContext($context);
+    }
+
+    // Set nid and uid.
+    $values['nid'] = $this->nid;
+    $values['uid'] = $user->uid;
+
+    // Create/update a report back submission.
+    $rbid = dosomething_reportback_save($values);
+
+    // Update user's profile if this is the first completed campaign.
+    $updateArgs = array();
+    if (empty($_REQUEST['profile_first_completed_campaign_id']) && !empty($this->mobileCommonsCompletedCampaignId)) {
+      $updateArgs['person[first_completed_campaign_id]'] = $this->mobileCommonsCompletedCampaignId;
+    }
+
+    // Opt the user out of the main campaign.
+    if (!empty($this->optOutCampaignId)) {
+      dosomething_sms_mobilecommons_opt_out($mobile, $this->optOutCampaignId);
+    }
+
+    // Opt user into a path to send the confirmation message.
+    dosomething_sms_mobilecommons_opt_in($mobile, $this->optInPathId, $updateArgs);
+
+    $state->setContext('ignore_no_response_error', TRUE);
+    $state->markCompleted();
+  }
+}

--- a/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/dosomething_sms_submit_reportback.inc
+++ b/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/dosomething_sms_submit_reportback.inc
@@ -1,0 +1,10 @@
+<?php
+
+if (!module_exists('dosomething_user') || !module_exists('dosomething_reportback'))
+  return;
+
+$plugin = array(
+  'title' => t('DoSomething SMS Submit Report Back'),
+  'description' => t('Creates or updates a report back delivered via SMS.'),
+  'handler' => array('class' => 'ConductorActivitySmsReportBack'),
+);

--- a/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.keywords.inc
+++ b/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.keywords.inc
@@ -6,3 +6,4 @@
  * associated with.
  */
 $keywords['start-campaign-transition'] = 'dosomething_sms_start_campaign_transition';
+$keywords['comeback-clothes-reportback'] = 'dosomething_sms_comeback_clothes_reportback';

--- a/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.workflows.inc
+++ b/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.workflows.inc
@@ -35,3 +35,59 @@ $activity->name = 'end';
 $activity->inputs = array('start_campaign');
 
 $workflows[$workflow->name] = $workflow;
+
+/**
+ * Report back for Comeback Clothes 2014.
+ */
+$workflow = new ConductorWorkflow();
+$workflow->wid = 'new';
+$workflow->name = 'dosomething_sms_comeback_clothes_reportback';
+$workflow->title = 'Comeback Clothes 2014 Report Back';
+$workflow->api_version = '1.0';
+
+$activity = $workflow->newActivity('start');
+$activity->name = 'start';
+$activity->outputs = array('ask_picture');
+
+$activity = $workflow->newActivity('mms_prompt');
+$activity->name = 'ask_picture';
+$activity->inputs = array('start');
+$activity->outputs = array('ask_quantity');
+$activity->noMmsResponse = 165425;
+
+$activity = $workflow->newActivity('mobilecommons_opt_in_prompt');
+$activity->name = 'ask_quantity';
+$activity->inputs = array('ask_picture');
+$activity->outputs = array('ask_why_participated');
+$activity->optInPathId = 165421;
+
+$activity = $workflow->newActivity('mobilecommons_opt_in_prompt');
+$activity->name = 'ask_why_participated';
+$activity->inputs = array('ask_quantity');
+$activity->outputs = array('strip_signature');
+$activity->optInPathId = 165423;
+
+$activity = $workflow->newActivity('sms_strip_signature');
+$activity->name = 'strip_signature';
+$activity->inputs = array('ask_why_participated');
+$activity->outputs = array('submit_reportback');
+
+$activity = $workflow->newActivity('dosomething_sms_submit_reportback');
+$activity->name = 'submit_reportback';
+$activity->inputs = array('strip_signature');
+$activity->outputs = array('end');
+$activity->nid = 362; // Comeback Clothes node id
+$activity->mmsContext = 'ask_picture:mms';
+$activity->propertyToContextMap = array(
+  'quantity' => 'ask_quantity:message',
+  'why_participated' => 'ask_why_participated:message',
+);
+$activity->optInPathId = 165405;
+$activity->optOutCampaignId = 124765;
+$activity->mobileCommonsCompletedCampaignId = 124797;
+
+$activity = $workflow->newActivity('end');
+$activity->name = 'end';
+$activity->inputs = array('submit_reportback');
+
+$workflows[$workflow->name] = $workflow;

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -404,9 +404,8 @@ function dosomething_user_clean_cell_number($number) {
 function dosomething_user_create_user_by_mobile($number) {
   if ($clean_number = dosomething_user_clean_cell_number($number)) {
     $user_data = array(
-      'name' => $clean_number, // @todo This doesn't seem to work. UID gets set as the name instead. Can it not be only numbers? meh, seems like $clean_number . '@mobile' does nothing either.
-      // Provide a dummy email address.
-      'mail' => $clean_number . '@mobile',
+      'name' => user_password(), // Generating unique dummy name. dosomething_user_user_insert() will convert this to the uid.
+      'mail' => $clean_number . '@mobile', // Provide a dummy email address.
       'pass' => user_password(),
       'status' => 1,
       'field_mobile' => array(LANGUAGE_NONE => array(0 => array('value' => $clean_number))),

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -401,7 +401,7 @@ function dosomething_user_clean_cell_number($number) {
  * @param string $number
  *   User's phone number.
  */
-function dosomething_user_create_user_by_cell($number) {
+function dosomething_user_create_user_by_mobile($number) {
   if ($clean_number = dosomething_user_clean_cell_number($number)) {
     $user_data = array(
       'name' => $clean_number, // @todo This doesn't seem to work. UID gets set as the name instead. Can it not be only numbers? meh, seems like $clean_number . '@mobile' does nothing either.

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -374,8 +374,7 @@ function dosomething_user_get_user_by_cell($number) {
  *   The user-input mobile number.
  *
  * @return string/bool
- *   Numeric-only 10-digit string of the phone number, or FALSE if not a 10-digit
- *   number or an 11-digit number with 1 as its international code.
+ *   Numeric-only string of the phone number, or FALSE if not a 10-digit number.
  */
 function dosomething_user_clean_cell_number($number) {
   if (dosomething_user_valid_cell($number)) {
@@ -384,11 +383,6 @@ function dosomething_user_clean_cell_number($number) {
     // Make sure the number is 10 digits long.
     if (strlen($trimmed_number) == 10) {
       return $trimmed_number;
-    }
-    // If number is 11 digits long and the first number is 1, then it's also ok.
-    elseif (strlen($trimmed_number) == 11 && substr($trimmed_number, 0, 1) == '1') {
-      // Return the 10 digit number minus the international code.
-      return substr($trimmed_number, 1, 10);
     }
     return FALSE;
   }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -374,7 +374,8 @@ function dosomething_user_get_user_by_cell($number) {
  *   The user-input mobile number.
  *
  * @return string/bool
- *   Numeric-only string of the phone number, or FALSE if not a 10-digit number.
+ *   Numeric-only 10-digit string of the phone number, or FALSE if not a 10-digit
+ *   number or an 11-digit number with 1 as its international code.
  */
 function dosomething_user_clean_cell_number($number) {
   if (dosomething_user_valid_cell($number)) {
@@ -384,10 +385,41 @@ function dosomething_user_clean_cell_number($number) {
     if (strlen($trimmed_number) == 10) {
       return $trimmed_number;
     }
+    // If number is 11 digits long and the first number is 1, then it's also ok.
+    elseif (strlen($trimmed_number) == 11 && substr($trimmed_number, 0, 1) == '1') {
+      // Return the 10 digit number minus the international code.
+      return substr($trimmed_number, 1, 10);
+    }
     return FALSE;
   }
   return FALSE;
 }
+
+/**
+ * Create a user account when provided with only a cell phone number.
+ *
+ * @param string $number
+ *   User's phone number.
+ */
+function dosomething_user_create_user_by_cell($number) {
+  if ($clean_number = dosomething_user_clean_cell_number($number)) {
+    $user_data = array(
+      'name' => $clean_number, // @todo This doesn't seem to work. UID gets set as the name instead. Can it not be only numbers? meh, seems like $clean_number . '@mobile' does nothing either.
+      // Provide a dummy email address.
+      'mail' => $clean_number . '@mobile',
+      'pass' => user_password(),
+      'status' => 1,
+      'field_mobile' => array(LANGUAGE_NONE => array(0 => array('value' => $clean_number))),
+    );
+
+    $user = user_save('', $user_data);
+
+    return $user;
+  }
+
+  return FALSE;
+}
+
 /**
  * A request to send a message via the Message Broker library:
  * https://github.com/DoSomething/messagebroker-phplib


### PR DESCRIPTION
Tested and works locally so far...

@aaronschachter and whoever else ends up looking at this, a couple things in particular that I'd appreciate eyes on:
- `dosomething_user_clean_cell_number()`:
  - Mobile Commons includes the leading `1` for mobile numbers in their payload. So I updated this to allow 11 digit numbers to be valid. But let me know if you'd want to handle this differently.
- `dosomething_user_create_user_by_cell()`:
  - Since some numbers may be trying to submit a report back without having come to our site to create an account first, I'm silently creating an account for them. It's like what we did on the old site. Did I create all that I needed to for the user account?
  - Also, the `name`/`username` field doesn't seem to be sticking with the way I'm doing it. Any ideas?
- Everything in `ConductorActivitySmsReportBack`. Am I doing this right? It seems like files and getting saved and the `dosomething_reportback` table is getting updated.:
  - Summary of the logic in there:
    - Find an existing account. If none, then create one.
    - Find an existing report back.
    - Download and save the MMS image.
    - Create/update the report back submission.
    - Update things on the Mobile Commons end: updating profile, opting out of one campaign, and opting into another.
