### PR TITLE
Show Error Messages

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/_hide.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/_hide.scss
@@ -5,13 +5,3 @@
 //  Furnes begins the site chrome and footer.
 // --------------------------------------------------------------
 
-.page-node-8,
-.page-node-362 {
-  .admin-menu-site-localhost,
-  .admin-menu-site-dev-dosomething-org,
-  .breadcrumbs,
-  .tabs,
-  .messages.error {
-    display: none;
-  }
-}


### PR DESCRIPTION
## Issue

Error messages were not displaying.
## Fix

Remove the `display: none` that was hiding them!

Fixes #1249
