### PR TITLE
Adding additional boost to campaign type to improve ranking

### DIFF
--- a/lib/modules/dosomething/dosomething_search/dosomething_search.module
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.module
@@ -77,6 +77,9 @@ function dosomething_search_apachesolr_query_alter(DrupalSolrQueryInterface $que
   foreach ($boosts as $field => $boost) {
     $params['bq'][] = "{$field}:true^$boost";
   }
+
+  $params['bq'][] = "bundle:campaign^100.0";
+
   if ($query) {
     $query->addParams($params);
   }


### PR DESCRIPTION
- Campaigns were showing up mixed in with 11 facts in search.
  Adding a large boost to campaign types to push them to the top.

Fixes #1310
