### PR TITLE
Fixes reportback field submit error

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -387,7 +387,6 @@ function dosomething_campaign_node_view($node, $view_mode, $langcode) {
           'why_participated' => NULL,
         ));
       }
-      $wrapper = entity_metadata_wrapper('node', $node->nid);
       // Set Reportback Form variable in node content for rendering in theme layer.
       $node->content['reportback_form'] = drupal_get_form('dosomething_reportback_form', $reportback);
     }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -497,7 +497,7 @@ function dosomething_reportback_exists($nid, $uid = NULL) {
 function dosomething_reportback_save($values) {
   $rbid = $values['rbid'];
   if ($rbid == 0) {
-    $entity = entity_create('reportback', array());
+    $entity = entity_create('reportback', array('nid' => $values['nid']));
   }
   else {
     $entity = entity_load_single('reportback', $rbid);

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -122,10 +122,18 @@ class ReportbackEntity extends Entity {
    */
   public function saveFieldValue($name, $value) {
     return db_merge($this->field_data_table)
-      ->key(array('rbid' => $this->rbid, 'name' => $name))
-      ->fields(array(
+      ->key(array(
+          'rbid' => $this->rbid,
+          'name'  => $name,
+        ))
+      ->insertFields(array(
+          'rbid' => $this->rbid,
+          'name'  => $name,
           'value' => $value,
-      ))
+        ))
+      ->updateFields(array(
+          'value' => $value,
+        ))
       ->execute();
   }
 


### PR DESCRIPTION
A new reportback entity must be created with a nid within the `entity_create` call, in order for it to be aware any `dosomething_reportback_field` field values it should be collecting.

The changes to the `db_merge` call don't actually fix anything, just makes it a little more readable.
