### PR TITLE
Reportback file directories

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
@@ -3,6 +3,7 @@ description = Provides Reportback entity and functionality.
 core = 7.x
 package = DoSomething
 dependencies[] = features
+dependencies[] = file
 dependencies[] = image
 dependencies[] = views
 features[ctools][] = views:views_default:3.0

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -558,14 +558,41 @@ function dosomething_reportback_entity_insert($entity, $type) {
 }
 
 /**
- * Returns the destination to write a reportback file for given node $nid.
+ * Returns the file destination for a new reportback file for given node $nid.
+ *
+ * @param string $filename
+ *   Original upload filename, used to retain the file extension.
+ * @param int $nid
+ *   The node nid that this reportback is associated with.
+ * @param int $uid
+ *   The users uid that this reportback is associated with.
+ *
+ * @return string
+ *   The file destination path to write the next reportback image to.
  */
-function dosomething_reportback_get_file_dest($name, $nid) {
-  $dir = 'public://reportbacks/' . $nid;
-  // If directory doesn't exist, create it.
-  if (file_prepare_directory($dir, FILE_CREATE_DIRECTORY)) {
-    return $dir . '/' . $name;
+function dosomething_reportback_get_file_dest($name, $nid, $uid = NULL) {
+  if ($uid == NULL) {
+    global $user;
+    $uid = $user->uid;
   }
+  // Parse original filename.
+  $pathinfo = pathinfo($name);
+  // Save its extension.
+  $ext = $pathinfo['extension'];
+  // Define reportback nid file directory.
+  $dir = 'public://reportbacks/' . $nid;
+  // If directory doesn't exist / can't be created:
+  if (!file_prepare_directory($dir, FILE_CREATE_DIRECTORY)) {
+    // Use default public directory instead.
+    $dir = 'public://';
+  }
+  $index = 0;
+  if ($rb = dosomething_reportback_exists($nid, $uid)) {
+    $reportback = reportback_load($rb);
+    $index = count($reportback->fids);
+  }
+  $filename = 'uid_' . $uid . '-nid_' . $nid . '-' . $index . '.' . $ext;
+  return $dir . '/' . $filename;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -356,8 +356,9 @@ function dosomething_reportback_form_validate_file($form, &$form_state) {
   // If the file passed validation:
   if ($file) {
     $nid = $form_state['values']['nid'];
-    // Move the file into its relevant reportbacks directory.
-    if ($file = file_move($file, dosomething_reportback_get_file_dir($nid))) {
+    // Move the file into its proper destination.
+    $new_dest = dosomething_reportback_get_file_dest($file->filename, $nid);
+    if ($file = file_move($file, $new_dest)) {
       // Save the file for use in the submit handler.
       $form_state['storage']['file'] = $file;
     }
@@ -557,12 +558,14 @@ function dosomething_reportback_entity_insert($entity, $type) {
 }
 
 /**
- * Returns the path to write a reportback file for given node $nid.
+ * Returns the destination to write a reportback file for given node $nid.
  */
-function dosomething_reportback_get_file_dir($nid) {
-  return 'public://';
-  // @todo: Make me work. @see Issue #1054.
-  // return 'public://reportbacks/' . $nid;
+function dosomething_reportback_get_file_dest($name, $nid) {
+  $dir = 'public://reportbacks/' . $nid;
+  // If directory doesn't exist, create it.
+  if (file_prepare_directory($dir, FILE_CREATE_DIRECTORY)) {
+    return $dir . '/' . $name;
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/ConductorActivitySmsReportBack.class.php
+++ b/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/ConductorActivitySmsReportBack.class.php
@@ -83,7 +83,7 @@ class ConductorActivitySmsReportBack extends ConductorActivity {
     // Download, save, and move the file to proper directory.
     $pictureContents = file_get_contents($pictureUrl);
     $file = file_save_data($pictureContents, $pictureFilename);
-    $new_dest = dosomething_reportback_get_file_dest($file->name, $this->nid);
+    $new_dest = dosomething_reportback_get_file_dest($file->name, $this->nid, $user->uid);
     $file = file_move($file, $new_dest);
 
     // Save UID and permanent status.

--- a/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/ConductorActivitySmsReportBack.class.php
+++ b/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/ConductorActivitySmsReportBack.class.php
@@ -83,7 +83,8 @@ class ConductorActivitySmsReportBack extends ConductorActivity {
     // Download, save, and move the file to proper directory.
     $pictureContents = file_get_contents($pictureUrl);
     $file = file_save_data($pictureContents, $pictureFilename);
-    $file = file_move($file, dosomething_reportback_get_file_dir($this->nid));
+    $new_dest = dosomething_reportback_get_file_dest($file->name, $this->nid);
+    $file = file_move($file, $new_dest);
 
     // Save UID and permanent status.
     $file->uid = $user->uid;


### PR DESCRIPTION
Writes reportback files into the "reportbacks/[nid]" directory within the public files directory, for whatever [nid] the reportback is associated with.

Renames reportback file with pattern `uid_[uid]-nid_[nid]-[index]`, retaining the file extension of the uploaded file.  e.g. "uid_5-nid_43-0.jpg", "uid_5-nid-43-1.png"
