### PR TITLE
Prepare dist package for asset versioning.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/main.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/main.js
@@ -11,16 +11,15 @@
  *  @see https://github.com/jrburke/r.js/blob/master/build/example.build.js
  */
 require.config({
-  baseUrl: "/profiles/dosomething/themes/dosomething/paraneue_dosomething/js/",
   include: "main",
   includeRequire: "main",
   paths: {
-    "neue": "../dist/bower_components/neue/js",
-    "mailcheck": "../dist/bower_components/mailcheck/src/mailcheck",
-    "lodash": "../dist/bower_components/lodash/dist/lodash",
-    "text": "../dist/bower_components/requirejs-text/text",
-    "rem-unit-polyfill": "../dist/bower_components/REM-unit-polyfill/js/rem",
-    "respond": "../dist/bower_components/respond/dest/respond.min"
+    "neue": "../bower_components/neue/js",
+    "mailcheck": "../bower_components/mailcheck/src/mailcheck",
+    "lodash": "../bower_components/lodash/dist/lodash",
+    "text": "../bower_components/requirejs-text/text",
+    "rem-unit-polyfill": "../bower_components/REM-unit-polyfill/js/rem",
+    "respond": "../bower_components/respond/dest/respond.min"
   },
   excludeShallow: [
     "respond",

--- a/lib/themes/dosomething/paraneue_dosomething/js/main.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/main.js
@@ -15,12 +15,12 @@ require.config({
   include: "main",
   includeRequire: "main",
   paths: {
-    "neue": "../bower_components/neue/js",
-    "mailcheck": "../bower_components/mailcheck/src/mailcheck",
-    "lodash": "../bower_components/lodash/dist/lodash",
-    "text": "../bower_components/requirejs-text/text",
-    "rem-unit-polyfill": "../bower_components/REM-unit-polyfill/js/rem",
-    "respond": "../bower_components/respond/dest/respond.min"
+    "neue": "../dist/bower_components/neue/js",
+    "mailcheck": "../dist/bower_components/mailcheck/src/mailcheck",
+    "lodash": "../dist/bower_components/lodash/dist/lodash",
+    "text": "../dist/bower_components/requirejs-text/text",
+    "rem-unit-polyfill": "../dist/bower_components/REM-unit-polyfill/js/rem",
+    "respond": "../dist/bower_components/respond/dest/respond.min"
   },
   excludeShallow: [
     "respond",

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/build.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/build.js
@@ -1,8 +1,8 @@
 module.exports = function(grunt) {
   // The `build` task lints, tests, and compiles assets.
-  grunt.registerTask("build", ["clean:dist", "sass:compile", "copy:main", "uglify:dev"]);
+  grunt.registerTask("build", ["clean:dist", "sass:compile", "copy:assets", "copy:js", "uglify:dev"]);
 
   // The `prod` build task is used when building for production. Since compiled assets
   // are ignored in version control, this is run in Continuous Integration on deploy.
-  grunt.registerTask("prod", ["clean:dist", "sass:compile", "cssmin:minify", "copy:main", "requirejs:compile", "uglify:prod"]);
+  grunt.registerTask("prod", ["clean:dist", "sass:compile", "cssmin:minify", "copy:assets", "copy:js", "requirejs:compile", "uglify:prod"]);
 }

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/default.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/default.js
@@ -1,3 +1,3 @@
 module.exports = function(grunt) {
-  grunt.registerTask("default", ["lint", "test", "build", "watch"]);
+  grunt.registerTask("default", ["lint", "build", "test", "watch"]);
 };

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/copy.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/copy.js
@@ -1,8 +1,13 @@
 module.exports = {
-  main: {
+  assets: {
     files: [
-    {expand: true, src: ["images/**"], dest: "dist/"},
-    {expand: true, src: ["bower_components/**"], dest: "dist/"},
+      {expand: true, src: ["images/**"], dest: "dist/"},
+      {expand: true, src: ["bower_components/**"], dest: "dist/"},
+    ]
+  },
+  js: {
+    files: [
+      {expand: true, src: ["js/**"], dest: "dist/"},
     ]
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/copy.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/copy.js
@@ -2,6 +2,7 @@ module.exports = {
   main: {
     files: [
     {expand: true, src: ["images/**"], dest: "dist/"},
+    {expand: true, src: ["bower_components/**"], dest: "dist/"},
     ]
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/watch.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/watch.js
@@ -8,7 +8,7 @@ module.exports = {
     tasks: ["lint:js", "copy:js", "test:js"]
   },
   requirejs: {
-    files: ["js/config.js", "js/config.dev.js"],
+    files: ["js/main.js", "js/config.dev.js"],
     tasks: ["uglify:dev"]
   },
   assets: {

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/watch.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/watch.js
@@ -5,14 +5,14 @@ module.exports = {
   },
   js: {
     files: ["js/**/*.js", "tests/**/*.js"],
-    tasks: ["lint:js", "test:js"]
+    tasks: ["lint:js", "copy:js", "test:js"]
   },
   requirejs: {
     files: ["js/config.js", "js/config.dev.js"],
     tasks: ["uglify:dev"]
   },
   assets: {
-    files: ["assets/**/*"],
-    tasks: ["copy"]
+    files: ["assets/**/*", "bower_components/**/*"],
+    tasks: ["copy:assets"]
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/template.php
+++ b/lib/themes/dosomething/paraneue_dosomething/template.php
@@ -1,13 +1,18 @@
 <?php
 
+// Define theme directory path
 define('PARANEUE_DS_PATH', drupal_get_path('theme', 'paraneue_dosomething'));
-define('NEUE_PATH', PARANEUE_DS_PATH . '/bower_components/neue');
 
+// Define asset directory paths
+define('DS_ASSET_PATH', '/' . PARANEUE_DS_PATH . '/dist');
+define('LIB_ASSET_PATH', DS_ASSET_PATH . '/bower_components');
+define('NEUE_ASSET_PATH', LIB_ASSET_PATH . '/neue');
+
+// Theme includes
 require_once PARANEUE_DS_PATH . '/includes/bootstrap.inc';
 require_once PARANEUE_DS_PATH . '/includes/theme.inc';
 require_once PARANEUE_DS_PATH . '/includes/preprocess.inc';
 require_once PARANEUE_DS_PATH . '/includes/helpers.inc';
-
 require_once PARANEUE_DS_PATH . '/includes/form.inc';
 require_once PARANEUE_DS_PATH . '/includes/auth/login.inc';
 require_once PARANEUE_DS_PATH . '/includes/auth/register.inc';

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -40,6 +40,11 @@
   <?php print $page_top; ?>
   <?php print $page; ?>
 
+  <script type="text/javascript" charset="utf-8">
+    var require = {
+      baseUrl: "<?php print DS_ASSET_PATH; ?>/js/"
+    };
+  </script>
   <script type="text/javascript" data-main="main" src="<?php print DS_ASSET_PATH; ?>/app.js"></script>
   <?php print $scripts; ?>
   <?php print $page_bottom; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -13,19 +13,20 @@
 
 <head>
   <title><?php print $head_title; ?></title>
-  <script type="text/javascript" src="/<?php print PARANEUE_DS_PATH; ?>/bower_components/neue/js/vendor/modernizr.js"></script>
+  <script type="text/javascript" src="<?php print NEUE_ASSET_PATH; ?>/js/vendor/modernizr.js"></script>
 
-  <link rel="stylesheet" href="/<?php print PARANEUE_DS_PATH; ?>/bower_components/neue/neue.css?dontcachethisbro" type="text/css" />
-  <link rel="stylesheet" href="/<?php print PARANEUE_DS_PATH; ?>/dist/app.css?dontcachethisbro" type="text/css" />
+  <link rel="stylesheet" href="<?php print NEUE_ASSET_PATH; ?>/neue.css" type="text/css" />
+  <link rel="stylesheet" href="<?php print DS_ASSET_PATH;; ?>/app.css" type="text/css" />
   <?php print $styles; ?>
 
   <!--[if lte IE 8]>
-      <link type="text/css" rel="stylesheet" href="/<?php print PARANEUE_DS_PATH; ?>/dist/ie.css" media="all" />
-      <script type="text/javascript" src="/<?php print PARANEUE_DS_PATH; ?>/bower_components/html5shiv/dist/html5shiv.js"></script>
+      <link type="text/css" rel="stylesheet" href="<?php print NEUE_ASSET_PATH; ?>/ie.css" media="all" />
+      <link type="text/css" rel="stylesheet" href="<?php print DS_ASSET_PATH; ?>/ie.css" media="all" />
+      <script type="text/javascript" src="<?php print LIB_ASSET_PATH; ?>/html5shiv/dist/html5shiv.js"></script>
   <![endif]-->
 
-  <link rel="shortcut icon" href="/<?php print NEUE_PATH; ?>/assets/images/favicon.ico">
-  <link rel="apple-touch-icon-precomposed" href="/<?php print NEUE_PATH; ?>/assets/images/apple-touch-icon-precomposed.png">
+  <link rel="shortcut icon" href="<?php print NEUE_ASSET_PATH; ?>/assets/images/favicon.ico">
+  <link rel="apple-touch-icon-precomposed" href="<?php print NEUE_ASSET_PATH; ?>/assets/images/apple-touch-icon-precomposed.png">
 
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
@@ -39,7 +40,7 @@
   <?php print $page_top; ?>
   <?php print $page; ?>
 
-  <script type="text/javascript" data-main="main" src="/<?php print PARANEUE_DS_PATH; ?>/dist/app.js?dontcachethisbro"></script>
+  <script type="text/javascript" data-main="main" src="<?php print DS_ASSET_PATH; ?>/app.js"></script>
   <?php print $scripts; ?>
   <?php print $page_bottom; ?>
 </body>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/navigation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/navigation.tpl.php
@@ -7,7 +7,7 @@
 ?>
 
 <nav class="chrome--nav">
-  <a class="logo" href="<?php print $base_path; ?>"><img src="/<?php print NEUE_PATH; ?>/assets/images/ds-logo.png" alt="DoSomething.org"></a>
+  <a class="logo" href="<?php print $base_path; ?>"><img src="<?php print NEUE_ASSET_PATH; ?>/assets/images/ds-logo.png" alt="DoSomething.org"></a>
   <a class="hamburger js-toggle-mobile-menu" href="#">&#xe606;</a>
   <div class="menu">
     <ul class="primary-nav">

--- a/lib/themes/dosomething/paraneue_dosomething/tests/index.html
+++ b/lib/themes/dosomething/paraneue_dosomething/tests/index.html
@@ -14,7 +14,12 @@
         var TEST = true;
       </script>
 
-      <script data-main="main" data-baseUrl="../js" src='../dist/app.js'></script>
+      <script type="text/javascript" charset="utf-8">
+        var require = {
+          baseUrl: "../js/"
+        };
+      </script>
+      <script data-main="main" src='../dist/app.js'></script>
       <!-- add any JS files under test (or put them in different .html files) -->
 
       <script src='lib/qunit-1.12.0.js'></script>

--- a/lib/themes/dosomething/paraneue_dosomething/tests/tests.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tests/tests.js
@@ -1,9 +1,4 @@
 /* jshint ignore:start */
-
-require.config({
-  baseUrl: "../js"
-})
-
 require(["neue/validation", "validation/auth"], function(Validation, Auth) {
 
   module("Validation");


### PR DESCRIPTION
Let's wait to merge this until after today's deploy. :construction_worker: 

This just sets Grunt to copy Bower components and JS source into the `dist/` directory, so that it can be packaged up by the versioned assets Jenkins task. Followup PR will swap the different asset path variables based on whether `ds_version` exists or not.

References #1841.
