### PR TITLE
Bower non-interactive flag

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -298,11 +298,11 @@ function bower {
   then
     cd $WEB_PATH/profiles/dosomething/themes/dosomething/paraneue
     echo -e "\e[4mInstalling bower dependencies for Paraneue...\e[0m"
-    eval "/usr/bin/bower update"
+    eval "/usr/bin/bower update --config.interactive=false"
 
     cd $LIB_PATH/themes/dosomething/paraneue_dosomething
     echo -e "\n\e[4mInstalling bower dependencies for Paraneue_DoSomething...\e[0m"
-    eval "/usr/bin/bower update"
+    eval "/usr/bin/bower update --config.interactive=false"
 
     cd $BASE_PATH
 

--- a/bin/ds
+++ b/bin/ds
@@ -126,9 +126,6 @@ function build {
   echo 'Install composer dependencies'
   composer
 
-  echo 'Install bower dependencies'
-  bower
-
   # Clear caches and Run updates
   cd "$WEB_DIR"
 


### PR DESCRIPTION
Prevents potential hang if newer version of Bower makes any prompts during CI task.
