### PR TITLE
Signup admin views / unsignup form

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -32,6 +32,7 @@ function dosomething_campaign_menu() {
     'access callback' => '_dosomething_campaign_pitch_page_access',
     'access arguments' => array(1),
     'type' => MENU_LOCAL_TASK,
+    'weight' => 60,
   );
   // User reportback confirmation page.
   $items['node/%node/confirmation'] = array(

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -612,7 +612,7 @@ function dosomething_reportback_mbp_request($entity) {
  * Implements hook_views_data().
  */
 function dosomething_reportback_views_data() {
-  $data['dosomething_reportback_file']['table']['group'] = t('Reportback');
+  $data['dosomething_reportback_file']['table']['group'] = t('Reportbacks');
   $data['dosomething_reportback_file']['table']['base'] = array(
     'field' => 'rbid', // This is the identifier field for the view.
     'title' => t('Reportback images'),

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
@@ -15,7 +15,7 @@ function dosomething_reportback_views_default_views() {
   $view->description = '';
   $view->tag = 'default';
   $view->base_table = 'dosomething_reportback';
-  $view->human_name = 'Campaign Reportbacks';
+  $view->human_name = 'Node Reportbacks';
   $view->core = 7;
   $view->api_version = '3.0';
   $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
@@ -103,7 +103,7 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['relationships']['uid']['table'] = 'dosomething_reportback';
   $handler->display->display_options['relationships']['uid']['field'] = 'uid';
   $handler->display->display_options['relationships']['uid']['required'] = TRUE;
-  /* Relationship: Reportback: Reportback image fid */
+  /* Relationship: Reportbacks: Reportback image fid */
   $handler->display->display_options['relationships']['fid']['id'] = 'fid';
   $handler->display->display_options['relationships']['fid']['table'] = 'dosomething_reportback_file';
   $handler->display->display_options['relationships']['fid']['field'] = 'fid';

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.info
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.info
@@ -8,5 +8,6 @@ features[ctools][] = views:views_default:3.0
 features[features_api][] = api:2
 features[user_permission][] = administer third party communication
 features[user_role][] = communications team
+features[views_view][] = node_signups
 features[views_view][] = user_signups
 files[] = dosomething_signup.test

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -23,12 +23,13 @@ function dosomething_signup_menu() {
     'file' => 'dosomething_signup.admin.inc'
   );
   $items['node/%node/unsignup'] = array(
-    'title callback' => 'Remove Signup',
+    'title' => 'Remove signup',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_signup_node_unsignup_form', 1),
     'access callback' => 'dosomething_signup_node_unsignup_access',
     'access arguments' => array(1),
     'type' => MENU_LOCAL_TASK,
+    'weight' => 70,
   );
   return $items;
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -22,7 +22,14 @@ function dosomething_signup_menu() {
     'access arguments' => array('administer third party communication'),
     'file' => 'dosomething_signup.admin.inc'
   );
-
+  $items['node/%node/unsignup'] = array(
+    'title callback' => 'Remove Signup',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_signup_node_unsignup_form', 1),
+    'access callback' => 'dosomething_signup_node_unsignup_access',
+    'access arguments' => array(1),
+    'type' => MENU_LOCAL_TASK,
+  );
   return $items;
 }
 
@@ -97,10 +104,12 @@ function dosomething_signup_delete($nid, $uid = NULL) {
       ->condition('uid', $uid)
       ->condition('nid', $nid)
       ->execute();
+    return TRUE;
   }
   catch (Exception $e) {
     watchdog('dosomething_signup', $e, array(), WATCHDOG_ERROR);
   }
+  return FALSE;
 }
 
 /**
@@ -356,4 +365,57 @@ function dosomething_signup_get_signup_nids_by_uid($uid) {
   $query->condition('uid', $uid);
   $result = $query->execute();
   return array_keys($result->fetchAllAssoc('nid'));
+}
+
+/**
+ * Access callback for node unsignup page.
+ *
+ * @param object $node
+ *   Loaded node to unsignup from.
+ *
+ * @return bool
+ *   Whether or not logged in user can remove signup (and if it exists).
+ */
+function dosomething_signup_node_unsignup_access($node) {
+  // Only allow access if user staff and is signed up.
+  return dosomething_user_is_staff() && dosomething_signup_exists($node->nid);
+}
+
+/**
+ * Form constructor for a node unsignup form.
+ *
+ * @param int $nid
+ *   The node nid to remove signup from.
+ *
+ * @ingroup forms
+ */
+function dosomething_signup_node_unsignup_form($form, &$form_state, $node) {
+  $form['nid'] = array(
+    '#type' => 'hidden',
+    '#default_value' => $node->nid,
+  );
+  $form['warning'] = array(
+    '#markup' => t("Are you sure you want to remove this signup?  This cannot be undone."),
+  );
+  $form['actions'] = array(
+    '#type' => 'actions',
+    'submit' => array(
+      '#type' => 'submit',
+      '#value' => t('Delete'),
+    ),
+  );
+  return $form;
+}
+
+/**
+ * Form submit handler for dosomething_signup_node_unsignup_form().
+ */
+function dosomething_signup_node_unsignup_form_submit($form, &$form_state) {
+  $nid = $form_state['values']['nid'];
+  if (dosomething_signup_delete($nid)) {
+    drupal_set_message("Signup removed.");
+    $form_state['redirect'] = 'node/' . $nid;
+    return;
+  }
+  drupal_set_message("There was an error with your request.");
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -46,6 +46,15 @@ function dosomething_signup_permission() {
 }
 
 /**
+ * Implements hook_admin_paths().
+ */
+function dosomething_signup_admin_paths() {
+  $paths = array(
+    'node/*/signups' => TRUE,
+  );
+  return $paths;
+}
+/**
  * Insert a user signup.
  *
  * @param int $nid

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.views_default.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.views_default.inc
@@ -11,6 +11,158 @@ function dosomething_signup_views_default_views() {
   $export = array();
 
   $view = new view();
+  $view->name = 'node_signups';
+  $view->description = '';
+  $view->tag = 'default';
+  $view->base_table = 'dosomething_signup';
+  $view->human_name = 'Node Signups';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'none';
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'full';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '100';
+  $handler->display->display_options['style_plugin'] = 'table';
+  $handler->display->display_options['style_options']['columns'] = array(
+    'uid' => 'uid',
+    'mail' => 'mail',
+    'timestamp' => 'timestamp',
+  );
+  $handler->display->display_options['style_options']['default'] = 'timestamp';
+  $handler->display->display_options['style_options']['info'] = array(
+    'uid' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'mail' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'timestamp' => array(
+      'sortable' => 1,
+      'default_sort_order' => 'desc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+  );
+  /* Relationship: Signups: Nid */
+  $handler->display->display_options['relationships']['nid']['id'] = 'nid';
+  $handler->display->display_options['relationships']['nid']['table'] = 'dosomething_signup';
+  $handler->display->display_options['relationships']['nid']['field'] = 'nid';
+  $handler->display->display_options['relationships']['nid']['label'] = 'Node';
+  $handler->display->display_options['relationships']['nid']['required'] = TRUE;
+  /* Relationship: Signups: Uid */
+  $handler->display->display_options['relationships']['uid']['id'] = 'uid';
+  $handler->display->display_options['relationships']['uid']['table'] = 'dosomething_signup';
+  $handler->display->display_options['relationships']['uid']['field'] = 'uid';
+  $handler->display->display_options['relationships']['uid']['label'] = 'User';
+  $handler->display->display_options['relationships']['uid']['required'] = TRUE;
+  /* Field: Signups: Date submitted */
+  $handler->display->display_options['fields']['timestamp']['id'] = 'timestamp';
+  $handler->display->display_options['fields']['timestamp']['table'] = 'dosomething_signup';
+  $handler->display->display_options['fields']['timestamp']['field'] = 'timestamp';
+  $handler->display->display_options['fields']['timestamp']['label'] = 'Submitted';
+  $handler->display->display_options['fields']['timestamp']['date_format'] = 'short';
+  /* Field: User: Uid */
+  $handler->display->display_options['fields']['uid']['id'] = 'uid';
+  $handler->display->display_options['fields']['uid']['table'] = 'users';
+  $handler->display->display_options['fields']['uid']['field'] = 'uid';
+  $handler->display->display_options['fields']['uid']['relationship'] = 'uid';
+  /* Field: User: E-mail */
+  $handler->display->display_options['fields']['mail']['id'] = 'mail';
+  $handler->display->display_options['fields']['mail']['table'] = 'users';
+  $handler->display->display_options['fields']['mail']['field'] = 'mail';
+  $handler->display->display_options['fields']['mail']['relationship'] = 'uid';
+  $handler->display->display_options['fields']['mail']['link_to_user'] = 'user';
+  /* Contextual filter: Content: Nid */
+  $handler->display->display_options['arguments']['nid']['id'] = 'nid';
+  $handler->display->display_options['arguments']['nid']['table'] = 'node';
+  $handler->display->display_options['arguments']['nid']['field'] = 'nid';
+  $handler->display->display_options['arguments']['nid']['relationship'] = 'nid';
+  $handler->display->display_options['arguments']['nid']['default_action'] = 'empty';
+  $handler->display->display_options['arguments']['nid']['title_enable'] = TRUE;
+  $handler->display->display_options['arguments']['nid']['title'] = 'Signups: %1';
+  $handler->display->display_options['arguments']['nid']['breadcrumb_enable'] = TRUE;
+  $handler->display->display_options['arguments']['nid']['breadcrumb'] = 'Signups';
+  $handler->display->display_options['arguments']['nid']['default_argument_type'] = 'fixed';
+  $handler->display->display_options['arguments']['nid']['summary']['number_of_records'] = '0';
+  $handler->display->display_options['arguments']['nid']['summary']['format'] = 'default_summary';
+  $handler->display->display_options['arguments']['nid']['summary_options']['items_per_page'] = '25';
+  $handler->display->display_options['arguments']['nid']['specify_validation'] = TRUE;
+  $handler->display->display_options['arguments']['nid']['validate']['type'] = 'node';
+  $handler->display->display_options['arguments']['nid']['validate_options']['types'] = array(
+    'campaign' => 'campaign',
+  );
+  $handler->display->display_options['arguments']['nid']['validate_options']['access'] = TRUE;
+  $handler->display->display_options['arguments']['nid']['validate_options']['access_op'] = 'update';
+  /* Filter criterion: Signups: Uid */
+  $handler->display->display_options['filters']['uid']['id'] = 'uid';
+  $handler->display->display_options['filters']['uid']['table'] = 'dosomething_signup';
+  $handler->display->display_options['filters']['uid']['field'] = 'uid';
+  $handler->display->display_options['filters']['uid']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['uid']['expose']['operator_id'] = 'uid_op';
+  $handler->display->display_options['filters']['uid']['expose']['label'] = 'Uid';
+  $handler->display->display_options['filters']['uid']['expose']['operator'] = 'uid_op';
+  $handler->display->display_options['filters']['uid']['expose']['identifier'] = 'uid';
+  $handler->display->display_options['filters']['uid']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+    6 => 0,
+  );
+
+  /* Display: Page */
+  $handler = $view->new_display('page', 'Page', 'page');
+  $handler->display->display_options['path'] = 'node/%/signups';
+  $handler->display->display_options['menu']['type'] = 'tab';
+  $handler->display->display_options['menu']['title'] = 'Signups';
+  $handler->display->display_options['menu']['description'] = 'Signups for this node';
+  $handler->display->display_options['menu']['weight'] = '80';
+  $handler->display->display_options['menu']['context'] = 0;
+  $handler->display->display_options['menu']['context_only_inline'] = 0;
+  $translatables['node_signups'] = array(
+    t('Master'),
+    t('more'),
+    t('Apply'),
+    t('Reset'),
+    t('Sort by'),
+    t('Asc'),
+    t('Desc'),
+    t('Items per page'),
+    t('- All -'),
+    t('Offset'),
+    t('« first'),
+    t('‹ previous'),
+    t('next ›'),
+    t('last »'),
+    t('Node'),
+    t('User'),
+    t('Submitted'),
+    t('Uid'),
+    t('E-mail'),
+    t('All'),
+    t('Signups: %1'),
+    t('Signups'),
+    t('Page'),
+  );
+  $export['node_signups'] = $view;
+
+  $view = new view();
   $view->name = 'user_signups';
   $view->description = '';
   $view->tag = 'default';


### PR DESCRIPTION
Creates a `node/*/signups` tab on campaigns, which is a new view `node_signups` which displays all signups for a given node.  Built to faciliate testing signups, provide overview to campaigns team, and visible to roles with permission to edit a campaign.

Also resolves #1129 by creating a `node/*/unsignup` tab to allow a staff user to delete their own signup. Built for better internal signup testing. Only visible to staff, and if you're signed up for the node.
