### PR TITLE
Fixes #893, mailchimp payload cleanup

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -387,15 +387,11 @@ function dosomething_signup_get_mbp_params_mailchimp(&$params, $node) {
   $nid = $node->nid;
   $prefix = 'dosomething_signup_nid_' . $nid;
   // Variable may be set as empty string, so set empty string as default.
-  // The mailchimp_id will be deprecated soon. 
-  // @see https://github.com/DoSomething/dosomething/issues/1476
-  $group_id =  variable_get($prefix . '_mailchimp_id', '');
   $grouping_id = variable_get($prefix . '_mailchimp_grouping_id', '');
   $group_name = variable_get($prefix . '_mailchimp_group_name', '');
   // If a value is present for Mailchimp groups:
-  if (!empty($group_id) || !empty($grouping_id) || !empty($group_name)) {
+  if (!empty($grouping_id) || !empty($group_name)) {
     // Add it into the mbp_request params.
-    $params['mailchimp_group_id'] = $group_id;
     $params['mailchimp_grouping_id'] = $grouping_id;
     $params['mailchimp_group_name'] = $group_name;
   }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -494,6 +494,12 @@ function dosomething_user_mbp_request($origin, $params = NULL) {
       break;
     case 'campaign_signup':
       $payload['event_id'] = $params['event_id'];
+      // Check for mailchimp grouping_id+group_name:
+      $mailchimp = isset($params['mailchimp_group_name']) && isset($params['mailchimp_grouping_id']);
+      if ( $mailchimp ) {
+        $payload['mailchimp_grouping_id'] = $params['mailchimp_grouping_id'];
+        $payload['mailchimp_group_name'] = $params['mailchimp_group_name'];
+      }
       $payload['merge_vars'] = array(
         'FNAME' => $params['first_name'],
         'CAMPAIGN_TITLE' => $params['campaign_title'],
@@ -503,16 +509,6 @@ function dosomething_user_mbp_request($origin, $params = NULL) {
         'STEP_TWO' => $params['step_two'],
         'STEP_THREE' => $params['step_three'],
       );
-      // Check for mailchimp grouping_id+group_name:
-      $mailchimp = isset($params['mailchimp_group_name']) && isset($params['mailchimp_grouping_id']);
-      // If set, or if soon to be depecrated group_id isset:
-      // @todo: Remove check for group_id when ready for cleanup.
-      if ( $mailchimp || isset($params['mailchimp_group_id']) ) {
-        //@todo: Remove group_id when ready for cleanup.
-        $payload['mailchimp_group_id'] = $params['mailchimp_group_id'];
-        $payload['mailchimp_grouping_id'] = $params['mailchimp_grouping_id'];
-        $payload['mailchimp_group_name'] = $params['mailchimp_group_name'];
-      }
       break;
     case 'campaign_reportback':
       $payload['event_id'] = $params['event_id'];


### PR DESCRIPTION
Fixes #893

Removes mailchimp_group_id from `$payload` values sent to Message Broker via `dosomething_user_mbp_request()` -> `message_broker_producer_request()`
