### PR TITLE
Campaign Modal Image Widths

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/feature/_modals.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/feature/_modals.scss
@@ -13,4 +13,10 @@
     // fit this guy to edge of modal
     margin: -2rem -1.5rem 0;
   }
+
+  // Ensure modal images do not break out of their
+  // parent containers on mobile
+  img {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Changes
- Sets width of images in modals to 100% to prevent overflow issue

Resolves #1437
