### PR TITLE
Properly floats images on campaigns again.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/_campaign.scss
@@ -1,3 +1,8 @@
+.node-type-campaign {
+  @include wrapper--nav-floating;
+}
+
+
 .campaign--wrapper {
   overflow: hidden;
   background: #fff;


### PR DESCRIPTION
Wasn't floating images on campaigns properly after we re-jiggered the nav to deal with unstyled pages.
