### PR TITLE
Reportback log fix

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -181,3 +181,15 @@ function dosomething_reportback_update_7002() {
     }
   }
 }
+
+/**
+ * Updates log records where uid==0 due to bug in $reportback->insertLog().
+ */
+function dosomething_reportback_update_7003() {
+  // Update records with uid==0 to the uid value stored on the reportback.
+  $sql = 'UPDATE dosomething_reportback_log log
+    INNER JOIN dosomething_reportback rb ON (rb.rbid = log.rbid)
+    SET log.uid = rb.uid
+    WHERE log.uid = 0;';
+  db_query($sql);
+}

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -98,6 +98,13 @@ class ReportbackEntity extends Entity {
    */
   public function insertLog($op) {
     global $user;
+    // Store global uid, in rare case this is staff editing a reportback record.
+    $uid = $user->uid;
+    // If there is no uid, it's because this is a mobile submission.
+    if ($uid == 0) {
+      // Use the uid on the reportback entity instead.
+      $uid = $this->uid;
+    }
     // If deleting, store current time.
     if ($op == 'delete') {
       $timestamp = REQUEST_TIME;
@@ -112,7 +119,7 @@ class ReportbackEntity extends Entity {
       $id = db_insert($this->log_table)
         ->fields(array(
           'rbid' => $this->rbid,
-          'uid' => $user->uid,
+          'uid' => $uid,
           'op' => $op,
           'timestamp' => $timestamp,
           'quantity' => $this->quantity,


### PR DESCRIPTION
- Fixes bug in reportback log records for mobile submissions, where a `global $user` is not present.
- Updates records with uid == 0, using the uid value stored on the reportback.
  - Using db_query instead of db_update because db_update doesn't cleanly support joining tables, and this should be a one time jam. http://drupal.stackexchange.com/questions/53774/drupal-db-update-with-joins
