### PR TITLE
Single-select on Campaign Finder

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/CampaignFinder.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/CampaignFinder.js
@@ -27,7 +27,7 @@ define(["jquery", "lodash", "finder/SolrAdapter", "finder/CampaignResults"], fun
      * @param  {JQuery} $actionTypeFields Input fields related to the action type field
      */
     init: function ($resultsDiv, $blankSlateDiv, $searchButton, $causeFields, $timeFields, $actionTypeFields) {
-      // Prepare checkboxes (?)
+      // Prepare toggles
       $("[data-toggle]").click(function () {
         var toggleClass = $(this).data("toggle");
         $(this).parents("." + toggleClass).toggleClass("open");
@@ -74,7 +74,13 @@ define(["jquery", "lodash", "finder/SolrAdapter", "finder/CampaignResults"], fun
       for (var i in CampaignFinder.$fields) {
         // Attach ourselves to the "change" event on the input fields
         CampaignFinder.$fields[i].change(function () {
+          // Temporarily force single-select until we have more things in the finder
+          // Not using [type="radio"] since we want options to be de-selectable.
+          $(this).parents("li").siblings("li").find("label").removeClass("checked");
+          $(this).parents("li").siblings("li").find("input").attr("checked", false);
+
           $(this).parents("label").toggleClass("checked", $(this).is(":checked"));
+
           // Save the last checkbox that we checked so we don"t disable any of
           // those fields if we"re trying to select multiple
           CampaignFinder.lastChanged = $(this).attr("name");
@@ -85,6 +91,7 @@ define(["jquery", "lodash", "finder/SolrAdapter", "finder/CampaignResults"], fun
           }
         });
 
+        // Search button appears on mobile in lieu of live filtering
         CampaignFinder.$searchButton.click(function () {
           CampaignFinder.query();
           $("html,body").animate({

--- a/lib/themes/dosomething/paraneue_dosomething/templates/home/node--home.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/home/node--home.tpl.php
@@ -39,9 +39,9 @@ if( theme_get_setting('show_campaign_finder') ) {
           <p class="facet-field">How long do you have?</p>
           <div class="dropdown-menu">
             <ul>
-              <li><label><input name="time" type="checkbox" value="[* TO 2]" />Less than 2 hours</label></li>
-              <li><label><input name="time" type="checkbox" value="[2 TO 5]" />5 hours</label></li>
-              <li><label><input name="time" type="checkbox" value="[5 TO *]" />10 hours</label></li>
+              <li><label><input name="time" type="checkbox" value="[* TO 2]" />1 hour or less</label></li>
+              <li><label><input name="time" type="checkbox" value="[2 TO 5]" />2-5 hours</label></li>
+              <li><label><input name="time" type="checkbox" value="[5 TO *]" />5+ hours</label></li>
             </ul>
           </div>
         </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/home/node--home.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/home/node--home.tpl.php
@@ -39,9 +39,9 @@ if( theme_get_setting('show_campaign_finder') ) {
           <p class="facet-field">How long do you have?</p>
           <div class="dropdown-menu">
             <ul>
-              <li><label><input name="time" type="checkbox" value="[* TO 2]" />1 hour or less</label></li>
+              <li><label><input name="time" type="checkbox" value="[* TO 1]" />1 hour or less</label></li>
               <li><label><input name="time" type="checkbox" value="[2 TO 5]" />2-5 hours</label></li>
-              <li><label><input name="time" type="checkbox" value="[5 TO *]" />5+ hours</label></li>
+              <li><label><input name="time" type="checkbox" value="[6 TO *]" />5+ hours</label></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Makes options on the campaign finder single-select by field group. Fixes #1722.
