### PR TITLE
Script to import signup data to the new world.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -50,7 +50,7 @@ function dosomething_signup_permission() {
  * @return mixed
  *   The sid of the newly inserted signup, or FALSE if error.
  */
-function dosomething_signup_insert($nid, $uid = NULL) {
+function dosomething_signup_insert($nid, $uid = NULL, $timestamp = NULL) {
   if ($uid == NULL) {
     global $user;
     $uid = $user->uid;
@@ -60,7 +60,7 @@ function dosomething_signup_insert($nid, $uid = NULL) {
         ->fields(array(
           'uid' => $uid,
           'nid' => $nid,
-          'timestamp' => REQUEST_TIME,
+          'timestamp' => isset($timestamp) ? $timestamp : REQUEST_TIME,
         )
       )
       ->execute();

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -46,6 +46,9 @@ function dosomething_signup_permission() {
  * @param int $uid
  *   Optional - the user uid who has signed up.
  *   If not provided, uses global $user->uid.
+ * @param int $timestamp
+ *   Optional - the timestamp of the signup.
+ *   If not provided, uses @dries time.
  *
  * @return mixed
  *   The sid of the newly inserted signup, or FALSE if error.

--- a/scripts/import-signups.php
+++ b/scripts/import-signups.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Script to import signup data from old world into new world.
+ *
+ * to run:
+ * grab the latest signup data from production.
+ *  SELECT uid, nid, timestamp from dosomething_campaign_signups
+ *  WHERE nid = 731234
+ *  OR nid = 731098;
+ *
+ * Insert data into temporary table '_signups_old_world'.
+ * drush --script-path=../scripts/ php-script import-signups.php
+ *
+ */
+
+// Mind on my Money = 731098 = 850
+// PB Jam Slam = 731234 = 955
+define('MONEY_OLD', 731098);
+define('MONEY', 850);
+define('PBJ_OLD', 731234);
+define('PBJ', 955);
+
+$signups = '_signups_old_world';
+
+
+$result = db_query('SELECT * FROM {' . $signups . '}');
+
+
+foreach ($result as $signup) {
+  if ($signup->nid == MONEY_OLD) {
+    $nid = MONEY;
+  }
+  else if ($signup->nid = PBJ_OLD) {
+    $nid = PBJ;
+  }
+  dosomething_signup_insert($nid, $signup->uid, $signup->timestamp);
+  }
+


### PR DESCRIPTION
Fixes #1217

Add optional 'timestamp' arg to `dosomething_signup_insert` to preserve old world timestamps.
Saves all signups as new world nids
