### PR TITLE
Moar fixie

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -376,15 +376,16 @@ function dosomething_campaign_node_view($node, $view_mode, $langcode) {
       }
     }
     if (module_exists('dosomething_reportback')) {
-      // Initalize reportback as a new entity for this nid.
-      $reportback = entity_create('reportback', array(
-        'nid' => $node->nid,
-        'quantity' => NULL,
-        'why_participated' => NULL,
-      ));
       if ($rbid = dosomething_reportback_exists($node->nid)) {
-        // Replace with existing reportback entity if it exists.
         $reportback = reportback_load($rbid);
+      }
+      else {
+        // Initalize reportback as a new entity for this nid.
+        $reportback = entity_create('reportback', array(
+          'nid' => $node->nid,
+          'quantity' => NULL,
+          'why_participated' => NULL,
+        ));
       }
       $wrapper = entity_metadata_wrapper('node', $node->nid);
       // Set Reportback Form variable in node content for rendering in theme layer.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -240,8 +240,9 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
       $action_guide = $target['entity'];
       $action_guide_wrapper = entity_metadata_wrapper('node', $action_guide);
       $action_guide_desc = $action_guide_wrapper->field_description->value();
+      $action_guide_content = node_view($action_guide);
       $vars['action_guides'][$delta]['desc'] = $action_guide_desc;
-      $vars['action_guides'][$delta]['content'] = render(node_view($action_guide));
+      $vars['action_guides'][$delta]['content'] = render($action_guide_content);
     }
   }
   // Preprocess signup data form link.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -559,7 +559,7 @@ function dosomething_reportback_set_files(&$entity, $values) {
 function dosomething_reportback_set_field_values(&$entity, $values) {
   $entity->field_values = NULL;
   // If this entity has an active custom field:
-  if ($entity->field != NULL && $entity->field['status'] == 1) {
+  if (isset($entity->field) && $entity->field['status'] == 1) {
     $field_name = $entity->field['name'];
     $entity->field_values = array(
       $field_name => $values[$field_name],

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -38,8 +38,8 @@ class ReportbackEntity extends Entity {
       $this->verb = $this->getNodeSingleTextValue('field_reportback_verb');
       // Store the field configuration info.
       $this->field = dosomething_reportback_get_reportback_field_info($this->nid);
-      // If active field:
-      if ($this->field && $this->field['status'] == 1) {
+      // If existing reportback and active field:
+      if (isset($this->rbid) && $this->field && $this->field['status'] == 1) {
         // Store the user value for the reportback field.
         $this->field['value'] = $this->getFieldValue($this->field['name']);
       }

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -38,7 +38,8 @@ class ReportbackEntity extends Entity {
       $this->verb = $this->getNodeSingleTextValue('field_reportback_verb');
       // Store the field configuration info.
       $this->field = dosomething_reportback_get_reportback_field_info($this->nid);
-      if ($this->field) {
+      // If active field:
+      if ($this->field && $this->field['status'] == 1) {
         // Store the user value for the reportback field.
         $this->field['value'] = $this->getFieldValue($this->field['name']);
       }


### PR DESCRIPTION
Getting rid of all these dang PHP errors!! 
#1718 was happening because there's an `entity_create` that was happening before loading the existing reportback, which isn't necessary if a reportback already exists.
