### PR TITLE
Adds VERSION marker and drupal variable

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,13 +11,6 @@ end
 
 set :ssh_options, { :forward_agent => true }
 
-# Default value for :linked_files is []
-# set :linked_files, %w{config/database.yml}
-
-# Default value for linked_dirs is []
-# set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
-
-
 namespace :deploy do
 
   desc "Run ds build tasks"
@@ -25,6 +18,8 @@ namespace :deploy do
     on roles(:app) do |host|
       execute "cd '#{release_path}'; #{release_path}/bin/ds build"
       execute "cd '#{release_path}/lib/themes/dosomething/paraneue_dosomething'; grunt prod"
+      execute "cd '#{release_path}/html'; drush vset --yes ds_version " + ENV['branch']
+      execute "cd '#{release_path}/html'; echo " + ENV['branch'] + " > VERSION"
     end
   end
 


### PR DESCRIPTION
### What's this PR do?

This pull request updates the deployment logic to create markers to indicate the current release version.  On deploy, a file named `VERSION` is created with the tag version and added to the webroot - an [example](http://staging.beta.dosomething.org/VERSION).  A Drupal variable `ds_version` is also updated with the current tag version as well.  It can be accessed like so: `variable_get('ds_version', NULL);`
### Where should the reviewer start?

https://github.com/desmondmorris/dosomething/blob/version-marker/config/deploy.rb#L28-L29
### How should this be manually tested?

Pull down this branch and run a test deployment on QA or the staging server.  I have already done so on staging.

Something like: `capistrano staging deploy branch=vX.X.X`

Then, visit: http://staging.beta.dosomething.org/VERSION AND from vagrant check the value of the ds_version variable like so: `drush @ds.staging vget ds_version`
### Any background context you want to provide?

This functionality gives us the ability to pull in akamai hosted paraneue assets by version number.  We also can check the version status across tiers.
### What are the relevant tickets?
#1841
