### PR TITLE
Refactored file saving code for SMS report backs to maintain file extension

### DIFF
--- a/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/ConductorActivitySmsReportBack.class.php
+++ b/lib/modules/dosomething/dosomething_sms/plugins/activity/reportback/dosomething_sms_submit_reportback/ConductorActivitySmsReportBack.class.php
@@ -80,11 +80,12 @@ class ConductorActivitySmsReportBack extends ConductorActivity {
     // Get the MMS URL from the provided context.
     $pictureUrl = $state->getContext($this->mmsContext);
 
-    // Download, save, and move the file to proper directory.
+    // Get the location for where file should be saved to.
+    $fileDest = dosomething_reportback_get_file_dest(basename($pictureUrl), $this->nid, $user->uid);
+
+    // Download and save file to that location.
     $pictureContents = file_get_contents($pictureUrl);
-    $file = file_save_data($pictureContents, $pictureFilename);
-    $new_dest = dosomething_reportback_get_file_dest($file->name, $this->nid, $user->uid);
-    $file = file_move($file, $new_dest);
+    $file = file_save_data($pictureContents, $fileDest);
 
     // Save UID and permanent status.
     $file->uid = $user->uid;


### PR DESCRIPTION
Previous logic was to:
- download the image
- save the image
- figure out where it should really live
- then move the file there

Logic now simplified to:
- figure out where the file should live
- download and save it there

`basename($pictureUrl)` in particular is what allows us to get the file extension in the first place. Then passing `$fileDest` into `file_save_data()` lets us keep it. 

Fixes https://github.com/DoSomething/dosomething/issues/1526

cc: @angaither 
