### PR TITLE
Theme setting to toggle CDN assets on or off.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
+++ b/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
@@ -13,6 +13,7 @@ features[] = main_menu
 features[] = secondary_menu
 
 ; Settings
+settings[use_cdn_assets] = 0
 settings[show_campaign_finder] = 0
 settings[show_sponsors] = 1
 

--- a/lib/themes/dosomething/paraneue_dosomething/template.php
+++ b/lib/themes/dosomething/paraneue_dosomething/template.php
@@ -3,8 +3,14 @@
 // Define theme directory path
 define('PARANEUE_DS_PATH', drupal_get_path('theme', 'paraneue_dosomething'));
 
+// If ds_version is set, use CDN assets
+if(theme_get_setting('use_cdn_assets')) {
+  define('DS_ASSET_PATH', 'https://dosomething-a.akamaihd.net/sites/default/files/assets/' . variable_get('ds_version', 'latest'));
+} else {
+  define('DS_ASSET_PATH', '/' . PARANEUE_DS_PATH . '/dist');
+}
+
 // Define asset directory paths
-define('DS_ASSET_PATH', '/' . PARANEUE_DS_PATH . '/dist');
 define('LIB_ASSET_PATH', DS_ASSET_PATH . '/bower_components');
 define('NEUE_ASSET_PATH', LIB_ASSET_PATH . '/neue');
 

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -1,12 +1,28 @@
 <?php
 
 function paraneue_dosomething_form_system_theme_settings_alter(&$form, $form_state) {
+  $form['theme_settings'] = array(
+      '#type'          => 'fieldset',
+      '#title'         => t('Theme Settings'),
+      '#collapsible' => FALSE,
+      '#collapsed' => FALSE,
+      '#weight'=> -19
+  );
+
+
+  $form['theme_settings']['use_cdn_assets'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Use CDN Assets'),
+    '#description' => t('Will use versiond assets hosted on Akamai CDN, generated when tagging deploy. On local development machines, this defaults to the latest assets on the CDN.'),
+    '#default_value' => theme_get_setting($name)
+  );
+
   $form['feature_flags'] = array(
       '#type'          => 'fieldset',
       '#title'         => t('Feature Flags'),
       '#description'   => t('Allows features to be toggled on or off in different environments.'),
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
+      '#collapsible' => FALSE,
+      '#collapsed' => FALSE,
       '#weight'=> -19
   );
 


### PR DESCRIPTION
Added a theme setting so we can toggle whether or not to use CDN assets. If `ds_version` isn't set (like on a local development box), it will default to the `latest` asset folder on the CDN.

Fixes #1841.
For review: @desmondmorris 
