### PR TITLE
Official Rules Fix

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -644,8 +644,8 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
 
   // Prove.
   $vars['reportback_copy'] = $wrapper->field_reportback_copy->value();
-  $official_rules = $wrapper->field_official_rules->value();
-  $vars['official_rules_src'] = file_create_url($official_rules['uri']);
+  $vars['official_rules'] = $wrapper->field_official_rules->value();
+  $vars['official_rules_src'] = file_create_url($vars['official_rules']['uri']);
 
   // Reportback gallery.
   if ($reportback_gallery = $wrapper->field_image_reportback_gallery->value()) {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/campaign/_prove.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/campaign/_prove.scss
@@ -45,10 +45,15 @@
     display: block;
     margin: 1.5rem 0 0 0;
     color: #fff;
+    text-align: center;
 
     &:hover {
       color: #fff;
       color: rgba(255, 255, 255, 0.9);
+    }
+
+    @include media( $tablet ) {
+      text-align: left;
     }
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/campaign/_prove.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/campaign/_prove.scss
@@ -43,6 +43,13 @@
 
   a.official-rules {
     display: block;
+    margin: 1.5rem 0 0 0;
+    color: #fff;
+
+    &:hover {
+      color: #fff;
+      color: rgba(255, 255, 255, 0.9);
+    }
   }
 
   .content {

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -254,7 +254,7 @@
         <?php if (isset($reportback_copy)): ?><div class="copy"><?php print $reportback_copy; ?></div><?php endif; ?>
 
         <?php if (isset($reportback_link_label)): ?><a href="#modal-report-back" class="js-modal-link btn large"><?php print $reportback_link_label; ?></a><?php endif; ?>
-        <?php if (isset($official_rules_src)): ?><a class="official-rules" href="<?php print $official_rules_src; ?>">Official Rules</a><?php endif; ?>
+        <?php if (isset($official_rules)): ?><a class="official-rules" href="<?php print $official_rules_src; ?>">Official Rules</a><?php endif; ?>
 
         <?php if (isset($reportback_form)): ?>
         <script id="modal-report-back" class="modal--reportback inline--alt-bg" type="text/cached-modal">


### PR DESCRIPTION
## Issue

The campaign "official rules" link was printing regardless of whether or not a PDF has been updated because the `src` was checked on the template which always has a base URL value set.

Visually, it was the wrong color and not spaced correctly.
## Fix

This change creates a `$official_rules` variable to check against in place of the site's base URL, makes the link white and gives it some breathing room.

Fixes #1147
Fixes #1205
