### PR TITLE
Grouped campaigns

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_group/README.md
+++ b/lib/modules/dosomething/dosomething_campaign_group/README.md
@@ -1,0 +1,18 @@
+# DoSomething Campaign Group
+
+This module defines the Grouped Campaign content type (machine name `campaign_group`).
+
+A Grouped Campaign contains an entityreference field, `field_campaigns`, which 
+determines which Campaign nodes belong to the Grouped Campaign.
+
+## Signups
+
+The `field_display_signup_form` field configures whether or not to display a 
+Signup form on the Grouped Campaign node template.
+
+This Signup form will store a signup for the Grouped Campaign nid.  A Grouped
+Campaign may be configured to subscribe the user to third-party services such as
+Mailchimp and Mobilecommons via the DoSomething Signup admin form.
+
+When a user signs up for a Campaign within the Grouped Campaign, a Signup will 
+also be created for the Grouped Campaign the Campaign belongs to.  See `dosomething_signup_entity_insert`. 

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.inc
@@ -22,9 +22,9 @@ function dosomething_campaign_group_ctools_plugin_api($module = NULL, $api = NUL
 function dosomething_campaign_group_node_info() {
   $items = array(
     'campaign_group' => array(
-      'name' => t('Campaign Group'),
+      'name' => t('Grouped Campaign'),
       'base' => 'node_content',
-      'description' => t('Grouping of campaigns'),
+      'description' => t('A grouping of campaigns, which can be configured to collect signups.'),
       'has_title' => '1',
       'title_label' => t('Title'),
       'help' => '',


### PR DESCRIPTION
Changes readable name of `campaign_group` to Grouped Campaign, adds a README to document Signups.
