### PR TITLE
Fixes Issue 1304, missing CAMPAIGN_LINK merge_var in campaign_signup

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -338,6 +338,7 @@ function dosomething_signup_mbp_request($account, $node) {
     'first_name' => dosomething_user_get_field('field_first_name', $account),
     'event_id' => $node->nid,
     'campaign_title' => $node->title,
+    'campaign_link' => $node->path,
     'call_to_action' => $wrapper->field_call_to_action->value(),
     'step_one' => $wrapper->field_pre_step_header->value(),
     'step_two' => DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER,

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -473,6 +473,7 @@ function dosomething_user_mbp_request($origin, $params = NULL) {
       $payload['merge_vars'] = array(
         'FNAME' => $params['first_name'],
         'CAMPAIGN_TITLE' => $params['campaign_title'],
+        'CAMPAIGN_LINK' => $params['campaign_link'],
         'CALL_TO_ACTION' => $params['call_to_action'],
         'STEP_ONE' => $params['step_one'],
         'STEP_TWO' => $params['step_two'],


### PR DESCRIPTION
Fixes #1304
- Adds CAMPAIGN_LINK to Message Broker merge_var payload values for campaign signups.
