### PR TITLE
Redirect with modal open on form error.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -223,14 +223,14 @@ function dosomething_signup_data_validate_address($form, &$form_state) {
 
   // Did we not get any results?
   if (in_array('sorry', $formatted_address)) {
-    drupal_goto($_SERVER['REQUEST_URI'], array('fragment' => 'modal-signup-data-form'));
     form_set_error('dosomething_user_validate_address', t('Hmmm, we couldn’t find that address. Please try again.'));
+    drupal_goto($_SERVER['REQUEST_URI'], array('fragment' => 'modal-signup-data-form'));
   }
   // Did it come back from the api as ambiguous? -- Check with the user.
   elseif (in_array('ambiguous', $formatted_address)) {
     dosomething_signup_data_set_address_values($form, $form_state, $formatted_address);
-    drupal_goto($_SERVER['REQUEST_URI'], array('fragment' => 'modal-signup-data-form'));
     form_set_error('dosomething_user_ambiguous_address', t('Hmmm, we couldn’t find that address. Did you mean:'));
+    drupal_goto($_SERVER['REQUEST_URI'], array('fragment' => 'modal-signup-data-form'));
   }
   // We have a full address, save it!
   else {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -223,11 +223,13 @@ function dosomething_signup_data_validate_address($form, &$form_state) {
 
   // Did we not get any results?
   if (in_array('sorry', $formatted_address)) {
+    drupal_goto($_SERVER['REQUEST_URI'], array('fragment' => 'modal-signup-data-form'));
     form_set_error('dosomething_user_validate_address', t('Hmmm, we couldn’t find that address. Please try again.'));
   }
   // Did it come back from the api as ambiguous? -- Check with the user.
   elseif (in_array('ambiguous', $formatted_address)) {
     dosomething_signup_data_set_address_values($form, $form_state, $formatted_address);
+    drupal_goto($_SERVER['REQUEST_URI'], array('fragment' => 'modal-signup-data-form'));
     form_set_error('dosomething_user_ambiguous_address', t('Hmmm, we couldn’t find that address. Did you mean:'));
   }
   // We have a full address, save it!

--- a/lib/themes/dosomething/paraneue_dosomething/bower.json
+++ b/lib/themes/dosomething/paraneue_dosomething/bower.json
@@ -20,7 +20,7 @@
     "tests"
   ],
   "dependencies": {
-    "neue": "DoSomething/neue#~3.3.0",
+    "neue": "DoSomething/neue#~3.4.0",
     "jquery": "~1.11.0",
     "mailcheck": "~1.0.3",
     "html5shiv": "~3.7.0",

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_modals.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_modals.scss
@@ -3,6 +3,11 @@
 .modal-content {
   word-wrap: break-word;
 
+  .modal-messages {
+    // fit this guy to edge of modal
+    margin: -2rem -1.5rem 2rem;
+  }
+
   h2.banner {
     // fit this guy to edge of modal
     margin: -2rem -1.5rem 1rem;

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -229,6 +229,7 @@
 
       <?php if (isset($signup_data_form)): ?>
       <script id="modal-signup-data-form" type="text/cached-modal">
+        <div class="js-messages-clone"></div>
         <a href="#" class="js-close-modal modal-close-button white">×</a>
           <div><?php print render($signup_data_form); ?></div>
         <a href="#" class="js-close-modal">Back to main page</a>


### PR DESCRIPTION
Redirects to page with modal hash in URL if there's a form error (will trigger modal on load with updates in Neue).
