### PR TITLE
High Priority Backlog

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -310,6 +310,7 @@ function dosomething_campaign_get_recommended_campaign_vars($nid) {
     'title' => l($wrapper->label(), $path),
     'call_to_action' => $wrapper->field_call_to_action->value(),
     'image' => $image,
+    'src' => $path,
   );
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/campaign/_do.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/campaign/_do.scss
@@ -62,6 +62,11 @@
     a.tip-header.active {
       display: inline-block;
       color: $off-black;
+      cursor: default;
+
+      &:hover {
+        cursor: default;
+      }
 
       &:after {
         content: "";

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
@@ -15,11 +15,13 @@
         <?php foreach ($recommended as $rec): ?>
           <div class="gallery-item">
             <?php if (isset($rec['image'])): ?>
-              <img src="<?php print $rec['image']; ?>"/>
+              <a href="<?php print $rec['src']; ?>"><img src="<?php print $rec['image']; ?>"/></a>
             <?php endif; ?>
+
             <?php if (isset($rec['title'])): ?>
                 <h3><?php print $rec['title']; ?></h3>
             <?php endif; ?>
+
             <?php if (isset($rec['call_to_action'])): ?>
               <div class="gallery-description"><?php print $rec['call_to_action']; ?></div>
             <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
@@ -19,7 +19,7 @@
             <?php endif; ?>
 
             <?php if (isset($rec['title'])): ?>
-                <h3><?php print $rec['title']; ?></h3>
+              <h3><?php print $rec['title']; ?></h3>
             <?php endif; ?>
 
             <?php if (isset($rec['call_to_action'])): ?>


### PR DESCRIPTION
## Changes
- Allows users to click images on the campaign confirmation page to view that campaign
- Disables "pointer" on hover to prevent the appearance of a clickable tip if only one tip is present

Resolves #1353
Resolves #1389
