### PR TITLE
Add version numbers to features.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -162,7 +162,7 @@ function build {
   drush --script-path=../bin/ php-script enable_modules.php
 
   echo 'Reverting Features'
-  drush fl | grep 'Overridden' | awk '{print ($(NF-2))}' | xargs -i drush fr {} --force -y
+  drush fl | grep 'Overridden' | awk '{print ($(NF-3))}' | xargs -i drush fr {} --force -y
 
   echo 'Clearing caches...'
   drush cc all

--- a/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.info
+++ b/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.info
@@ -1,6 +1,7 @@
 name = DoSomething Action Guide
 core = 7.x
 package = DoSomething
+version = 7.x-1.0
 dependencies[] = ctools
 dependencies[] = dosomething_static_content
 dependencies[] = entityreference

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.info
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.info
@@ -2,6 +2,7 @@ name = DoSomething Campaign Group
 description = Campaign group content type and associated code
 core = 7.x
 package = DoSomething
+version = 7.x-1.0
 dependencies[] = ctools
 dependencies[] = dosomething_campaign
 dependencies[] = dosomething_static_content

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.info
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.info
@@ -2,6 +2,7 @@ name = DoSomething Fact
 description = Provides a custom Fact Entity and its functionality.
 core = 7.x
 package = DoSomething
+version = 7.x-1.0
 dependencies[] = ctools
 dependencies[] = entity
 dependencies[] = features

--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.info
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.info
@@ -1,6 +1,7 @@
 name = DoSomething Fact Page
 core = 7.x
 package = DoSomething
+version = 7.x-1.0
 dependencies[] = ctools
 dependencies[] = dosomething_campaign
 dependencies[] = dosomething_static_content

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.info
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.info
@@ -2,6 +2,7 @@ name = Dosomething helpers
 description = Collection of helper functions for DoSomething
 core = 7.x
 package = DoSomething
+version = 7.x-1.0
 dependencies[] = ctools
 dependencies[] = entityconnect
 dependencies[] = features

--- a/lib/modules/dosomething/dosomething_image/dosomething_image.info
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.info
@@ -2,6 +2,7 @@ name = Dosomething Image
 description = Provides an image type with various crops.
 core = 7.x
 package = DoSomething
+version = 7.x-1.0
 dependencies[] = dosomething_taxonomy
 dependencies[] = features
 dependencies[] = image

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.info
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.info
@@ -1,6 +1,7 @@
 name = DoSomething Metatag
 core = 7.x
-package = Dosomething
+package = DoSomething
+version = 7.x-1.0
 dependencies[] = features
 dependencies[] = metatag
 features[features_api][] = api:2

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
@@ -2,6 +2,7 @@ name = DoSomething Reportback
 description = Provides Reportback entity and functionality.
 core = 7.x
 package = DoSomething
+version = 7.x-1.0
 dependencies[] = dosomething_helpers
 dependencies[] = features
 dependencies[] = file

--- a/lib/modules/dosomething/dosomething_search/dosomething_search.info
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.info
@@ -1,6 +1,7 @@
 name = DoSomething Search
 core = 7.x
-package = Features
+package = DoSomething
+version = 7.x-1.0
 dependencies[] = apachesolr
 dependencies[] = ctools
 dependencies[] = entity

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.info
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.info
@@ -2,6 +2,7 @@ name = DoSomething Signup
 description = Provides Signup table and functionality.
 core = 7.x
 package = DoSomething
+version = 7.x-1.0
 dependencies[] = entity
 dependencies[] = features
 dependencies[] = views

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.info
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.info
@@ -2,6 +2,7 @@ name = DoSomething Static Content
 description = Content type and theme function definitions for the Static Content type
 core = 7.x
 package = DoSomething
+version = 7.x-1.0
 dependencies[] = ctools
 dependencies[] = dosomething_campaign
 dependencies[] = entityconnect


### PR DESCRIPTION
This will fix the features not reverting automatically.
When the feature was listed with a versoin number it changed the arg of the title of the module.
Adding a version number to all will make reverts consistent.
Also updated the custom features to all be in the `DoSomething` features group

Fixes #1986
