### PR TITLE
Prove It QA

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -281,10 +281,12 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   }
 
   // Reportback form.
-  $vars['reportback_link_label'] = t("Submit Your Pic");
+  $vars['reportback_link']['label'] = t("Submit Your Pic");
+  $vars['reportback_link']['size'] = "medium";
   // If logged in user's reportback exists for this node,
   if ($rbid = dosomething_reportback_exists($vars['nid'])) {
-    $vars['reportback_link_label'] = t("Update Submission");
+    $vars['reportback_link']['label'] = t("Update Submission");
+    $vars['reportback_link']['size'] = "small";
   }
   $vars['reportback_form'] = $vars['content']['reportback_form'];
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_footer.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_footer.scss
@@ -43,8 +43,7 @@ footer.sponsors {
   }
 }
 
-footer.help,
-footer.sources {
+footer.help {
   padding: 1rem 0;
   text-align: center;
   clear: both;
@@ -64,18 +63,5 @@ footer.help {
     &:hover {
       color: #fff;
     }
-  }
-}
-
-footer.sources {
-  display: block;
-  background: $off-black;
-
-  @include media($tablet) {
-    display: none;
-  }
-
-  div {
-    margin: 0 0 1rem;
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_nav.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_nav.scss
@@ -60,7 +60,7 @@
   a {
     display: inline-block;
     margin: 0 auto;
-    padding: 0.75rem;
+    padding: 0.75rem 0.65rem;
     color: $med-gray;
     text-decoration: none;
     text-transform: uppercase;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_nav.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_nav.scss
@@ -18,13 +18,13 @@
   // @NOTE: This is a custom breakpoint set for the campaign nav
   // It is not stored in a mixin as it is context-specic and
   // should not be used elsewhere!
-  $nav-break: 960px;
+  $nav-break: 1020px;
 
   @media all and (min-width: $nav-break) {
     position: absolute;
     top: 4rem;
     padding-top: 3rem;
-    width: 105px; // need pixel width since it loses percent sizing when "fixed"
+    width: 120px; // need pixel width since it loses percent sizing when "fixed"
   }
 
   &.is-stuck {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_prove.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_prove.scss
@@ -59,7 +59,7 @@
     margin-bottom: 3rem;
 
     @include media($tablet) {
-      @include span-columns(5);
+      @include span-columns(6);
       @include shift(2);
     }
   }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_prove.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_prove.scss
@@ -61,7 +61,7 @@
     @include media($tablet) {
       text-align: left;
 
-      @include span-columns(6.31);
+      @include span-columns(6);
       @include shift(2);
     }
   }
@@ -70,7 +70,7 @@
     margin: 2rem 0;
 
     @include media($tablet) {
-      @include span-columns(5.69);
+      @include span-columns(6);
       @include shift(1);
     }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_prove.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_prove.scss
@@ -61,7 +61,7 @@
     @include media($tablet) {
       text-align: left;
 
-      @include span-columns(6);
+      @include span-columns(6.31);
       @include shift(2);
     }
   }
@@ -70,7 +70,7 @@
     margin: 2rem 0;
 
     @include media($tablet) {
-      @include span-columns(6);
+      @include span-columns(5.69);
       @include shift(1);
     }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_prove.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_prove.scss
@@ -30,7 +30,6 @@
   }
 
   .btn {
-    display: block;
     margin: 0 auto;
 
     @include media($tablet) {
@@ -57,8 +56,11 @@
 
   .content {
     margin-bottom: 3rem;
+    text-align: center;
 
     @include media($tablet) {
+      text-align: left;
+
       @include span-columns(6);
       @include shift(2);
     }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -381,17 +381,6 @@
         <?php print render($zendesk_form); ?>
       </script>
       <?php endif; ?>
-
-      <?php if (isset($fact_sources)): ?>
-      <footer class="sources">
-        <div class="legal">
-          <strong>Sources:</strong>
-          <?php foreach ($fact_sources as $key => $source): ?>
-            <div><sup><?php print ($key + 1); ?></sup> <?php print $source; ?></div>
-          <?php endforeach; ?>
-        </div>
-      </footer>
-      <?php endif; ?>
     </section>
   </div>
 </section>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -176,7 +176,7 @@
             <div><?php print $location_finder_copy['safe_value']; ?></div>
           <?php endif; ?>
 
-          <a class="btn secondary" href="<?php print $location_finder_url['url']; ?>" target="_blank">Locate</a>
+          <a class="btn small secondary" href="<?php print $location_finder_url['url']; ?>" target="_blank">Locate</a>
         </div>
       <?php endif; ?>
 
@@ -323,7 +323,7 @@
         <h3 class="title">Pics or It Didn't Happen</h3>
         <?php if (isset($reportback_copy)): ?><div class="copy"><?php print $reportback_copy; ?></div><?php endif; ?>
 
-        <?php if (isset($reportback_link_label)): ?><a href="#modal-report-back" class="js-modal-link btn large"><?php print $reportback_link_label; ?></a><?php endif; ?>
+        <?php if (isset($reportback_link_label)): ?><a href="#modal-report-back" class="js-modal-link btn medium"><?php print $reportback_link_label; ?></a><?php endif; ?>
         <?php if (isset($official_rules)): ?><a class="official-rules" href="<?php print $official_rules_src; ?>">Official Rules</a><?php endif; ?>
 
         <?php if (isset($reportback_form)): ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -323,7 +323,7 @@
         <h3 class="title">Pics or It Didn't Happen</h3>
         <?php if (isset($reportback_copy)): ?><div class="copy"><?php print $reportback_copy; ?></div><?php endif; ?>
 
-        <?php if (isset($reportback_link_label)): ?><a href="#modal-report-back" class="js-modal-link btn medium"><?php print $reportback_link_label; ?></a><?php endif; ?>
+        <?php if (isset($reportback_link)): ?><a href="#modal-report-back" class="js-modal-link btn <?php print $reportback_link['size']; ?>"><?php print $reportback_link['label']; ?></a><?php endif; ?>
         <?php if (isset($official_rules)): ?><a class="official-rules" href="<?php print $official_rules_src; ?>">Official Rules</a><?php endif; ?>
 
         <?php if (isset($reportback_form)): ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -368,7 +368,7 @@
           </div>
           <?php endif; ?>
 
-          <div class="help-wrapper">Have a question? <a href="#modal-help" class="js-modal-link secondary">Give us a shout</a></div>
+          <div class="help-wrapper">Have a question? <a href="#modal-help" class="js-modal-link secondary">Contact us</a></div>
         </div>
       </footer>
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -8,7 +8,7 @@
 
       <?php if (isset($sponsors[0]['display'])): ?>
       <div class="sponsor-wrapper">
-        <p class="copy">Powered by:</p>
+        <p class="copy">Powered by</p>
         <?php foreach ($sponsors as $key => $sponsor) :?>
           <?php if (isset($sponsor['display'])): print $sponsor['display']; endif; ?>
         <?php endforeach; ?>


### PR DESCRIPTION
## Changes
- Help footer copy change
- Sponsored header copy cleanup
- Reduces default size of location finder and report back buttons
- Tweaks "Prove It" column widths to prevent buttons from breaking to two lines after font-size increase
- Tweaks campaign navigation width and mobile breakpoint after font-size increase

Resolves #1455
