### PR TITLE
Update default local settings to use environment vars

### DIFF
--- a/config/default.settings.local.php
+++ b/config/default.settings.local.php
@@ -53,8 +53,6 @@ $conf['varnish_control_key'] = '00c9203c65874ca5b4c359e19f00bf56';
 // This needs to be disabled.
 $conf['page_cache_invoke_hooks'] = FALSE;
 
-// These settings point to the solr instance on staging.
-$conf['apachesolr_host'] = '192.168.1.169';
-$conf['apachesolr_port'] = '8008';
-$conf['apachesolr_path'] = '/solr/collection1';
-$conf['apachesolr_read_only'] = 1;
+$conf['apachesolr_host'] = getenv('DS_APACHESOLR_HOST') ?: '192.168.1.169';
+$conf['apachesolr_path'] = getenv('DS_APACHESOLR_PORT') ?: '8080';
+$conf['apachesolr_read_only'] = getenv('DS_APACHESOLR_READ_ONLY') ?: 1;

--- a/lib/modules/dosomething/dosomething_search/dosomething_search.apachesolr_environments.inc
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.apachesolr_environments.inc
@@ -10,9 +10,9 @@
 function dosomething_search_apachesolr_environments() {
   $export = array();
   
-  $host = variable_get('apachesolr_host', '192.168.1.169');
-  $port = variable_get('apachesolr_port', '8080');
-  $path = variable_get('apachesolr_path', 'solr/collection1');
+  $host = variable_get('apachesolr_host');
+  $port = variable_get('apachesolr_port');
+  $path = variable_get('apachesolr_path');
 
   $environment = new stdClass();
   $environment->api_version = 1;


### PR DESCRIPTION
- Using environment variables to avoid putting the production solr
  IP address into the public repo.  If a rebuild happens in production
  this may require a restart of the php fpm pool to reload the settings.

Fixes #1585
