### PR TITLE
 Allow users to remove campaign signups.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -429,8 +429,8 @@ function dosomething_signup_get_signup_nids_by_uid($uid) {
  *   Whether or not logged in user can remove signup (and if it exists).
  */
 function dosomething_signup_node_unsignup_access($node) {
-  // Only allow access if user staff and is signed up.
-  return dosomething_user_is_staff() && dosomething_signup_exists($node->nid);
+  // Only allow access if user is signed up.
+  return dosomething_signup_exists($node->nid);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.views_default.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.views_default.inc
@@ -228,6 +228,24 @@ function dosomething_signup_views_default_views() {
     'image_style' => '310x310',
     'image_link' => '',
   );
+  /* Field: Content: Nid */
+  $handler->display->display_options['fields']['nid']['id'] = 'nid';
+  $handler->display->display_options['fields']['nid']['table'] = 'node';
+  $handler->display->display_options['fields']['nid']['field'] = 'nid';
+  $handler->display->display_options['fields']['nid']['relationship'] = 'nid';
+  $handler->display->display_options['fields']['nid']['label'] = '';
+  $handler->display->display_options['fields']['nid']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['nid']['element_label_colon'] = FALSE;
+  /* Field: Global: Custom text */
+  $handler->display->display_options['fields']['nothing']['id'] = 'nothing';
+  $handler->display->display_options['fields']['nothing']['table'] = 'views';
+  $handler->display->display_options['fields']['nothing']['field'] = 'nothing';
+  $handler->display->display_options['fields']['nothing']['label'] = '';
+  $handler->display->display_options['fields']['nothing']['alter']['text'] = 'Remove Signup';
+  $handler->display->display_options['fields']['nothing']['alter']['make_link'] = TRUE;
+  $handler->display->display_options['fields']['nothing']['alter']['path'] = 'node/[nid]/unsignup';
+  $handler->display->display_options['fields']['nothing']['alter']['alt'] = 'Remove Signup';
+  $handler->display->display_options['fields']['nothing']['element_label_colon'] = FALSE;
   /* Sort criterion: Signups: Date submitted */
   $handler->display->display_options['sorts']['timestamp']['id'] = 'timestamp';
   $handler->display->display_options['sorts']['timestamp']['table'] = 'dosomething_signup';
@@ -261,6 +279,7 @@ function dosomething_signup_views_default_views() {
     t('User'),
     t('Cover Image Reference'),
     t('Signed up'),
+    t('Remove Signup'),
     t('All'),
     t('Block'),
   );


### PR DESCRIPTION
:warning:
- add link in 'signups' view 
- update access callback, allow non-staffers to have access.

Fixes #1638
