### PR TITLE
Falls back to normal image upload field on IE8.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
@@ -69,7 +69,10 @@ define(function(require) {
 
   // When we open a modal, we prepare any `.js-image-upload`s that we find there
   Events.subscribe("Modal:opened", function(topic, args) {
-    prepareImageUploadUI(args);
+    var ie8 = jQuery.browser.msie && jQuery.browser.version <= 8;
+    if(!ie8) {
+      prepareImageUploadUI(args);
+    }
   });
 
 });

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
@@ -69,8 +69,9 @@ define(function(require) {
 
   // When we open a modal, we prepare any `.js-image-upload`s that we find there
   Events.subscribe("Modal:opened", function(topic, args) {
-    var ie8 = jQuery.browser.msie && jQuery.browser.version <= 8;
-    if(!ie8) {
+    // @NOTE: We don't want to use this image upload UI on IE8, since it doesn't
+    // allow manipulation of input[type="file"] fields through JavaScript
+    if(!$("html").hasClass("ie8")) {
       prepareImageUploadUI(args);
     }
   });

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-reportback.scss
@@ -71,9 +71,5 @@
         width: auto;
       }
     }
-
-    input[type="file"] {
-      color: #fff;
-    }
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -8,7 +8,8 @@
 ?>
 
 <!DOCTYPE html>
-<html class="no-js">
+<!--[if lte IE 8 ]> <html dir="ltr" lang="en-US" class="no-js ie8"> <![endif]-->
+<!--[if (gte IE 9)|!(IE)]><!--><html class="no-js"><!--<![endif]-->
 
 <head>
   <title><?php print $head_title; ?></title>
@@ -34,6 +35,7 @@
 </head>
 
 <body class="<?php print $classes; ?>" <?php print $attributes;?>>
+  <!--[if lt IE 8 ]> <div class="messages error">You're using an unsupported browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to make sure everything works nicely!</div>  <![endif]-->
   <?php print $page_top; ?>
   <?php print $page; ?>
 


### PR DESCRIPTION
IE8 doesn't allow changing the value of `input[type="file"]` fields using JavaScript, which was causing errors on report backs for IE8 users. Also makes file field a bit easier to read for the way IE8 renders the filename portion of the field.

Fixes https://trello.com/c/b5JlKZEp/1125-having-a-hard-time-reporting-back-for-pb-jam-slam
For review: @DoSomething/front-end 
