### PR TITLE
Action Page Alignment

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -27,6 +27,7 @@
   // immediately before each section.step
   .banner {
     margin: 0;
+    padding: 0.1em 0 0; // Override default banner padding to prevent left indent
 
     span {
       @include section-padding;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -33,7 +33,7 @@
 
       @include media($tablet) {
         padding: 0;
-        @include shift(3 of 16);
+        @include shift(2 of 16);
       }
     }
   }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -70,16 +70,6 @@
       color: $purple;
       font-size: $font-medium;
     }
-
-    li {
-      list-style-type: disc;
-      margin: 0 0 0 1.5rem;
-      padding: 0 0 0 0.25rem;
-
-      @include media($tablet) {
-        margin: 0 0 0 1rem;
-      }
-    }
   }
 
   .legal {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_do.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_do.scss
@@ -6,7 +6,7 @@
   .content {
     @include media($tablet) {
       @include span-columns(9);
-      @include shift(3);
+      @include shift(2);
     }
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_footer.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_footer.scss
@@ -38,14 +38,14 @@ footer.sponsors {
   .footer-content {
     @include media($tablet) {
       @include span-columns(12);
-      @include shift(3);
+      @include shift(2);
     }
   }
 }
 
 footer.help,
 footer.sources {
-  padding: 1rem 1.5rem;
+  padding: 1rem 0;
   text-align: center;
   clear: both;
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_layout.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_layout.scss
@@ -2,7 +2,7 @@
 div.col.first {
   @include media($tablet) {
     @include span-columns(6);
-    @include shift(3);
+    @include shift(2);
   }
 }
 
@@ -16,6 +16,6 @@ div.col.second {
 div.col.sources {
   @include media($tablet) {
     @include span-columns(12);
-    @include shift(3);
+    @include shift(2);
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_nav.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_nav.scss
@@ -15,7 +15,12 @@
   width: 100%;
   -webkit-font-smoothing: subpixel-antialiased; // fixes antialiasing issue on positioned elements in Safari
 
-  @include media($tablet) {
+  // @NOTE: This is a custom breakpoint set for the campaign nav
+  // It is not stored in a mixin as it is context-specic and
+  // should not be used elsewhere!
+  $nav-break: 960px;
+
+  @media all and (min-width: $nav-break) {
     position: absolute;
     top: 4rem;
     padding-top: 3rem;
@@ -34,7 +39,7 @@
     overflow: hidden;
     padding: 0;
 
-    @include media($tablet) {
+    @media all and (min-width: $nav-break) {
       text-align: left;
     }
   }
@@ -42,7 +47,7 @@
   li {
     display: inline-block;
 
-    @include media($tablet) {
+    @media all and (min-width: $nav-break) {
       display: block;
       width: 100%;
     }
@@ -62,7 +67,7 @@
     font-weight: $weight-sbold;
     font-size: $font-regular;
 
-    @include media($tablet) {
+    @media all and (min-width: $nav-break) {
       display: block;
       padding: 0.5rem 1rem;
     }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_nav.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_nav.scss
@@ -19,7 +19,7 @@
     position: absolute;
     top: 4rem;
     padding-top: 3rem;
-    width: 130px; // need pixel width since it loses percent sizing when "fixed"
+    width: 105px; // need pixel width since it loses percent sizing when "fixed"
   }
 
   &.is-stuck {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_plan.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_plan.scss
@@ -5,7 +5,7 @@
 
   @include media($tablet) {
     @include span-columns(9);
-    @include shift(3);
+    @include shift(2);
   }
 
   p {
@@ -18,7 +18,7 @@
 
   @include media($tablet) {
     @include span-columns(11);
-    @include shift(3);
+    @include shift(2);
   }
 
   p {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_prove.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_prove.scss
@@ -60,7 +60,7 @@
 
     @include media($tablet) {
       @include span-columns(5);
-      @include shift(3);
+      @include shift(2);
     }
   }
 


### PR DESCRIPTION
## Changes
- Sets all shift values for left-most columns from `3` to `2`
- Reduces width of `<nav>` element to account for new layout
- Removes `<li>` style overrides now that default styles are set in Neue
- Removes left padding from `.banner` and `<footer>` to prevent misalignment with the grid columns
- Adds one-off breakpoint to remedy `<nav>` width issue to allow for a full-width navigation earlier
## Rationale

Static content pages across the site span `12` of `16` columns with a two column gutter on either side to center the content. Campaign Action Pages, however, were designed with a three column gutter. Having only one template laid out with a three column gutter was inconsistent with the site.
## Screenshot

![new-layout](https://cloud.githubusercontent.com/assets/1479130/2550642/2e7963ec-b685-11e3-85de-9f60699a79b2.png)

Resolves #1446
