### PR TITLE
Remove environment_indicator module from profile

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -172,10 +172,6 @@ projects[message_broker_producer][subdir] = "contrib"
 projects[devel] = "1.3"
 projects[devel][subdir] = "contrib"
 
-; Environment Indicator
-projects[environment_indicator] = "2.0"
-projects[environment_indicator][subdir] = "contrib"
-
 ; Coder
 projects[coder] = "2.0"
 projects[coder][subdir] = "contrib"


### PR DESCRIPTION
We tried finally turning it on and it adds all that dang javascript!  Get it out of here.

Refs #1889 -- goal is to add some custom code later to handle indicating environments.
