### PR TITLE
Reportback IP address

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -17,6 +17,19 @@ function dosomething_helpers_ctools_plugin_api($module = NULL, $api = NULL) {
 }
 
 /**
+ * Wrapper function for Drupal's ip_address function.
+ *
+ * Because varnish only likes to expose its own IP, and 
+ * apache and nginx will give different results as well.
+ *
+ * @return string
+ *   The IP address of the client machine.
+ */
+function dosomething_helpers_ip_address() {
+  return isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : ip_address();
+}
+
+/**
  * Implements hook_form_alter().
  */
 function dosomething_helpers_form_alter(&$form, &$form_state, $form_id) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
@@ -2,6 +2,7 @@ name = DoSomething Reportback
 description = Provides Reportback entity and functionality.
 core = 7.x
 package = DoSomething
+dependencies[] = dosomething_helpers
 dependencies[] = features
 dependencies[] = file
 dependencies[] = image

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -117,6 +117,12 @@ function dosomething_reportback_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'remote_addr' => array(
+        'description' => 'The IP address of the user that submitted the form.',
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => FALSE,
+      ),
     ),
     'primary key' => array('id'),
   );
@@ -136,6 +142,12 @@ function dosomething_reportback_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'remote_addr' => array(
+        'description' => 'The IP address of the user that submitted the file.',
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => FALSE,
+      ),
     ),
     'primary key' => array('rbid', 'fid'),
   );
@@ -150,4 +162,22 @@ function dosomething_reportback_update_7001(&$sandbox) {
   $table_name = 'dosomething_reportback_file';
   $schema = dosomething_reportback_schema();
   db_create_table($table_name, $schema[$table_name]);
+}
+
+/**
+ * Adds remote_addr field to reportback file and log tables.
+ */
+function dosomething_reportback_update_7002() {
+  $field_name = 'remote_addr';
+  // Tables to add remote_addr to.
+  $tables = array('dosomething_reportback_log', 'dosomething_reportback_file');
+  // Load schema for field definitions.
+  $schema = dosomething_reportback_schema();
+  foreach ($tables as $tbl_name) {
+    // If the field doesn't exist already:
+    if (!db_field_exists($tbl_name, $field_name)) {
+      // Add it per the schema field definition.
+      db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
+    }
+  }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -660,5 +660,22 @@ function dosomething_reportback_views_data() {
       'label' => t('Reportback image'),
     ),
   );
+  $data['dosomething_reportback_file']['remote_addr'] = array(
+    'title' => t('Remote address'),
+    'help' => t('IP address which submitted the reportback file.'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_string',
+    ),
+  );
   return $data;
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -99,27 +99,29 @@ function dosomething_reportback_entity_property_info() {
 function dosomething_reportback_menu() {
   $items = array();
   $items['reportback/%reportback'] = array(
-    'title callback' => 'Reportback',
+    'title' => 'Reportback',
     'page callback' => 'dosomething_reportback_view_entity',
     'page arguments' => array(1),
     'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('view', 1),
   );
   $items['reportback/%reportback/edit'] = array(
-    'title callback' => 'Edit Reportback',
+    'title' => 'Edit',
     'page callback' => 'dosomething_reportback_edit_entity',
     'page arguments' => array(1),
     'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('edit', 1),
     'type' => MENU_LOCAL_TASK,
+    'weight' => 20,
   );
   $items['reportback/%reportback/delete'] = array(
-    'title callback' => 'Delete Reportback',
+    'title' => 'Delete',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_reportback_delete_form', 1),
     'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('delete', 1),
     'type' => MENU_LOCAL_TASK,
+    'weight' => 30,
   );
   return $items;
 }
@@ -219,12 +221,6 @@ function dosomething_reportback_preprocess_entity(&$variables) {
     // Enables reportback.tpl.php naming suggestion.
     $variables['theme_hook_suggestions'][] = 'reportback';
     $entity = $variables['elements']['#entity'];
-    if (dosomething_reportback_access('edit', $entity)) {
-      $variables['edit_link'] = l('Update', 'reportback/' . $entity->rbid . '/edit');
-    }
-    if (dosomething_reportback_access('delete', $entity)) {
-      $variables['delete_link'] = l('Delete', 'reportback/' . $entity->rbid . '/delete');
-    }
   }
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
@@ -166,6 +166,10 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['fields']['fid']['relationship'] = 'fid';
   $handler->display->display_options['fields']['fid']['label'] = 'Fid';
   $handler->display->display_options['fields']['fid']['link_to_file'] = TRUE;
+  /* Field: Reportbacks: Remote address */
+  $handler->display->display_options['fields']['remote_addr']['id'] = 'remote_addr';
+  $handler->display->display_options['fields']['remote_addr']['table'] = 'dosomething_reportback_file';
+  $handler->display->display_options['fields']['remote_addr']['field'] = 'remote_addr';
   /* Sort criterion: Reportback: Created Date */
   $handler->display->display_options['sorts']['created']['id'] = 'created';
   $handler->display->display_options['sorts']['created']['table'] = 'dosomething_reportback';
@@ -245,6 +249,7 @@ function dosomething_reportback_views_default_views() {
     t('Pic'),
     t('<img src="[uri]" width="200" height="200"/>'),
     t('Fid'),
+    t('Remote address'),
     t('All'),
     t('Reportbacks: %1'),
     t('Page'),

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -88,6 +88,7 @@ class ReportbackEntity extends Entity {
       ->fields(array(
         'rbid' => $this->rbid,
         'fid' => $fid,
+        'remote_addr' => ip_address(),
         ))
       ->execute();
   }
@@ -118,6 +119,7 @@ class ReportbackEntity extends Entity {
           'why_participated' => $this->why_participated,
           'files' => implode(',', $fids),
           'num_files' => count($fids),
+          'remote_addr' => ip_address(),
         ))
         ->execute();
     }

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -88,7 +88,7 @@ class ReportbackEntity extends Entity {
       ->fields(array(
         'rbid' => $this->rbid,
         'fid' => $fid,
-        'remote_addr' => ip_address(),
+        'remote_addr' => dosomething_helpers_ip_address(),
         ))
       ->execute();
   }
@@ -119,7 +119,7 @@ class ReportbackEntity extends Entity {
           'why_participated' => $this->why_participated,
           'files' => implode(',', $fids),
           'num_files' => count($fids),
-          'remote_addr' => ip_address(),
+          'remote_addr' => dosomething_helpers_ip_address(),
         ))
         ->execute();
     }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback.tpl.php
@@ -2,19 +2,6 @@
 <h3><?php print render($content['node_title']); ?></h3>
 <p><?php print render($content['username']); ?></p>
 
-<?php if (isset($edit_link) || isset($delete_link)): ?>
-<nav class"tabs">
-  <ul>
-    <?php if (isset($edit_link)): ?>
-    <li><?php print $edit_link; ?></li>
-    <?php endif; ?>
-    <?php if (isset($delete_link)): ?>
-    <li><?php print $delete_link; ?></li>
-    <?php endif; ?>
-  </ul>
-  <?php endif; ?>
-</nav>
-
 <p><strong><?php print render($content['quantity_count']); ?></strong> <?php print render($content['quantity_label']); ?></p>
 <p><?php print render($content['why_participated']); ?></p>
 


### PR DESCRIPTION
Fixes #1541

Store IP address in the `dosomething_reportback_file` table to track where images are submitted from, and also store in the `dosomething_reportback_log` table to track every update.

Also fixes the reportback tabs on the view reportback page (admin only)
