### PR TITLE
Signup Data Form configuration: required + why_signedup

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -456,7 +456,10 @@ function dosomething_campaign_node_view($node, $view_mode, $langcode) {
       // Only include signup data form if the status field is checked.
       if ($signup_data_info['status'] == 1) {
         $node->content['signup_data_form_link'] = $signup_data_info['link_text'];
-        $node->content['signup_data_form'] = drupal_get_form('dosomething_signup_user_signup_data_form', $node->nid);
+        // Load the signup entity.
+        $signup = signup_load(dosomething_signup_exists($node->nid));
+        // Pass to the user signup data form.
+        $node->content['signup_data_form'] = drupal_get_form('dosomething_signup_user_signup_data_form', $signup);
       }
     }
     if (module_exists('dosomething_reportback')) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -144,11 +144,11 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
  * @param int $nid
  *   The node which the signup data form is rendered on.
  */
-function dosomething_signup_user_signup_data_form($form, &$form_state, $nid) {
-  $config = dosomething_signup_get_signup_data_form_info($nid);
+function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) {
+  $config = dosomething_signup_get_signup_data_form_info($signup->nid);
   $form['nid'] = array(
     '#type' => 'hidden',
-    '#value' => $nid,
+    '#value' => $signup->nid,
     '#access' => FALSE,
   );
   $form['header'] = array(
@@ -156,8 +156,6 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $nid) {
     '#markup' => $config['form_header'],
     '#suffix' => '</h2>',
   );
-  // Load signup entity.
-  $signup = signup_load(dosomething_signup_exists($nid));
   // If the user has submitted form already:
   if ($timestamp = $signup->signup_data_form_timestamp) {
     // Get filtered form_submitted_copy.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -91,9 +91,21 @@ function _dosomething_signup_node_signup_data_form(&$form, &$form_state) {
   );
   $form[$fieldset]['config'][$prefix . 'collect_why_signedup'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Collect why signedup'),
+    '#title' => t('Collect signup reason'),
     '#default_value' => $values['collect_why_signedup'],
     '#description' => t('If checked, collect the reason why the user signed up for the campaign.'),
+  );
+  $form[$fieldset]['config'][$prefix . 'why_signedup_label'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Signup Reason Label'),
+    '#default_value' => $values['why_signedup_label'],
+    '#description' => t('This is the label for the field which collects the signup reason. e.g. <em>Tell us why you would like to receive Thumb Socks for Thumb Wars</em>.'),
+    // Why_signedup label should only be visible if collect_why_signedup is checked.
+    '#states' => array(
+      'visible' => array(
+        ':input[name="' . $prefix . 'collect_why_signedup"]' => array('checked' => TRUE),
+      ),
+    ),
   );
   $form[$fieldset]['config'][$prefix . 'confirm_msg'] = array(
     '#type' => 'textarea',
@@ -149,6 +161,7 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
         'confirm_msg' => $values[$prefix . 'confirm_msg'],
         'collect_user_address' => $values[$prefix . 'collect_user_address'],
         'collect_why_signedup' => $values[$prefix . 'collect_why_signedup'],
+        'why_signedup_label' => $values[$prefix . 'why_signedup_label'],
     ))
     ->execute();
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -62,10 +62,17 @@ function _dosomething_signup_node_signup_data_form(&$form, &$form_state) {
       ),
     ),
   );
+  $form[$fieldset]['config'][$prefix . 'required'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Display after signup'),
+    '#default_value' => $values['required'],
+    '#description' => t('If checked, the form will be displayed after the user first signs up.'),
+  );
   $form[$fieldset]['config'][$prefix . 'collect_user_address'] = array(
     '#type' => 'checkbox',
     '#title' => t('Collect user address'),
     '#default_value' => $values['collect_user_address'],
+    '#description' => t('If checked, collect the user address and save to profile.'),
   );
   $form[$fieldset]['config'][$prefix . 'link_text'] = array(
     '#type' => 'textfield',
@@ -91,7 +98,7 @@ function _dosomething_signup_node_signup_data_form(&$form, &$form_state) {
     '#type' => 'textarea',
     '#title' => t('Form submitted copy'),
     '#default_value' => $values['form_submitted_copy'],
-    '#description' => t('This is the message that will appear if a user views the form after submitting. <p>You can use ' . DOSOMETHING_SIGNUP_DATA_FORM_TIMESTAMP_TOKEN .' to display the time the user submitted the form, e.g. <em>You submitted this form on ' . DOSOMETHING_SIGNUP_DATA_FORM_TIMESTAMP_TOKEN . ', your banner should arrive within 2 weeks from then!</em></p>'),
+    '#description' => t('This is the copy that will appear if a user views the form after submitting. <p>You can use ' . DOSOMETHING_SIGNUP_DATA_FORM_TIMESTAMP_TOKEN .' to display the time the user submitted the form, e.g. <em>You submitted this form on ' . DOSOMETHING_SIGNUP_DATA_FORM_TIMESTAMP_TOKEN . ', your banner should arrive within 2 weeks from then!</em></p>'),
   );
 }
 
@@ -128,6 +135,7 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
     ->key(array('nid' => $nid))
     ->fields(array(
         'status' => $values[$prefix . 'status'],
+        'required' => $values[$prefix . 'required'],
         'link_text' => $values[$prefix . 'link_text'],
         'form_header' => $values[$prefix . 'form_header'],
         'form_copy' => $values[$prefix . 'form_copy'],

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -68,12 +68,6 @@ function _dosomething_signup_node_signup_data_form(&$form, &$form_state) {
     '#default_value' => $values['required'],
     '#description' => t('If checked, the form will be displayed after the user first signs up.'),
   );
-  $form[$fieldset]['config'][$prefix . 'collect_user_address'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Collect user address'),
-    '#default_value' => $values['collect_user_address'],
-    '#description' => t('If checked, collect the user address and save to profile.'),
-  );
   $form[$fieldset]['config'][$prefix . 'link_text'] = array(
     '#type' => 'textfield',
     '#title' => t('Link text'),
@@ -88,6 +82,18 @@ function _dosomething_signup_node_signup_data_form(&$form, &$form_state) {
     '#type' => 'textarea',
     '#title' => t('Form copy'),
     '#default_value' => $values['form_copy'],
+  );
+  $form[$fieldset]['config'][$prefix . 'collect_user_address'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Collect user address'),
+    '#default_value' => $values['collect_user_address'],
+    '#description' => t('If checked, collect the user address and save to profile.'),
+  );
+  $form[$fieldset]['config'][$prefix . 'collect_why_signedup'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Collect why signedup'),
+    '#default_value' => $values['collect_why_signedup'],
+    '#description' => t('If checked, collect the reason why the user signed up for the campaign.'),
   );
   $form[$fieldset]['config'][$prefix . 'confirm_msg'] = array(
     '#type' => 'textarea',
@@ -142,6 +148,7 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
         'form_submitted_copy' => $values[$prefix . 'form_submitted_copy'],
         'confirm_msg' => $values[$prefix . 'confirm_msg'],
         'collect_user_address' => $values[$prefix . 'collect_user_address'],
+        'collect_why_signedup' => $values[$prefix . 'collect_why_signedup'],
     ))
     ->execute();
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -66,36 +66,46 @@ function _dosomething_signup_node_signup_data_form(&$form, &$form_state) {
     '#type' => 'checkbox',
     '#title' => t('Display after signup'),
     '#default_value' => $values['required'],
-    '#description' => t('If checked, the form will be displayed after the user first signs up.'),
+    '#description' => t('If checked, the form modal will be displayed after the user first signs up.'),
   );
   $form[$fieldset]['config'][$prefix . 'link_text'] = array(
     '#type' => 'textfield',
     '#title' => t('Link text'),
     '#default_value' => $values['link_text'],
+    '#description' => t('This is label of the link in "Stuff You Need" which opens the form modal.'),
   );
   $form[$fieldset]['config'][$prefix . 'form_header'] = array(
     '#type' => 'textfield',
     '#title' => t('Form header'),
     '#default_value' => $values['form_header'],
+    '#description' => t('This is the headline that appears in the form modal.'),
   );
   $form[$fieldset]['config'][$prefix . 'form_copy'] = array(
     '#type' => 'textarea',
     '#title' => t('Form copy'),
     '#default_value' => $values['form_copy'],
+    '#description' => t('This is the copy that appears above the form elements.'),
   );
-  $form[$fieldset]['config'][$prefix . 'collect_user_address'] = array(
+  // Create fieldset to group configuration of the actual form elements.
+  $form[$fieldset]['config']['elements'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Form Elements'),
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+  );
+  $form[$fieldset]['config']['elements'] [$prefix . 'collect_user_address'] = array(
     '#type' => 'checkbox',
     '#title' => t('Collect user address'),
     '#default_value' => $values['collect_user_address'],
     '#description' => t('If checked, collect the user address and save to profile.'),
   );
-  $form[$fieldset]['config'][$prefix . 'collect_why_signedup'] = array(
+  $form[$fieldset]['config']['elements'] [$prefix . 'collect_why_signedup'] = array(
     '#type' => 'checkbox',
     '#title' => t('Collect signup reason'),
     '#default_value' => $values['collect_why_signedup'],
     '#description' => t('If checked, collect the reason why the user signed up for the campaign.'),
   );
-  $form[$fieldset]['config'][$prefix . 'why_signedup_label'] = array(
+  $form[$fieldset]['config']['elements'][$prefix . 'why_signedup_label'] = array(
     '#type' => 'textarea',
     '#title' => t('Signup Reason Label'),
     '#default_value' => $values['why_signedup_label'],
@@ -111,12 +121,13 @@ function _dosomething_signup_node_signup_data_form(&$form, &$form_state) {
     '#type' => 'textarea',
     '#title' => t('Confirmation message'),
     '#default_value' => $values['confirm_msg'],
+    '#description' => t('This is the message displayed after the user submits the form.'),
   );
   $form[$fieldset]['config'][$prefix . 'form_submitted_copy'] = array(
     '#type' => 'textarea',
     '#title' => t('Form submitted copy'),
     '#default_value' => $values['form_submitted_copy'],
-    '#description' => t('This is the copy that will appear if a user views the form after submitting. <p>You can use ' . DOSOMETHING_SIGNUP_DATA_FORM_TIMESTAMP_TOKEN .' to display the time the user submitted the form, e.g. <em>You submitted this form on ' . DOSOMETHING_SIGNUP_DATA_FORM_TIMESTAMP_TOKEN . ', your banner should arrive within 2 weeks from then!</em></p>'),
+    '#description' => t('This is the copy that will appear if a user views the form again after submitting. <p>You can use ' . DOSOMETHING_SIGNUP_DATA_FORM_TIMESTAMP_TOKEN .' to display the time the user submitted the form, e.g. <em>You submitted this form on ' . DOSOMETHING_SIGNUP_DATA_FORM_TIMESTAMP_TOKEN . ', your banner should arrive within 2 weeks from then!</em></p>'),
   );
 }
 


### PR DESCRIPTION
This PR is for editors to configure the signup data form to collect additional data and set the `required` property.  The user facing changes will be implemented in a separate PR, just wanted to open this one to make it more review-able.

Fixes #1903: Configuration for the `why_signedup` property.  Checkbox to collect `why_signedup` and textarea to set the `why_signedup_label`.

Fixes #1904: Checkbox to set the `required` property. 
