### PR TITLE
Zero downtime deploy & cleanup

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,27 +3,8 @@ lock '3.1.0'
 
 set :application, 'beta.dosomething.org'
 set :repo_url, 'git@github.com:DoSomething/dosomething.git'
-
-# Default branch is :master
-# ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }
-
 set :branch, "dev"
-
-# Default deploy_to directory is /var/www/my_app
-# set :deploy_to, '/var/www/my_app'
-
-# Default value for :scm is :git
-set :scm, :git
-
-# Default value for :format is :pretty
-set :format, :pretty
-
-# Default value for :log_level is :debug
-set :log_level, :debug
-
 set :ssh_options, { :forward_agent => true }
-# Default value for :pty is false
-# set :pty, true
 
 # Default value for :linked_files is []
 # set :linked_files, %w{config/database.yml}
@@ -31,20 +12,17 @@ set :ssh_options, { :forward_agent => true }
 # Default value for linked_dirs is []
 # set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
 
-# Default value for default_env is {}
-# set :default_env, { path: "/opt/ruby/bin:$PATH" }
-
-# Default value for keep_releases is 5
-# set :keep_releases, 5
 
 namespace :deploy do
 
-  after :deploy, :build do
+  desc "Run ds build tasks"
+  task :build do
     on roles(:app) do |host|
       execute "cd '#{release_path}'; #{release_path}/bin/ds build"
       execute "cd '#{release_path}/lib/themes/dosomething/paraneue_dosomething'; grunt prod"
-      execute "sudo rm -rf #{release_path}/html/sites/default/settings.local.php"
     end
   end
+
+  after :updated, 'deploy:build'
 
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,37 +1,18 @@
-# Simple Role Syntax
-# ==================
-# Supports bulk-adding hosts to roles, the primary
-# server in each group is considered to be the first
-# unless any hosts have the primary property set.
-# Don't declare `role :all`, it's a meta role
-role :app, %w{ubuntu@10.241.0.27}
+set :deploy_to, "/var/www/beta.dosomething.org"
 
-# Extended Server Syntax
-# ======================
-# This can be used to drop a more detailed server
-# definition into the server list. The second argument
-# something that quacks like a hash can be used to set
-# extended properties on the server.
-server '10.241.0.27', user: 'ubuntu', roles: %w{app}
+role :app, %w{dosomething@98.129.111.169}
 
-# you can set custom ssh options
-# it's possible to pass any option but you need to keep in mind that net/ssh understand limited list of options
-# you can see them in [net/ssh documentation](http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start)
-# set it globally
-#  set :ssh_options, {
-#    keys: %w(/home/rlisowski/.ssh/id_rsa),
-#    forward_agent: false,
-#    auth_methods: %w(password)
-#  }
-# and/or per server
-# server 'example.com',
-#   user: 'user_name',
-#   roles: %w{web app},
-#   ssh_options: {
-#     user: 'user_name', # overrides user setting above
-#     keys: %w(/home/user_name/.ssh/id_rsa),
-#     forward_agent: false,
-#     auth_methods: %w(publickey password)
-#     # password: 'please use keys'
-#   }
-# setting per server overrides global ssh_options
+server '98.129.111.169', user: 'dosomething', roles: %w{app}
+
+namespace :deploy do
+
+  task :shared_links do
+    on roles(:app) do |host|
+      execute "cd '#{release_path}/html/sites/default'; rm -rf files 2> /dev/null; ln -s #{shared_path}/files files"
+      execute "ln -s #{shared_path}/settings.production.php #{release_path}/html/sites/default/settings.production.php"
+    end
+  end
+
+  after :build, 'deploy:shared_links'
+
+end

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -4,12 +4,10 @@ role :app, %w{dosomething@staging.beta.dosomething.org}
 
 server 'staging.beta.dosomething.org', user: 'dosomething', roles: %w{app}
 
-
 namespace :deploy do
 
-  after :deploy, :symlink_shared do
+  task :shared_links do
     on roles(:app) do |host|
-
       execute "cd '#{release_path}/html/sites/default'; sudo rm -rf files 2> /dev/null; sudo ln -s #{shared_path}/files files"
       execute "sudo ln -s #{shared_path}/settings.staging.php #{release_path}/html/sites/default/settings.staging.php"
 
@@ -17,5 +15,7 @@ namespace :deploy do
       execute "printf 'User-agent: *\nDisallow: /' > #{release_path}/html/robots.txt"
     end
   end
+
+  after :build, 'deploy:shared_links'
 
 end


### PR DESCRIPTION
This merge provides:
- **zero-downtime deployment** by moving the build task to an earlier point in the in pipeline
- **cleanup** default settings that come stock with capistrano install
- **production** tier deploy task for web1 in beta RPC env
