### PR TITLE
Adds font mimetypes to vhost config in VM

### DIFF
--- a/provision/salt/roots/salt/apache2/vhost.conf
+++ b/provision/salt/roots/salt/apache2/vhost.conf
@@ -21,4 +21,8 @@
 
 	CustomLog ${APACHE_LOG_DIR}/access.log combined
 
+	AddType application/vnd.ms-fontobject .eot
+	AddType application/font-sfnt .otf .ttf
+	AddType application/font-woff .woff
+
 </VirtualHost>


### PR DESCRIPTION
Adds proper font mimetypes to local VM instances

This will require a VM provision to take effect

References #1254
