### PR TITLE
Campaign Starter Statement field group

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
@@ -1112,7 +1112,7 @@ function dosomething_campaign_field_default_field_instances() {
         'size' => 60,
       ),
       'type' => 'entityreference_autocomplete',
-      'weight' => 12,
+      'weight' => 11,
     ),
   );
 
@@ -2103,7 +2103,7 @@ function dosomething_campaign_field_default_field_instances() {
         'rows' => 5,
       ),
       'type' => 'text_textarea',
-      'weight' => 11,
+      'weight' => 10,
     ),
   );
 
@@ -2155,7 +2155,7 @@ function dosomething_campaign_field_default_field_instances() {
         'rows' => 5,
       ),
       'type' => 'text_textarea',
-      'weight' => 10,
+      'weight' => 9,
     ),
   );
 
@@ -2207,7 +2207,7 @@ function dosomething_campaign_field_default_field_instances() {
         'size' => 60,
       ),
       'type' => 'text_textfield',
-      'weight' => 8,
+      'weight' => 7,
     ),
   );
 
@@ -2259,7 +2259,7 @@ function dosomething_campaign_field_default_field_instances() {
         'size' => 60,
       ),
       'type' => 'text_textfield',
-      'weight' => 9,
+      'weight' => 8,
     ),
   );
 
@@ -2523,7 +2523,7 @@ function dosomething_campaign_field_default_field_instances() {
     'entity_type' => 'node',
     'field_name' => 'field_starter_statement',
     'label' => 'Campaign Specific Starter Statement',
-    'required' => 0,
+    'required' => 1,
     'settings' => array(
       'text_processing' => 1,
       'user_register_form' => FALSE,

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.field_group.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.field_group.inc
@@ -52,7 +52,7 @@ function dosomething_campaign_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Do It',
-    'weight' => '4',
+    'weight' => '5',
     'children' => array(
       0 => 'field_image_step_gallery',
       1 => 'field_photo_step',
@@ -87,7 +87,7 @@ function dosomething_campaign_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Incentives',
-    'weight' => '6',
+    'weight' => '7',
     'children' => array(
       0 => 'field_official_rules',
       1 => 'field_scholarship_amount',
@@ -124,9 +124,8 @@ function dosomething_campaign_field_group_info() {
       3 => 'field_faq',
       4 => 'field_image_psa_replacement',
       5 => 'field_solution_support',
-      6 => 'field_starter_statement',
-      7 => 'field_solution_copy',
-      8 => 'field_video',
+      6 => 'field_solution_copy',
+      7 => 'field_video',
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(
@@ -182,7 +181,7 @@ function dosomething_campaign_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Sponsors and Partners',
-    'weight' => '8',
+    'weight' => '9',
     'children' => array(
       0 => 'field_partners',
     ),
@@ -210,7 +209,7 @@ function dosomething_campaign_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Plan It',
-    'weight' => '3',
+    'weight' => '4',
     'children' => array(
       0 => 'field_items_needed',
       1 => 'field_promoting_tips',
@@ -225,7 +224,7 @@ function dosomething_campaign_field_group_info() {
       'instance_settings' => array(
         'required_fields' => 0,
         'classes' => '',
-        'description' => 'This section describes what a user needs to do BEFORE they can start taking the action (i.e. things they\'ll need, people to talk to, etc.). The Campaign Starter Statement is required. All other fields are optional however you MUST fill out AT LEAST TWO of Stuff You Need, Time and Place, VIPs, and Hype.',
+        'description' => 'This section describes what a user needs to do BEFORE they can start taking the action (i.e. things they\'ll need, people to talk to, etc.).  You MUST fill out AT LEAST TWO of Stuff You Need, Time and Place, VIPs, and Hype.',
       ),
       'formatter' => 'collapsed',
     ),
@@ -243,7 +242,7 @@ function dosomething_campaign_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Prove It',
-    'weight' => '5',
+    'weight' => '6',
     'children' => array(
       0 => 'field_image_reportback_gallery',
       1 => 'field_reportback_confirm_msg',
@@ -267,6 +266,34 @@ function dosomething_campaign_field_group_info() {
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
   $field_group->api_version = 1;
+  $field_group->identifier = 'group_starter_statement|node|campaign|form';
+  $field_group->group_name = 'group_starter_statement';
+  $field_group->entity_type = 'node';
+  $field_group->bundle = 'campaign';
+  $field_group->mode = 'form';
+  $field_group->parent_name = '';
+  $field_group->data = array(
+    'label' => 'Starter Statement',
+    'weight' => '3',
+    'children' => array(
+      0 => 'field_starter_statement',
+    ),
+    'format_type' => 'fieldset',
+    'format_settings' => array(
+      'label' => 'Starter Statement',
+      'instance_settings' => array(
+        'required_fields' => 1,
+        'classes' => 'group-starter-statement field-group-fieldset',
+        'description' => '',
+      ),
+      'formatter' => 'collapsed',
+    ),
+  );
+  $export['group_starter_statement|node|campaign|form'] = $field_group;
+
+  $field_group = new stdClass();
+  $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
+  $field_group->api_version = 1;
   $field_group->identifier = 'group_taxonomy|node|campaign|form';
   $field_group->group_name = 'group_taxonomy';
   $field_group->entity_type = 'node';
@@ -275,7 +302,7 @@ function dosomething_campaign_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Taxonomy and Discovery',
-    'weight' => '7',
+    'weight' => '8',
     'children' => array(
       0 => 'field_action_type',
       1 => 'field_active_hours',

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
@@ -77,6 +77,7 @@ features[field_group][] = group_location_finder|node|campaign|form
 features[field_group][] = group_partners|node|campaign|form
 features[field_group][] = group_prep_it|node|campaign|form
 features[field_group][] = group_report_back|node|campaign|form
+features[field_group][] = group_starter_statement|node|campaign|form
 features[field_group][] = group_taxonomy|node|campaign|form
 features[field_group][] = group_timing|node|campaign|form
 features[field_instance][] = field_collection_item-field_faq-field_compound_text_copy

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.strongarm.inc
@@ -22,16 +22,16 @@ function dosomething_campaign_strongarm() {
           'weight' => '1',
         ),
         'path' => array(
-          'weight' => '11',
+          'weight' => '10',
         ),
         'metatags' => array(
-          'weight' => '12',
+          'weight' => '11',
         ),
         'redirect' => array(
-          'weight' => '13',
+          'weight' => '12',
         ),
         'xmlsitemap' => array(
-          'weight' => '14',
+          'weight' => '13',
         ),
       ),
       'display' => array(),


### PR DESCRIPTION
@angaither Please review.

Moves the "Starter Statement" field into its own field_group, to easily make it accessible to both campaign types, and also in a field_group that makes sense (moving it out of "Know it").

Makes the field required and updates help text for its old field_group accordingly.
