### PR TITLE
Updates to pass missing vars array to theme function.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -6,7 +6,7 @@
 function paraneue_dosomething_preprocess_page(&$vars) {
   $vars['logo'] = $vars['base_path'] . NEUE_PATH . '/assets/images/ds-logo.png';
 
-  $vars['navigation'] = theme('navigation');
+  $vars['navigation'] = theme('navigation', $vars);
   $vars['footer'] = theme('footer');
 }
 


### PR DESCRIPTION
Should fix 'undefined variable' issue coming from watchdog. @_@ Didn't catch this when I made the update yesterday.

Basically navigation partial was calling variables that were no longer defined, and I needed to pass in the $vars array so variables would be set.

Resolves #1641
