### PR TITLE
Confirmation page tweaks

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.field_group.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.field_group.inc
@@ -44,6 +44,34 @@ function dosomething_campaign_field_group_info() {
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
   $field_group->api_version = 1;
+  $field_group->identifier = 'group_confirmation|node|campaign|form';
+  $field_group->group_name = 'group_confirmation';
+  $field_group->entity_type = 'node';
+  $field_group->bundle = 'campaign';
+  $field_group->mode = 'form';
+  $field_group->parent_name = '';
+  $field_group->data = array(
+    'label' => 'Confirmation',
+    'weight' => '7',
+    'children' => array(
+      0 => 'field_reportback_confirm_msg',
+    ),
+    'format_type' => 'fieldset',
+    'format_settings' => array(
+      'label' => 'Confirmation',
+      'instance_settings' => array(
+        'required_fields' => 1,
+        'classes' => 'group-confirmation field-group-fieldset',
+        'description' => '',
+      ),
+      'formatter' => 'collapsed',
+    ),
+  );
+  $export['group_confirmation|node|campaign|form'] = $field_group;
+
+  $field_group = new stdClass();
+  $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
+  $field_group->api_version = 1;
   $field_group->identifier = 'group_do_it|node|campaign|form';
   $field_group->group_name = 'group_do_it';
   $field_group->entity_type = 'node';
@@ -87,7 +115,7 @@ function dosomething_campaign_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Incentives',
-    'weight' => '7',
+    'weight' => '8',
     'children' => array(
       0 => 'field_official_rules',
       1 => 'field_scholarship_amount',
@@ -181,7 +209,7 @@ function dosomething_campaign_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Sponsors and Partners',
-    'weight' => '9',
+    'weight' => '10',
     'children' => array(
       0 => 'field_partners',
     ),
@@ -245,10 +273,9 @@ function dosomething_campaign_field_group_info() {
     'weight' => '6',
     'children' => array(
       0 => 'field_image_reportback_gallery',
-      1 => 'field_reportback_confirm_msg',
-      2 => 'field_reportback_copy',
-      3 => 'field_reportback_noun',
-      4 => 'field_reportback_verb',
+      1 => 'field_reportback_copy',
+      2 => 'field_reportback_noun',
+      3 => 'field_reportback_verb',
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(
@@ -302,7 +329,7 @@ function dosomething_campaign_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Taxonomy and Discovery',
-    'weight' => '8',
+    'weight' => '9',
     'children' => array(
       0 => 'field_action_type',
       1 => 'field_active_hours',

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
@@ -70,6 +70,7 @@ features[field_base][] = field_step_pre
 features[field_base][] = field_time_and_place
 features[field_base][] = field_vips
 features[field_group][] = group_basic_info|node|campaign|form
+features[field_group][] = group_confirmation|node|campaign|form
 features[field_group][] = group_do_it|node|campaign|form
 features[field_group][] = group_incentives|node|campaign|form
 features[field_group][] = group_know_it|node|campaign|form

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -48,7 +48,8 @@ function dosomething_campaign_menu() {
   );
   // User reportback confirmation page.
   $items['node/%node/confirmation'] = array(
-    'title' => 'You Did It!',
+    'title callback' => 'dosomething_campaign_reportback_confirmation_page_title',
+    'title arguments' => array(1),
     'page callback' => 'dosomething_campaign_reportback_confirmation_page',
     'page arguments' => array(1),
     'access callback' => 'dosomething_campaign_reportback_confirmation_page_access',
@@ -150,6 +151,24 @@ function _dosomething_campaign_pitch_view_mode($node) {
 }
 
 /**
+ * Determines page title of the reportback confirmation page.
+ *
+ * @param object $node
+ *   The loaded campaign node.
+ *
+ * @return string
+ */
+function dosomething_campaign_reportback_confirmation_page_title($node) {
+  if (dosomething_campaign_get_campaign_type($node) == 'sms_game') {
+    $title = 'Thanks for sharing!';
+  }
+  else {
+    $title = 'You did it!';
+  }
+  return t($title);
+}
+
+/**
  * Determines whether a user has access to the user reportback confirmation page.
  *
  * @param object $node
@@ -218,6 +237,7 @@ function dosomething_campaign_theme($existing, $type, $theme, $path) {
       'template' => 'reportback-confirmation',
       'path' => drupal_get_path('module', 'dosomething_campaign') . '/theme',
       'variables' => array(
+        'page_title' => NULL,
         'copy' => NULL,
         'more_campaigns_link' => NULL,
         'back_to_campaign_link' => NULL,

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
@@ -35,6 +35,7 @@ function dosomething_campaign_reportback_confirmation_page($node) {
     $rec_vars[] = dosomething_campaign_get_campaign_block_vars($nid);
   }
   return theme('reportback_confirmation', array(
+    'page_title' => dosomething_campaign_reportback_confirmation_page_title($node),
     'copy' => $wrapper->field_reportback_confirm_msg->value(),
     'more_campaigns_link' => $more_campaigns_link,
     'back_to_campaign_link' => $back_to_campaign_link,

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.strongarm.inc
@@ -22,16 +22,16 @@ function dosomething_campaign_strongarm() {
           'weight' => '1',
         ),
         'path' => array(
-          'weight' => '10',
-        ),
-        'metatags' => array(
           'weight' => '11',
         ),
-        'redirect' => array(
+        'metatags' => array(
           'weight' => '12',
         ),
-        'xmlsitemap' => array(
+        'redirect' => array(
           'weight' => '13',
+        ),
+        'xmlsitemap' => array(
+          'weight' => '14',
         ),
       ),
       'display' => array(),

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
@@ -3,6 +3,7 @@
  * Returns the HTML for the Campaign Reportback Confirmation.
  *
  * Available Variables
+ * - $page_title: The page title (string).
  * - $copy: Positive note message copy (string).
  * - $more_campaigns_link: Link to find more campaigns (string).
  * - $back_to_campaign_link: Link to head back to originating campagin (string).
@@ -22,7 +23,7 @@
 
   <header role="banner" class="-basic">
     <div class="wrapper">
-      <h1 class="__title">You Did It!</h1>
+      <h1 class="__title"><?php print $page_title; ?></h1>
       <?php if (isset($copy)): ?>
         <h2 class="__subtitle"><?php print $copy; ?></h2>
       <?php endif; ?>


### PR DESCRIPTION
@angaither Please review
- Moves the `field_reportback_confirm_msg` out of "Prove It" group and into a new group "Confirmation", so it's editable to both campaign types
- Creates a title callback to display different reportback confirmation page titles based on campaign type
