### PR TITLE
Node signups fix

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.views_default.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.views_default.inc
@@ -77,6 +77,7 @@ function dosomething_signup_views_default_views() {
   $handler->display->display_options['fields']['sid']['table'] = 'dosomething_signup';
   $handler->display->display_options['fields']['sid']['field'] = 'sid';
   $handler->display->display_options['fields']['sid']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['sid']['separator'] = '';
   /* Field: Signups: Date submitted */
   $handler->display->display_options['fields']['timestamp']['id'] = 'timestamp';
   $handler->display->display_options['fields']['timestamp']['table'] = 'dosomething_signup';
@@ -179,7 +180,6 @@ function dosomething_signup_views_default_views() {
     t('User'),
     t('Signup sid'),
     t('.'),
-    t(','),
     t('Submitted'),
     t('Uid'),
     t('E-mail'),


### PR DESCRIPTION
@blisteringherb Please review

The comma separator in the SID field was causing the outputted signup/[sid] link to break in the Node Signups view on production.
