### PR TITLE
Fix to radio button inputs on report back modal on campaigns.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-reportback.scss
@@ -21,5 +21,22 @@
         }
       }
     }
+
+    .form-type-radio {
+      clear: both;
+      margin-bottom: 0.25rem;
+      overflow: auto;
+
+      input[type="radio"] {
+        float: left;
+      }
+
+      label {
+        clear: none;
+        float: left;
+        margin: 0 0 0 0.25rem;
+        width: auto;
+      }
+    }
   }
 }


### PR DESCRIPTION
Resolves #1693

Isolated the fix to only the reportback modal. I was concerned that doing it more globally could bork other forms!
