### PR TITLE
Adding a check for drush when calling drupal_goto in hook_init

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -19,7 +19,9 @@ function dosomething_user_init() {
       // If logged in user is not staff:
       if (!dosomething_user_is_staff()) {
         // No node for you.  Redirect to front page for now.
-        drupal_goto();
+        if (!function_exists('drush_main')) {
+          drupal_goto();
+        }
       }
     }
   }


### PR DESCRIPTION
- Drush doesn't like drupal_goto in hook_init().
  https://drupal.org/node/1230132

Fixes #1568 
