### PR TITLE
Campaign Group: Child signups

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -602,6 +602,7 @@ function dosomething_campaign_get_recommended_campaign_nids($tid = NULL, $uid = 
 
 /**
  * Returns all staff pick campaigns.
+ *
  * @return array
  *  Array of nids and titles of all published/unpublished staff picks.
  */

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
@@ -6,6 +6,7 @@
 
 include_once 'dosomething_campaign_group.features.inc';
 
+
 function dosomething_campaign_group_preprocess_node(&$vars) {
   if ($vars['type'] == 'campaign_group') {
     $content = $vars['content'];
@@ -63,4 +64,17 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
     // Preprocess gallery variables.
     dosomething_static_content_preprocess_gallery_vars($vars);
   }
+}
+
+/**
+ * Returns a Campaign Group parent nid for a given node $nid.
+ *
+ */
+function dosomething_campaign_group_get_parent_nid($nid) {
+  $result = db_select('field_data_field_campaigns', 'c')
+    ->condition('field_campaigns_target_id', $nid)
+    ->condition('deleted', 0)
+    ->fields('c', array('entity_id'))
+    ->execute();
+  return $result->fetchField(0);
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -159,3 +159,26 @@ function dosomething_helpers_get_field_collection_values($wrapper, $field_name) 
   }
   return NULL;
 }
+
+/*
+ * Returns array of nid and titles of all nodes with given $type.
+ *
+ * @return array
+ *  Array of nids and titles of all campaign group nodes.
+ */
+function dosomething_helpers_get_node_vars($type) {
+  $query = db_select('node', 'n')
+    ->fields('n', array('nid', 'title'))
+    ->condition('type', $type);
+  $results = $query->execute();
+
+  foreach($results as $key => $result) {
+    $vars[$key]['nid'] = $result->nid;
+    $vars[$key]['title'] = $result->title;
+  }
+  if ($vars) {
+    return $vars;
+  }
+  return NULL;
+}
+

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -8,7 +8,7 @@
 /**
  * Settings form third party opt-in ids.
  */
-function dosomething_signup_optin_config($form, &$form_state) {
+function dosomething_signup_optin_config_form($form, &$form_state) {
   $form = array();
 
   // Main campaign/ds general ids.
@@ -23,47 +23,67 @@ function dosomething_signup_optin_config($form, &$form_state) {
     '#title' => t('Mobile Commons Campaigns Opt-In'),
     '#default_value' => variable_get('dosomething_mobilecommons_campaign_general'),
   );
-
+  $form['staff_picks'] = array(
+    '#prefix' => '<h3>',
+    '#markup' => 'Staff Picks',
+    '#suffix' => '</h3>',
+  );
   // Each staff pick could have a special opt-in for third party communications.
   $staff_picks = dosomething_campaign_get_staff_picks();
   if ($staff_picks) {
-    foreach ($staff_picks as $staff_pick) {
-      $nid = $staff_pick['nid'];
-      $title = $staff_pick['title'];
-      $prefix = 'dosomething_signup_nid_' . $nid;
-      $mailchimp_grouping_id = $prefix . '_mailchimp_grouping_id';
-      $mailchimp_group_name = $prefix . '_mailchimp_group_name';
-      $mobilecommons_id = $prefix . '_mobilecommons_id';
-
-      // Create a fieldset for each campaign.
-      $form[$nid] = array(
-        '#type' => 'fieldset',
-        '#title' => $title . ' : NID ' . $nid,
-        '#collapsible' => TRUE,
-        '#collapsed' => TRUE,
-      );
-
-      // Each campaign gets a mailchimp grouping_id/group_name & mobilecommons id.
-      $form[$nid][$mailchimp_grouping_id] = array(
-        '#type' => 'textfield',
-        '#title' => t('MailChimp Grouping ID'),
-        '#default_value' => variable_get($mailchimp_grouping_id),
-        '#description' => t('The numeric Grouping ID that the Group Name belongs to.'),
-      );
-      $form[$nid][$mailchimp_group_name] = array(
-        '#type' => 'textfield',
-        '#title' => t('MailChimp Group Name'),
-        '#default_value' => variable_get($mailchimp_group_name),
-        '#description' => t('The alphanumeric Interest Group name.'),
-      );
-      $form[$nid][$mobilecommons_id] = array(
-        '#type' => 'textfield',
-        '#title' => t('Mobile Commons Opt-In Path'),
-        '#default_value' => variable_get($mobilecommons_id),
-        '#description' => t("The numeric Mobilecommons opt-in path."),
-      );
+    foreach ($staff_picks as $vars) {
+      dosomething_signup_optin_config_form_add_elements($form, $vars);
     }
   }
-
+  $form['campaign_groups'] = array(
+    '#prefix' => '<h3>',
+    '#markup' => 'Campaign Groups',
+    '#suffix' => '</h3>',
+  );
+  if ($campaign_groups = dosomething_helpers_get_node_vars('campaign_group')) {
+    foreach ($campaign_groups as $vars) {
+      dosomething_signup_optin_config_form_add_elements($form, $vars);
+    }
+  }
   return system_settings_form($form);
+}
+
+/**
+ * Adds form elements to store third party values for given set of $vars.
+ */
+function dosomething_signup_optin_config_form_add_elements(&$form, $vars) {
+  $nid = $vars['nid'];
+  $title = $vars['title'];
+  $prefix = 'dosomething_signup_nid_' . $nid;
+  $mailchimp_grouping_id = $prefix . '_mailchimp_grouping_id';
+  $mailchimp_group_name = $prefix . '_mailchimp_group_name';
+  $mobilecommons_id = $prefix . '_mobilecommons_id';
+
+  // Create a fieldset for each campaign.
+  $form[$nid] = array(
+    '#type' => 'fieldset',
+    '#title' => $title . ' : NID ' . $nid,
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+
+  // Each campaign gets a mailchimp grouping_id/group_name & mobilecommons id.
+  $form[$nid][$mailchimp_grouping_id] = array(
+    '#type' => 'textfield',
+    '#title' => t('MailChimp Grouping ID'),
+    '#default_value' => variable_get($mailchimp_grouping_id),
+    '#description' => t('The numeric Grouping ID that the Group Name belongs to.'),
+  );
+  $form[$nid][$mailchimp_group_name] = array(
+    '#type' => 'textfield',
+    '#title' => t('MailChimp Group Name'),
+    '#default_value' => variable_get($mailchimp_group_name),
+    '#description' => t('The alphanumeric Interest Group name.'),
+  );
+  $form[$nid][$mobilecommons_id] = array(
+    '#type' => 'textfield',
+    '#title' => t('Mobile Commons Opt-In Path'),
+    '#default_value' => variable_get($mobilecommons_id),
+    '#description' => t("The numeric Mobilecommons opt-in path."),
+  );
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -458,18 +458,21 @@ function dosomething_signup_set_signup_message($title = NULL) {
 }
 
 /**
- * Returns array of nid's that a user has signed up for.
+ * Returns array of campaign nid's that a user has signed up for.
  *
  * @param int $uid
- *   The user uid of signup record to check.
+ *   The user uid to return signups for.
  *
  * @return array
  *   Array of node nid's.
  */
 function dosomething_signup_get_signup_nids_by_uid($uid) {
   $query = db_select('dosomething_signup', 's');
+  $query->join('node', 'n', 'n.nid = s.nid');
   $query->fields('s', array('nid'));
-  $query->condition('uid', $uid);
+  $query->condition('s.uid', $uid);
+  // Only return signups for campaign nodes.
+  $query->condition('n.type', 'campaign');
   $query->orderBy('timestamp', 'DESC');
   $result = $query->execute();
   return array_keys($result->fetchAllAssoc('nid'));

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -119,6 +119,9 @@ function dosomething_signup_admin_paths() {
  *   The sid of the newly inserted signup, or FALSE if error.
  */
 function dosomething_signup_create($nid, $uid = NULL, $data = NULL, $timestamp = NULL) {
+  // If a signup already exists, exit.
+  if (dosomething_signup_exists($nid, $uid)) { return FALSE; }
+
   $values = array(
     'nid' => $nid,
     'uid' => $uid,
@@ -347,8 +350,6 @@ function dosomething_signup_user_signup($nid, $account = NULL) {
     global $user;
     $account = $user;
   }
-  // If a signup already exists, exit.
-  if (dosomething_signup_exists($nid, $account->uid)) { return; }
 
   // Insert signup.
   if ($sid = dosomething_signup_create($nid, $account->uid)) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -18,7 +18,7 @@ function dosomething_signup_menu() {
     'title' => t('Third Party Opt-Ins'),
     'description' => 'Admin form to manage custom opt-ins',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('dosomething_signup_optin_config'),
+    'page arguments' => array('dosomething_signup_optin_config_form'),
     'access callback' => 'user_access',
     'access arguments' => array('administer third party communication'),
     'file' => 'dosomething_signup.admin.inc'

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -316,6 +316,24 @@ function dosomething_signup_views_data() {
 }
 
 /**
+ * Implements hook_entity_insert().
+ */
+function dosomething_signup_entity_insert($entity, $type) {
+  // If not a signup, exit out of function.
+  if ($type != 'signup') { return; }
+
+  // Check if inserted signup nid belongs to a Campaign Group.
+  if (module_exists('dosomething_campaign_group')) {
+    $group_nid = dosomething_campaign_group_get_parent_nid($entity->nid);
+    // If a campaign group exists:
+    if ($group_nid) {
+      // Create a signup for the group nid.
+      dosomething_signup_create($group_nid);
+    }
+  }
+}
+
+/**
  * Signup a user $uid for a given node $nid.
  *
  * @param int $nid

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -324,6 +324,11 @@ function dosomething_signup_views_data() {
 function dosomething_signup_entity_insert($entity, $type) {
   // If not a signup, exit out of function.
   if ($type != 'signup') { return; }
+  
+  $account = user_load($entity->uid);
+  $node = node_load($entity->nid);
+  // Send relevant third-party subscribe requests.
+  dosomething_signup_third_party_subscribe($account, $node);
 
   // Check if inserted signup nid belongs to a Campaign Group.
   if (module_exists('dosomething_campaign_group')) {
@@ -337,7 +342,24 @@ function dosomething_signup_entity_insert($entity, $type) {
 }
 
 /**
- * Signup a user $uid for a given node $nid.
+ * Sends third-party subscription requests for given $account and $node.
+ */
+function dosomething_signup_third_party_subscribe($account, $node) {
+  // Is there an override set on this campaign?
+  $opt_in_override = variable_get('dosomething_signup_nid_' . $node->nid . '_mobilecommons_id');
+  $opt_in_general = variable_get('dosomething_mobilecommons_campaign_general');
+  // Opt-in to mobilecommons.
+  $opt_in = isset($opt_in_override) ? $opt_in_override : $opt_in_general;
+  dosomething_signup_mobilecommons_opt_in($account, $opt_in, $node->title);
+  // Send message broker request.
+  dosomething_signup_mbp_request($account, $node);
+}
+
+/**
+ * Signup a user $uid for a given node $nid and display a confirmation message.
+ *
+ * This is most likely being within a form submit handler, hence displaying the
+ * confirmation message.
  *
  * @param int $nid
  *   The node nid the user is signing up for.
@@ -354,17 +376,8 @@ function dosomething_signup_user_signup($nid, $account = NULL) {
   // Insert signup.
   if ($sid = dosomething_signup_create($nid, $account->uid)) {
     $node = node_load($nid);
-
-    // Is there an override set on this campaign?
-    $opt_in_override = variable_get('dosomething_signup_nid_' . $node->nid . '_mobilecommons_id');
-    $opt_in_general = variable_get('dosomething_mobilecommons_campaign_general');
-
-    // Opt-in to mobilecommons.
-    $opt_in = isset($opt_in_override) ? $opt_in_override : $opt_in_general;
-    dosomething_signup_mobilecommons_opt_in($account, $opt_in, $node->title);
-    // Send external message request
-    dosomething_signup_mbp_request($account, $node);
     // Set success message.
+    // @todo: Will need to drupal_set_message the campaign group's confirm msg.
     dosomething_signup_set_signup_message($node->title);
   }
 }
@@ -382,6 +395,8 @@ function dosomething_signup_mbp_request($account, $node) {
   $params = dosomething_signup_get_mbp_params($account, $node);
   // Send MBP request.
   if (module_exists('dosomething_mbp')) {
+    // @todo: Check $node->type for campaign or campaign_group and send 
+    // the relevant call to mbp_request.
     dosomething_mbp_request('campaign_signup', $params);
   }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -395,9 +395,9 @@ function dosomething_signup_mbp_request($account, $node) {
   $params = dosomething_signup_get_mbp_params($account, $node);
   // Send MBP request.
   if (module_exists('dosomething_mbp')) {
-    // @todo: Check $node->type for campaign or campaign_group and send 
-    // the relevant call to mbp_request.
-    dosomething_mbp_request('campaign_signup', $params);
+    if ($node->type == 'campaign') {
+      dosomething_mbp_request('campaign_signup', $params);
+    }
   }
 }
 


### PR DESCRIPTION
Adds third-party variables for Campaign Groups on `admin/config/services/optins` form.

Checks to see if the signup NID belongs to a campaign_group.  If so, creates a signup for the campaign_group NID as well.

Closes #1811 by implementing `hook_entity_insert`.  Adds third party subscribe code here, upon a signup entity creation (allowing for the triggered parent signup to subscribe to 3rd party vars)

Fixes #1932 -- adds 3rd party variables into the Signup admin form to configure for Campaign Groups
