### PR TITLE
Fixes issue with address field validation in IE.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/address.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/address.js
@@ -93,7 +93,7 @@ define(function(require) {
   Validation.registerValidationFunction("ups_address", function($el, done) {
     var $sorryError = $("<div class='messages error'><strong>We couldn't find that address.</strong> Double check for typos and try submitting again.</div>");
     var $networkError= $("<div class='messages error'>We're having trouble submitting the form, are you sure your internet connection is working? Email us if you continue having problems.</div>");
-    var addressFieldData = $el.find("fieldset").serializeArray();
+    var addressFieldData = $el.find("select, input").serializeArray();
 
     // Remove previous messages.
     $el.find(".messages").slideUp(function() { $(this).remove() });


### PR DESCRIPTION
jQuery's [serializeArray](http://api.jquery.com/serializearray/) seems not to work when given a `fieldset` in Internet Explorer. Giving it the specific fields we want validated seems to fix things.

:construction_worker: Doing some more cross-browser testing before merging this.
