### PR TITLE
dosomething_signup_create

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -82,8 +82,7 @@ function dosomething_signup_permission() {
  * Menu autoloader for /signup.
  */
 function signup_load($id) {
-  $entity = entity_load('signup', array($id));
-  return array_pop($entity);
+  return entity_load_single('signup', $id);
 }
 
 /**
@@ -119,22 +118,19 @@ function dosomething_signup_admin_paths() {
  * @return mixed
  *   The sid of the newly inserted signup, or FALSE if error.
  */
-function dosomething_signup_insert($nid, $uid = NULL, $data = NULL, $timestamp = NULL) {
-  if ($uid == NULL) {
-    global $user;
-    $uid = $user->uid;
-  }
+function dosomething_signup_create($nid, $uid = NULL, $data = NULL, $timestamp = NULL) {
+  $values = array(
+    'nid' => $nid,
+    'uid' => $uid,
+    'data'=> $data,
+    'timestamp' => $timestamp,
+  );
   try {
-    $sid = db_insert('dosomething_signup')
-        ->fields(array(
-          'uid' => $uid,
-          'nid' => $nid,
-          'data' => $data,
-          'timestamp' => isset($timestamp) ? $timestamp : REQUEST_TIME,
-        )
-      )
-      ->execute();
-    return $sid;
+    // Create a signup entity.
+    $entity = entity_create('signup', $values);
+    // The SignupEntityController save method handles any NULL values.
+    $entity->save();
+    return $entity->sid;
   }
   catch (Exception $e) {
     // Keep message general in case a user ever sees it.
@@ -341,7 +337,7 @@ function dosomething_signup_user_signup($nid, $account = NULL) {
   if (dosomething_signup_exists($nid, $account->uid)) { return; }
 
   // Insert signup.
-  if ($sid = dosomething_signup_insert($nid, $account->uid)) {
+  if ($sid = dosomething_signup_create($nid, $account->uid)) {
     $node = node_load($nid);
 
     // Is there an override set on this campaign?

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -150,16 +150,12 @@ function dosomething_signup_create($nid, $uid = NULL, $data = NULL, $timestamp =
  *   Optional - the user uid of signup record to be deleted.
  *   If not given, uses global $user->uid.
  */
-function dosomething_signup_delete($nid, $uid = NULL) {
-  if ($uid == NULL) {
-    global $user;
-    $uid = $user->uid;
-  }
+function dosomething_signup_delete_signup($nid, $uid = NULL) {
+  $sid = dosomething_signup_exists($nid, $uid);
   try {
-    db_delete('dosomething_signup')
-      ->condition('uid', $uid)
-      ->condition('nid', $nid)
-      ->execute();
+    if ($sid) {
+      entity_delete('signup', $sid);
+    }
     return TRUE;
   }
   catch (Exception $e) {
@@ -505,7 +501,7 @@ function dosomething_signup_node_unsignup_form($form, &$form_state, $node) {
  */
 function dosomething_signup_node_unsignup_form_submit($form, &$form_state) {
   $nid = $form_state['values']['nid'];
-  if (dosomething_signup_delete($nid)) {
+  if (dosomething_signup_delete_signup($nid)) {
     drupal_set_message("Signup removed.");
     $form_state['redirect'] = 'node/' . $nid;
     return;

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.test
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.test
@@ -102,7 +102,7 @@ class DoSomethingSignupWebTestCase extends DrupalWebTestCase {
   }
 
   /**
-   * Test for dosomething_signup_delete().
+   * Test for dosomething_signup_delete_signup().
    */
   public function testDelete() {
     // Delete all signups to test clean.
@@ -114,7 +114,7 @@ class DoSomethingSignupWebTestCase extends DrupalWebTestCase {
     $sid2 = $this->insertSignup($this->nid, $this->uid + 1);
     $this->assertTrue(is_numeric($sid2), "Signup record 2 inserted.");
     // Delete signup record 1.
-    dosomething_signup_delete($this->nid, $this->uid);
+    dosomething_signup_delete_signup($this->nid, $this->uid);
     // Query for signup record we just deleted.
     $sid = $this->querySignup($this->nid, $this->uid);
     $this->assertIdentical($sid, FALSE, "Signup record 1 deleted.");
@@ -127,7 +127,7 @@ class DoSomethingSignupWebTestCase extends DrupalWebTestCase {
     $sid3 = $this->insertSignup($this->nid, $user->uid);
     $this->assertTrue(is_numeric($sid3), "Signup record for global user inserted.");
     // Excluding 2nd param should delete record for global $user->uid.
-    dosomething_signup_delete($this->nid);
+    dosomething_signup_delete_signup($this->nid);
     // Query for global $user->uid's signup record.
     $sid = $this->querySignup($this->nid, $user->uid);
     // Test that has been deleted.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.test
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.test
@@ -80,22 +80,22 @@ class DoSomethingSignupWebTestCase extends DrupalWebTestCase {
   }
 
   /**
-   * Test for dosomething_signup_insert().
+   * Test for dosomething_signup_create().
    */
   public function testInsert() {
     $uid = $this->uid;
     $nid = $this->nid;
-    $sid = dosomething_signup_insert($nid, $uid);
+    $sid = dosomething_signup_create($nid, $uid);
     // Test that numeric sid has been returned.
     $this->assertTrue(is_numeric($sid), "A numeric sid was returned on insert.");
     // Test that the record actually exists in the database.
     $query_sid = $this->querySignup($nid, $uid);
     $this->assertIdentical($query_sid, $sid, "Record exists in db.");
     // Test that can't insert a duplicate uid/nid record.
-    $sid = dosomething_signup_insert($nid, $uid);
+    $sid = dosomething_signup_create($nid, $uid);
     $this->assertIdentical($sid, FALSE, "FALSE was returned on duplicate nid/uid insert.");
     // Test that global $user uid is inserted when no 2nd param.
-    $sid = dosomething_signup_insert($nid);
+    $sid = dosomething_signup_create($nid);
     global $user;
     $query_sid = $this->querySignup($nid, $user->uid);
     $this->assertIdentical($query_sid, $sid, "Record inserted for global user uid.");

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.inc
@@ -57,4 +57,22 @@ class SignupEntityController extends EntityAPIController {
     }
     return $build;
   }
+
+  /**
+   * Overrides save() method.
+   *
+   * Populates timestamp and uid automatically.
+   */
+  public function save($entity, DatabaseTransaction $transaction = NULL) {
+    if (isset($entity->is_new)) {
+      if (!isset($entity->timestamp)) {
+        $entity->timestamp = REQUEST_TIME;
+      }
+      if (!isset($entity->uid)) {
+        global $user;
+        $entity->uid = $user->uid;
+      }
+    }
+    parent::save($entity, $transaction);
+  }
 }

--- a/scripts/import-signups.php
+++ b/scripts/import-signups.php
@@ -34,6 +34,6 @@ foreach ($result as $signup) {
   else if ($signup->nid = PBJ_OLD) {
     $nid = PBJ;
   }
-  dosomething_signup_insert($nid, $signup->uid, $signup->data, $signup->timestamp);
+  dosomething_signup_create($nid, $signup->uid, $signup->data, $signup->timestamp);
   }
 


### PR DESCRIPTION
Refs #1811

Uses `entity_save` instead of a `db_insert` to tap into Entity goodness later.

There was a namespace collision with the function name `dosomething_signup_insert`, where it was calling a `hook_insert` and inserting a signup with nid =1, so the function name has been globally changed to `dosomething_signup_create`.
