### PR TITLE
Prompt signup data form

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -498,7 +498,7 @@ function dosomething_campaign_add_signup_data_form_vars(&$node) {
     // If the user has not submitted the signup_data_form:
     if (!$signup->signup_data_form_timestamp) {
       // Store flag to prompt user.
-      $node->prompt_for_signup_data_form = 1;
+      $node->content['required_signup_data_form'] = 1;
       // If form is configured to include a skip button:
       if ($config['required_allow_skip']) {
         // Include the skip form:

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -451,22 +451,9 @@ function dosomething_campaign_theme($existing, $type, $theme, $path) {
  */
 function dosomething_campaign_node_view($node, $view_mode, $langcode) {
   if ($node->type == 'campaign' && $view_mode == 'full') {
-    // Check if node has a signup data form.
-    if ($signup_data_info = dosomething_signup_get_signup_data_form_info($node->nid)) {
-      // Only include signup data form if the status field is checked.
-      if ($signup_data_info['status'] == 1) {
-        $node->content['signup_data_form_link'] = $signup_data_info['link_text'];
-        // Load the signup entity.
-        $signup = signup_load(dosomething_signup_exists($node->nid));
-        // Pass to the user signup data form.
-        $node->content['signup_data_form'] = drupal_get_form('dosomething_signup_user_signup_data_form', $signup);
-        // If form is set to include a skip button, and user has never submitted:
-        if ($signup_data_info['required_allow_skip'] && !$signup->signup_data_form_timestamp) {
-          // Include the skip form:
-          $node->content['skip_signup_data_form'] = drupal_get_form('dosomething_signup_user_skip_signup_data_form', $signup);
-        }
-      }
-    }
+    // Add signup_data_form variables if needed.
+    dosomething_campaign_add_signup_data_form_vars($node);
+    // Add reportback form variable:
     if (module_exists('dosomething_reportback')) {
       if ($rbid = dosomething_reportback_exists($node->nid)) {
         $reportback = reportback_load($rbid);
@@ -482,8 +469,41 @@ function dosomething_campaign_node_view($node, $view_mode, $langcode) {
       // Set Reportback Form variable in node content for rendering in theme layer.
       $node->content['reportback_form'] = drupal_get_form('dosomething_reportback_form', $reportback);
     }
+    // Add Zendesk form variable:
     if (module_exists('dosomething_zendesk')) {
       $node->content['zendesk_form'] = drupal_get_form('dosomething_zendesk_form', $node);
+    }
+  }
+}
+
+/**
+ * Adds relevant signup_data_form variables into the $node.
+ */
+function dosomething_campaign_add_signup_data_form_vars(&$node) {
+  // Load signup_data_form configuration data.
+  $config = dosomething_signup_get_signup_data_form_info($node->nid);
+  // If it doesn't exist, or is not active:
+  if (!$config || $config['status'] != 1) {
+    // Exit out of function.
+    return;
+  }
+  // Store the label for the modal link.
+  $node->content['signup_data_form_link'] = $config['link_text'];
+  // Load the signup entity.
+  $signup = signup_load(dosomething_signup_exists($node->nid));
+  // Pass to the user signup data form.
+  $node->content['signup_data_form'] = drupal_get_form('dosomething_signup_user_signup_data_form', $signup);
+  // If the signup_data_form needs to be prompted upon first signup:
+  if ($config['required']) {
+    // If the user has not submitted the signup_data_form:
+    if (!$signup->signup_data_form_timestamp) {
+      // Store flag to prompt user.
+      $node->prompt_for_signup_data_form = 1;
+      // If form is configured to include a skip button:
+      if ($config['required_allow_skip']) {
+        // Include the skip form:
+        $node->content['skip_signup_data_form'] = drupal_get_form('dosomething_signup_user_skip_signup_data_form', $signup);
+      }
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -498,7 +498,7 @@ function dosomething_campaign_add_signup_data_form_vars(&$node) {
     // If the user has not submitted the signup_data_form:
     if (!$signup->signup_data_form_timestamp) {
       // Store flag to prompt user.
-      $node->content['required_signup_data_form'] = 1;
+      $node->required_signup_data_form = 1;
       // If form is configured to include a skip button:
       if ($config['required_allow_skip']) {
         // Include the skip form:

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -482,28 +482,36 @@ function dosomething_campaign_node_view($node, $view_mode, $langcode) {
 function dosomething_campaign_add_signup_data_form_vars(&$node) {
   // Load signup_data_form configuration data.
   $config = dosomething_signup_get_signup_data_form_info($node->nid);
-  // If it doesn't exist, or is not active:
+  // If it doesn't exist, or is not active.
   if (!$config || $config['status'] != 1) {
-    // Exit out of function.
+    // Nothing to see here.
     return;
   }
-  // Store the label for the modal link.
+
+  // Store the label for the link to the modal.
   $node->content['signup_data_form_link'] = $config['link_text'];
+  // Load signup sid.
+  $sid = dosomething_signup_exists($node->nid);
+  // If no signup exists:
+  if (!$sid) {
+    // Staff is viewing a campaign which they haven't signed up for.
+    $node->content['signup_data_form'] = array(
+      '#markup' => "You haven't signed up for this campaign!",
+    );
+    return;
+  }
   // Load the signup entity.
-  $signup = signup_load(dosomething_signup_exists($node->nid));
+  $signup = signup_load($sid);
   // Pass to the user signup data form.
   $node->content['signup_data_form'] = drupal_get_form('dosomething_signup_user_signup_data_form', $signup);
-  // If the signup_data_form needs to be prompted upon first signup:
-  if ($config['required']) {
-    // If the user has not submitted the signup_data_form:
-    if (!$signup->signup_data_form_timestamp) {
-      // Store flag to prompt user.
-      $node->required_signup_data_form = 1;
-      // If form is configured to include a skip button:
-      if ($config['required_allow_skip']) {
-        // Include the skip form:
-        $node->content['skip_signup_data_form'] = drupal_get_form('dosomething_signup_user_skip_signup_data_form', $signup);
-      }
+  // If the signup_data_form is required and user has not submitted form yet:
+  if ($config['required'] && !$signup->signup_data_form_timestamp) {
+    // Store flag to indicate we need to prompt user (handled in theme).
+    $node->required_signup_data_form = 1;
+    // If form is configured to include a skip button:
+    if ($config['required_allow_skip']) {
+      // Include the skip form:
+      $node->content['skip_signup_data_form'] = drupal_get_form('dosomething_signup_user_skip_signup_data_form', $signup);
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -333,7 +333,9 @@ function dosomething_campaign_preprocess_signup_data_form(&$vars) {
     $vars['signup_data_form_link'] = $vars['content']['signup_data_form_link'];
     $vars['signup_data_form'] = $vars['content']['signup_data_form'];
   }
+  // If the skip form is present:
   if (isset($vars['content']['skip_signup_data_form'])) {
+    // Store as a variable.
     $vars['skip_signup_data_form'] = $vars['content']['skip_signup_data_form'];
   }
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -334,13 +334,6 @@ function dosomething_campaign_preprocess_signup_data_form(&$vars) {
     $vars['signup_data_form_link'] = $vars['content']['signup_data_form_link'];
     $vars['signup_data_form'] = $vars['content']['signup_data_form'];
   }
-  // If the signup data form is required to submit:
-  if (isset($vars['content']['required_signup_data_form'])) {
-    // Add JS to open the signup data form modal.
-    $id = 'modal-signup-data-form';
-    $js = '$(function() {window.NEUE.Modal.open( $("#' . $id . '", false) ); });';
-    drupal_add_js($js, 'inline');
-  }
   // If the skip form is present:
   if (isset($vars['content']['skip_signup_data_form'])) {
     // Store as a variable.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -329,9 +329,17 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
  * Preprocesses variables for the link to a signup data form.
  */
 function dosomething_campaign_preprocess_signup_data_form(&$vars) {
+  // If the signup data form link is present:
   if (isset($vars['content']['signup_data_form_link'])) {
     $vars['signup_data_form_link'] = $vars['content']['signup_data_form_link'];
     $vars['signup_data_form'] = $vars['content']['signup_data_form'];
+  }
+  // If the signup data form is required to submit:
+  if (isset($vars['content']['required_signup_data_form'])) {
+    // Add JS to open the signup data form modal.
+    $id = 'modal-signup-data-form';
+    $js = '$(function() {window.NEUE.Modal.open( $("#' . $id . '", false) ); });';
+    drupal_add_js($js, 'inline');
   }
   // If the skip form is present:
   if (isset($vars['content']['skip_signup_data_form'])) {

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -26,7 +26,16 @@ function paraneue_dosomething_preprocess_page(&$vars) {
  * Implements theme_preprocess_node().
  */
 function paraneue_dosomething_preprocess_node(&$variables) {
-  if($variables['node']->type == "home") {
+  if ($variables['node']->type == "campaign") {
+    // If the campaign requires a signup modal to display:
+    if (isset($variables['node']->required_signup_data_form)) {
+      // Add JS to open the signup data form modal.
+      $id = 'modal-signup-data-form';
+      $js = 'require(["neue/modal"], function(Modal) { Modal.open( $("#[' . $id . ']"), false); });';
+      drupal_add_js($js, 'inline');
+    }
+  }
+  elseif ($variables['node']->type == "home") {
     $homepage_nids = array(362, 843, 955, 832, 15, 31, 55, 850, 18);
     $thumbnails = array();
 


### PR DESCRIPTION
Refs #1913

Abstracts all variable logic for the signup_data_form into a new function, `dosomething_campaign_add_signup_data_form_vars($node)`.

Stores a flag `$node-> required_signup_data_form` which indicates the signup data form should be displayed when a user is viewing an action page.  Adds inline JS into the theme if this flag is set.

@DFurnes Tried the second code snippet but still no luck.  This PR sets up all the variables in order to know when to prompt the user, will pass #1913 over to you to actually get the JS working to automatically open the modal.
