### PR TITLE
Campaign block template

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -436,6 +436,13 @@ function dosomething_campaign_theme($existing, $type, $theme, $path) {
         'recommended' => NULL,
       ),
     ),
+    'campaign_block' => array(
+      'template' => 'campaign-block',
+      'path' => drupal_get_path('module', 'dosomething_campaign') . '/theme',
+      'variables' => array(
+        'vars' => NULL,
+      ),
+    ),
   );
 }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -72,7 +72,7 @@ function dosomething_campaign_scholarships_page() {
     if (isset($scholarships)) {
       // Get a link, CTA, image, etc for each campaign.
       foreach($scholarships as $key => $scholarship) {
-        $rows[$key]['data'] = dosomething_campaign_get_recommended_campaign_vars($scholarship['nid']);
+        $rows[$key]['data'] = dosomething_campaign_get_campaign_block_vars($scholarship['nid']);
         unset($rows[$key]['data']['src']);
         $rows[$key]['data']['amount'] = '$' . $scholarship['amount'];
         $rows[$key]['data']['deadline'] = $scholarship['deadline'];
@@ -384,7 +384,7 @@ function dosomething_campaign_reportback_confirmation_page($node) {
   $rec_vars = array();
   // Loop through rec_nids to load relevant variables.
   foreach ($rec_nids as $nid) {
-    $rec_vars[] = dosomething_campaign_get_recommended_campaign_vars($nid);
+    $rec_vars[] = dosomething_campaign_get_campaign_block_vars($nid);
   }
   return theme('reportback_confirmation', array(
     'copy' => $wrapper->field_reportback_confirm_msg->value(),
@@ -404,7 +404,7 @@ function dosomething_campaign_reportback_confirmation_page($node) {
  * @return array
  *   An array of variables.
  */
-function dosomething_campaign_get_recommended_campaign_vars($nid) {
+function dosomething_campaign_get_campaign_block_vars($nid) {
   $wrapper = entity_metadata_wrapper('node', $nid);
   $path = 'node/' . $nid;
   $image = NULL;

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -404,13 +404,13 @@ function dosomething_campaign_reportback_confirmation_page($node) {
  * @return array
  *   An array of variables.
  */
-function dosomething_campaign_get_campaign_block_vars($nid) {
+function dosomething_campaign_get_campaign_block_vars($nid, $image_size = '740x480') {
   $wrapper = entity_metadata_wrapper('node', $nid);
   $path = 'node/' . $nid;
   $image = NULL;
   $image_nid = $wrapper->field_image_campaign_cover->getIdentifier();
   if ($image_nid) {
-    $image = dosomething_image_get_themed_image_url($image_nid, 'landscape', '740x480');
+    $image = dosomething_image_get_themed_image_url($image_nid, 'landscape', $image_size);
   }
   return array(
     'nid' => $wrapper->getIdentifier(),

--- a/lib/modules/dosomething/dosomething_campaign/theme/campaign-block.tpl.php
+++ b/lib/modules/dosomething/dosomething_campaign/theme/campaign-block.tpl.php
@@ -1,0 +1,5 @@
+<div>
+  <h4><?php print $vars['title']; ?></h4>
+  <p><?php print $vars['call_to_action']; ?></p>
+  <img src="<?php print $vars['image']; ?>" />
+</div>

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -459,6 +459,7 @@ function dosomething_signup_get_signup_nids_by_uid($uid) {
   $query = db_select('dosomething_signup', 's');
   $query->fields('s', array('nid'));
   $query->condition('uid', $uid);
+  $query->orderBy('timestamp', 'DESC');
   $result = $query->execute();
   return array_keys($result->fetchAllAssoc('nid'));
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_profile.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_profile.inc
@@ -5,10 +5,11 @@
  * Implements hook_user_view().
  */
 function dosomething_user_user_view($account, $view_mode, $langcode) {
+  $image_size = '310x310';
   // Output user signups.
   $signup_nids = dosomething_signup_get_signup_nids_by_uid($account->uid);
   foreach ($signup_nids as $delta => $nid) {
-    $vars = dosomething_campaign_get_campaign_block_vars($nid);
+    $vars = dosomething_campaign_get_campaign_block_vars($nid, $image_size);
     $account->content['signup_' . $delta] = array(
       '#markup' => theme('campaign_block', array('vars' => $vars)),
     );
@@ -16,7 +17,7 @@ function dosomething_user_user_view($account, $view_mode, $langcode) {
   // Output recommended campaigns.
   $rec_nids = dosomething_campaign_get_recommended_campaign_nids('', $account->uid);
   foreach ($rec_nids as $delta => $nid) {
-    $vars = dosomething_campaign_get_campaign_block_vars($nid);
+    $vars = dosomething_campaign_get_campaign_block_vars($nid, $image_size);
     $account->content['recommended_' . $delta] = array(
       '#markup' => theme('campaign_block', array('vars' => $vars)),
     );

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_profile.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_profile.inc
@@ -6,11 +6,13 @@
  */
 function dosomething_user_user_view($account, $view_mode, $langcode) {
   // Output user signups.
-  $account->content['campaigns'] = array(
-    '#type' => 'user_profile_item',
-    '#title' => t('Campaigns'),
-    '#markup' => views_embed_view('user_signups', 'block', $account->uid),
-  );
+  $signup_nids = dosomething_signup_get_signup_nids_by_uid($account->uid);
+  foreach ($signup_nids as $delta => $nid) {
+    $vars = dosomething_campaign_get_campaign_block_vars($nid);
+    $account->content['signup_' . $delta] = array(
+      '#markup' => theme('campaign_block', array('vars' => $vars)),
+    );
+  }  
   // Output recommended campaigns.
   $rec_nids = dosomething_campaign_get_recommended_campaign_nids('', $account->uid);
   foreach ($rec_nids as $delta => $nid) {
@@ -23,6 +25,7 @@ function dosomething_user_user_view($account, $view_mode, $langcode) {
   $account->content['updated'] = array(
     '#type' => 'user_profile_item',
     '#markup' => l('Update', 'user/' . $account->uid . '/edit'),
+    '#weight' => 300,
   );
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_profile.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_profile.inc
@@ -11,17 +11,14 @@ function dosomething_user_user_view($account, $view_mode, $langcode) {
     '#title' => t('Campaigns'),
     '#markup' => views_embed_view('user_signups', 'block', $account->uid),
   );
-
+  // Output recommended campaigns.
   $rec_nids = dosomething_campaign_get_recommended_campaign_nids('', $account->uid);
-  foreach ($rec_nids as $nid) {
-    $rec_vars[] = dosomething_campaign_get_campaign_block_vars($nid);
+  foreach ($rec_nids as $delta => $nid) {
+    $vars = dosomething_campaign_get_campaign_block_vars($nid);
+    $account->content['recommended_' . $delta] = array(
+      '#markup' => theme('campaign_block', array('vars' => $vars)),
+    );
   }
-  // Leave this out till it's themed.
-  // $account->content['recommended'] = array(
-  //   '#type' => 'user_profile_item',
-  //   '#title' => t('Recommended'),
-  //   '#markup' => $rec_vars, //@TODO: theme this.
-  // );
 
   $account->content['updated'] = array(
     '#type' => 'user_profile_item',

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_profile.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_profile.inc
@@ -14,7 +14,7 @@ function dosomething_user_user_view($account, $view_mode, $langcode) {
 
   $rec_nids = dosomething_campaign_get_recommended_campaign_nids('', $account->uid);
   foreach ($rec_nids as $nid) {
-    $rec_vars[] = dosomething_campaign_get_recommended_campaign_vars($nid);
+    $rec_vars[] = dosomething_campaign_get_campaign_block_vars($nid);
   }
   // Leave this out till it's themed.
   // $account->content['recommended'] = array(

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/campaign-block.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/campaign-block.tpl.php
@@ -1,0 +1,5 @@
+<div>
+  <h4><?php print $vars['title']; ?></h4>
+  <p><?php print $vars['call_to_action']; ?></p>
+  <img src="<?php print $vars['image']; ?>" />
+</div>


### PR DESCRIPTION
Creates a themeable `campaign_block` function and template file, and updates the user profile to call them for each recommended  / signup campaign.

TODO:
- Add signup date into the `$vars` if exists
- Remove deprecated `user_signups` view from codebase
