### PR TITLE
Campaign Group: Signup form

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -280,18 +280,6 @@ function dosomething_campaign_preprocess_signup_data_form(&$vars) {
  *   The corresponding entity wrapper for the node in $vars.
  */
 function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
-  // Define label for signup button.
-  $label = t("Sign Up");
-  // If user is logged in:
-  if (user_is_logged_in()) {
-    // Render button as sign up form.
-    $vars['signup_button'] = drupal_get_form('dosomething_signup_form', $vars['nid'], $label);
-  }
-  // Otherwise, for anonymous user:
-  else {
-    // Render button as link to open up the login modal.
-    $vars['signup_button'] = array(
-      '#markup' => '<a href="#modal--login" class="js-modal-link btn medium">' . $label . '</a>',
-    );
-  }
+  // Adds a signup_button variable.
+  dosomething_signup_preprocess_signup_button($vars);
 }

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
@@ -66,8 +66,12 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
 
     $vars['display_signup_form'] = $vars['field_display_signup_form'][0]['value'];
     if ($vars['display_signup_form']) {
-      //@todo: Add CTA Button label as 2nd param.
-      dosomething_signup_preprocess_signup_button($vars);
+      // Set default in case CTA label is not set.
+      $label = NULL;
+      if (isset($content['field_cta_link'][0]['#element']['title'])) {
+        $label = $content['field_cta_link'][0]['#element']['title'];
+      }
+      dosomething_signup_preprocess_signup_button($vars, $label);
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
@@ -21,9 +21,6 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
         'post_signup_body',
         'call_to_action',
       ),
-      'link' => array(
-        'cta_link'
-      ),
     );
 
     foreach ($template_vars as $key => $labels) {
@@ -34,9 +31,6 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
             case 'text':
               $vars[$label] = $content[$field][0]['#markup'];
               break;
-            case 'link':
-              $vars[$label] = l($content[$field][0]['#element']['title'], $content[$field][0]['#element']['url'], array('attributes' => array('class' => 'btn')));
-            break;
             default:
               break;
           }

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
@@ -63,6 +63,12 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
 
     // Preprocess gallery variables.
     dosomething_static_content_preprocess_gallery_vars($vars);
+
+    $vars['display_signup_form'] = $vars['field_display_signup_form'][0]['value'];
+    if ($vars['display_signup_form']) {
+      //@todo: Add CTA Button label as 2nd param.
+      dosomething_signup_preprocess_signup_button($vars);
+    }
   }
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -392,10 +392,11 @@ function dosomething_signup_user_signup($nid, $account = NULL) {
  *   Details about the node that the signup was made on.
  */
 function dosomething_signup_mbp_request($account, $node) {
-  // Gather mbp params for the signup.
-  $params = dosomething_signup_get_mbp_params($account, $node);
   // Send MBP request.
   if (module_exists('dosomething_mbp')) {
+    // Gather mbp params for the signup.
+    $params = dosomething_signup_get_mbp_params($account, $node);
+    // Send campaign mbp request.
     if ($node->type == 'campaign') {
       dosomething_mbp_request('campaign_signup', $params);
     }
@@ -414,6 +415,10 @@ function dosomething_signup_mbp_request($account, $node) {
  *   Associative array of values to use as params to a mbp_request.
  */
 function dosomething_signup_get_mbp_params($account, $node) {
+  // @todo: Add checks and relevant vars for campaign_group when we're ready.
+  if ($node->type != 'campaign') {
+    return FALSE;
+  }
   $wrapper = entity_metadata_wrapper('node', $node);
   $params = array(
     'email' => $account->mail,

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -6,6 +6,7 @@
 
 include_once 'dosomething_signup.features.inc';
 include_once 'dosomething_signup.signup_data_form.inc';
+include_once 'dosomething_signup.theme.inc';
 include_once 'includes/dosomething_signup.mobilecommons.inc';
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
@@ -8,7 +8,8 @@
 /**
  * Preprocesses variables for a signup button.
  *
- * Will add either a signup form, or a link to open the login/registration modal.
+ * Adds a $signup_button variable into $vars, which is set to either a signup form, 
+ * or a link to open the login/registration modal.
  *
  * @param array $vars
  *   Node variables, passed from preprocess_node.  Must contain $vars['nid'].

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
@@ -1,0 +1,32 @@
+
+<?php
+/**
+ * @file
+ * Preprocess functions for the dosomething_signup module.
+ */
+
+/**
+ * Preprocesses variables for a signup button.
+ *
+ * Will add either a signup form, or a link to open the login/registration modal.
+ *
+ * @param array $vars
+ *   Node variables, passed from preprocess_node.  Must contain $vars['nid'].
+ * @param string $label
+ *   The label to display fon the button.
+ */
+function dosomething_signup_preprocess_signup_button(&$vars, $label = "Sign Up") {
+  $label = t($label);
+  // If user is logged in:
+  if (user_is_logged_in()) {
+    // Render button as sign up form.
+    $vars['signup_button'] = drupal_get_form('dosomething_signup_form', $vars['nid'], $label);
+  }
+  // Otherwise, for anonymous user:
+  else {
+    // Render button as link to open up the login modal.
+    $vars['signup_button'] = array(
+      '#markup' => '<a href="#modal--login" class="js-modal-link btn medium">' . $label . '</a>',
+    );
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
@@ -36,11 +36,11 @@
       <a href="#modal-faq" class="js-modal-link"><?php print $faq[0]['header']; ?></a>
     <?php endif; ?>
 
-    <?php if (isset($call_to_action)): ?>
+    <?php if (isset($signup_button)): ?>
       <div class="cta-wrapper">
         <div class="cta">
           <h3><?php print $call_to_action; ?></h3>
-          <div class="cta_button"><?php print $cta_link; ?></div>
+          <div class="cta_button"><?php print render($signup_button); ?></div>
         </div>
       </div>
     <?php endif; ?>
@@ -75,15 +75,6 @@
         <p><?php print $additional_text; ?></p>
       </div>
     </div>
-    <?php endif; ?>
-
-    <?php if (isset($call_to_action)): ?>
-      <div class="cta-wrapper">
-        <div class="cta">
-          <h3><?php print $call_to_action; ?></h3>
-          <div class="cta_button"><?php print $cta_link; ?></div>
-        </div>
-      </div>
     <?php endif; ?>
 
     <?php if (!empty($galleries)): ?>


### PR DESCRIPTION
@angaither Can you please review? This PR is high priority to keep things moving on The Hunt.

Abstracts the `signup_button` preprocess logic into a `dosomething_signup_preprocess_signup_button` function, to be used by both the Campaign and Campaign group node templates.

Also closes #1989 by removing duplicate CTA section.
