### PR TITLE
Reportback form: Custom field

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -48,6 +48,7 @@ function dosomething_campaign_menu() {
  * Adds form elements for non-field campaign elements.
  */
 function _dosomething_campaign_form_extras(&$form, &$form_state) {
+  global $user;
   // If this is a node create form, display help text and exit out of extras.
   if (!isset($form['nid']['#value'])) {
     $form['custom'] = array(
@@ -57,7 +58,7 @@ function _dosomething_campaign_form_extras(&$form, &$form_state) {
     return;
   }
   // If admin:
-  if (user_access('administer modules') && module_exists('dosomething_reportback')) {
+  if (in_array('administrator', $user->roles) && module_exists('dosomething_reportback')) {
     // Include reportback field configuration form.
     _dosomething_reportback_node_reportback_field_form($form, $form_state);
   }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -56,6 +56,11 @@ function _dosomething_campaign_form_extras(&$form, &$form_state) {
     );
     return;
   }
+  // If admin:
+  if (user_access('administer modules') && module_exists('dosomething_reportback')) {
+    // Include reportback field configuration form.
+    _dosomething_reportback_node_reportback_field_form($form, $form_state);
+  }
   // Include signup data form configuration form.
   _dosomething_signup_node_signup_data_form($form, $form_state);
   // Set prefix for custom variables.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -97,26 +97,32 @@ function dosomething_reportback_node_reportback_field_form_submit(&$form, &$form
 }
 
 /**
- * Returns a Form API element based on given dosomething_reportback_field values.
+ * Returns a Form API element based on given entity values.
  *
- * @param array $config
- *   The dosomething_reportback_value record.
- * @param string $value
- *   Optional. The user value (if exists).
+ * @param array $rb_field
+ *   The field array as per returned by a loaded reportback $entity->field.
+ *
+ * @return array
+ *   An array to use as a form element.
  */
-function dosomething_reportback_get_reportback_field_form_element($config, $value = '') {
+function dosomething_reportback_get_reportback_field_form_element($rb_field) {
   $element = array(
-    '#title' => $config['label'],
-    '#type' => $config['type'],
+    '#title' => $rb_field['label'],
+    '#type' => $rb_field['type'],
     '#required' => TRUE,
   );
-  // @todo. Make this dynamic. Hardcoded for now, for Comeback Clothes.
-  $element['#options'] = array(
-    1 => t('Yes'),
-    0 => t('No'),
-  );
-  if (!empty($value)) {
-    $element['#default_value'] = $value;
+  if ($element['#type'] == 'radios') {
+    // @todo. Make this read $rb_field['options']. 
+    // Hardcoded for now, for Comeback Clothes.
+    $element['#options'] = array(
+      1 => t('Yes'),
+      0 => t('No'),
+    ); 
+  }
+  // If a value exists for the entity:
+  if (isset($rb_field['value'])) {
+    // Set it as the default value.
+    $element['#default_value'] = $rb_field['value'];
   }
   return $element;
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -95,3 +95,28 @@ function dosomething_reportback_node_reportback_field_form_submit(&$form, &$form
     ))
     ->execute();
 }
+
+/**
+ * Returns a Form API element based on given dosomething_reportback_field values.
+ *
+ * @param array $config
+ *   The dosomething_reportback_value record.
+ * @param string $value
+ *   Optional. The user value (if exists).
+ */
+function dosomething_reportback_get_reportback_field_form_element($config, $value = '') {
+  $element = array(
+    '#title' => $config['label'],
+    '#type' => $config['type'],
+    '#required' => TRUE,
+  );
+  // @todo. Make this dynamic. Hardcoded for now, for Comeback Clothes.
+  $element['#options'] = array(
+    1 => t('Yes'),
+    0 => t('No'),
+  );
+  if (!empty($value)) {
+    $element['#default_value'] = $value;
+  }
+  return $element;
+}

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @file
+ * Provides form constructors for the DoSomething Reportback module.
+ */
+
+/**
+ * Adds form elements to given node $form to add additional reportback field.
+ *
+ * For now, this only supports adding one additional reportback field to a node.
+ *
+ * Note there is no submit form element returned.
+ * This function is always called from within a node edit form.
+ */
+function _dosomething_reportback_node_reportback_field_form(&$form, &$form_state) {
+  $nid = $form['nid']['#value'];
+  $values = dosomething_reportback_get_reportback_field_info($nid);
+  $fieldset = 'reportback_field';
+  $prefix = $fieldset . '_';
+  // Set an additional submit handler to save the dosomething_reportback_field values.
+  $form['#submit'][] = 'dosomething_reportback_node_reportback_field_form_submit';
+  // Create fieldset to collect signup data form values.
+  $form[$fieldset] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Reportback Fields'),
+    '#weight' => 60,
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form[$fieldset][$prefix . 'status'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Add additional reportback field'),
+    '#default_value' => $values['status'],
+  );
+  $form[$fieldset]['config'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Configuration'),
+    '#weight' => 60,
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+    // Config fieldset should only be visible if the status field is checked.
+    '#states' => array(
+      'visible' => array(
+        ':input[name="' . $prefix . 'status"]' => array('checked' => TRUE),
+      ),
+    ),
+  );
+  $form[$fieldset]['config'][$prefix . 'name'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Field name'),
+    '#default_value' => $values['name'],
+  );
+  // If a name value is set:
+  if (isset($values['name']) && !empty($values['name'])) {
+    // Don't allow editing.
+    $form[$fieldset]['config'][$prefix . 'name']['#disabled'] = TRUE;
+  }
+  $form[$fieldset]['config'][$prefix . 'label'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Field label'),
+    '#default_value' => $values['label'],
+  );
+  $form[$fieldset]['config'][$prefix . 'type']= array(
+     '#type' => 'select',
+     '#title' => t('Field type'),
+     // Only support radios for now.
+     '#options' => array(
+        'radios' => t('Radios'),
+     ),
+     '#default_value' => $values['type'],
+  );
+  $form[$fieldset]['config'][$prefix . 'options'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Field options'),
+    '#default_value' => $values['options'],
+  );
+}
+
+/**
+ * Saves node reportback_field values into dosomething_reportback_field table.
+ */
+function dosomething_reportback_node_reportback_field_form_submit(&$form, &$form_state) {
+  $nid = $form['nid']['#value'];
+  $values = $form_state['values'];
+  $prefix = 'reportback_field_';
+  // Use db_merge to either insert or update existing record for $nid / $name.
+  db_merge('dosomething_reportback_field')
+    ->key(array('nid' => $nid, 'name' => $values[$prefix . 'name']))
+    ->fields(array(
+        'status' => $values[$prefix . 'status'],
+        'label' => $values[$prefix . 'label'],
+        'type' => $values[$prefix . 'type'],
+        'options' => $values[$prefix . 'options'],
+    ))
+    ->execute();
+}

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -295,3 +295,29 @@ function dosomething_reportback_update_7004() {
     db_add_field($tbl_name, $fld_name, $schema[$tbl_name]['fields'][$fld_name]);
   }
 }
+
+/**
+ * Adds a dosomething_reportback_field for Comeback Clothes (nid 362).
+ */
+function dosomething_reportback_update_7005() {
+  $nid = 362;
+  $name = 'dropoff_hm';
+  $label = 'Did you recycle the clothes through H&M?';
+  // Looks funny but we wanna keep the line break.
+  $options = '1|Yes
+0|No';
+
+  // If a record does not exist for $nid and $name:
+  if (!dosomething_reportback_get_reportback_field_info($nid, $name)) {
+    $bada_bing = db_insert('dosomething_reportback_field')
+      ->fields(array(
+        'nid' => $nid,
+        'name' => $name,
+        'status' => 0,
+        'label' => $label,
+        'type' => 'radios',
+        'options' => $options,
+      ))
+      ->execute();
+  }
+}

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -271,12 +271,6 @@ function dosomething_reportback_form($form, &$form_state, $entity) {
     '#type' => 'file',
     '#title' => t('Upload a pic'),
   );
-  // If a custom reportback field exists and is set to active:
-  if (isset($entity->field) && $entity->field['status'] == 1) {
-    $field_name = $entity->field['name'];
-    // Add it as a form element.
-    $form[$field_name] = dosomething_reportback_get_reportback_field_form_element($entity->field);
-  }
   $form['quantity'] = array(
     '#type' => 'textfield',
     '#required' => TRUE,
@@ -294,6 +288,12 @@ function dosomething_reportback_form($form, &$form_state, $entity) {
     ),
     '#default_value' => $entity->quantity,
   );
+  // If a custom reportback field exists and is set to active:
+  if (isset($entity->field) && $entity->field['status'] == 1) {
+    $field_name = $entity->field['name'];
+    // Add it as a form element.
+    $form[$field_name] = dosomething_reportback_get_reportback_field_form_element($entity->field);
+  }
   $form['why_participated'] = array(
     '#type' => 'textarea',
     '#required' => TRUE,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -271,8 +271,8 @@ function dosomething_reportback_form($form, &$form_state, $entity) {
     '#type' => 'file',
     '#title' => t('Upload a pic'),
   );
-  // If a custom reportback field exists:
-  if (isset($entity->field)) {
+  // If a custom reportback field exists and is set to active:
+  if (isset($entity->field) && $entity->field['status'] == 1) {
     $field_name = $entity->field['name'];
     // Add it as a form element.
     $form[$field_name] = dosomething_reportback_get_reportback_field_form_element($entity->field);
@@ -558,8 +558,8 @@ function dosomething_reportback_set_files(&$entity, $values) {
  */
 function dosomething_reportback_set_field_values(&$entity, $values) {
   $entity->field_values = NULL;
-  // If this entity has a custom field:
-  if ($entity->field) {
+  // If this entity has an active custom field:
+  if ($entity->field != NULL && $entity->field['status'] == 1) {
     $field_name = $entity->field['name'];
     $entity->field_values = array(
       $field_name => $values[$field_name],

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -271,6 +271,12 @@ function dosomething_reportback_form($form, &$form_state, $entity) {
     '#type' => 'file',
     '#title' => t('Upload a pic'),
   );
+  // If a custom reportback field exists:
+  if (isset($entity->field)) {
+    $field_name = $entity->field['name'];
+    // Add it as a form element.
+    $form[$field_name] = dosomething_reportback_get_reportback_field_form_element($entity->field);
+  }
   $form['quantity'] = array(
     '#type' => 'textfield',
     '#required' => TRUE,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -5,6 +5,7 @@
  */
 
 include_once 'dosomething_reportback.features.inc';
+include_once 'dosomething_reportback.forms.inc';
 
 /**
  * Implements hook_entity_info().
@@ -678,4 +679,21 @@ function dosomething_reportback_views_data() {
     ),
   );
   return $data;
+}
+
+/**
+ * Returns the dosomething_reportback_field values for a given $nid.
+ *
+ * @param int $nid
+ *   The node nid to query dosomething_reportback_field with.
+ *
+ * @return mixed
+ *   An array of the reportback_field values if exists, NULL if doesn't exist.
+ */
+function dosomething_reportback_get_reportback_field_info($nid) {
+  return db_select('dosomething_reportback_field', 'f')
+    ->fields('f')
+    ->condition('nid', $nid)
+    ->execute()
+    ->fetchAssoc();
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -708,14 +708,18 @@ function dosomething_reportback_views_data() {
  *
  * @param int $nid
  *   The node nid to query dosomething_reportback_field with.
+ * @param string $name
+ *   Optional - The field name to additionally query by.
  *
  * @return mixed
  *   An array of the reportback_field values if exists, NULL if doesn't exist.
  */
-function dosomething_reportback_get_reportback_field_info($nid) {
-  return db_select('dosomething_reportback_field', 'f')
+function dosomething_reportback_get_reportback_field_info($nid, $name = NULL) {
+  $query = db_select('dosomething_reportback_field', 'f')
     ->fields('f')
-    ->condition('nid', $nid)
-    ->execute()
-    ->fetchAssoc();
+    ->condition('nid', $nid);
+  if ($name) {
+    $query->condition('name', $name);
+  }
+  return $query->execute()->fetchAssoc();
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -505,6 +505,8 @@ function dosomething_reportback_save($values) {
     dosomething_reportback_set_properties($entity, $values);
     // Set entity files.
     dosomething_reportback_set_files($entity, $values);
+    // Set reportback field values.
+    dosomething_reportback_set_field_values($entity, $values);
     // Save the entity.
     $entity->save();
     // Return reportback rbid.
@@ -548,6 +550,20 @@ function dosomething_reportback_set_properties(&$entity, $values) {
 function dosomething_reportback_set_files(&$entity, $values) {
   if (isset($values['fid']) && !empty($values['fid'])) {
     $entity->fid = $values['fid'];
+  }
+}
+
+/**
+ * Sets a reportback entity's reportback field values.
+ */
+function dosomething_reportback_set_field_values(&$entity, $values) {
+  $entity->field_values = NULL;
+  // If this entity has a custom field:
+  if ($entity->field) {
+    $field_name = $entity->field['name'];
+    $entity->field_values = array(
+      $field_name => $values[$field_name],
+    );
   }
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -35,6 +35,7 @@ class ReportbackEntity extends Entity {
       $this->node_title = $this->getNodeTitle();
       $this->noun = $this->getNodeSingleTextValue('field_reportback_noun');
       $this->verb = $this->getNodeSingleTextValue('field_reportback_verb');
+      $this->field = dosomething_reportback_get_reportback_field_info($this->nid);
     }
   }
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -149,7 +149,15 @@ class ReportbackEntity extends Entity {
       $timestamp = $this->updated;
     }
     try {
+      // Grab file fids to keep as a record.
       $fids = $this->getFids();
+      // Gather field_data to log all changes.
+      $field_values = $this->field_values;
+      // If a field value exists:
+      if ($field_values != NULL) {
+        // Serialize to store in the log table.
+        $field_values = serialize($field_values);
+      }
       // Log the entity values into the log table.
       $id = db_insert($this->log_table)
         ->fields(array(
@@ -162,6 +170,7 @@ class ReportbackEntity extends Entity {
           'files' => implode(',', $fids),
           'num_files' => count($fids),
           'remote_addr' => dosomething_helpers_ip_address(),
+          'field_data' => $field_values,
         ))
         ->execute();
     }

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -95,6 +95,18 @@ class ReportbackEntity extends Entity {
   }
 
   /**
+   * Saves given $value into dosomething_reportback_field_data for given $name.
+   */
+  public function saveFieldValue($name, $value) {
+    return db_merge('dosomething_reportback_field_data')
+      ->key(array('rbid' => $this->rbid, 'name' => $name))
+      ->fields(array(
+          'value' => $value,
+      ))
+      ->execute();
+}
+
+  /**
    * Logs current entity values with given $op string.
    */
   public function insertLog($op) {
@@ -213,6 +225,12 @@ class ReportbackEntityController extends EntityAPIController {
     if (isset($entity->fid)) {
       // Add it into the reportback files.
       $entity->insertFid($entity->fid);
+    }
+    // If reportback field values exist:
+    if (isset($entity->field_values)) {
+      foreach ($entity->field_values as $name => $value) {
+        $entity->saveFieldValue($name, $value);
+      }
     }
     // Log the write operation.
     $entity->insertLog($op);

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -11,6 +11,7 @@
 class ReportbackEntity extends Entity {
   protected $files_table = 'dosomething_reportback_file';
   protected $log_table = 'dosomething_reportback_log';
+  protected $field_data_table = 'dosomething_reportback_field_data';
 
   /**
    * Override this in order to implement a custom default URI.
@@ -35,7 +36,12 @@ class ReportbackEntity extends Entity {
       $this->node_title = $this->getNodeTitle();
       $this->noun = $this->getNodeSingleTextValue('field_reportback_noun');
       $this->verb = $this->getNodeSingleTextValue('field_reportback_verb');
+      // Store the field configuration info.
       $this->field = dosomething_reportback_get_reportback_field_info($this->nid);
+      if ($this->field) {
+        // Store the user value for the reportback field.
+        $this->field['value'] = $this->getFieldValue($this->field['name']);
+      }
     }
   }
 
@@ -82,6 +88,22 @@ class ReportbackEntity extends Entity {
   }
 
   /**
+   * Gets value from dosomething_reportback_field_data table for given $name.
+   */
+  public function getFieldValue($name) {
+    $result = db_select($this->field_data_table, 'd')
+      ->fields('d', array('value'))
+      ->condition('rbid', $this->rbid)
+      ->condition('name', $name)
+      ->execute()
+      ->fetchCol();
+    if ($result) {
+      return $result[0];
+    }
+    return NULL;
+  }
+
+  /**
    * Inserts given fid into dosomething_reportback_files table for this entity.
    */
   public function insertFid($fid) {
@@ -98,13 +120,13 @@ class ReportbackEntity extends Entity {
    * Saves given $value into dosomething_reportback_field_data for given $name.
    */
   public function saveFieldValue($name, $value) {
-    return db_merge('dosomething_reportback_field_data')
+    return db_merge($this->field_data_table)
       ->key(array('rbid' => $this->rbid, 'name' => $name))
       ->fields(array(
           'value' => $value,
       ))
       ->execute();
-}
+  }
 
   /**
    * Logs current entity values with given $op string.


### PR DESCRIPTION
Fixes #1647

Renders an additional field in the reportback form based on configurations in the "Reportback Fields" section.
-- Hardcodes the "options" element for radios for now, in the interest of getting this out for production tomorrow.

Adds a dosomething_reportback_field record for Comeback Clothes with status = 0, which means the additional question will not appear by default.  Must manually edit node 362 and check the "Add additional reportback field" checkbox to get it to appear.
