### PR TITLE
New dosomething_signup_data_form table

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -17,6 +17,7 @@ function dosomething_campaign_form_campaign_node_form_alter(&$form, &$form_state
   // If we're updating an existing node, add the custom settings fieldset.
   if (isset($form['nid']['#value'])) {
     _dosomething_campaign_form_extras($form, $form_state);
+    dosomething_signup_node_signup_data_form($form, $form_state);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -45,11 +45,96 @@ function dosomething_signup_schema() {
       'uid' => array('uid'),
     ),
   );
+  $schema['dosomething_signup_data_form'] = array(
+    'description' => 'Table of signup data forms.',
+    'fields' => array(
+      'nid' => array(
+        'description' => 'The {node}.nid that uses the signup form.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'status' => array(
+        'description' => 'Boolean indicating the form is enabled.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'required' => array(
+        'description' => 'Boolean indicating the form is required for signup.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'required_allow_skip' => array(
+        'description' => 'Boolean indicating display skip link avaiable if required.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'link_text' => array(
+        'description' => 'The text to display in the link to the form.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'form_header' => array(
+        'description' => 'Form header text',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+      ),
+      'form_copy' => array(
+        'description' => 'Form copy.',
+        'type' => 'text',
+        'length' => '2048',
+        'not null' => FALSE,
+      ),
+      'collect_why_signedup' => array(
+        'description' => 'Boolean whether to collect why_signedup.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'why_signedup_label' => array(
+        'description' => 'Label for why_signedup field.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+      ),
+      'collect_user_address' => array(
+        'description' => 'Boolean whether to collect user address.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'collect_user_school' => array(
+        'description' => 'Boolean whether to collect user school.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'collect_user_mobile' => array(
+        'description' => 'Boolean whether to collect user mobile.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'collect_user_birthdate' => array(
+        'description' => 'Boolean whether to collect user birthdate.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+    ),
+    'primary key' => array('nid'),
+  );
   return $schema;
 }
 
 /**
- * Adds a data colum to the signup table.
+ * Adds a data column to the signup table.
  */
 function dosomething_signup_update_7001() {
   $spec = array(
@@ -61,3 +146,18 @@ function dosomething_signup_update_7001() {
   );
   db_add_field('dosomething_signup', 'data', $spec);
 }
+
+/**
+ * Adds dosomething_signup_data_form table.
+ */
+function dosomething_signup_update_7002() {
+  $tbl_name = 'dosomething_signup_data_form';
+  // Load schema to get table definition.
+  $schema = dosomething_signup_schema();
+  // If table not present:
+  if (!db_table_exists($tbl_name)) {
+    // Create it.
+    db_create_table($tbl_name, $schema[$tbl_name]);
+  }
+}
+

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -5,6 +5,7 @@
  */
 
 include_once 'dosomething_signup.features.inc';
+include_once 'dosomething_signup.signup_data_form.inc';
 include_once 'includes/dosomething_signup.mobilecommons.inc';
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @file
+ * Code for dosomething_signup_data_form functionality.
+ */
+
+/**
+ * Returns the dosomething_signup_data_form values for a given $nid.
+ *
+ * @param int $nid
+ *   The node nid of the signup_data_form record to check.
+ *
+ * @return mixed
+ *   An array of the signup data form values if exists, NULL if doesn't exist.
+ */
+function dosomething_signup_get_signup_data_form_info($nid) {
+  return db_select('dosomething_signup_data_form', 's')
+    ->fields('s')
+    ->condition('nid', $nid)
+    ->execute()
+    ->fetchAssoc();
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -20,3 +20,43 @@ function dosomething_signup_get_signup_data_form_info($nid) {
     ->execute()
     ->fetchAssoc();
 }
+
+/**
+ * Adds form elements to given node $form to store nid signup_data_form values.
+ *
+ * Note there is no submit form element returned.
+ * This function is always called from within a node edit form. 
+ */
+function dosomething_signup_node_signup_data_form(&$form, &$form_state) {
+  $nid = $form['nid']['#value'];
+  $values = dosomething_signup_get_signup_data_form_info($nid);
+  // Set an additional submit handler to save the signup_data_form values.
+  $form['#submit'][] = 'dosomething_signup_node_signup_data_form_submit';
+  $form['signup_data_form'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Signup Data Form'),
+    '#weight' => 60,
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['signup_data_form']['signup_data_form_status'] = array(
+    '#type' => 'checkbox', 
+    '#title' => t('Collect additional signup data'),
+    '#default_value' => $values['status'],
+  );
+}
+
+/**
+ * Saves node signup_data_form values into dosomething_signup_data_form.
+ */
+function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
+  $nid = $form['nid']['#value'];
+  $values = $form_state['values'];
+  // Use db_merge to either insert or update existing record for $nid.
+  db_merge('dosomething_signup_data_form')
+    ->key(array('nid' => $nid))
+    ->fields(array(
+        'status' => $values['signup_data_form_status'],
+    ))
+    ->execute();
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -30,19 +30,52 @@ function dosomething_signup_get_signup_data_form_info($nid) {
 function dosomething_signup_node_signup_data_form(&$form, &$form_state) {
   $nid = $form['nid']['#value'];
   $values = dosomething_signup_get_signup_data_form_info($nid);
+  $fieldset = 'signup_data_form';
+  $prefix = $fieldset . '_';
   // Set an additional submit handler to save the signup_data_form values.
   $form['#submit'][] = 'dosomething_signup_node_signup_data_form_submit';
-  $form['signup_data_form'] = array(
+  // Create fieldset to collect signup data form values.
+  $form[$fieldset] = array(
     '#type' => 'fieldset',
     '#title' => t('Signup Data Form'),
     '#weight' => 60,
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $form['signup_data_form']['signup_data_form_status'] = array(
+  $form[$fieldset][$prefix . 'status'] = array(
     '#type' => 'checkbox', 
     '#title' => t('Collect additional signup data'),
     '#default_value' => $values['status'],
+  );
+  $form[$fieldset][$prefix . 'link_text'] = array(
+    '#type' => 'textfield', 
+    '#title' => t('Link text'),
+    '#default_value' => $values['link_text'],
+  );
+  $form[$fieldset][$prefix . 'form_header'] = array(
+    '#type' => 'textfield', 
+    '#title' => t('Form header'),
+    '#default_value' => $values['form_header'],
+  );
+  $form[$fieldset][$prefix . 'form_copy'] = array(
+    '#type' => 'textarea', 
+    '#title' => t('Form copy'),
+    '#default_value' => $values['form_copy'],
+  );
+  $form[$fieldset][$prefix . 'collect_user_address'] = array(
+    '#type' => 'checkbox', 
+    '#title' => t('Collect user address'),
+    '#default_value' => $values['collect_user_address'],
+  );
+  $form[$fieldset][$prefix . 'collect_user_mobile'] = array(
+    '#type' => 'checkbox', 
+    '#title' => t('Collect user mobile'),
+    '#default_value' => $values['collect_user_birthdate'],
+  );
+  $form[$fieldset][$prefix . 'collect_user_birthdate'] = array(
+    '#type' => 'checkbox', 
+    '#title' => t('Collect user birthdate'),
+    '#default_value' => $values['collect_user_birthdate'],
   );
 }
 
@@ -52,11 +85,18 @@ function dosomething_signup_node_signup_data_form(&$form, &$form_state) {
 function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
   $nid = $form['nid']['#value'];
   $values = $form_state['values'];
+  $prefix = 'signup_data_form_';
   // Use db_merge to either insert or update existing record for $nid.
   db_merge('dosomething_signup_data_form')
     ->key(array('nid' => $nid))
     ->fields(array(
-        'status' => $values['signup_data_form_status'],
+        'status' => $values[$prefix . 'status'],
+        'link_text' => $values[$prefix . 'link_text'],
+        'form_header' => $values[$prefix . 'form_header'],
+        'form_copy' => $values[$prefix . 'form_copy'],
+        'collect_user_address' => $values[$prefix . 'collect_user_address'],
+        'collect_user_birthdate' => $values[$prefix . 'collect_user_mobile'],
+        'collect_user_birthdate' => $values[$prefix . 'collect_user_birthdate'],
     ))
     ->execute();
 }


### PR DESCRIPTION
Groundwork for #1484

This is still a work in progress, but submitting as a PR now so it's not millions of lines of code to review.
- Adds a new db table `dosomething_signup_data_form` which stores configuration for a node's signup data form.
- Adds additional form elements into the campaign node edit form to allow editing per node.
