### PR TITLE
Pitch Button Width

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_header.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_header.scss
@@ -61,13 +61,11 @@ header.header {
   input.btn {
     margin: 0 auto;
     display: block;
-    width: 135px;
     color: #fff;
     font-size: $font-medium;
 
     @include media($tablet) {
       float: left;
-      width: 150px;
       font-size: 1.5rem; // @TODO Should we bump the button size for .btn.large?
     }
   }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_header.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_header.scss
@@ -62,11 +62,9 @@ header.header {
     margin: 0 auto;
     display: block;
     color: #fff;
-    font-size: $font-medium;
 
     @include media($tablet) {
       float: left;
-      font-size: 1.5rem; // @TODO Should we bump the button size for .btn.large?
     }
   }
 


### PR DESCRIPTION
## Changes
- Removes fixed button sizes for pitch page header
## Rationale

After the base font-size bump, the fixed widths were breaking button text onto two lines.
