### PR TITLE
Adds mobile for MailChimp submissions

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -359,6 +359,7 @@ function dosomething_signup_get_mbp_params($account, $node) {
     'email' => $account->mail,
     'uid' => $account->uid,
     'first_name' => dosomething_user_get_field('field_first_name', $account),
+    'mobile' => dosomething_user_get_field('field_mobile', $account),
     'event_id' => $node->nid,
     'campaign_title' => $node->title,
     'campaign_link' => url(drupal_get_path_alias('node/' . $node->nid), array('absolute' => TRUE)),

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -359,7 +359,7 @@ function dosomething_signup_get_mbp_params($account, $node) {
     'email' => $account->mail,
     'uid' => $account->uid,
     'first_name' => dosomething_user_get_field('field_first_name', $account),
-    'mobile' => dosomething_user_get_field('field_mobile', $account),
+    'mobile' => dosomething_user_get_mobile($account),
     'event_id' => $node->nid,
     'campaign_title' => $node->title,
     'campaign_link' => url(drupal_get_path_alias('node/' . $node->nid), array('absolute' => TRUE)),

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -463,6 +463,7 @@ function dosomething_user_mbp_request($origin, $params = NULL) {
   switch ($origin) {
     case 'user_register':
       $payload['birthdate'] = $params['birthdate'];
+      $payload['mobile'] = $params['mobile'];
       $payload['merge_vars'] = array(
         'FNAME' => $params['first_name'],
       );


### PR DESCRIPTION
Fixes #892

Adds mobile value submitted as part of "user_signup" to `dosomething_user_mbp_request() -> message_broker_producer_request()`
