### PR TITLE
RequireJS dev environment

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/config.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/config.js
@@ -9,6 +9,7 @@
   "use strict";
 
   require.config({
+    baseUrl: "/profiles/dosomething/themes/dosomething/paraneue_dosomething/js/",
     optimize: "none",
     include: "main",
     paths: {
@@ -21,6 +22,4 @@
       "mailcheck": { exports: "Kicksend.mailcheck" }
     }
   });
-
-  require(["main"]);
 })();

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/build.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/build.js
@@ -1,6 +1,6 @@
 module.exports = function(grunt) {
   // The `build` task lints, tests, and compiles assets.
-  grunt.registerTask("build", ["lint", "test", "clean:dist", "sass:compile", "copy:main", "requirejs:compile"]);
+  grunt.registerTask("build", ["lint", "test", "clean:dist", "sass:compile", "copy:main", "uglify:dev"]);
 
   // The `prod` build task is used when building for production. Since compiled assets
   // are ignored in version control, this is run in Continuous Integration on deploy.

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/requirejs.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/requirejs.js
@@ -3,7 +3,7 @@ module.exports = {
     options: {
       baseUrl: "js/",
       name: "../bower_components/requirejs/require",
-      mainConfigFile: "js/app.js",
+      mainConfigFile: "js/config.js",
       out: "dist/app.js"
     }
   }

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/uglify.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/uglify.js
@@ -14,7 +14,7 @@ module.exports = {
       beautify: true
     },
     files: {
-      "dist/app.js": ["dist/app.js"],
+      "dist/app.js": ["bower_components/requirejs/require.js", "js/config.js"],
     }
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/watch.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/watch.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   js: {
     files: ["js/**/*.js", "tests/**/*.js"],
-    tasks: ["lint:js", "requirejs:compile", "test:js"]
+    tasks: ["lint:js", "test:js"]
   },
   assets: {
     files: ["assets/**/*"],


### PR DESCRIPTION
Sets up dev build to pull in RequireJS modules on-demand through the loader, rather than requiring a re-build of the `app.js` file on every change. :rocket: 
