### PR TITLE
Campaign PSA

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -215,14 +215,14 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   if (!empty($vars['field_video'])) {
     $vars['psa'] = theme('dosomething_video_embed', array(
       'field' => $wrapper->field_video->value(),
-      'width' => 640,
-      'height' => 390,
+      'width' => 550,
+      'height' => 300,
     ));
   }
   else {
     if (isset($vars['field_image_psa_replacement'][0])) {
       $psa_nid = $vars['field_image_psa_replacement'][0]['entity']->nid;
-      $vars['psa'] = dosomething_image_get_themed_image($psa_nid, 'landscape', '720x310');
+      $vars['psa'] = dosomething_image_get_themed_image($psa_nid, 'landscape', '550x300');
     }
   }
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -59,7 +59,7 @@ function theme_dosomething_video_embed($variables) {
   $output .= " width=\"{$variables['width']}\"";
   $output .= " height=\"{$variables['height']}\"";
   if ($variables['field']->field_provider['und'][0]['value'] == 'youtube') {
-    $output .= ' src="//www.' . $variables['field']->field_provider['und'][0]['value'] . '.com/embed/' . $variables['field']->field_video_id['und'][0]['value'] . '?wmode=transparent"';
+    $output .= ' src="//www.' . $variables['field']->field_provider['und'][0]['value'] . '.com/embed/' . $variables['field']->field_video_id['und'][0]['value'] . '?wmode=transparent&hd=1&rel=0&autohide=1&showinfo=0"';
   }
   $output .= ' frameborder="0" allowfullscreen></iframe>';
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_know.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_know.scss
@@ -2,8 +2,40 @@
 // Know It
 .step.know {
 
+  img {
+    width: 100%;
+  }
+
+  // @TODO - This is gross. Overrides needed because of the padding
+  //         hack we put in place to protect full-width images on
+  //         smaller devices. Once that gets refactored by either
+  //         allowing for a default page-width that affects all
+  //         elements or using a size + negative margin fix for the
+  //         images as needed.
+
+  .psa-wrapper {
+    position: relative;
+    padding-bottom: 56.25% !important;
+    height: 0;
+    overflow: hidden;
+
+    iframe {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+
   // NOTE: .legal styles are in _campaign.scss as they
   //       apply to "Know It" and "Prove It" sections!
+
+  .col.second {
+    ul {
+      padding-top: 30px !important;
+    }
+  }
 
   .fact-solution,
   .fact-problem {

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -39,21 +39,33 @@
         <div class="fact-problem"><?php print $fact_problem['fact']; ?><sup><?php print $fact_problem['footnotes']; ?></sup></div>
         <?php endif; ?>
 
-        <ul class="modal-links">
-          <?php if (isset($faq)): ?>
-            <li><a href="#modal-faq" class="js-modal-link">Check out our FAQs</a></li>
-          <?php endif; ?>
+        <?php if (isset($psa)): ?>
+          <div class="psa-wrapper"><?php print $psa; ?></div>
+        <?php endif; ?>
 
-          <?php if (isset($more_facts)): ?>
-            <li><a href="#modal-facts" class="js-modal-link">Learn more about <?php print $issue; ?></a></li>
-          <?php endif; ?>
+        <?php /* @TODO
+           Modal links are printed in either the left or right column depending
+           on whether or not there is a PSA/PSA fallback image associated with
+           the campaign. This code should be refactored to DRY it up.
+        */ ?>
 
-          <?php if (isset($partner_info)): ?>
-          <?php foreach ($partner_info as $delta => $partner): ?>
-            <li><a href="#modal-partner-<?php print $delta; ?>" class="js-modal-link">Why we &lt;3 <?php print $partner['name']; ?></a>
-          <?php endforeach; ?>
-          <?php endif; ?>
-        </ul>
+        <?php if (!isset($psa)): ?>
+          <ul class="modal-links">
+            <?php if (isset($faq)): ?>
+              <li><a href="#modal-faq" class="js-modal-link">Check out our FAQs</a></li>
+            <?php endif; ?>
+
+            <?php if (isset($more_facts)): ?>
+              <li><a href="#modal-facts" class="js-modal-link">Learn more about <?php print $issue; ?></a></li>
+            <?php endif; ?>
+
+            <?php if (isset($partner_info)): ?>
+            <?php foreach ($partner_info as $delta => $partner): ?>
+              <li><a href="#modal-partner-<?php print $delta; ?>" class="js-modal-link">Why we &lt;3 <?php print $partner['name']; ?></a>
+            <?php endforeach; ?>
+            <?php endif; ?>
+          </ul>
+        <?php endif; ?>
       </div>
 
       <div class="col second">
@@ -67,6 +79,24 @@
 
         <?php if (isset($solution_support)): ?>
         <div class="solution-supporting-copy"><?php print $solution_support; ?></div>
+        <?php endif; ?>
+
+        <?php if (isset($psa)): ?>
+          <ul class="modal-links">
+            <?php if (isset($faq)): ?>
+              <li><a href="#modal-faq" class="js-modal-link">Check out our FAQs</a></li>
+            <?php endif; ?>
+
+            <?php if (isset($more_facts)): ?>
+              <li><a href="#modal-facts" class="js-modal-link">Learn more about <?php print $issue; ?></a></li>
+            <?php endif; ?>
+
+            <?php if (isset($partner_info)): ?>
+            <?php foreach ($partner_info as $delta => $partner): ?>
+              <li><a href="#modal-partner-<?php print $delta; ?>" class="js-modal-link">Why we &lt;3 <?php print $partner['name']; ?></a>
+            <?php endforeach; ?>
+            <?php endif; ?>
+          </ul>
         <?php endif; ?>
       </div>
 


### PR DESCRIPTION
## Changes
- Calls a `~16:9` PSA/PSA replacement image
- Removes the default YouTube embedded video chrome to display cleaner videos
- Adds conditional logic to display modal links depending on the existence of a PSA/PSA replacement image
- Adds styles for responsive embedded videos
## Notes
- Modal links should included as a partial to DRY up the template
- `!important` should not be necessary here—we haven't gotten around to refactoring the indenting of content
- `first` and `second` layout modifiers should be replaced with Bourbon's `omega`
- `.col` should not be used as a selector—`.solution` / `.problem` should be moved higher up!
## Screenshots
### PSA

![video](https://cloud.githubusercontent.com/assets/1479130/2596443/4be690aa-baa7-11e3-9994-7e2c47655d88.png)
### PSA Fallback Image

![image](https://cloud.githubusercontent.com/assets/1479130/2596447/566e1f02-baa7-11e3-9490-25de9a1ddefc.png)
### Neither

![neither](https://cloud.githubusercontent.com/assets/1479130/2596448/567ecf6e-baa7-11e3-850e-8cbc92c464f9.png)

Closes #844
