### PR TITLE
Replaces local html5shiv reference with the CDN version

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/template_hooks/preprocess_page/html5shiv.php
+++ b/lib/themes/dosomething/paraneue_dosomething/template_hooks/preprocess_page/html5shiv.php
@@ -3,12 +3,12 @@
 /**
  * Adds html5shiv script for IE8 users.
  *
- * Implements hook_preprocess_page(). 
+ * Implements hook_preprocess_page().
  */
 function paraneue_dosomething_preprocess_page_html5shiv(&$vars, $hook) {
   $html5shiv = array(
     '#type' => 'markup',
-    '#markup' => '<!--[if lte IE 8]> <script type="text/javascript" src="' . NEUE_PATH . '/bower_components/dist/html5shiv.js' . '"></script> <![endif]-->'
+    '#markup' => '<!--[if lte IE 8]> <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7/html5shiv.js"></script> <![endif]-->'
   );
 
   drupal_add_html_head($html5shiv, 'html5shiv');


### PR DESCRIPTION
The original path to html5shiv seems to be borked.  This replaces it with the cdn version and order is restored.

This is a temp fix until we sort of the local path reference.  Though, I do not see an issue with using the cdn version either

Fixes #1207
