### PR TITLE
Installing redirect module

### DIFF
--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -44,6 +44,7 @@ dependencies[] = metatag
 dependencies[] = mobilecommons
 dependencies[] = module_filter
 dependencies[] = pathauto
+dependencies[] = redirect
 dependencies[] = search
 dependencies[] = strongarm
 dependencies[] = uuid

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -101,6 +101,10 @@ projects[optimizely][subdir] = "contrib"
 projects[pathauto] = "1.2"
 projects[pathauto][subdir] = "contrib"
 
+; Redirect
+projects[redirect] = "1.0-rc1"
+projects[redirect][subdir] = "contrib"
+
 ; Secure Pages
 projects[securepages] = "1.0-beta2"
 projects[securepages][subdir] "contrib"


### PR DESCRIPTION
- Redirect module will be used to redirect dummy campaigns that
  are created in the new world.

Fixes #960
