### PR TITLE
Fixed zip code regex.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/address.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/address.js
@@ -66,7 +66,7 @@ define(function(require) {
   });
 
   Validation.registerValidationFunction("zipcode", function(string, done) {
-    if( string.match(/\d{5}/) ) {
+    if( string.match(/^\d{5}$/) ) {
       return done({
         success: true,
         message: "Almost done!"


### PR DESCRIPTION
Fixes [Trello Bug Board #89](https://trello.com/c/16FbqzuI/89-thumb-wars-allows-me-to-enter-more-than-5-digits-in-the-zip-code-box-for-the-thumb-socks-form). Regex, good.
