### PR TITLE
Zendesk form for Grouped Campaigns

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
@@ -85,6 +85,18 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
 }
 
 /**
+ * Implements hook_node_view().
+ */
+function dosomething_campaign_group_node_view($node, $view_mode, $langcode) {
+  if ($node->type == 'campaign_group' && $view_mode == 'full') {
+    // Add Zendesk form variable:
+    if (module_exists('dosomething_zendesk')) {
+      $node->content['zendesk_form'] = drupal_get_form('dosomething_zendesk_form', $node);
+    }
+  }
+}
+
+/**
  * Returns a Campaign Group parent nid for a given node $nid.
  *
  */

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
@@ -75,7 +75,7 @@ function dosomething_zendesk_groups_config_form() {
   $terms = taxonomy_get_tree($vocab->vid);
   // Foreach cause: term
   foreach ($terms as $term) {
-    $var = dosomething_zendesk_get_group_varname($term->tid);
+    $var = dosomething_zendesk_get_group_varname('tid', $term->tid);
     $form['cause'][$var] = array(
       '#type' => 'textfield',
       '#title' => t($term->name),

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
@@ -64,6 +64,8 @@ function dosomething_zendesk_groups_config_form() {
       '#markup' => '<p>' . $group_name . ': ' . $group_id . '</p>',
     );
   }
+
+  // Store Zendesk group id's for each term in the Cause vocabulary.
   $form['cause'] = array(
     '#title' => t('Cause'),
     '#type' => 'fieldset',
@@ -84,6 +86,29 @@ function dosomething_zendesk_groups_config_form() {
       '#default_value' => variable_get($var),
     );
   }
+
+  // Store Zendesk group id's for each campaign_group node.
+  $form['campaign_group'] = array(
+    '#title' => t('Grouped Campaigns'),
+    '#type' => 'fieldset',
+    '#collapsible' => TRUE,
+  );
+  if (module_exists('dosomething_helpers')) {
+    // Load nid and titles of all campaign_group nodes.
+    if ($campaign_groups = dosomething_helpers_get_node_vars('campaign_group')) {
+      // For each campaign_group:
+      foreach ($campaign_groups as $campaign_group) {
+        $var = dosomething_zendesk_get_group_varname('nid', $campaign_group['nid']);
+        $form['campaign_group'][$var] = array(
+          '#type' => 'textfield',
+          '#required' => TRUE,
+          '#title' => t($campaign_group['title']),
+          '#default_value' => variable_get($var),
+        );
+      }
+    }
+  }
+
   $form['actions'] = array(
     '#type' => 'actions',
     'submit' => array(

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
@@ -53,7 +53,7 @@ function dosomething_zendesk_config_form($form, &$form_state)  {
  */
 function dosomething_zendesk_groups_config_form() {
   $form['groups'] = array(
-    '#title' => t('Available Groups'),
+    '#title' => t('Available Zendesk Groups'),
     '#type' => 'fieldset',
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
@@ -67,9 +67,10 @@ function dosomething_zendesk_groups_config_form() {
 
   // Store Zendesk group id's for each term in the Cause vocabulary.
   $form['cause'] = array(
-    '#title' => t('Cause'),
+    '#title' => t('Terms: Cause'),
     '#type' => 'fieldset',
     '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
   );
   // Load the cause vocbulary.
   $vocab = taxonomy_vocabulary_machine_name_load('cause');
@@ -89,9 +90,10 @@ function dosomething_zendesk_groups_config_form() {
 
   // Store Zendesk group id's for each campaign_group node.
   $form['campaign_group'] = array(
-    '#title' => t('Grouped Campaigns'),
+    '#title' => t('Nodes: Grouped Campaigns'),
     '#type' => 'fieldset',
     '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
   );
   if (module_exists('dosomething_helpers')) {
     // Load nid and titles of all campaign_group nodes.

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.install
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.install
@@ -26,7 +26,7 @@ function dosomething_zendesk_update_7001(&$sandbox) {
         ->execute()
         ->fetchField();
       // Get the tid's variable name.
-      $var = dosomething_zendesk_get_group_varname($tid);
+      $var = dosomething_zendesk_get_group_varname('tid', $tid);
       // Set this tid's group variable to the group_id.
       variable_set($var, $group_id);
     }

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -82,6 +82,13 @@ function dosomething_zendesk_form($form, &$form_state, $node = NULL)  {
       // Store zendesk group_id of the primary cause.
       $group_id = variable_get(dosomething_zendesk_get_group_varname('tid', $tid));
     }
+    // If staff_pick field exists:
+    if (isset($node->field_staff_pick[LANGUAGE_NONE][0])) {
+      // If node is a staff pick:
+      if ($node->field_staff_pick[LANGUAGE_NONE][0]['value'] == 1) {
+        $form['priority']['#value'] = 'high';
+      }
+    }
   }
 
   // If a Zendesk group_id variable exists:
@@ -92,14 +99,6 @@ function dosomething_zendesk_form($form, &$form_state, $node = NULL)  {
       '#access' => FALSE,
       '#value' => $group_id,
     );
-  }
-
-  // If staff_pick field exists:
-  if (isset($node->field_staff_pick[LANGUAGE_NONE][0])) {
-    // If node is a staff pick:
-    if ($node->field_staff_pick[LANGUAGE_NONE][0]['value'] == 1) {
-      $form['priority']['#value'] = 'high';
-    }
   }
 
   $form['body'] = array(

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -72,7 +72,7 @@ function dosomething_zendesk_form($form, &$form_state, $node = NULL)  {
   // If node has a primary cause:
   if (isset($node->field_primary_cause[LANGUAGE_NONE][0])) {
     $tid = $node->field_primary_cause[LANGUAGE_NONE][0]['tid'];
-    $group_id = variable_get(dosomething_zendesk_get_group_varname($tid));
+    $group_id = variable_get(dosomething_zendesk_get_group_varname('tid', $tid));
     // If a Zendesk group_id variable exists:
     if ($group_id) {
       // Render as a hidden element:
@@ -291,14 +291,16 @@ function dosomething_zendesk_get_zendesk_groups() {
 }
 
 /**
- * Returns the variable name that stores a taxonomy term's Zendesk Group ID.
+ * Returns the variable name that stores an entity's Zendesk Group ID.
  *
+ * @param string $identifier
+ *   The identifier of the id to lookup. e.g. nid, tid.
  * @param int $tid
- *   The taxonomy term to lookup.
+ *   The id of the entity to lookup.
  *
  * @return string
- *  The variable name which stores the tid's Zendesk Group ID.
+ *  The variable name which stores the ids's Zendesk Group ID.
  */
-function dosomething_zendesk_get_group_varname($tid) {
-  return 'dosomething_zendesk_tid_' . $tid . '_group_id';
+function dosomething_zendesk_get_group_varname($identifier, $id) {
+  return 'dosomething_zendesk_' . $identifier . '_' . $id . '_group_id';
 }

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -59,6 +59,9 @@ function dosomething_zendesk_get_client() {
  *   Optional. A loaded node which this zendesk form is being rendered on.
  */
 function dosomething_zendesk_form($form, &$form_state, $node = NULL)  {
+  // Initialize zendesk group_id as NULL.
+  $group_id = NULL;
+
   $form['subject'] = array(
     '#type' => 'hidden',
     '#access' => FALSE,
@@ -69,20 +72,28 @@ function dosomething_zendesk_form($form, &$form_state, $node = NULL)  {
     '#access' => FALSE,
     '#value' => 'normal',
   );
-  // If node has a primary cause:
-  if (isset($node->field_primary_cause[LANGUAGE_NONE][0])) {
-    $tid = $node->field_primary_cause[LANGUAGE_NONE][0]['tid'];
-    $group_id = variable_get(dosomething_zendesk_get_group_varname('tid', $tid));
-    // If a Zendesk group_id variable exists:
-    if ($group_id) {
-      // Render as a hidden element:
-      $form['group_id'] = array(
-        '#type' => 'hidden',
-        '#access' => FALSE,
-        '#value' => $group_id,
-      );
+
+  if ($node) {
+     // Check if node has its own Zendesk group_id:
+    $group_id = variable_get(dosomething_zendesk_get_group_varname('nid', $node->nid));   
+    // If not, check if node has a primary cause:
+    if (!$group_id && isset($node->field_primary_cause[LANGUAGE_NONE][0])) {
+      $tid = $node->field_primary_cause[LANGUAGE_NONE][0]['tid'];
+      // Store zendesk group_id of the primary cause.
+      $group_id = variable_get(dosomething_zendesk_get_group_varname('tid', $tid));
     }
   }
+
+  // If a Zendesk group_id variable exists:
+  if ($group_id) {
+    // Render as a hidden element:
+    $form['group_id'] = array(
+      '#type' => 'hidden',
+      '#access' => FALSE,
+      '#value' => $group_id,
+    );
+  }
+
   // If staff_pick field exists:
   if (isset($node->field_staff_pick[LANGUAGE_NONE][0])) {
     // If node is a staff pick:
@@ -90,6 +101,7 @@ function dosomething_zendesk_form($form, &$form_state, $node = NULL)  {
       $form['priority']['#value'] = 'high';
     }
   }
+
   $form['body'] = array(
     '#type' => 'textarea',
     '#required' => TRUE,

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
@@ -101,5 +101,9 @@
       <?php endforeach; ?>
     </section>
   <?php endif; ?>
-
+<?php 
+// @todo: Modalize and link to me. 
+// Or preprocess me if you don't liek the $content['zendesk_form'].
+print render($content['zendesk_form']); 
+?>
 </article>


### PR DESCRIPTION
Fixes #1898
- Adds form input on the Zendesk admin form to store zendesk group_ids for `campaign_group` nodes 
- Alters the `dosomething_zendesk_form` to first check to see if a zendesk group_id variable exists for the current node nid.  if so, passes this value as the group_id for create the Zendesk ticket.  if not, checks for the node's primary cause, if it exists (which is the default behavior for campaigns)
