### PR TITLE
More Flexible Campaign Header Sponsor Logo Styles

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_header.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_header.scss
@@ -93,55 +93,50 @@ header.header {
   }
 
   div.sponsor-wrapper {
-    margin: 0 auto;
+    margin: 1rem auto;
     float: none;
-    width: 125px;
 
     @include media($tablet) {
-      overflow: hidden;
-      float: right;
-      width: 200px;
+      margin: 0;
+      width: auto;
       position: absolute;
       right: 0;
       bottom: 0;
     }
 
-    // Sponsor logo and "Powered By"
-    img,
-    .copy {
-      display: inline-block;
-      float: left;
-    }
-
     img {
-      width: 50px;
+      display: block;
       height: 50px;
+      margin: 0 auto;
 
       @include media($tablet) {
-        font-size: $font-regular;
-        width: 100px;
-        height: 100px;
+        float: right;
+        margin: 0;
       }
     }
 
-    .copy {
-      color: #fff;
-      padding: 15px 0 0;
+    p.copy {
+      margin: 0 0 1rem 0;
+      padding: 0;
+      float: none;
       font-size: $font-small;
-      width: 70px;
-      height: 50px;
+      font-weight: $weight-bold;
+      text-align: center;
+      text-transform: uppercase;
+
+      @include rgba(color, #fff, 0.7);
 
       @include media($tablet) {
-        font-size: $font-regular;
         margin: 0;
-        width: 100px;
-        height: 100px;
-        line-height: 100px;
+        padding: 0 0.5rem 0 0;
+        position: relative;
+        bottom: -1.8rem;
+        float: left;
       }
     }
   }
 
-  .scholarship-wrapper {
+  div.scholarship-wrapper {
     width: 200px;
     margin: 20px auto 0;
     position: relative;
@@ -164,6 +159,7 @@ header.header {
       float: right;
       position: relative;
       right: -40px;
+      margin: 0;
 
       @include media($tablet) {
         float: none;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_header.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_header.scss
@@ -95,6 +95,7 @@ header.header {
   div.sponsor-wrapper {
     margin: 1rem auto;
     float: none;
+    clear: both; // Accounts for floating scholarship callout above div.sponsor-wrapper
 
     @include media($tablet) {
       margin: 0;
@@ -139,11 +140,13 @@ header.header {
   div.scholarship-wrapper {
     width: 200px;
     margin: 20px auto 0;
+    padding: 0 0 2rem 0;
     position: relative;
 
     @include media($tablet) {
       width: 130px;
       margin: -10px 0 0 15px;
+      padding: 0;
       float: left;
 
       @include transform(rotate(-6deg));

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -16,7 +16,7 @@
 
       <?php if (isset($sponsors[0]['display'])): ?>
       <div class="sponsor-wrapper">
-        <p class="copy">Powered by:</p>
+        <p class="copy">Powered by</p>
         <?php foreach ($sponsors as $key => $sponsor) :?>
           <?php if (isset($sponsor['display'])): print $sponsor['display']; endif; ?>
         <?php endforeach; ?>


### PR DESCRIPTION
## Changes
- Removes fixed width of sponsor logos to allow for H&R Block "Dollars & Sense"
- Vertically stacks "Powered By" text to future proof design against variable logo widths
- Vertically aligns sponsor logo section with `SIGN UP` call to action
- Changes `Powered by:` to `POWERED BY` (cleans up visual design)

Resolves #1280
