### PR TITLE
Last step in removing the Mail System module

### DIFF
--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -38,7 +38,6 @@ dependencies[] = i18n
 dependencies[] = libraries
 dependencies[] = link
 dependencies[] = locale
-dependencies[] = mailsystem
 dependencies[] = markdown
 dependencies[] = message_broker_producer
 dependencies[] = metatag

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -79,10 +79,6 @@ projects[libraries][subdir] = "contrib"
 projects[link] = "1.2"
 projects[link][subdir] = "contrib"
 
-; MailSystem
-projects[mailsystem] = "2.34"
-projects[mailsystem][subdir] = "contrib"
-
 ; Markdown
 projects[markdown] = "1.2"
 projects[markdown][subdir] = "contrib"


### PR DESCRIPTION
Fixes #1794
Fixes #1759

Last step in removing the Mail System module.

The Mail System module has been disabled and uninstalled on both the production and staging sites.
