### PR TITLE
Zendesk Tickets: groups and priority

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -377,7 +377,7 @@ function dosomething_campaign_node_view($node, $view_mode, $langcode) {
       $node->content['reportback_form'] = drupal_get_form('dosomething_reportback_form', $reportback);
     }
     if (module_exists('dosomething_zendesk')) {
-      $node->content['zendesk_form'] = drupal_get_form('dosomething_zendesk_form');
+      $node->content['zendesk_form'] = drupal_get_form('dosomething_zendesk_form', $node);
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
@@ -5,6 +5,18 @@
  * Zendesk admin settings.
  */
 
+function dosomething_zendesk_admin_page() {
+  $auth = render(drupal_get_form('dosomething_zendesk_config_form'));
+  $output = $auth;
+  // If authenticated:
+  if ($client = dosomething_zendesk_get_client()) {
+    $output .= '<hr>';
+    // Include the groups settings form.
+    $output .= render(drupal_get_form('dosomething_zendesk_groups_config_form'));
+  }
+  return $output;
+}
+
 /**
  * System settings form for auth settings.
  */

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
@@ -34,3 +34,67 @@ function dosomething_zendesk_config_form($form, &$form_state)  {
   );
   return system_settings_form($form);
 }
+
+/**
+ * Form constructor for entering Zendesk group_ids.
+ */
+function dosomething_zendesk_groups_config_form() {
+  $form['groups'] = array(
+    '#title' => t('Available Groups'),
+    '#type' => 'fieldset',
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  // List available groups and group id's from Zendesk API.
+  foreach (dosomething_zendesk_get_zendesk_groups() as $group_id => $group_name) {
+    $form['groups'][$group_id] = array(
+      '#markup' => '<p>' . $group_name . ': ' . $group_id . '</p>',
+    );
+  }
+  $form['cause'] = array(
+    '#title' => t('Cause'),
+    '#type' => 'fieldset',
+    '#collapsible' => TRUE,
+  );
+  // Load the cause vocbulary.
+  $vocab = taxonomy_vocabulary_machine_name_load('cause');
+  // Load all terms in the cause vocabulary.
+  $terms = taxonomy_get_tree($vocab->vid);
+  // Foreach cause: term
+  foreach ($terms as $term) {
+    $var = dosomething_zendesk_get_group_varname($term->tid);
+    $form['cause'][$var] = array(
+      '#type' => 'textfield',
+      '#title' => t($term->name),
+      '#required' => TRUE,
+      '#size' => 10,
+      '#default_value' => variable_get($var),
+    );
+  }
+  $form['actions'] = array(
+    '#type' => 'actions',
+    'submit' => array(
+      '#type' => 'submit',
+      '#value' => 'Submit',
+    ),
+  );
+  return system_settings_form($form);
+}
+
+/**
+ * Submit callback for dosomething_zendesk_groups_config_form().
+ */
+function dosomething_zendesk_groups_config_form_validate($form, &$form_state) {
+  // Exclude unnecessary elements.
+  form_state_values_clean($form_state);
+  // Get all available group ids from Zendesk API.
+  $group_ids = array_keys(dosomething_zendesk_get_zendesk_groups());
+  // Foreach value:
+  foreach ($form_state['values'] as $key => $value) {
+    // If the value is not in the group ids:
+    if (!in_array($value, $group_ids)) {
+      // Set error.
+      form_set_error($key, 'Group_id ' . $value . ' does not exist.');
+    }
+  }
+}

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.install
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.install
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @file
+ * Installation and schema hooks for dosomething_zendesk.module.
+ */
+
+
+/**
+ * Populates Zendesk group_id variables for all Cause terms.
+ */
+function dosomething_zendesk_update_7001(&$sandbox) {
+  // We can get away with this for now because all Zendesk groups are
+  // named with identical names as the Cause terms, and we only have Groups for
+  // Causes.
+  $vocab = taxonomy_vocabulary_machine_name_load('cause');
+
+  // Get group data from Zendesk API.
+  if ($groups = dosomething_zendesk_get_zendesk_groups()) {
+    // Loop through each group.
+    foreach ($groups as $group_id => $group_name) {
+      // Find tid by name.
+      $tid = db_select("taxonomy_term_data", "td")
+        ->fields("td", array("tid"))
+        ->condition("name", $group_name)
+        ->condition("vid", $vocab->vid)
+        ->execute()
+        ->fetchField();
+      // Get the tid's variable name.
+      $var = dosomething_zendesk_get_group_varname($tid);
+      // Set this tid's group variable to the group_id.
+      variable_set($var, $group_id);
+    }
+  }
+}

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -228,3 +228,32 @@ function dosomething_zendesk_create_zendesk_user($account, $client = NULL) {
     return FALSE;
   }
 }
+
+/**
+ * Retrieves all non-deleted Zendesk groups from the API.
+ *
+ * @return mixed
+ *   A multi-dimensional array, or FALSE if exception was thrown.
+ */
+function dosomething_zendesk_get_zendesk_groups() {
+  $groups = array();
+  try {
+    $client = dosomething_zendesk_get_client();
+    $result = $client->groups()->findAll();
+    if (!empty($result->groups)) {
+      foreach ($result->groups as $group) {
+        if (!$group->deleted) {
+          $groups[] = array(
+            'id' => $group->id,
+            'name' => $group->name,
+          );
+        }
+      }
+    }
+    return $groups;
+  }
+  catch (Exception $e) {
+    watchdog('dosomething_zendesk', $e, array(), WATCHDOG_ERROR);
+    return FALSE;
+  }
+}

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -9,19 +9,10 @@
  */
 function dosomething_zendesk_menu() {
   $items = array();
-  $items['admin/config/services/dosomething_zendesk/auth'] = array(
-    'title' => 'DoSomething Zendesk auth',
+  $items['admin/config/services/dosomething_zendesk'] = array(
+    'title' => 'DoSomething Zendesk settings',
     'description' => 'Manage Zendesk settings.',
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('dosomething_zendesk_config_form'),
-    'access arguments' => array('administer modules'),
-    'file' => 'dosomething_zendesk.admin.inc',
-  );
-  $items['admin/config/services/dosomething_zendesk/groups'] = array(
-    'title' => 'DoSomething Zendesk groups',
-    'description' => 'Manage Zendesk Group IDs.',
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('dosomething_zendesk_groups_config_form'),
+    'page callback' => 'dosomething_zendesk_admin_page',
     'access arguments' => array('administer modules'),
     'file' => 'dosomething_zendesk.admin.inc',
   );

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -54,14 +54,47 @@ function dosomething_zendesk_get_client() {
 
 /**
  * Form constructor for submitting a Zendesk ticket.
+ *
+ * @param object $node
+ *   Optional. A loaded node which this zendesk form is being rendered on.
  */
-function dosomething_zendesk_form($form, &$form_state)  {
+function dosomething_zendesk_form($form, &$form_state, $node = NULL)  {
+  $form['subject'] = array(
+    '#type' => 'hidden',
+    '#access' => FALSE,
+    '#value' => t('Question about') . ' ' . drupal_get_title(),
+  );
+  // If node has a primary cause:
+  if (isset($node->field_primary_cause[LANGUAGE_NONE][0])) {
+    $tid = $node->field_primary_cause[LANGUAGE_NONE][0]['tid'];
+    $group_id = variable_get(dosomething_zendesk_get_group_varname($tid));
+    // If a Zendesk group_id variable exists:
+    if ($group_id) {
+      // Render as a hidden element:
+      $form['group_id'] = array(
+        '#type' => 'hidden',
+        '#access' => FALSE,
+        '#value' => $group_id,
+      );
+    }
+  }
+  // If staff_pick field exists:
+  if (isset($node->field_staff_pick[LANGUAGE_NONE][0])) {
+    // If node is a staff pick:
+    if ($node->field_staff_pick[LANGUAGE_NONE][0]['value']) {
+      // Render as a hidden element:
+      $form['priority'] = array(
+        '#type' => 'hidden',
+        '#access' => FALSE,
+        '#value' => 'high',
+      );
+    }
+  }
   $form['body'] = array(
     '#type' => 'textarea',
     '#required' => TRUE,
     '#title' => t('Your Question'),
   );
-  
   $form['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Submit'),
@@ -80,7 +113,6 @@ function dosomething_zendesk_form_submit($form, &$form_state) {
   global $user;
   $values = $form_state['values'];
   $values['email'] = $user->mail;
-  $values['subject'] = t('Question about') . ' ' . drupal_get_title();
   // Attempt to submit a ticket via Zendesk API.
   if (dosomething_zendesk_create_ticket($values)) {
     $msg = t("Thanks for submitting your question.") . ' ';

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -9,11 +9,19 @@
  */
 function dosomething_zendesk_menu() {
   $items = array();
-  $items['admin/config/services/dosomething_zendesk'] = array(
-    'title' => 'DoSomething Zendesk settings',
+  $items['admin/config/services/dosomething_zendesk/auth'] = array(
+    'title' => 'DoSomething Zendesk auth',
     'description' => 'Manage Zendesk settings.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_zendesk_config_form'),
+    'access arguments' => array('administer modules'),
+    'file' => 'dosomething_zendesk.admin.inc',
+  );
+  $items['admin/config/services/dosomething_zendesk/groups'] = array(
+    'title' => 'DoSomething Zendesk groups',
+    'description' => 'Manage Zendesk Group IDs.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_zendesk_groups_config_form'),
     'access arguments' => array('administer modules'),
     'file' => 'dosomething_zendesk.admin.inc',
   );
@@ -243,10 +251,7 @@ function dosomething_zendesk_get_zendesk_groups() {
     if (!empty($result->groups)) {
       foreach ($result->groups as $group) {
         if (!$group->deleted) {
-          $groups[] = array(
-            'id' => $group->id,
-            'name' => $group->name,
-          );
+          $groups[$group->id] = $group->name;
         }
       }
     }
@@ -256,4 +261,17 @@ function dosomething_zendesk_get_zendesk_groups() {
     watchdog('dosomething_zendesk', $e, array(), WATCHDOG_ERROR);
     return FALSE;
   }
+}
+
+/**
+ * Returns the variable name that stores a taxonomy term's Zendesk Group ID.
+ *
+ * @param int $tid
+ *   The taxonomy term to lookup.
+ *
+ * @return string
+ *  The variable name which stores the tid's Zendesk Group ID.
+ */
+function dosomething_zendesk_get_group_varname($tid) {
+  return 'dosomething_zendesk_tid_' . $tid . '_group_id';
 }

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -64,6 +64,11 @@ function dosomething_zendesk_form($form, &$form_state, $node = NULL)  {
     '#access' => FALSE,
     '#value' => t('Question about') . ' ' . drupal_get_title(),
   );
+  $form['priority'] = array(
+    '#type' => 'hidden',
+    '#access' => FALSE,
+    '#value' => 'normal',
+  );
   // If node has a primary cause:
   if (isset($node->field_primary_cause[LANGUAGE_NONE][0])) {
     $tid = $node->field_primary_cause[LANGUAGE_NONE][0]['tid'];
@@ -81,13 +86,8 @@ function dosomething_zendesk_form($form, &$form_state, $node = NULL)  {
   // If staff_pick field exists:
   if (isset($node->field_staff_pick[LANGUAGE_NONE][0])) {
     // If node is a staff pick:
-    if ($node->field_staff_pick[LANGUAGE_NONE][0]['value']) {
-      // Render as a hidden element:
-      $form['priority'] = array(
-        '#type' => 'hidden',
-        '#access' => FALSE,
-        '#value' => 'high',
-      );
+    if ($node->field_staff_pick[LANGUAGE_NONE][0]['value'] == 1) {
+      $form['priority']['#value'] = 'high';
     }
   }
   $form['body'] = array(
@@ -175,7 +175,7 @@ function dosomething_zendesk_create_ticket($values) {
  */
 function dosomething_zendesk_get_ticket_array($values) {
   // List expected array keys.
-  $keys = array('email', 'subject', 'body');
+  $keys = array('email', 'subject', 'body', 'priority');
   // Loop through $values to make sure all keys are present.
   foreach ($keys as $key) {
     if (!isset($values[$key])) {
@@ -183,8 +183,8 @@ function dosomething_zendesk_get_ticket_array($values) {
       return FALSE;
     }
   }
-  // Return expected format for Ticket creation.
-  return array(
+  // Build array with expected format for Ticket creation.
+  $ticket = array(
     'requester' => array(
       'email' => $values['email'],
     ),
@@ -192,8 +192,12 @@ function dosomething_zendesk_get_ticket_array($values) {
     'comment' => array(
       'body' => $values['body'],
     ),
-    'priority' => 'normal',
+    'priority' => $values['priority'],
   );
+  if (isset($values['group_id'])) {
+    $ticket['group_id'] = $values['group_id'];
+  }
+  return $ticket;
 }
 
 /**


### PR DESCRIPTION
Closes #928

Creates admin form to configure each Cause term's with a corresponding Zendesk group_id.

Because each group is created with the same name as the Cause term, we can get away with populating the variables in a `hook_update_N` function.  

The admin form exists for if/when the names or groups should ever change.  Also validates entered values against the Zendesk API to make sure the entered group_id value is valid.

Creates ticket with the group_id if it exists.  Also if the form is rendered on a staff pick, the ticket is given high priority.
