### PR TITLE
Mailchimp grouping_id and group_name vars

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -57,8 +57,14 @@ function _dosomething_campaign_form_extras(&$form, &$form_state) {
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
+  $form['custom']['styles'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Styles'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
   $alt_color = $prefix . 'alt_color';
-  $form['custom'][$alt_color] = array(
+  $form['custom']['styles'][$alt_color] = array(
     '#type' => 'textfield',
     '#title' => t('Alt color'),
     '#default_value' => variable_get($alt_color),
@@ -67,7 +73,7 @@ function _dosomething_campaign_form_extras(&$form, &$form_state) {
   );
   // Alt bg pattern variable.
   $alt_bg_fid = $prefix . 'alt_bg_fid';
-  $form['custom'][$alt_bg_fid] = array(
+  $form['custom']['styles'][$alt_bg_fid] = array(
     '#type' => 'managed_file',
     '#title' => t('Alt background pattern'),
     '#default_value' => variable_get($alt_bg_fid),
@@ -79,16 +85,24 @@ function _dosomething_campaign_form_extras(&$form, &$form_state) {
     '#type' => 'fieldset',
     '#title' => t('Third Party Opt-ins'),
     '#description' => t('Custom campaign opt-in values.'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
   );
-  $form['custom']['optins']['mailchimp'] = array(
+  $form['custom']['optins']['mailchimp_grouping_id'] = array(
     '#type' => 'textfield',
-    '#title' => t('MailChimp Opt-in'),
-    '#default_value' => variable_get('dosomething_signup_nid_' . $form['nid']['#value'] . '_mailchimp_id'),
+    '#title' => t('MailChimp Grouping ID'),
+    '#default_value' => variable_get('dosomething_signup_nid_' . $form['nid']['#value'] . '_mailchimp_grouping_id'),
+    '#disabled' => TRUE,
+  );
+  $form['custom']['optins']['mailchimp_group_name'] = array(
+    '#type' => 'textfield',
+    '#title' => t('MailChimp Group Name'),
+    '#default_value' => variable_get('dosomething_signup_nid_' . $form['nid']['#value'] . '_mailchimp_group_name'),
     '#disabled' => TRUE,
   );
   $form['custom']['optins']['mobilecommons'] = array(
     '#type' => 'textfield',
-    '#title' => t('MobileCommons Opt-in'),
+    '#title' => t('MobileCommons Opt-in Path'),
     '#default_value' => variable_get('dosomething_signup_nid_' . $form['nid']['#value'] . '_mobilecommons_id'),
     '#disabled' => TRUE,
   );

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -30,6 +30,11 @@ function dosomething_signup_optin_config($form, &$form_state) {
     foreach ($staff_picks as $staff_pick) {
       $nid = $staff_pick['nid'];
       $title = $staff_pick['title'];
+      $prefix = 'dosomething_signup_nid_' . $nid;
+      $mailchimp_grouping_id = $prefix . '_mailchimp_grouping_id';
+      $mailchimp_group_name = $prefix . '_mailchimp_group_name';
+      $mobilecommons_id = $prefix . '_mobilecommons_id';
+
       // Create a fieldset for each campaign.
       $form[$nid] = array(
         '#type' => 'fieldset',
@@ -38,18 +43,24 @@ function dosomething_signup_optin_config($form, &$form_state) {
         '#collapsed' => TRUE,
       );
 
-      // Each campagin gets a mailchimp & mobile commons id.
-      $form[$nid]['dosomething_signup_nid_' . $nid . '_mailchimp_id'] = array(
+      // Each campaign gets a mailchimp grouping_id/group_name & mobilecommons id.
+      $form[$nid][$mailchimp_grouping_id] = array(
         '#type' => 'textfield',
-        '#title' => t('MailChimp Group ID'),
-        '#default_value' => variable_get('dosomething_signup_nid_' . $nid . '_mailchimp_id', ''),
-        '#description' => t("Enter the campaign's <strong>numeric</strong> Mailchimp Group group_id value."),
+        '#title' => t('MailChimp Grouping ID'),
+        '#default_value' => variable_get($mailchimp_grouping_id),
+        '#description' => t('The numeric Grouping ID that the Group Name belongs to.'),
       );
-      $form[$nid]['dosomething_signup_nid_' . $nid . '_mobilecommons_id'] = array(
+      $form[$nid][$mailchimp_group_name] = array(
         '#type' => 'textfield',
-        '#title' => t('Mobile Commons Opt-In'),
-        '#default_value' => variable_get('dosomething_signup_nid_' . $nid . '_mobilecommons_id', ''),
-        '#description' => t("Enter the campaign's Mobilecommons opt-in path."),
+        '#title' => t('MailChimp Group Name'),
+        '#default_value' => variable_get($mailchimp_group_name),
+        '#description' => t('The alphanumeric Interest Group name.'),
+      );
+      $form[$nid][$mobilecommons_id] = array(
+        '#type' => 'textfield',
+        '#title' => t('Mobile Commons Opt-In Path'),
+        '#default_value' => variable_get($mobilecommons_id),
+        '#description' => t("The numeric Mobilecommons opt-in path."),
       );
     }
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -382,13 +382,20 @@ function dosomething_signup_get_mbp_params($account, $node) {
  *   Details about the node that the signup was made on.
  */
 function dosomething_signup_get_mbp_params_mailchimp(&$params, $node) {
-  $varname = 'dosomething_signup_nid_' . $node->nid . '_mailchimp_id';
+  $nid = $node->nid;
+  $prefix = 'dosomething_signup_nid_' . $nid;
   // Variable may be set as empty string, so set empty string as default.
-  $group_id = variable_get($varname, '');
-  // If a value is present for Mailchimp Group ID:
-  if (!empty($group_id) && is_numeric($group_id)) {
+  // The mailchimp_id will be deprecated soon. 
+  // @see https://github.com/DoSomething/dosomething/issues/1476
+  $group_id =  variable_get($prefix . '_mailchimp_id', '');
+  $grouping_id = variable_get($prefix . '_mailchimp_grouping_id', '');
+  $group_name = variable_get($prefix . '_mailchimp_group_name', '');
+  // If a value is present for Mailchimp groups:
+  if (!empty($group_id) || !empty($grouping_id) || !empty($group_name)) {
     // Add it into the mbp_request params.
     $params['mailchimp_group_id'] = $group_id;
+    $params['mailchimp_grouping_id'] = $grouping_id;
+    $params['mailchimp_group_name'] = $group_name;
   }
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -485,9 +485,13 @@ function dosomething_user_mbp_request($origin, $params = NULL) {
         'STEP_TWO' => $params['step_two'],
         'STEP_THREE' => $params['step_three'],
       );
-      // Check for mailchimp group:
-      if (isset($params['mailchimp_group_id'])) {
+      // Check for mailchimp grouping_id+group_name:
+      $mailchimp = isset($params['mailchimp_group_name']) && isset($params['mailchimp_grouping_id']);
+      // If set, or if soon to be depecrated group_id isset:
+      if ( $mailchimp || isset($params['mailchimp_group_id']) ) {
         $payload['merge_vars']['MAILCHIMP_GROUP_ID'] = $params['mailchimp_group_id'];
+        $payload['merge_vars']['MAILCHIMP_GROUPING_ID'] = $params['mailchimp_grouping_id'];
+        $payload['merge_vars']['MAILCHIMP_GROUP_NAME'] = $params['mailchimp_group_name'];
       }
       break;
     case 'campaign_reportback':

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -488,10 +488,12 @@ function dosomething_user_mbp_request($origin, $params = NULL) {
       // Check for mailchimp grouping_id+group_name:
       $mailchimp = isset($params['mailchimp_group_name']) && isset($params['mailchimp_grouping_id']);
       // If set, or if soon to be depecrated group_id isset:
+      // @todo: Remove check for group_id when ready for cleanup.
       if ( $mailchimp || isset($params['mailchimp_group_id']) ) {
-        $payload['merge_vars']['MAILCHIMP_GROUP_ID'] = $params['mailchimp_group_id'];
-        $payload['merge_vars']['MAILCHIMP_GROUPING_ID'] = $params['mailchimp_grouping_id'];
-        $payload['merge_vars']['MAILCHIMP_GROUP_NAME'] = $params['mailchimp_group_name'];
+        //@todo: Remove group_id when ready for cleanup.
+        $payload['mailchimp_group_id'] = $params['mailchimp_group_id'];
+        $payload['mailchimp_grouping_id'] = $params['mailchimp_grouping_id'];
+        $payload['mailchimp_group_name'] = $params['mailchimp_group_name'];
       }
       break;
     case 'campaign_reportback':


### PR DESCRIPTION
This PR handles all code necessary for #1454.  Will close out once we update the config form with the relevant `grouping_id` and `group_name` values.

Adds `grouping_id` and `group_name` variables into signup config so we can avoid hardcoding them in Message Broker.
