### PR TITLE
Updates the revert script.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -162,7 +162,7 @@ function build {
   drush --script-path=../bin/ php-script enable_modules.php
 
   echo 'Reverting Features'
-  drush fl | grep 'Overridden' | awk '{print ($(NF-3))}' | xargs -i drush fr {} --force -y
+  drush fl | grep 'Overridden' | awk '{gsub("review", "");print ($(NF-3))}' | xargs -i drush fr {} --force -y
 
   echo 'Clearing caches...'
   drush cc all


### PR DESCRIPTION
This handles reverting features that are in a needs review state.
In the piped command it ignores the word 'review' so that modules are listed in the same place.

Fixes #1986
