### PR TITLE
Added support for legacy campaign redirects.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -390,6 +390,17 @@ function dosomething_campaign_entity_view_mode_alter(&$view_mode, $context) {
         $view_mode = 'pitch';
       }
     }
+    // Is this a legacy campaign?
+    if (module_exists('dosomething_legacy') && dosomething_legacy_check($node)) {
+      if (dosomething_signup_exists($node->nid)) {
+        // If the user is signed up redirect to old world campaign page.
+        dosomething_legacy_goto($node->nid, TRUE);
+      }
+      if (!dosomething_signup_exists($node->nid)) {
+        // If not signed up, old world join page.
+        dosomething_legacy_goto($node->nid, FALSE);
+      }
+    }
   }
 }
 

--- a/lib/modules/dosomething/dosomething_legacy/dosomething_legacy.info
+++ b/lib/modules/dosomething/dosomething_legacy/dosomething_legacy.info
@@ -1,0 +1,4 @@
+name = DoSomething Legacy
+description = Provides support for the legacy app.
+core = 7.x
+package = DoSomething

--- a/lib/modules/dosomething/dosomething_legacy/dosomething_legacy.module
+++ b/lib/modules/dosomething/dosomething_legacy/dosomething_legacy.module
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @file
+ * Code for the DoSomething Legacy module.
+ */
+define('MOMM_NID', 850);
+define('MOMM_NID_LEGACY', 731098);
+/**
+ * Determines if a campaign is a legacy campaign.
+ *
+ * @param object $node
+ *  A node object.
+ * @return bool
+ *  Returns true if node is a legacy campaign, else false.
+ */
+function dosomething_legacy_check($node) {
+  if ($node->nid == MOMM_NID) {
+    return TRUE;
+  }
+  return FALSE;
+}
+
+/**
+ * Handles redirects to the legacy app.
+ *
+ * @param int $nid
+ *  Old world nid.
+ * @param bool $signedup
+ *  True if user is signed up for campaign, else false.
+ */
+function dosomething_legacy_goto($nid, $signedup) {
+  if ($signedup) {
+    drupal_goto('https://www.dosomething.org/node/' . MOMM_NID_LEGACY);
+  }
+  else {
+    drupal_goto('https://www.dosomething.org/campaign/join/' . MOMM_NID_LEGACY);
+  }
+}


### PR DESCRIPTION
Only handles mind on my money redirects.
Does not add the module to the .info file, we don't want this turned on by default.
Hardcoding mind of my money urls to point to production, this won't work in stage/qa.

Fixes #1219
Refs #1213
