### PR TITLE
Go home, grandpa

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -322,6 +322,7 @@ function dosomething_campaign_add_signup_data_form_vars(&$node) {
   $node->content['signup_data_form_link'] = $config['link_text'];
   // Load signup sid.
   $sid = dosomething_signup_exists($node->nid);
+
   // If no signup exists:
   if (!$sid) {
     // Staff is viewing a campaign which they haven't signed up for.
@@ -330,6 +331,19 @@ function dosomething_campaign_add_signup_data_form_vars(&$node) {
     );
     return;
   }
+
+  // If form is set to prevent Old People from submitting, and you're Old:
+  if ($config['prevent_old_people_submit'] && dosomething_user_is_old_person()) {
+    // Set the form to the Old People copy config property.
+    $node->content['signup_data_form'] = array(
+      '#markup' => $config['old_people_copy'],
+    );
+    // By exiting out of function now, we don't check to set the 
+    // required_signup_data_form variable, meaning Old People will never be
+    // auto prompted.
+    return;
+  }
+
   // Load the signup entity.
   $signup = signup_load($sid);
   // Pass to the user signup data form.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -155,6 +155,18 @@ function dosomething_signup_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'prevent_old_people_submit' => array(
+        'description' => 'Whether or not to prevent old people from submitting.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'old_people_copy' => array(
+        'description' => 'Copy to display when old person cannot submit.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ),
     ),
     'primary key' => array('nid'),
   );
@@ -255,4 +267,23 @@ function dosomething_signup_update_7005() {
     ))
     ->isNotNull('signup_data_form_timestamp')
     ->execute();
+}
+
+/**
+ * Adds old people columns to the dosomething_signup_data_form table.
+ */
+function dosomething_signup_update_7006() {
+  // Load schema for field definitions.
+  $schema = dosomething_signup_schema();
+  $tbl_name = 'dosomething_signup_data_form';
+  // New fields to add.
+  $fields = array('prevent_old_people_submit', 'old_people_copy');
+  // If the field doesn't exist already:
+  foreach ($fields as $field_name) {
+    // If the field doesn't exist already:
+    if (!db_field_exists($tbl_name, $field_name)) {
+      // Add it per the schema field definition.
+      db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
+    }
+  }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -80,6 +80,24 @@ function _dosomething_signup_node_signup_data_form(&$form, &$form_state) {
       ),
     ),
   );
+  $form[$fieldset]['config'][$prefix . 'prevent_old_people_submit'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Prevent Old People from submitting'),
+    '#default_value' => $values['prevent_old_people_submit'],
+    '#description' => t('If checked, Old People will be unable to submit the form.'),
+  );
+  $form[$fieldset]['config'][$prefix . 'old_people_copy'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Old People copy'),
+    '#default_value' => $values['link_text'],
+    '#description' => t('The copy displayed in the modal form for Old People.'),
+    // Should only be visible if old peeps can't submit.
+    '#states' => array(
+      'visible' => array(
+        ':input[name="' . $prefix . 'prevent_old_people_submit"]' => array('checked' => TRUE),
+      ),
+    ),
+  );
   $form[$fieldset]['config'][$prefix . 'link_text'] = array(
     '#type' => 'textfield',
     '#title' => t('Link text'),
@@ -186,6 +204,8 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
         'collect_user_address' => $values[$prefix . 'collect_user_address'],
         'collect_why_signedup' => $values[$prefix . 'collect_why_signedup'],
         'why_signedup_label' => $values[$prefix . 'why_signedup_label'],
+        'prevent_old_people_submit' => $values[$prefix . 'prevent_old_people_submit'],
+        'old_people_copy' => $values[$prefix . 'old_people_copy'],
     ))
     ->execute();
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -339,6 +339,7 @@ function dosomething_user_new_user($form, &$form_state) {
     }
   }
 }
+
 /**
  * Checks that user is over 13.
  *
@@ -366,6 +367,22 @@ function dosomething_user_is_under_thirteen($user = NULL) {
   else {
     return FALSE;
   }
+}
+
+/**
+ * Checks if user is an "old person", meaning over age 25.
+ *
+ * @return bool
+ *  Returns TRUE if user is an old person, else FALSE.
+ */
+function dosomething_user_is_old_person($user = NULL) {
+  if ($user == NULL) {
+    global $user;
+  }
+  $birthday = dosomething_user_get_birthdate(NULL, $user);
+  // Get the date 25 years ago today.
+  $date_cutoff = strtotime('-25 years');
+  return $date_cutoff > $birthday;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -370,7 +370,7 @@ function dosomething_user_is_under_thirteen($user = NULL) {
 }
 
 /**
- * Checks if user is an "old person", meaning over age 25.
+ * Checks if user is an "old person", meaning age 26 or older.
  *
  * @return bool
  *  Returns TRUE if user is an old person, else FALSE.
@@ -380,8 +380,8 @@ function dosomething_user_is_old_person($user = NULL) {
     global $user;
   }
   $birthday = dosomething_user_get_birthdate(NULL, $user);
-  // Get the date 25 years ago today.
-  $date_cutoff = strtotime('-25 years');
+  // Get the date 26 years ago today.
+  $date_cutoff = strtotime('-26 years');
   return $date_cutoff > $birthday;
 }
 


### PR DESCRIPTION
@angaither Can you please review?

Fixes #1921.

Adds two new properties to the Signup Data Form configuration:
- Prevent old people from submitting
- Old people copy

Displays old people copy if an old person clicks on the modal form.  Also makes sure not to auto-prompt an old person if the form is required.
