### PR TITLE
Better image upload

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -270,6 +270,9 @@ function dosomething_reportback_form($form, &$form_state, $entity) {
   $form['reportback_file'] = array(
     '#type' => 'file',
     '#title' => t('Upload a pic'),
+    '#attributes' => array(
+      'class' => array('js-image-upload'),
+    ),
   );
   $form['quantity'] = array(
     '#type' => 'textfield',

--- a/lib/themes/dosomething/paraneue_dosomething/bower.json
+++ b/lib/themes/dosomething/paraneue_dosomething/bower.json
@@ -20,7 +20,7 @@
     "tests"
   ],
   "dependencies": {
-    "neue": "DoSomething/neue#~3.5.0",
+    "neue": "DoSomething/neue#~3.6.0",
     "jquery": "1.8.3",
     "mailcheck": "~1.0.3",
     "html5shiv": "~3.7.0",

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
@@ -15,7 +15,7 @@ define(function(require) {
       $(el).css("visibility", "hidden");
       $(el).css("position", "absolute");
 
-      var $uploadBtn = $("<a href='#' class='btn secondary small'>Upload A Pic</a>")
+      var $uploadBtn = $("<a href='#' class='btn secondary small'>Upload A Pic</a>");
       $uploadBtn.insertAfter( $(el) );
 
       var $imgPreview = $("<img class='preview' src=''>");
@@ -49,7 +49,9 @@ define(function(require) {
         }
 
         // If no file selected/no FileReader support, we're all done
-        if (!files.length || !window.FileReader) return;
+        if (!files.length || !window.FileReader) {
+          return;
+        }
 
         if (/^image/.test( files[0].type)) {
           var reader = new FileReader();
@@ -58,7 +60,7 @@ define(function(require) {
           reader.onloadend = function() {
             $imgPreview.show();
             $imgPreview.attr("src", this.result);
-          }
+          };
         }
 
       });

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
@@ -9,7 +9,11 @@ define(function(require) {
     var $imageUploads = $context.find(".js-image-upload");
 
     $imageUploads.each(function(i, el) {
-      $(el).hide();
+      // We set the field's visibility to "hidden", rather than
+      // "display: none" to keep some browsers from disabling the
+      // field's "click" action when it is not on the page.
+      $(el).css("visibility", "hidden");
+      $(el).css("position", "absolute");
 
       var $uploadBtn = $("<a href='#' class='btn secondary small'>Upload A Pic</a>")
       $uploadBtn.insertAfter( $(el) );

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
@@ -39,12 +39,17 @@ define(function(require) {
         $uploadBtn.text("Change Pic");
 
         var files = !!this.files ? this.files : [];
-        
+
         // Show file name below field
-        $fileName.text( files[0].name );
+        if( files[0] && files[0].name ) {
+          $fileName.text( files[0].name );
+        } else {
+          var file = $(el).val().replace("C:\\fakepath\\", "");
+          $fileName.text(file);
+        }
 
         // If no file selected/no FileReader support, we're all done
-        if (!files.length || !window.FileReader) return; 
+        if (!files.length || !window.FileReader) return;
 
         if (/^image/.test( files[0].type)) {
           var reader = new FileReader();

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
@@ -1,0 +1,64 @@
+define(function(require) {
+  "use strict";
+
+  var $ = window.jQuery;
+  var Events = require("neue/events");
+
+  var prepareImageUploadUI = function($context) {
+    // Toggle visibility of upload button and hide that guy
+    var $imageUploads = $context.find(".js-image-upload");
+
+    $imageUploads.each(function(i, el) {
+      $(el).hide();
+
+      var $uploadBtn = $("<a href='#' class='btn secondary small'>Upload A Pic</a>")
+      $uploadBtn.insertAfter( $(el) );
+
+      var $imgPreview = $("<img class='preview' src=''>");
+      $imgPreview.insertAfter( $(el) );
+      $imgPreview.hide();
+
+      var $fileName = $("<p class='filename'></p>");
+      $fileName.insertAfter($uploadBtn);
+
+      $uploadBtn.on("click", function(event) {
+        event.preventDefault();
+        $(el).trigger("click");
+      });
+
+      // Show image preview on upload
+      $(el).on("change", function(event) {
+        event.preventDefault();
+        $imgPreview.hide();
+
+        // Change button state
+        $uploadBtn.text("Change Pic");
+
+        var files = !!this.files ? this.files : [];
+        
+        // Show file name below field
+        $fileName.text( files[0].name );
+
+        // If no file selected/no FileReader support, we're all done
+        if (!files.length || !window.FileReader) return; 
+
+        if (/^image/.test( files[0].type)) {
+          var reader = new FileReader();
+          reader.readAsDataURL(files[0]);
+
+          reader.onloadend = function() {
+            $imgPreview.show();
+            $imgPreview.attr("src", this.result);
+          }
+        }
+
+      });
+    });
+  };
+
+  // When we open a modal, we prepare any `.js-image-upload`s that we find there
+  Events.subscribe("Modal:opened", function(topic, args) {
+    prepareImageUploadUI(args);
+  });
+
+});

--- a/lib/themes/dosomething/paraneue_dosomething/js/main.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/main.js
@@ -20,6 +20,7 @@ define("main", function(require) {
   // Initialize modules on load
   require("campaign/sources");
   require("campaign/tips");
+  require("campaign/ImageUploader");
   require("validation/auth");
   require("validation/reportback");
   require("validation/address");

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-reportback.scss
@@ -22,6 +22,22 @@
       }
     }
 
+    .filename {
+      color: #fff;
+      font-size: $font-small;
+      font-weight: $weight-bold;
+    }
+
+    .preview {
+      float: left;
+      width: auto;
+      height: auto;
+      max-width: 100px;
+      max-height: 200px;
+      border: 5px solid #fff;
+      margin: 0.25rem 1rem;
+    }
+
     .submitted-image {
       text-align: center;
 


### PR DESCRIPTION
Makes the image upload field a lot nicer to use.
- Uses properly styled secondary button.
- Shows filename after selecting a file across platforms (previously was OS specific behavior).
- Shows image upload thumbnail on Safari, Chrome, Firefox, IE 10+, iOS 6+.

Typical behavior:
![6272b6be-d0b9-11e3-8400-49b2646c4afe](https://cloud.githubusercontent.com/assets/583202/2853161/76ac78ae-d140-11e3-8e86-a01b7d0c8aec.gif)

Fallback (IE8, IE9):
![screen shot 2014-05-01 at 10 58 52 am](https://cloud.githubusercontent.com/assets/583202/2853193/245b4692-d141-11e3-9b42-b645aa22f7bb.png)

Relies on DoSomething/neue#255. Fixes #1890.
