### PR TITLE
Restores Uglify task for production build.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/tasks/build.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/build.js
@@ -4,5 +4,5 @@ module.exports = function(grunt) {
 
   // The `prod` build task is used when building for production. Since compiled assets
   // are ignored in version control, this is run in Continuous Integration on deploy.
-  grunt.registerTask("prod", ["clean:dist", "sass:compile", "cssmin:minify", "copy:main", "requirejs:compile"]);
+  grunt.registerTask("prod", ["clean:dist", "sass:compile", "cssmin:minify", "copy:main", "requirejs:compile", "uglify:prod"]);
 }


### PR DESCRIPTION
Restores uglify task for production build. Accidentally got turned off when hooking up RequireJS.
