### PR TITLE
Adding Optimizely to ds.info and adding default OPT project ID

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -119,3 +119,5 @@ if (is_readable('sites/default/settings.'. $environment .'.php')) {
 $conf['locale_custom_strings_en'][''] = array(
    'Registration successful. You are now logged in.' => "You've created an account with DoSomething.org."
  );
+
+$conf['optimizely_id'] = '747623297';

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -44,6 +44,7 @@ dependencies[] = message_broker_producer
 dependencies[] = metatag
 dependencies[] = mobilecommons
 dependencies[] = module_filter
+dependencies[] = optimizely
 dependencies[] = pathauto
 dependencies[] = redirect
 dependencies[] = redis


### PR DESCRIPTION
- There's a new project called "New Site Tracking" set up in the
  Optimizely admin.  We'll need experiments to be added to that.
- Adding the "New Site Tracking" project as the default project for
  Optimizely.

@Bladt
@mikefantini

Fixes #1034
