### PR TITLE
Rb cleanup

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -303,7 +303,7 @@ function dosomething_campaign_reportback_confirmation_page($node) {
 function dosomething_campaign_get_recommended_campaign_vars($nid) {
   $wrapper = entity_metadata_wrapper('node', $nid);
   $path = 'node/' . $nid;
-  $image_link = NULL;
+  $image = NULL;
   $image_nid = $wrapper->field_image_campaign_cover->getIdentifier();
   if ($image_nid) {
     $image = dosomething_image_get_themed_image_url($image_nid, 'landscape', '740x480');

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -340,10 +340,10 @@ function dosomething_campaign_theme($existing, $type, $theme, $path) {
 function dosomething_campaign_node_view($node, $view_mode, $langcode) {
   if ($node->type == 'campaign' && $view_mode == 'full') {
     if (module_exists('dosomething_reportback')) {
-      // Initalize reportback to NULL.
-      $reportback = NULL;
+      // Initalize reportback to a new entity for this nid.
+      $reportback = entity_create('reportback', array('nid' => $node->nid));
       if ($rbid = dosomething_reportback_exists($node->nid)) {
-        // Load existing reportback entity to pass through to reportback form.
+        // Replace with existing reportback entity if it exists.
         $reportback = reportback_load($rbid);
       }
       $wrapper = entity_metadata_wrapper('node', $node->nid);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -340,15 +340,19 @@ function dosomething_campaign_theme($existing, $type, $theme, $path) {
 function dosomething_campaign_node_view($node, $view_mode, $langcode) {
   if ($node->type == 'campaign' && $view_mode == 'full') {
     if (module_exists('dosomething_reportback')) {
-      // Initalize reportback to a new entity for this nid.
-      $reportback = entity_create('reportback', array('nid' => $node->nid));
+      // Initalize reportback as a new entity for this nid.
+      $reportback = entity_create('reportback', array(
+        'nid' => $node->nid,
+        'quantity' => NULL,
+        'why_participated' => NULL,
+      ));
       if ($rbid = dosomething_reportback_exists($node->nid)) {
         // Replace with existing reportback entity if it exists.
         $reportback = reportback_load($rbid);
       }
       $wrapper = entity_metadata_wrapper('node', $node->nid);
       // Set Reportback Form variable in node content for rendering in theme layer.
-      $node->content['reportback_form'] = drupal_get_form('dosomething_reportback_form', $wrapper, $reportback);
+      $node->content['reportback_form'] = drupal_get_form('dosomething_reportback_form', $reportback);
     }
     if (module_exists('dosomething_zendesk')) {
       $node->content['zendesk_form'] = drupal_get_form('dosomething_zendesk_form');

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -239,24 +239,17 @@ function dosomething_reportback_edit_entity($entity) {
 }
 
 /**
- * Form constructor for a node reportback create/update form.
+ * Form constructor for a reportback create/update form.
  *
- * @param object $wrapper
- *   An entity_metadata_wrapper of the node to report back for.
  * @param object $entity
- *   Optional. The reportback entity to update, if updating an entity.
- *   If NULL, submitting the form will create a new reportback entity.
+ *   A reportback entity to create or update. Must have a nid property set.
  *
  * @ingroup forms
  */
-function dosomething_reportback_form($form, &$form_state, $wrapper, $entity = NULL) {
-  // If entity is not set, this is a create form.
-  if (!isset($entity)) {
-    $entity = entity_create('reportback', array(
-      'rbid' => 0,
-      'quantity' => '',
-      'why_participated' => NULL,
-    ));
+function dosomething_reportback_form($form, &$form_state, $entity) {
+  // If rbid doesn't exist, this is a create form.
+  if (!isset($entity->rbid)) {
+    $entity->rbid = 0;
     $submit_label = t("Submit your pic");
   }
   // Else, it's update form.
@@ -274,7 +267,7 @@ function dosomething_reportback_form($form, &$form_state, $wrapper, $entity = NU
   );
   $form['nid'] = array(
     '#type' => 'hidden',
-    '#default_value' => $wrapper->nid->value(),
+    '#default_value' => $entity->nid,
   );
   $form['reportback_file'] = array(
     '#type' => 'file',
@@ -288,8 +281,8 @@ function dosomething_reportback_form($form, &$form_state, $wrapper, $entity = NU
     ),
     '#element_validate' => array('element_validate_integer_positive'),
     '#title' => t("Total # of @noun @verb", array(
-        '@noun' => $wrapper->field_reportback_noun->value(),
-        '@verb' => $wrapper->field_reportback_verb->value(),
+        '@noun' => $entity->noun,
+        '@verb' => $entity->verb,
       )
     ),
     '#default_value' => $entity->quantity,
@@ -553,7 +546,10 @@ function dosomething_reportback_set_files(&$entity, $values) {
  */
 function dosomething_reportback_entity_insert($entity, $type) {
   if ($type == 'reportback') {
-    dosomething_reportback_mbp_request($entity);
+    // Reload entity to grab the relevant node variables.
+    $reportback = reportback_load($entity->rbid);
+    // Pass it into mbp request.
+    dosomething_reportback_mbp_request($reportback);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -24,13 +24,18 @@ class ReportbackEntity extends Entity {
    */
   public function __construct(array $values = array(), $entityType = NULL) {
     parent::__construct($values, $entityType);
-    // Set the reportback file fids as an array.
-    $this->fids = $this->getFids();
-    // Set properties found on the reportback's node nid.
-    $this->node_title = $this->getNodeTitle();
-    $this->noun = $this->getNodeSingleTextValue('field_reportback_noun');
-    $this->verb = $this->getNodeSingleTextValue('field_reportback_verb');
-
+    $this->fids = array();
+    // If this is a new entity, rbid may not be set.
+    if (isset($this->rbid)) {
+      $this->fids = $this->getFids();
+    }
+    // If a reportback nid exists:
+    if (isset($this->nid)) {
+      // Set properties found on the reportback's node nid.
+      $this->node_title = $this->getNodeTitle();
+      $this->noun = $this->getNodeSingleTextValue('field_reportback_noun');
+      $this->verb = $this->getNodeSingleTextValue('field_reportback_verb');
+    }
   }
 
   /**


### PR DESCRIPTION
- Fixes bug in #1236
  - `$entity->node_title`, `noun`, `verb` variables were not available at time of `mbp_request`, so reloading the reportback to get them.
- Fixes #1231 
  - Simplifies `dosomething_reportback_form` to use the calculated properties instead of sending node `$wrapper` as a param
- Fixes PHP Notice on the reportback confirmation page if recommended campaign does not have an image
