### PR TITLE
Remove the needs review reverts.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -162,7 +162,7 @@ function build {
   drush --script-path=../bin/ php-script enable_modules.php
 
   echo 'Reverting Features'
-  drush fl | grep 'Overridden' | awk '{gsub("review", "");print ($(NF-3))}' | xargs -i drush fr {} --force -y
+  drush fl | grep 'Overridden' | awk '{print ($(NF-3))}' | xargs -i drush fr {} --force -y
 
   echo 'Clearing caches...'
   drush cc all


### PR DESCRIPTION
I changed my mind...the 'needs review' shouldn't be automaticaly reverted because bad things could happen, I guess Dries makes these different for a reason and we shouldn't force magic upon them when he wants a human to fix the issue.
