### PR TITLE
Sets base url protocol dynamically

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -17,14 +17,16 @@ $databases['default']['default'] = array(
  */
 $hostname = getenv('DS_HOSTNAME') ?: 'dev.dosomething.org';
 
+$protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
+
 $insecure_port = getenv('DS_INSECURE_PORT') ?: 8888;
 $secure_port = getenv('DS_SECURE_PORT') ?: 8889;
 
 if (!empty($insecure_port) && ($insecure_port != 80)) {
-  $base_url = 'http://' . $hostname . ':' . $insecure_port;
+  $base_url = $protocol . $hostname . ':' . $insecure_port;
 }
 else {
-  $base_url = 'http://' . $hostname;
+  $base_url = $protocol . $hostname;
 }
 
 $conf['https'] = TRUE;

--- a/config/settings.php
+++ b/config/settings.php
@@ -30,14 +30,6 @@ else {
 }
 
 $conf['https'] = TRUE;
-$conf['securepages_basepath'] = $base_url;
-
-if (!empty($secure_port) && ($insecure_port != 443)) {
-  $conf['securepages_basepath_ssl'] = 'https://' . $hostname . ':' . $secure_port;
-}
-else {
-  $conf['securepages_basepath_ssl'] = 'https://' . $hostname;
-}
 
 /**
  * Caching


### PR DESCRIPTION
This merge makes sure the base_url is using the proper protocol.  The logic was shamefully stolen from this poor [soul](http://stackoverflow.com/questions/4503135/php-get-site-url-protocol-http-vs-https)

This will make sure our assets get served behind the correct protocols 
