### PR TITLE
Track user signup_data_form submissions

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -36,6 +36,17 @@ function dosomething_signup_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'signup_data_form_timestamp' => array(
+        'description' => 'The Unix timestamp when the signup data form submitted.',
+        'type' => 'int',
+        'not null' => FALSE,
+      ),
+      'why_signedup' => array(
+        'description' => 'Why the user signed up.',
+        'type' => 'text',
+        'length' => '2048',
+        'not null' => FALSE,
+      ),
     ),
     'primary key' => array('sid'),
     'unique keys' => array(
@@ -161,3 +172,20 @@ function dosomething_signup_update_7002() {
   }
 }
 
+/**
+ * Adds relevant signup_data_form fields to dosomething_signups table.
+ */
+function dosomething_signup_update_7003() {
+  $tbl_name = 'dosomething_signup';
+  // New fields to add.
+  $fields = array('signup_data_form_timestamp', 'why_signedup');
+  // Load schema for field definitions.
+  $schema = dosomething_signup_schema();
+  foreach ($fields as $field_name) {
+    // If the field doesn't exist already:
+    if (!db_field_exists($tbl_name, $field_name)) {
+      // Add it per the schema field definition.
+      db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
+    }
+  }
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -102,6 +102,12 @@ function dosomething_signup_schema() {
         'length' => '2048',
         'not null' => FALSE,
       ),
+      'confirm_msg' => array(
+        'description' => 'Confirmation message displayed upon submit.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+      ),
       'collect_why_signedup' => array(
         'description' => 'Boolean whether to collect why_signedup.',
         'type' => 'int',
@@ -173,9 +179,10 @@ function dosomething_signup_update_7002() {
 }
 
 /**
- * Adds relevant signup_data_form fields to dosomething_signups table.
+ * Adds fields to dosomething_signup and dosomething_signup_data_form table.
  */
 function dosomething_signup_update_7003() {
+  // Add fields on signup to track signup_data_form submissions.
   $tbl_name = 'dosomething_signup';
   // New fields to add.
   $fields = array('signup_data_form_timestamp', 'why_signedup');
@@ -187,5 +194,14 @@ function dosomething_signup_update_7003() {
       // Add it per the schema field definition.
       db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
     }
+  }
+  // Add field on data_signup_form to customize the confirmation message.
+  $tbl_name = 'dosomething_signup_data_form';
+  // New field to add.
+  $field_name = 'confirm_msg';
+  // If the field doesn't exist already:
+  if (!db_field_exists($tbl_name, $field_name)) {
+    // Add it per the schema field definition.
+    db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
   }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -62,6 +62,11 @@ function _dosomething_signup_node_signup_data_form(&$form, &$form_state) {
     '#title' => t('Form copy'),
     '#default_value' => $values['form_copy'],
   );
+  $form[$fieldset][$prefix . 'confirm_msg'] = array(
+    '#type' => 'textarea', 
+    '#title' => t('Confirmation message'),
+    '#default_value' => $values['confirm_msg'],
+  );
   $form[$fieldset][$prefix . 'collect_user_address'] = array(
     '#type' => 'checkbox', 
     '#title' => t('Collect user address'),
@@ -94,6 +99,7 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
         'link_text' => $values[$prefix . 'link_text'],
         'form_header' => $values[$prefix . 'form_header'],
         'form_copy' => $values[$prefix . 'form_copy'],
+        'confirm_msg' => $values[$prefix . 'confirm_msg'],
         'collect_user_address' => $values[$prefix . 'collect_user_address'],
         'collect_user_birthdate' => $values[$prefix . 'collect_user_mobile'],
         'collect_user_birthdate' => $values[$prefix . 'collect_user_birthdate'],
@@ -109,10 +115,9 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
  */
 function dosomething_signup_user_signup_data_form($form, &$form_state, $nid) {
   $config = dosomething_signup_get_signup_data_form_info($nid);
-  // Store the logged-in user's signup sid.
-  $form['sid'] = array(
+  $form['nid'] = array(
     '#type' => 'hidden',
-    '#value' => dosomething_signup_exists($nid),
+    '#value' => $nid,
   );
   $form['header'] = array(
     '#prefix' => '<h3>',
@@ -141,22 +146,26 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $nid) {
  * Form submit handler for dosomething_signup_user_signup_data_form().
  */
 function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
+  $values = $form_state['values'];
+  $config = dosomething_signup_get_signup_data_form_info($values['nid']);
   // Update signup record.
-  dosomething_signup_update_signup_data($form_state['values']);
-  //@todo: Update with confirmation_msg stored on signup_data_form record.
-  drupal_set_message("Great success!");
+  dosomething_signup_update_signup_data($values);
+  // Display the signup_data_form's confirm_msg field.
+  drupal_set_message($config['confirm_msg']);
 }
 
 /**
  * Saves signup_form_data to the relevant signup.
  */
 function dosomething_signup_update_signup_data($values) {
+  // Find the relevant signup sid to update.
+  $sid = dosomething_signup_exists($values['nid']);
   try {
     db_update('dosomething_signup')
     ->fields(array(
       'signup_data_form_timestamp' => REQUEST_TIME,
     ))
-    ->condition('sid', $values['sid'])
+    ->condition('sid', $sid)
     ->execute();  
     return TRUE;
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -109,6 +109,11 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
  */
 function dosomething_signup_user_signup_data_form($form, &$form_state, $nid) {
   $config = dosomething_signup_get_signup_data_form_info($nid);
+  // Store the logged-in user's signup sid.
+  $form['sid'] = array(
+    '#type' => 'hidden',
+    '#value' => dosomething_signup_exists($nid),
+  );
   $form['header'] = array(
     '#prefix' => '<h3>',
     '#markup' => $config['form_header'],
@@ -130,4 +135,33 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $nid) {
     ),
   );
   return $form;
+}
+
+/**
+ * Form submit handler for dosomething_signup_user_signup_data_form().
+ */
+function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
+  // Update signup record.
+  dosomething_signup_update_signup_data($form_state['values']);
+  //@todo: Update with confirmation_msg stored on signup_data_form record.
+  drupal_set_message("Great success!");
+}
+
+/**
+ * Saves signup_form_data to the relevant signup.
+ */
+function dosomething_signup_update_signup_data($values) {
+  try {
+    db_update('dosomething_signup')
+    ->fields(array(
+      'signup_data_form_timestamp' => REQUEST_TIME,
+    ))
+    ->condition('sid', $values['sid'])
+    ->execute();  
+    return TRUE;
+  }
+  catch (Exception $e) {
+    watchdog('dosomething_signup', $e, array(), WATCHDOG_ERROR);
+  }
+  return FALSE;
 }


### PR DESCRIPTION
Refs #1484

Tracks when a user submits a `signup_data_form` via new fields added to the `dosomething_signup` table.

Next up will be actually presenting the user with fields to collect account data within the `dosomething_signup_user_signup_data_form`, and saving to the user account upon submit.
