### PR TITLE
Mailchimp MBP vars

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -33,7 +33,7 @@ function dosomething_signup_optin_config($form, &$form_state) {
       // Create a fieldset for each campaign.
       $form[$nid] = array(
         '#type' => 'fieldset',
-        '#title' => $title . ' : ' . $nid,
+        '#title' => $title . ' : NID ' . $nid,
         '#collapsible' => TRUE,
         '#collapsed' => TRUE,
       );
@@ -41,13 +41,15 @@ function dosomething_signup_optin_config($form, &$form_state) {
       // Each campagin gets a mailchimp & mobile commons id.
       $form[$nid]['dosomething_signup_nid_' . $nid . '_mailchimp_id'] = array(
         '#type' => 'textfield',
-        '#title' => t('MailChimp Group'),
+        '#title' => t('MailChimp Group ID'),
         '#default_value' => variable_get('dosomething_signup_nid_' . $nid . '_mailchimp_id', ''),
+        '#description' => t("Enter the campaign's <strong>numeric</strong> Mailchimp Group group_id value."),
       );
       $form[$nid]['dosomething_signup_nid_' . $nid . '_mobilecommons_id'] = array(
         '#type' => 'textfield',
         '#title' => t('Mobile Commons Opt-In'),
         '#default_value' => variable_get('dosomething_signup_nid_' . $nid . '_mobilecommons_id', ''),
+        '#description' => t("Enter the campaign's Mobilecommons opt-in path."),
       );
     }
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -331,6 +331,24 @@ function dosomething_signup_user_signup($nid, $account = NULL) {
  *   Details about the node that the signup was made on.
  */
 function dosomething_signup_mbp_request($account, $node) {
+  // Gather mbp params for the signup.
+  $params = dosomething_signup_get_mbp_params($account, $node);
+  // Send MBP request.
+  dosomething_user_mbp_request('campaign_signup', $params);
+}
+
+/**
+ * Get params for a signup mbp request.
+ *
+ * @param object $account
+ *   Details about the user account that made the signup.
+ * @param object $node
+ *   Details about the node that the signup was made on.
+ *
+ * @return array
+ *   Associative array of values to use as params to a mbp_request.
+ */
+function dosomething_signup_get_mbp_params($account, $node) {
   $wrapper = entity_metadata_wrapper('node', $node);
   $params = array(
     'email' => $account->mail,
@@ -343,9 +361,29 @@ function dosomething_signup_mbp_request($account, $node) {
     'step_one' => $wrapper->field_pre_step_header->value(),
     'step_two' => DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER,
     'step_three' => $wrapper->field_post_step_header->value(),
-    'mailchimp_group_id' => '??'
   );
-  dosomething_user_mbp_request('campaign_signup', $params);
+  // Add any mailchimp params if needed.
+  dosomething_signup_get_mbp_params_mailchimp($params, $node);
+  return $params;
+}
+
+/**
+ * Checks if Mailchimp params should be included in a signup mbp request.
+ *
+ * @param array $params
+ *   Params array to be sent to a mbp request.
+ * @param object $node
+ *   Details about the node that the signup was made on.
+ */
+function dosomething_signup_get_mbp_params_mailchimp(&$params, $node) {
+  $varname = 'dosomething_signup_nid_' . $node->nid . '_mailchimp_id';
+  // Variable may be set as empty string, so set empty string as default.
+  $group_id = variable_get($varname, '');
+  // If a value is present for Mailchimp Group ID:
+  if (!empty($group_id) && is_numeric($group_id)) {
+    // Add it into the mbp_request params.
+    $params['mailchimp_group_id'] = $group_id;
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -480,8 +480,11 @@ function dosomething_user_mbp_request($origin, $params = NULL) {
         'STEP_ONE' => $params['step_one'],
         'STEP_TWO' => $params['step_two'],
         'STEP_THREE' => $params['step_three'],
-        'MAILCHIMP_GROUP_ID' => $params['mailchimp_group_id']
       );
+      // Check for mailchimp group:
+      if (isset($params['mailchimp_group_id'])) {
+        $payload['merge_vars']['MAILCHIMP_GROUP_ID'] = $params['mailchimp_group_id'];
+      }
       break;
     case 'campaign_reportback':
       $payload['event_id'] = $params['event_id'];

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -172,7 +172,7 @@ function dosomething_user_new_user($form, &$form_state) {
       'email' => $account->mail,
       'uid' => $account->uid,
       'first_name' => dosomething_user_get_field('field_first_name', $account),
-      'birthdate' => '??',
+      'birthdate' => dosomething_user_get_birthdate(),
     );
     dosomething_user_mbp_request('user_register', $params);
     // Sign user up for mobile commons


### PR DESCRIPTION
Fixes #1322

Only passes the Mailchimp Group ID into MBP if a corresponding signup `mailchimp_id` variable exists for the given signup `$node`. 
