### PR TITLE
Restores IE8 polyfills.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/main.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/main.js
@@ -13,6 +13,10 @@ define("main", function(require) {
 
   require("neue/main");
 
+  // Load polyfills
+  require("neue/vendor/polyfills/respond");
+  require("neue/vendor/polyfills/rem");
+
   // Initialize modules on load
   require("campaign/sources");
   require("campaign/tips");


### PR DESCRIPTION
Brings back IE 8 polyfills, since they're not being included in base Neue build now.

:truck: 
