### PR TITLE
Toggle sponsors block from theme settings

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
+++ b/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
@@ -14,6 +14,7 @@ features[] = secondary_menu
 
 ; Settings
 settings[show_campaign_finder] = 0
+settings[show_sponsors] = 1
 
 ;Exclude
 ;javascript

--- a/lib/themes/dosomething/paraneue_dosomething/templates/home/node--home.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/home/node--home.tpl.php
@@ -150,6 +150,7 @@ if( theme_get_setting('show_campaign_finder') ) {
     </div>
   </div>
 
+<?php if( theme_get_setting('show_sponsors') ) : ?>
   <div class="homepage--sponsors">
     <h4>Sponsors</h4>
     <p>
@@ -168,6 +169,7 @@ if( theme_get_setting('show_campaign_finder') ) {
     </p>
   </div>
 </div>
+<?php endif; ?>
 
 <?php
 

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -10,17 +10,25 @@ function paraneue_dosomething_form_system_theme_settings_alter(&$form, $form_sta
       '#weight'=> -19
   );
 
-  $form['feature_flags']['show_campaign_finder'] = array(
-    '#type'          => 'checkbox',
-    '#title'         => t('Campaign Finder') ,
-    '#description'   => t('Toggles campaign finder on homepage/expore campaigns page.'),
-    '#default_value' => theme_get_setting('show_campaign_finder')
+  $flags = array(
+    'show_campaign_finder' => array(
+      '#title' => t('Campaign Finder'),
+      '#description' => t('Toggles campaign finder on homepage/expore campaigns page.')
+    ),
+    'show_profile_link' => array(
+      '#title' => t('User Profile Link'),
+      '#description' => t('Toggles the user profile/create an account link in the main navigation.')
+    ),
+    'show_sponsors' => array(
+      '#title' => t('Show sponsors'),
+      '#description' => t('Toggles the sponsors block on the home page when finder is enabled.')
+    )
   );
 
-  $form['feature_flags']['show_profile_link'] = array(
-    '#type'          => 'checkbox',
-    '#title'         => t('User Profile Link') ,
-    '#description'   => t('Toggles the user profile/create an account link in the main navigation.'),
-    '#default_value' => theme_get_setting('show_profile_link')
-  );
+  foreach ($flags as $name => $flag) {
+    $form['feature_flags'][$name] = $flag;
+    $form['feature_flags'][$name]['#type'] = 'checkbox';
+    $form['feature_flags'][$name]['#default_value'] = theme_get_setting($name);
+  }
+
 }


### PR DESCRIPTION
Adds theme setting to toggle sponsors block. This is needed to make international home page play nice.  I cleaned up the feature flag logic a little bit as well.
