### PR TITLE
Campaign Group Text formats

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
@@ -281,7 +281,7 @@ function dosomething_campaign_group_field_default_field_instances() {
         'size' => 60,
       ),
       'type' => 'entityreference_autocomplete',
-      'weight' => 9,
+      'weight' => 8,
     ),
   );
 
@@ -516,7 +516,7 @@ function dosomething_campaign_group_field_default_field_instances() {
       'module' => 'field_collection',
       'settings' => array(),
       'type' => 'field_collection_embed',
-      'weight' => 10,
+      'weight' => 9,
     ),
   );
 
@@ -759,7 +759,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Intro Title',
     'required' => 0,
     'settings' => array(
-      'text_processing' => 1,
+      'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -960,7 +960,7 @@ function dosomething_campaign_group_field_default_field_instances() {
       'module' => 'number',
       'settings' => array(),
       'type' => 'number',
-      'weight' => 8,
+      'weight' => 7,
     ),
   );
 
@@ -1042,7 +1042,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Signup Form Button Text',
     'required' => 0,
     'settings' => array(
-      'text_processing' => 1,
+      'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -1052,7 +1052,7 @@ function dosomething_campaign_group_field_default_field_instances() {
         'size' => 60,
       ),
       'type' => 'text_textfield',
-      'weight' => 18,
+      'weight' => 20,
     ),
   );
 
@@ -1183,7 +1183,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Transactional Email Copy',
     'required' => 0,
     'settings' => array(
-      'text_processing' => 1,
+      'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -1193,7 +1193,7 @@ function dosomething_campaign_group_field_default_field_instances() {
         'rows' => 5,
       ),
       'type' => 'text_textarea',
-      'weight' => 3,
+      'weight' => 2,
     ),
   );
 

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.field_group.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.field_group.inc
@@ -54,10 +54,10 @@ function dosomething_campaign_group_field_group_info() {
     'children' => array(
       0 => 'field_faq',
       1 => 'field_intro',
-      2 => 'field_intro_title',
-      3 => 'field_partners',
-      4 => 'field_video',
-      5 => 'field_intro_image',
+      2 => 'field_intro_image',
+      3 => 'field_intro_title',
+      4 => 'field_partners',
+      5 => 'field_video',
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(
@@ -82,7 +82,7 @@ function dosomething_campaign_group_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Post Sign Up',
-    'weight' => '6',
+    'weight' => '5',
     'children' => array(
       0 => 'field_post_signup_body',
       1 => 'field_signup_confirm_msg',
@@ -111,7 +111,7 @@ function dosomething_campaign_group_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Pre-Live',
-    'weight' => '5',
+    'weight' => '4',
     'children' => array(
       0 => 'field_additional_text',
       1 => 'field_additional_text_title',
@@ -139,7 +139,7 @@ function dosomething_campaign_group_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Signup Form',
-    'weight' => '4',
+    'weight' => '3',
     'children' => array(
       0 => 'field_display_signup_form',
       1 => 'field_signup_form_button_text',
@@ -167,12 +167,12 @@ function dosomething_campaign_group_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Taxonomy and Discovery',
-    'weight' => '11',
+    'weight' => '10',
     'children' => array(
       0 => 'field_cause',
       1 => 'field_action_type',
-      2 => 'field_staff_pick',
-      3 => 'field_active_hours',
+      2 => 'field_active_hours',
+      3 => 'field_staff_pick',
       4 => 'field_tags',
     ),
     'format_type' => 'fieldset',
@@ -198,10 +198,10 @@ function dosomething_campaign_group_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Timing',
-    'weight' => '7',
+    'weight' => '6',
     'children' => array(
-      0 => 'field_high_season',
-      1 => 'field_display_end_date',
+      0 => 'field_display_end_date',
+      1 => 'field_high_season',
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.strongarm.inc
@@ -19,19 +19,19 @@ function dosomething_campaign_group_strongarm() {
     'extra_fields' => array(
       'form' => array(
         'metatags' => array(
-          'weight' => '18',
+          'weight' => '14',
         ),
         'title' => array(
           'weight' => '2',
         ),
         'path' => array(
-          'weight' => '17',
+          'weight' => '13',
         ),
         'redirect' => array(
-          'weight' => '16',
+          'weight' => '12',
         ),
         'xmlsitemap' => array(
-          'weight' => '13',
+          'weight' => '11',
         ),
       ),
       'display' => array(),


### PR DESCRIPTION
Changes Intro Title, Signup Button Label, and Transactional Email fields to plain text.  

Other minimal changes are byproduct of a `drush fu dosomething_campaign_group`.. which hopefully will cause the feature to stop overriding (it's currently overriden on stage)
