### PR TITLE
Signup: Response data

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -460,6 +460,11 @@ function dosomething_campaign_node_view($node, $view_mode, $langcode) {
         $signup = signup_load(dosomething_signup_exists($node->nid));
         // Pass to the user signup data form.
         $node->content['signup_data_form'] = drupal_get_form('dosomething_signup_user_signup_data_form', $signup);
+        // If form is set to include a skip button, and user has never submitted:
+        if ($signup_data_info['required_allow_skip'] && !$signup->signup_data_form_timestamp) {
+          // Include the skip form:
+          $node->content['skip_signup_data_form'] = drupal_get_form('dosomething_signup_user_skip_signup_data_form', $signup);
+        }
       }
     }
     if (module_exists('dosomething_reportback')) {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -333,6 +333,9 @@ function dosomething_campaign_preprocess_signup_data_form(&$vars) {
     $vars['signup_data_form_link'] = $vars['content']['signup_data_form_link'];
     $vars['signup_data_form'] = $vars['content']['signup_data_form'];
   }
+  if (isset($vars['content']['skip_signup_data_form'])) {
+    $vars['skip_signup_data_form'] = $vars['content']['skip_signup_data_form'];
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -41,6 +41,11 @@ function dosomething_signup_schema() {
         'type' => 'int',
         'not null' => FALSE,
       ),
+      'signup_data_form_response' => array(
+        'description' => 'The response to signup data form.  If 0, user has skipped.',
+        'type' => 'int',
+        'not null' => FALSE,
+      ),
       'why_signedup' => array(
         'description' => 'Why the user signed up.',
         'type' => 'text',
@@ -226,4 +231,28 @@ function dosomething_signup_update_7004() {
     // Add it per the schema field definition.
     db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
   }
+}
+
+/**
+ * Adds signup_data_form_response column to the dosomething_signup table.
+ * Updates existing signup records for this column where form was submitted.
+ */
+function dosomething_signup_update_7005() {
+  // Load schema for field definitions.
+  $schema = dosomething_signup_schema();
+  $tbl_name = 'dosomething_signup';
+  // New field to add.
+  $field_name = 'signup_data_form_response';
+  // If the field doesn't exist already:
+  if (!db_field_exists($tbl_name, $field_name)) {
+    // Add it per the schema field definition.
+    db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
+  }
+  // Next, update existing signups.
+  $num_updated = db_update('dosomething_signup')
+    ->fields(array(
+      'signup_data_form_response' => 1,
+    ))
+    ->isNotNull('signup_data_form_timestamp')
+    ->execute();
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -64,9 +64,21 @@ function _dosomething_signup_node_signup_data_form(&$form, &$form_state) {
   );
   $form[$fieldset]['config'][$prefix . 'required'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Display after signup'),
+    '#title' => t('Prompt after signup'),
     '#default_value' => $values['required'],
     '#description' => t('If checked, the form modal will be displayed after the user first signs up.'),
+  );
+  $form[$fieldset]['config'][$prefix . 'required_allow_skip'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Allow skip'),
+    '#default_value' => $values['required_allow_skip'],
+    '#description' => t('If checked, the form modal will provide a Skip button when the user is first prompted.'),
+    // Should only be visible if form is required.
+    '#states' => array(
+      'visible' => array(
+        ':input[name="' . $prefix . 'required"]' => array('checked' => TRUE),
+      ),
+    ),
   );
   $form[$fieldset]['config'][$prefix . 'link_text'] = array(
     '#type' => 'textfield',
@@ -165,6 +177,7 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
     ->fields(array(
         'status' => $values[$prefix . 'status'],
         'required' => $values[$prefix . 'required'],
+        'required_allow_skip' => $values[$prefix . 'required_allow_skip'],
         'link_text' => $values[$prefix . 'link_text'],
         'form_header' => $values[$prefix . 'form_header'],
         'form_copy' => $values[$prefix . 'form_copy'],
@@ -267,7 +280,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       '#title' => $config['why_signedup_label'],
     );
   }
-  $form['submit'] = array(
+  $form['actions']['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Submit'),
     '#attributes' => array(
@@ -277,6 +290,20 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       ),
     ),
   );
+  // If form is set to include a skip button, and user has never submitted:
+  if ($config['required_allow_skip'] && !$signup->signup_data_form_timestamp) {
+    // Include a Skip button.
+    $form['actions']['skip'] = array(
+      '#type' => 'submit',
+      '#value' => t('Skip'),
+      '#attributes' => array(
+        'class' => array(
+          'btn',
+          'secondary',
+        ),
+      ),
+    );
+  }
 
   $form['#action'] = "#modal-signup-data-form";
   $form['#after_build'][] = 'dosomething_user_remove_extra_values_from_address_field';

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -396,6 +396,8 @@ function dosomething_signup_update_signup_data($values) {
     // Load the signup entity to update.
     $entity = signup_load($values['sid']);
     $entity->signup_data_form_timestamp = REQUEST_TIME;
+    //@todo: If user submitted "skip", save response value = 0.
+    $entity->signup_data_form_response = 1;
     if (isset($values['why_signedup'])) {
       $entity->why_signedup = $values['why_signedup'];
     }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -276,8 +276,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     // Add it as a form element.
     $form['why_signedup'] = array(
       '#type' => 'textarea',
-      // @todo: This needs to be conditional. Can't be required if you skip.
-      //'#required' => TRUE,
+      '#required' => TRUE,
       '#title' => $config['why_signedup_label'],
     );
   }
@@ -291,22 +290,6 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       ),
     ),
   );
-  // If form is set to include a skip button, and user has never submitted:
-  if ($config['required_allow_skip'] && !$signup->signup_data_form_timestamp) {
-    // Include a Skip button.
-    $form['actions']['skip'] = array(
-      '#type' => 'submit',
-      '#value' => t('Skip'),
-      '#submit' => array('dosomething_signup_user_signup_data_form_skip'),
-      '#attributes' => array(
-        'class' => array(
-          'btn',
-          'secondary',
-        ),
-      ),
-    );
-  }
-
   $form['#action'] = "#modal-signup-data-form";
   $form['#after_build'][] = 'dosomething_user_remove_extra_values_from_address_field';
 
@@ -376,10 +359,35 @@ function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
   drupal_set_message($config['confirm_msg']);
 }
 
+/**
+ * Form constructor for a user signup data form.
+ *
+ * @param int $nid
+ *   The node which the signup data form is rendered on.
+ */
+function dosomething_signup_user_skip_signup_data_form($form, &$form_state, $signup) {
+  $form['sid'] = array(
+    '#type' => 'hidden',
+    '#value' => $signup->sid,
+    '#access' => FALSE,
+  );
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Skip'),
+    '#attributes' => array(
+      'class' => array(
+        'btn',
+        'secondary',
+      ),
+    ),
+  );
+  return $form;
+}
+
 /*
  * Custom submit for the skip button in dosomething_signup_user_signup_data_form().
  */
-function dosomething_signup_user_signup_data_form_skip($form, &$form_state) {
+function dosomething_signup_user_skip_signup_data_form_submit($form, &$form_state) {
   // Update signup record with response = 0.
   dosomething_signup_update_signup_data($form_state['values'], 0);
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -276,7 +276,8 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     // Add it as a form element.
     $form['why_signedup'] = array(
       '#type' => 'textarea',
-      '#required' => TRUE,
+      // @todo: This needs to be conditional. Can't be required if you skip.
+      //'#required' => TRUE,
       '#title' => $config['why_signedup_label'],
     );
   }
@@ -296,6 +297,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     $form['actions']['skip'] = array(
       '#type' => 'submit',
       '#value' => t('Skip'),
+      '#submit' => array('dosomething_signup_user_signup_data_form_skip'),
       '#attributes' => array(
         'class' => array(
           'btn',
@@ -374,6 +376,14 @@ function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
   drupal_set_message($config['confirm_msg']);
 }
 
+/*
+ * Custom submit for the skip button in dosomething_signup_user_signup_data_form().
+ */
+function dosomething_signup_user_signup_data_form_skip($form, &$form_state) {
+  // Update signup record with response = 0.
+  dosomething_signup_update_signup_data($form_state['values'], 0);
+}
+
 /**
  * Saves signup_form_data to fields on the user.
  *
@@ -417,16 +427,20 @@ function dosomething_signup_update_user_data($values) {
  *
  * @param array $values
  *   The values passed from a user signup_data_form submission.
+ * @param int $response
+ *   If 0, the user chose to skip the form. Else, should be 1.
  */
-function dosomething_signup_update_signup_data($values) {
+function dosomething_signup_update_signup_data($values, $response = 1) {
   try {
     // Load the signup entity to update.
     $entity = signup_load($values['sid']);
     $entity->signup_data_form_timestamp = REQUEST_TIME;
-    //@todo: If user submitted "skip", save response value = 0.
-    $entity->signup_data_form_response = 1;
-    if (isset($values['why_signedup'])) {
-      $entity->why_signedup = $values['why_signedup'];
+    $entity->signup_data_form_response = $response;
+    // If non-skip, store any additional signup data:
+    if ($response) {
+      if (isset($values['why_signedup'])) {
+        $entity->why_signedup = $values['why_signedup'];
+      } 
     }
     $entity->save();
     return TRUE;

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -193,8 +193,8 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
 /**
  * Form constructor for a user signup data form.
  *
- * @param int $nid
- *   The node which the signup data form is rendered on.
+ * @param object $signup
+ *   The signup entity to save additional data to.
  */
 function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) {
   // Load signup data form config to determine what form elements we need.
@@ -280,7 +280,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       '#title' => $config['why_signedup_label'],
     );
   }
-  $form['actions']['submit'] = array(
+  $form['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Submit'),
     '#attributes' => array(
@@ -296,6 +296,9 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
   return $form;
 }
 
+/**
+ * Validation callback for address field in dosomething_signup_user_signup_data_form().
+ */
 function dosomething_signup_data_validate_address($form, &$form_state) {
   // Validate address against UPS api.
   $address = $form_state['input']['user_address'];
@@ -360,10 +363,10 @@ function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
 }
 
 /**
- * Form constructor for a user signup data form.
+ * Form constructor for a user skip signup data form.
  *
- * @param int $nid
- *   The node which the signup data form is rendered on.
+ * @param object $signup
+ *   The signup entity to save additional data to.
  */
 function dosomething_signup_user_skip_signup_data_form($form, &$form_state, $signup) {
   $form['sid'] = array(
@@ -385,7 +388,7 @@ function dosomething_signup_user_skip_signup_data_form($form, &$form_state, $sig
 }
 
 /*
- * Custom submit for the skip button in dosomething_signup_user_signup_data_form().
+ * Form submit handler for dosomething_signup_user_skip_signup_data_form().
  */
 function dosomething_signup_user_skip_signup_data_form_submit($form, &$form_state) {
   // Update signup record with response = 0.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -215,7 +215,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     '#suffix' => '</h2>',
   );
   // If the user has submitted form already:
-  if ($timestamp = $signup->signup_data_form_timestamp && $signup->response) {
+  if ($timestamp = $signup->signup_data_form_timestamp && $signup->signup_data_form_response == 1) {
     // Get filtered form_submitted_copy.
     $copy = dosomething_signup_filter_form_submitted_copy($config['form_submitted_copy'], $timestamp);
     // Display the form submitted copy:
@@ -380,7 +380,7 @@ function dosomething_signup_user_skip_signup_data_form($form, &$form_state, $sig
     '#attributes' => array(
       'class' => array(
         'btn',
-        'secondary',
+        'tertiary',
       ),
     ),
   );

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -215,7 +215,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     '#suffix' => '</h2>',
   );
   // If the user has submitted form already:
-  if ($timestamp = $signup->signup_data_form_timestamp) {
+  if ($timestamp = $signup->signup_data_form_timestamp && $signup->response) {
     // Get filtered form_submitted_copy.
     $copy = dosomething_signup_filter_form_submitted_copy($config['form_submitted_copy'], $timestamp);
     // Display the form submitted copy:

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -232,6 +232,9 @@
         <div class="js-messages-clone"></div>
         <a href="#" class="js-close-modal modal-close-button white">×</a>
           <div><?php print render($signup_data_form); ?></div>
+          <?php if (isset($skip_signup_data_form)): ?>
+          <div><?php print render($skip_signup_data_form); ?></div>
+          <?php endif; ?>
         <a href="#" class="js-close-modal">Back to main page</a>
       </script>
       <?php endif; ?>


### PR DESCRIPTION
Fixes #1924
Fixes #1920

Allows configuration of a signup data form to allow a user to hit a "Skip" button.  This response is stored in the `signup_data_form_response` column, so that we don't prompt a user to "Skip" again when they view the form in the modal.  It's a one time jam. 
