### PR TITLE
Signup Button label override

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -242,6 +242,12 @@ function dosomething_campaign_preprocess_signup_data_form(&$vars) {
  *   The corresponding entity wrapper for the node in $vars.
  */
 function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
+  // Check for a signup button label override.
+  $label_varname = 'dosomething_campaign_nid_' . $vars['nid']. '_pitch_page_label';
+  $label = variable_get($label_varname, '');
+  if (empty($label)) {
+    $label = NULL;
+  }
   // Adds a signup_button variable.
-  dosomething_signup_preprocess_signup_button($vars);
+  dosomething_signup_preprocess_signup_button($vars, $label);
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -322,6 +322,13 @@ function dosomething_helpers_form_extras(&$form, &$form_state) {
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
+  $pitch_page_label = $prefix . 'pitch_page_label';
+  $form['custom'][$pitch_page_label] = array(
+    '#type' => 'textfield',
+    '#title' => t('Signup Form Button Label'),
+    '#default_value' => variable_get($pitch_page_label),
+    '#description' => t('If set, this will override the label on the signup form.'),
+  );
   $form['custom']['styles'] = array(
     '#type' => 'fieldset',
     '#title' => t('Styles'),
@@ -333,14 +340,6 @@ function dosomething_helpers_form_extras(&$form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Alt color'),
     '#default_value' => variable_get($alt_color),
-    '#field_prefix' => '#',
-    '#size' => 6,
-  );
-  $pitch_page_label = $prefix . 'pitch_page_label';
-  $form['custom']['styles'][$pitch_page_label] = array(
-    '#type' => 'textfield',
-    '#title' => t('Pitch Page Label'),
-    '#default_value' => variable_get($pitch_page_label),
     '#field_prefix' => '#',
     '#size' => 6,
   );


### PR DESCRIPTION
@angaither Can you please review?

Closes #1915 by outputting a campaign's `pitch_page_label` variable on the Signup Button if it's set.
