### PR TITLE
Upgrade the drupal version for safety.

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -5,7 +5,7 @@ core = 7.x
 
 ; Drupal Core
 projects[drupal][type] = core
-projects[drupal][version] = 7.26
+projects[drupal][version] = 7.27
 
 ; Patch for File module
 ; https://drupal.org/comment/7895935#comment-7895935


### PR DESCRIPTION
built and tested locally, didn't see any issues.

There is actually a newer version of drupal core, but for some reason upgrading to that version was failing.

Fixes #1839
