### PR TITLE
Campaign Custom Settings tab

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -5,6 +5,21 @@
  */
 
 /**
+ * Page callback for campaign admin custom settings page.
+ *
+ * @param object $node
+ *   A loaded node.
+ */
+function dosomething_campaign_admin_custom_settings_page($node) {
+  $output = '';
+  if (module_exists('dosomething_reportback')) {
+    $reportback_field_form = drupal_get_form('dosomething_reportback_node_reportback_field_form', $node);
+    $output .= render($reportback_field_form);
+  }
+  return $output;
+}
+
+/**
  * Page callback for campaign admin status page.
  */
 function dosomething_campaign_admin_status_page() {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -46,6 +46,17 @@ function dosomething_campaign_menu() {
     'type' => MENU_LOCAL_TASK,
     'weight' => 60,
   );
+  // Campaign custom settings admin page.
+  $items['node/%node/custom-settings'] = array(
+    'title' => 'Custom Settings',
+    'page callback' => 'dosomething_campaign_admin_custom_settings_page',
+    'page arguments' => array(1),
+    'access callback' => 'dosomething_campaign_admin_custom_settings_page_access',
+    'access arguments' => array(1),
+    'file' => 'dosomething_campaign.admin.inc',
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 40,
+  );
   // User reportback confirmation page.
   $items['node/%node/confirmation'] = array(
     'title callback' => 'dosomething_campaign_reportback_confirmation_page_title',
@@ -122,6 +133,23 @@ function dosomething_campaign_node_delete($node) {
   }
   // Delete alt bg fid variable from db.
   variable_del($prefix . 'alt_bg_fid');
+}
+
+/**
+ * Implements hook_admin_paths().
+ */
+function dosomething_campaign_admin_paths() {
+  $paths = array(
+    'node/*/custom-settings' => TRUE,
+  );
+  return $paths;
+}
+
+/**
+ * Page access callback for admin custom settings form.
+ */
+function dosomething_campaign_admin_custom_settings_page_access($node) {
+  return ($node->type == 'campaign' && dosomething_user_is_staff());
 }
 
 /*

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -348,12 +348,6 @@ function dosomething_helpers_form_extras(&$form, &$form_state) {
     // Include signup data form configuration form.
     _dosomething_signup_node_signup_data_form($form, $form_state);
 
-    // If admin:
-    if (in_array('administrator', $user->roles) && module_exists('dosomething_reportback')) {
-      // Include reportback field configuration form.
-      _dosomething_reportback_node_reportback_field_form($form, $form_state);
-    }
-
     // Alt bg pattern variable.
     $alt_bg_fid = $prefix . 'alt_bg_fid';
     $form['custom']['styles'][$alt_bg_fid] = array(

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -65,15 +65,10 @@ function dosomething_reportback_node_reportback_field_form($form, &$form_state, 
      '#type' => 'select',
      '#title' => t('Field type'),
      '#options' => array(
-        'radios' => t('Radios'),
+        'radios' => t('Yes/No'),
         'textarea' => t('Textarea'),
      ),
      '#default_value' => $values['type'],
-  );
-  $form[$fieldset]['config'][$prefix . 'options'] = array(
-    '#type' => 'textarea',
-    '#title' => t('Field options'),
-    '#default_value' => $values['options'],
   );
   $form[$fieldset]['actions'] = array(
     '#type' => 'actions',
@@ -99,7 +94,6 @@ function dosomething_reportback_node_reportback_field_form_submit(&$form, &$form
         'status' => $values[$prefix . 'status'],
         'label' => $values[$prefix . 'label'],
         'type' => $values[$prefix . 'type'],
-        'options' => $values[$prefix . 'options'],
     ))
     ->execute();
   drupal_set_message(t("Reportback field configuration saved."));
@@ -121,8 +115,7 @@ function dosomething_reportback_get_reportback_field_form_element($rb_field) {
     '#required' => TRUE,
   );
   if ($element['#type'] == 'radios') {
-    // @todo. Make this read $rb_field['options']. 
-    // Hardcoded for now, for Comeback Clothes.
+    // Hardcoded for now until we take on Github issue #1710.
     $element['#options'] = array(
       1 => t('Yes'),
       0 => t('No'),

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -64,9 +64,9 @@ function dosomething_reportback_node_reportback_field_form($form, &$form_state, 
   $form[$fieldset]['config'][$prefix . 'type']= array(
      '#type' => 'select',
      '#title' => t('Field type'),
-     // Only support radios for now.
      '#options' => array(
         'radios' => t('Radios'),
+        'textarea' => t('Textarea'),
      ),
      '#default_value' => $values['type'],
   );

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -6,21 +6,21 @@
  */
 
 /**
- * Adds form elements to given node $form to add additional reportback field.
+ * Form constructor to add additional reportback field to given $node.
  *
  * For now, this only supports adding one additional reportback field to a node.
- *
- * Note there is no submit form element returned.
- * This function is always called from within a node edit form.
  */
-function _dosomething_reportback_node_reportback_field_form(&$form, &$form_state) {
-  $nid = $form['nid']['#value'];
+function dosomething_reportback_node_reportback_field_form($form, &$form_state, $node) {
+  $nid = $node->nid;
+  // Load existing reportback_field config info.
   $values = dosomething_reportback_get_reportback_field_info($nid);
   $fieldset = 'reportback_field';
   $prefix = $fieldset . '_';
-  // Set an additional submit handler to save the dosomething_reportback_field values.
-  $form['#submit'][] = 'dosomething_reportback_node_reportback_field_form_submit';
-  // Create fieldset to collect signup data form values.
+  $form['nid'] = array(
+    '#type' => 'hidden',
+    '#value' => $nid,
+
+  );
   $form[$fieldset] = array(
     '#type' => 'fieldset',
     '#title' => t('Reportback Fields'),
@@ -75,14 +75,22 @@ function _dosomething_reportback_node_reportback_field_form(&$form, &$form_state
     '#title' => t('Field options'),
     '#default_value' => $values['options'],
   );
+  $form[$fieldset]['actions'] = array(
+    '#type' => 'actions',
+    'submit' => array(
+      '#type' => 'submit',
+      '#value' => t('Submit'),
+    ),
+  );
+  return $form;
 }
 
 /**
  * Saves node reportback_field values into dosomething_reportback_field table.
  */
 function dosomething_reportback_node_reportback_field_form_submit(&$form, &$form_state) {
-  $nid = $form['nid']['#value'];
   $values = $form_state['values'];
+  $nid = $values['nid'];
   $prefix = 'reportback_field_';
   // Use db_merge to either insert or update existing record for $nid / $name.
   db_merge('dosomething_reportback_field')
@@ -94,6 +102,7 @@ function dosomething_reportback_node_reportback_field_form_submit(&$form, &$form
         'options' => $values[$prefix . 'options'],
     ))
     ->execute();
+  drupal_set_message(t("Reportback field configuration saved."));
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -321,3 +321,12 @@ function dosomething_reportback_update_7005() {
       ->execute();
   }
 }
+
+/**
+ * Deletes empty records in the dosomething_reportback_field table.
+ */
+function dosomething_reportback_update_7006() {
+  $num_deleted = db_delete('dosomething_reportback_field')
+    ->condition('status', 0)
+    ->execute();
+}


### PR DESCRIPTION
@angaither Please review.  Needed for deploy today.

Creates a new page callback, `node/%node/custom-settings` and places the Reportback Field config form there. This will also be the home for the other non-content-type settings, such as the Signup Data Form config, custom settings etc.

This makes the form submit logic much easier for the Reportback Field form, and will stop the form from saving empty values into `dosomething_reportback_field`, since it won't be called on every node save.

Adds a `textarea` option into the Reportback Field type options, to allow adding an additional textarea into the Reportback Form.

Also removes the Reportback field "options" input to keep the config form cleaner, until we need it (if/when we determine to implement #1710)
