### PR TITLE
Adds branch argument to enable passing of tags to capistrano

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,7 +3,12 @@ lock '3.1.0'
 
 set :application, 'beta.dosomething.org'
 set :repo_url, 'git@github.com:DoSomething/dosomething.git'
+
 set :branch, "dev"
+if ENV['branch']
+    set :branch, ENV['branch'] || 'dev'
+end
+
 set :ssh_options, { :forward_agent => true }
 
 # Default value for :linked_files is []


### PR DESCRIPTION
#### What's this PR do?

This pull request adds logic to set the default branch that capistrano uses via a command line argument.  The branch variable can also be set to a tag.  This will allow us to deploy from specific tags.
#### Where should the reviewer start?

https://github.com/desmondmorris/dosomething/blob/d800ff0223fb3b29ae7c3be1f2b8e8e4698360c7/config/deploy.rb#L7-L10
#### How should this be manually tested?

We should run a deployment to the staging environment via the command line.
`capistrano staging deploy branch=v0.2.2`
#### Any background context you want to provide?

Once this is in place, our Hubot deployment scripts must be updated to accept a tag parameter
#### What are the relevant tickets?
#1574 #1669
