### PR TITLE
Headless Horseman Crop Fix

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -640,7 +640,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     }
     // We only need one image for tpl for now, so get the image for key 0.
     $vars['step_image_square'] = dosomething_image_get_themed_image($step_images[0]['nid'], 'square', '310x310');
-    $vars['step_image_landscape'] = dosomething_image_get_themed_image($step_images[0]['nid'], 'landscape', '720x310');
+    $vars['step_image_landscape'] = dosomething_image_get_themed_image($step_images[0]['nid'], 'landscape', '740x480');
   }
 
   // Prove.


### PR DESCRIPTION
## Issue

The "Do It" gallery image on mobile was not displaying a 16:9 crop. This resulted in a headless sports fan.
## Fix

Bumped the width and height of the image requested in the Campaign Module to render a more appropriate size.

![landscape](https://f.cloud.github.com/assets/1479130/2422118/f6051b50-ab8a-11e3-9530-d9106c53b3d0.png)

Fixes #1204
