### PR TITLE
Updating all features with a node type to have the sms display mode.

### DIFF
--- a/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.features.field_instance.inc
@@ -30,6 +30,12 @@ function dosomething_action_guide_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -71,6 +77,12 @@ function dosomething_action_guide_field_default_field_instances() {
         'weight' => 6,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -118,6 +130,12 @@ function dosomething_action_guide_field_default_field_instances() {
         'weight' => 8,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -175,6 +193,12 @@ function dosomething_action_guide_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -213,6 +237,12 @@ function dosomething_action_guide_field_default_field_instances() {
         'weight' => 3,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -261,6 +291,12 @@ function dosomething_action_guide_field_default_field_instances() {
         'weight' => 4,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -315,6 +351,12 @@ function dosomething_action_guide_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -356,6 +398,12 @@ function dosomething_action_guide_field_default_field_instances() {
         'weight' => 1,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.features.field_instance.inc
@@ -30,6 +30,12 @@ function dosomething_fact_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),

--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.features.field_instance.inc
@@ -30,6 +30,12 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -71,6 +77,12 @@ function dosomething_fact_page_field_default_field_instances() {
         'weight' => 7,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -122,6 +134,12 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -162,6 +180,12 @@ function dosomething_fact_page_field_default_field_instances() {
         'weight' => 8,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -229,6 +253,12 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -275,6 +305,12 @@ function dosomething_fact_page_field_default_field_instances() {
         'weight' => 2,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -329,6 +365,12 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -372,6 +414,12 @@ function dosomething_fact_page_field_default_field_instances() {
         'weight' => 5,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -426,6 +474,12 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -467,6 +521,12 @@ function dosomething_fact_page_field_default_field_instances() {
         'weight' => 3,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',

--- a/lib/modules/dosomething/dosomething_home/dosomething_home.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_home/dosomething_home.features.field_instance.inc
@@ -32,6 +32,12 @@ function dosomething_home_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -76,6 +82,12 @@ function dosomething_home_field_default_field_instances() {
         'weight' => 0,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',

--- a/lib/modules/dosomething/dosomething_image/dosomething_image.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.features.field_instance.inc
@@ -30,6 +30,12 @@ function dosomething_image_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -70,6 +76,12 @@ function dosomething_image_field_default_field_instances() {
         'weight' => 0,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -131,6 +143,12 @@ function dosomething_image_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -187,6 +205,12 @@ function dosomething_image_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -236,6 +260,12 @@ function dosomething_image_field_default_field_instances() {
         'weight' => 4,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.features.field_instance.inc
@@ -291,6 +291,12 @@ function dosomething_static_content_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -332,6 +338,12 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 12,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -383,6 +395,12 @@ function dosomething_static_content_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -424,6 +442,12 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 14,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -495,6 +519,12 @@ function dosomething_static_content_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -535,6 +565,12 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 7,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -589,6 +625,12 @@ function dosomething_static_content_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -632,6 +674,12 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 9,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -681,6 +729,12 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 8,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -737,6 +791,12 @@ function dosomething_static_content_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'sms_game' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -774,6 +834,12 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 11,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -826,6 +892,12 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 15,
       ),
       'pitch' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',


### PR DESCRIPTION
All features with node types are showing as overriden because they don't have the field instance display for the new sms view mode.

this will fix the overriden features. 
