### PR TITLE
Zendesk error catching

### DIFF
--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -108,29 +108,16 @@ function dosomething_zendesk_form_submit($form, &$form_state) {
  */
 function dosomething_zendesk_create_ticket($values) {
   global $user;
-
   // Get expected format for a create Ticket request.
   $ticket = dosomething_zendesk_get_ticket_array($values);
   if ($ticket && $client = dosomething_zendesk_get_client()) {
-    // Check whether a user exists
-    $zen_desk_user = $client->search(array('query' => "type:user email:{$ticket['requester']['email']}"));
-    $account = user_load($user->uid);
-    $wrapper = entity_metadata_wrapper('user', $account);
-
-    if (empty($zen_desk_user->results)) {
-      // Use the email address as the name if there's no first name.
-      $first_name = $wrapper->field_first_name->value();
-      $name = isset($first_name) ? ucfirst($wrapper->field_first_name->value()) : $values['email'];
-      $new_user = array(
-        'email' => $values['email'],
-        'name' => $name,
-      );
-      $client->users()->create($new_user);
-    }
-    // Submit API request to create ticket.
     try {
-      $client->tickets()->create($ticket);
-      return TRUE;
+      // Make sure user exists as a Zendesk user (required to create Ticket).
+      if (dosomething_zendesk_verify_zendesk_user($user, $client)) {
+        // Submit API request to create Zendesk ticket.
+        $client->tickets()->create($ticket);
+        return TRUE;
+      }
     }
     catch (Exception $e) {
       watchdog('dosomething_zendesk', $e, array(), WATCHDOG_ERROR);
@@ -176,4 +163,68 @@ function dosomething_zendesk_get_ticket_array($values) {
     ),
     'priority' => 'normal',
   );
+}
+
+/**
+ * Verifies that given user exists as zendesk user.
+ * 
+ * If a zendesk user doesn't exist for account, creates one.
+ *
+ * @param object $user
+ *   The user object to verify.
+ *
+ * @return mixed
+ *   An API response, or FALSE if exception was thrown.
+ */
+function dosomething_zendesk_verify_zendesk_user($account, $client = NULL) {
+  if ($client == NULL) {
+    $client = dosomething_zendesk_get_client();
+  }
+  try {
+    $search = $client->search(array(
+      'query' => "type:user email:{$account->mail}",
+    ));
+    // If a zendesk user was not found:
+    if (empty($search->results)) {
+      // Create a zendesk user.
+      return dosomething_zendesk_create_zendesk_user($account, $client);
+    }
+    return $search->results;
+  }
+  catch (Exception $e) {
+    watchdog('dosomething_zendesk', $e, array(), WATCHDOG_ERROR);
+    return FALSE;
+  }
+}
+
+/**
+ * Creates a zendesk user for a given user.
+ *
+ * @param object $user
+ *   The user object to create a zendesk user for.
+ *
+ * @return mixed
+ *   An API response, or FALSE if exception was thrown.
+ */
+function dosomething_zendesk_create_zendesk_user($account, $client = NULL) {
+  if ($client == NULL) {
+    $client = dosomething_zendesk_get_client();
+  }  
+  $first_name = dosomething_user_get_field('field_first_name', $account);
+  // Use the email address as the name if there's no first name available.
+  if (!$first_name) {
+    $first_name = $account->mail;
+  }
+  $new_user = array(
+    'email' => $account->mail,
+    'name' => $first_name,
+  );
+  try {
+    // Send API request to create new user.
+    return $client->users()->create($new_user);
+  }
+  catch (Exception $e) {
+    watchdog('dosomething_zendesk', $e, array(), WATCHDOG_ERROR);
+    return FALSE;
+  }
 }


### PR DESCRIPTION
Abstracts Zendesk user search/creation into functions with try / catch statements.

If you create a new account, submit the zendesk form, and then immediately submit the form again, you'll get a nice error message instead of the WSOD style:

![ahh nice error message](https://cloud.githubusercontent.com/assets/1236811/2541352/5b84530a-b5dc-11e3-9682-652b1d16a4eb.png)

I've replicated the error still, but after the 4th submisison (within a minute), the user is then found and a new ticket created.

So per a suggestion I made in https://github.com/DoSomething/dosomething/issues/1388#issuecomment-38729401 ... we could create a zendesk user upon user registration, to avoid this potential lag issue.  My thoughts here are that it's going to be rare that a user submits the form immediately after submitting once, and not worth the overhead of creating a zendesk user for each user registration.  Thoughts?
