### PR TITLE
Adding 'q' param for apachesolr views to enable elevate queries

### DIFF
--- a/lib/modules/dosomething/dosomething_search/dosomething_search.module
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.module
@@ -62,10 +62,17 @@ function dosomething_search_apachesolr_query_alter(DrupalSolrQueryInterface $que
     ),
   );
 
+  // Add a 'q' param to apachesolr_views queries to enable the
+  // elevate.xml to work properly.
+  $query_params = $query->getParams();
+  if (!isset($query_params['q'])) {
+    $params['q'] = '*:*';
+  }
+
   $boosts = array(
-    'bs_high_season' => '5.0',
-    'bm_field_staff_pick' => '4.0',
-    'bs_sponsored' => '3.0',
+    'bs_high_season' => '1.0',
+    'bs_field_staff_pick' => '5.0',
+    'bs_sponsored' => '4.0',
   );
   foreach ($boosts as $field => $boost) {
     $params['bq'][] = "{$field}:true^$boost";


### PR DESCRIPTION
- The Solr QueryElevationComponent can be leveraged to bubble up
  a static list of nodes for a given query.  For /campaigns, 
  the desired results can't be achieved with boosts alone, so
  the list and order of campaigns that should show up first has
  been added to elevate.xml, and the elevate component has been
  enabled in solrconfig.xml.
- Elevate queries specified in elevate.xml need a 'q' param
  to operate properly.  apachsolr_views doesn't automatically include
  one.
- Since this is a static list that's not editorially controllable,
  this may need to be rethought in the future.

Fixes #1306

@mikefantini 
