### PR TITLE
Collect user address in signup data form

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/README.md
+++ b/lib/modules/dosomething/dosomething_signup/README.md
@@ -1,0 +1,117 @@
+# DoSomething Signup
+
+This module provides functionality for users to signup for a node type which
+implements it (currently only Campaigns).
+
+Technically, a signup is simply a record in the `dosomething_signup` table, 
+which stores the user uid, the node nid, and the timestamp of the signup.
+
+## View Signups
+
+Each campaign has a corresponding `node/[nid]/signups` path, which calls
+a `node_signups` view, displaying the signups for the given node.
+
+Users with the custom `view any signup` permission are able to access this view. 
+
+## Unsignup
+
+Members (authenticated users) are currently unable to remove their signup from 
+a node.
+
+Staff users (see `dosomething_user`) who signed up for a campaign are able to
+remove their signup record at `node/[nid]/unsignup`.  This is available for
+testing purposes.
+
+
+## Third Party Opt-In
+
+Currently we opt-in users to Mailchimp and Mobilecommons upon signup, depending
+on the node they are signing up for.
+
+Users with `administer third party communication` are able to set custom 
+Mailchimp groups and Mobilecommons opt-in paths for specific nodes at 
+`admin/config/services/optins`.
+
+* Currently only staff picks are able to be assigned custom Mailchimp and/or
+Mobilecommons opt-in paths.  
+* If a user signs up for a non-staff-pick campaign,
+they are opted into a general campaign Mobilecommons opt-in path.
+
+Any node which needs a Mailchimp subscription must include a Mailchimp Interest
+Group Name, an alphanumeric identifier, and a Mailchimp Grouping ID, a numeric
+ID which the Group belongs to. 
+
+## Signup Data Form
+
+Some campaigns collect additional data during the signup process.  Examples:
+
+* __Teens For Jeans__
+    * Upon signup, user must select/confirm what school they belong to, or 
+    indicate that they are not affiliated with a school. 
+
+* __Comeback Clothes__
+    * Users can optionally enter/confirm their address to be sent a promotional banner.
+
+* __Thumb Wars__
+    * Upon signup, user is prompted why they want thumb socks, and must enter/confirm
+    their mailing address to be sent the thumb socks.
+
+* __Give A Spit__
+    * Upon signup, user is prompted to enter/confirm birthdate.
+
+A "Signup Data Form" refers to the form that collects this additional signup 
+data.  The form configuration is stored in a custom table, `dosomething_signup_data_form`, 
+with fields:
+
+* `nid` - The node nid which the `signup_data_form` record corresponds to.
+
+* `status` - If this is 1, the form is considered active and rendered on the campaign template.
+
+* `required` - If this is 1, the user must complete the form to access the campaign
+action page.  If they navigate away from the campaign without submitting the form, 
+they will be presented with the signup form again until they submit. Currently not implemented.
+
+* `required_allow_skip` - If this is 1, the user is presented with the option to 
+skip on a required form.  We track that they submitted, and don't prompt again.
+Currently not implemented.
+
+* `link_text` - The text to display on the link that opens a signup data form 
+in a modal.
+
+* `form_header` - Header text displayed on the signup data form.
+
+* `form_copy` - Copy text displayed on the signup data form.
+
+* `confirm_msg` - Text displayed in the message that appears after submission.
+
+* `collect_why_signedup` - Whether or not to prompt user for why they signed up. 
+Currently not implemented.
+
+* `why_signedup_label` - The label to display on the textarea for user to enter
+reason why they signed up.  Currently not implemented.
+
+* `collect_user_address` - Whether or not to prompt user for mailing address.
+
+* `collect_user_school` - Currently not implemented.
+
+* `collect_user_mobile` - Currently not implemented.
+
+* `collect_user_birthdate` - Currently not implemented.
+
+Upon submititng a Signup Data Form, the relevant user information is stored to
+the user object (address, school, birthdate) and the timestamp of submission is
+stored in the `dosomething_signup.signup_data_form_timestamp` column.
+
+If the form is set to `collect_why_signedup`, the user's input for the `why_signedup`
+field is stored in the `dosomething_signup.why_signedup` column.
+
+The `dosomething_signup.signup_data_form.inc` file code contains:
+
+*  `_dosomething_signup_node_signup_data_form`
+To be called from within a node edit form.  Adds form elements which correspond 
+to the values in the node nid's `dosomething_signup_data_form` record.
+
+* `dosomething_signup_user_signup_data_form`
+The form the user is presented with to enter additional signup data, dynamically
+rendered based on the values in the node `dosomething_signup_data_form` record.
+

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -47,6 +47,11 @@ function _dosomething_signup_node_signup_data_form(&$form, &$form_state) {
     '#title' => t('Collect additional signup data'),
     '#default_value' => $values['status'],
   );
+  $form[$fieldset][$prefix . 'collect_user_address'] = array(
+    '#type' => 'checkbox', 
+    '#title' => t('Collect user address'),
+    '#default_value' => $values['collect_user_address'],
+  );
   $form[$fieldset][$prefix . 'link_text'] = array(
     '#type' => 'textfield', 
     '#title' => t('Link text'),
@@ -67,21 +72,6 @@ function _dosomething_signup_node_signup_data_form(&$form, &$form_state) {
     '#title' => t('Confirmation message'),
     '#default_value' => $values['confirm_msg'],
   );
-  $form[$fieldset][$prefix . 'collect_user_address'] = array(
-    '#type' => 'checkbox', 
-    '#title' => t('Collect user address'),
-    '#default_value' => $values['collect_user_address'],
-  );
-  $form[$fieldset][$prefix . 'collect_user_mobile'] = array(
-    '#type' => 'checkbox', 
-    '#title' => t('Collect user mobile'),
-    '#default_value' => $values['collect_user_birthdate'],
-  );
-  $form[$fieldset][$prefix . 'collect_user_birthdate'] = array(
-    '#type' => 'checkbox', 
-    '#title' => t('Collect user birthdate'),
-    '#default_value' => $values['collect_user_birthdate'],
-  );
 }
 
 /**
@@ -101,8 +91,6 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
         'form_copy' => $values[$prefix . 'form_copy'],
         'confirm_msg' => $values[$prefix . 'confirm_msg'],
         'collect_user_address' => $values[$prefix . 'collect_user_address'],
-        'collect_user_birthdate' => $values[$prefix . 'collect_user_mobile'],
-        'collect_user_birthdate' => $values[$prefix . 'collect_user_birthdate'],
     ))
     ->execute();
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -134,6 +134,10 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $nid) {
   if ($config['collect_user_address']) {
     $form['user_address'] = array(
       '#type' => 'addressfield',
+      '#handlers' => array(
+        'address' => 'address',
+        'address-hide-country' => 'address-hide-country',
+      ),
       '#required' => TRUE,
       '#context' => array('countries' => array('US')),
       '#default_value' => $account->field_address[LANGUAGE_NONE][0],

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -102,8 +102,6 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
  *   The node which the signup data form is rendered on.
  */
 function dosomething_signup_user_signup_data_form($form, &$form_state, $nid) {
-  global $user;
-  $account = user_load($user->uid);
   $config = dosomething_signup_get_signup_data_form_info($nid);
   $form['nid'] = array(
     '#type' => 'hidden',
@@ -120,6 +118,9 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $nid) {
     '#suffix' => '</p>',
   ); 
   if ($config['collect_user_address']) {
+    global $user;
+    // Load user to get relevant field values as form default_values.
+    $account = user_load($user->uid);
     $form['user_address'] = array(
       '#type' => 'addressfield',
       '#handlers' => array(
@@ -170,7 +171,7 @@ function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
  */
 function dosomething_signup_update_user_data($values) {
   global $user;
-  $account = user_load($user->uid);
+  $account = $user;
   if (isset($values['user_address'])) {
     $account->field_address[LANGUAGE_NONE][0] = $values['user_address'];
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -114,6 +114,8 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
  *   The node which the signup data form is rendered on.
  */
 function dosomething_signup_user_signup_data_form($form, &$form_state, $nid) {
+  global $user;
+  $account = user_load($user->uid);
   $config = dosomething_signup_get_signup_data_form_info($nid);
   $form['nid'] = array(
     '#type' => 'hidden',
@@ -128,7 +130,16 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $nid) {
     '#prefix' => '<p>',
     '#markup' => $config['form_copy'],
     '#suffix' => '</p>',
-  );
+  ); 
+  if ($config['collect_user_address']) {
+    $form['user_address'] = array(
+      '#type' => 'addressfield',
+      '#required' => TRUE,
+      '#context' => array('countries' => array('US')),
+      '#default_value' => $account->field_address[LANGUAGE_NONE][0],
+      '#required' => TRUE,
+    );
+  }
   $form['submit'] = array(
     '#type' => 'submit',
     '#value' => $label,
@@ -147,7 +158,12 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $nid) {
  */
 function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
   $values = $form_state['values'];
+  // Load signup_data_form record to gather relevant config and confirm_msg.
   $config = dosomething_signup_get_signup_data_form_info($values['nid']);
+  if ($config['collect_user_address']) {
+    // Update user data.
+    dosomething_signup_update_user_data($values);
+  }
   // Update signup record.
   dosomething_signup_update_signup_data($values);
   // Display the signup_data_form's confirm_msg field.
@@ -155,7 +171,25 @@ function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
 }
 
 /**
- * Saves signup_form_data to the relevant signup.
+ * Saves signup_form_data to fields on the user.
+ *
+ * @param array $values
+ *   The values passed from a user signup_data_form submission.
+ */
+function dosomething_signup_update_user_data($values) {
+  global $user;
+  $account = user_load($user->uid);
+  if (isset($values['user_address'])) {
+    $account->field_address[LANGUAGE_NONE][0] = $values['user_address'];
+  }
+  user_save($account);
+}
+
+/**
+ * Saves signup_form_data to the relevant signup record.
+ *
+ * @param array $values
+ *   The values passed from a user signup_data_form submission.
  */
 function dosomething_signup_update_signup_data($values) {
   // Find the relevant signup sid to update.

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -8,6 +8,8 @@ core = 7.x
 ; Address Field
 projects[addressfield] = "1.0-beta5"
 projects[addressfield][subdir] = "contrib"
+; Allows addressfield as form element: https://drupal.org/node/970048
+projects[addressfield][patch][] = https://drupal.org/files/addressfield-element_info-970048-71.patch
 
 ; Admin menu
 projects[admin_menu] = "3.0-rc4"


### PR DESCRIPTION
Closes #1484
- Implements only what we need for Comeback Clothes, which is just enter/confirm user address in a modal.
- Adds a patch for addressfield module to enable a sweet `addressfield` form element to do that.
- Adds documentation, listing what hasn't been implemented yet.
