### PR TITLE
Polaroid Style Fix

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/campaign/_do.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/campaign/_do.scss
@@ -106,10 +106,17 @@
   }
 
   div.step-image-wrapper {
-    float: left;
-    position: relative;
-    width: 100%;
+    @include media( $tablet ) {
+      overflow: hidden;
+      position: relative;
+      width: 180px;
+      height: 210px;
+      top: 150px;
+    }
 
+    // Display a full-width landscape
+    // crop for smaller screens viewing
+    // the campaign in a single column
     &.mobile {
      display: block;
 
@@ -123,6 +130,9 @@
      }
     }
 
+    // Only show the Polaroid version
+    // containing a square image crop
+    // on large viewports
     &.desktop {
       display: none;
 
@@ -131,11 +141,11 @@
       }
 
       figure.step-image {
-        position: relative;
-        top: 200px;
-
         @include transform(rotate(-3deg));
 
+        // Position a pseudo-element above the
+        // "Do It" gallery image with a Polaroid-
+        // style image background
         &:after {
           content: "";
           position: absolute;
@@ -144,8 +154,9 @@
           background-image: url(../images/campaign-polaroid-frame.png);
           background-repeat: no-repeat;
           background-position: 50% 50%;
-          width: 200px;
-          height: 230px;
+          background-size: 170px;
+          width: 180px;
+          height: 210px;
         }
 
         img {
@@ -153,7 +164,7 @@
           left: 12px;
           top: 9px;
           padding: 0;
-          max-width: 175px;
+          max-width: 160px;
         }
       }
     }


### PR DESCRIPTION
## Polaroid Styles

![polaroid-styles](https://f.cloud.github.com/assets/1479130/2414223/cf80eb6a-aae7-11e3-9342-9c7a41bd1184.png)

Tested across Safari, Firefox and Chrome from `1440px` down to `320px`.
Fixes #1226
