### PR TITLE
Default Container Widths

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/_campaign.scss
@@ -1,3 +1,7 @@
+.node-type-campaign .region-content {
+  @include designed-width;
+}
+
 .campaign--wrapper {
   overflow: hidden;
   background: #fff;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/_content.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/_content.scss
@@ -2,6 +2,10 @@
 //  STATIC CONTENT
 // ----------------
 
+.node-type-static-content .region-content {
+  @include designed-width;
+}
+
 .node-type-static-content {
   background: $purple;
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/_drupal.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/_drupal.scss
@@ -37,3 +37,9 @@
 .container-inline-date > .form-item {
   margin-right: 0;
 }
+
+// Default container styles for stock Drupal pages
+// NOTE - This is overridden for all designed pages
+.region-content {
+  @include default-width;
+}

--- a/lib/themes/dosomething/paraneue_dosomething/scss/mixins.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/mixins.scss
@@ -61,3 +61,24 @@
   }
 }
 
+// Applies a default width to a container for Drupal's stock pages
+@mixin default-width {
+  padding: 100px 1.5rem 50px;
+
+  @include media( $tablet ) {
+    @include span-columns(8);
+    @include shift(4);
+
+    padding: 150px 0 100px;
+  }
+}
+
+// Overrides the default width for all "designed" pages (full-width campaigns, static content, etc.)
+@mixin designed-width {
+  padding: 0;
+
+  @include media( $tablet ) {
+    @include span-columns(16);
+    @include shift(0);
+  }
+}


### PR DESCRIPTION
Sets a default width to all Drupal containers then overrides that width for "designed" pages (e.g. campaigns, static content, etc.).

Described in #1395
