### PR TITLE
Fixes padding for static content and 11 Facts pages.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/_content.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/_content.scss
@@ -10,6 +10,7 @@
     .hamburger {
       color: #fff !important;
     }
+
     a {
       color: #fff !important;
     }
@@ -28,11 +29,12 @@
     color: $purple;
   }
 
-   // @TODO: Abstract all of these base styles to ds-neue
+  // @TODO: Abstract all of these base styles to ds-neue
   a {
     font-weight: 600;
     text-decoration: none;
   }
+
   a:hover {
     text-decoration: underline;
   }
@@ -42,10 +44,18 @@
     margin: 0 0 0 20px;
   }
 
+  .header-wrapper {
+    padding: 7rem 1rem 0;
+    @include row; 
+    @include media($tablet) {
+      padding: 7rem 0 0;
+    }
+  }
+
   // Set gutters on mobile
-  .header-wrapper, .intro-wrapper, .cta-wrapper, .additional-text-wrapper, .gallery-wrapper {
-    padding: 0 1rem;
-    @include outer-container;
+  .intro-wrapper, .cta-wrapper, .additional-text-wrapper, .gallery-wrapper {
+    padding: 1rem;
+    @include row; 
     @include media($tablet) {
       padding: 0;
     }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/_fact-page.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/_fact-page.scss
@@ -36,8 +36,16 @@
     color: $purple;
   }
 
+  .header-wrapper {
+    padding: 7rem 1rem 1rem;
+    @include row;
+    @include media($tablet) {
+      padding: 7rem 0 0;
+    }
+  }
+
   // Set gutters on mobile
-  .header-wrapper, .intro-wrapper, .facts-wrapper, .sources-wrapper {
+  .intro-wrapper, .facts-wrapper, .sources-wrapper {
     padding: 1rem;
     @include row;
     @include media($tablet) {


### PR DESCRIPTION
Before:
![screen shot 2014-03-16 at 2 57 58 pm](https://f.cloud.github.com/assets/583202/2431691/69701ebe-ad3e-11e3-948f-552c7cb6ce6f.png)

After:
![screen shot 2014-03-16 at 3 07 38 pm](https://f.cloud.github.com/assets/583202/2431692/6e78acd2-ad3e-11e3-86ea-159c800232ee.png)

Ahh, much better. :leaves: 
