### PR TITLE
Unset /node view

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -42,6 +42,15 @@ function dosomething_helpers_form_alter(&$form, &$form_state, $form_id) {
 }
 
 /**
+ * Implements hook_menu_alter().
+ */
+function dosomething_helpers_menu_alter(&$items) {
+  // This removes the default '/node' view on drupal.
+  unset($items['node']);
+}
+
+
+/**
  * Gets node nid's that reference the given $nid in a given $field_name.
  *
  * @param int $nid


### PR DESCRIPTION
This will return a lovely 404 page instead of ![](http://shelovesmagazine.com/wp-content/uploads/2013/09/all-the-things.jpg)

Fixes #2097
