### PR TITLE
Signup variable table

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @file
+ * Helper functions for dosomething_campaign functionality.
+ */
+
+/**
+ * Returns variables for campaigns with field_campaign_type.
+ *
+ * @return array
+ *  Array of nids and titles of all published/unpublished staff picks.
+ */
+function dosomething_campaign_get_sms_games() {
+ $query = db_select('node', 'n')
+    ->fields('n', array('nid', 'title'))
+    ->condition('type', 'campaign');
+  $query->innerJoin('field_data_field_campaign_type', 'ct', 'ct.entity_id = n.nid');
+  $query->condition('field_campaign_type_value' , 'sms_game');
+  $results = $query->execute();
+
+  foreach($results as $key => $result) {
+    $sms_games[$key]['nid'] = $result->nid;
+    $sms_games[$key]['title'] = $result->title;
+  }
+  if ($sms_games) {
+    return $sms_games;
+  }
+  // If no SMS Games, return null.
+  return NULL;
+}

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -5,6 +5,7 @@
  */
 
 include_once 'dosomething_campaign.features.inc';
+include_once 'dosomething_campaign.helpers.inc';
 include_once 'dosomething_campaign.theme.inc';
 define('DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER', 'Snap a Pic');
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -6,6 +6,74 @@
  */
 
 /**
+ * Page callback for the Signup Opt In configuration page.
+ */
+function dosomething_signup_opt_in_config_page() {
+  $output = '';
+  // This is the form we'll replace.
+  $variables_form = drupal_get_form('dosomething_signup_optin_config_form');
+  $output .= drupal_render($variables_form);
+  // This is the new form writes to the signup_variable table.
+  $config_form = drupal_get_form('dosomething_signup_admin_config_form');
+  $output .= drupal_render($config_form);
+  return $output;
+}
+
+function dosomething_signup_admin_config_form($form, &$form_state) {
+  $form['header'] = array(
+    '#prefix' => '<h3>',
+    '#markup' => 'SMS Games',
+    '#suffix' => '</h3>',
+  );
+  $sms_games = dosomething_campaign_get_sms_games();
+  if ($sms_games) {
+    foreach ($sms_games as $vars) {
+      $nid = $vars['nid'];
+      // Create a fieldset for each SMS Game.
+      $form[$nid] = array(
+        '#type' => 'fieldset',
+        '#title' => $vars['title'] . ' : NID ' . $nid,
+        '#collapsible' => TRUE,
+        '#collapsed' => TRUE,
+      );
+      $form[$nid][$nid . '_alpha'] = array(
+        '#type' => 'textfield',
+        '#title' => t('Mobile Commons Alpha Opt-In Path'),
+        '#required' => TRUE,
+        '#default_value' => dosomething_signup_variable_get($nid, 'mobilecommons_opt_in_alpha'),
+      );
+      $form[$nid][$nid . '_beta'] = array(
+        '#type' => 'textfield',
+        '#title' => t('Mobile Commons Beta Opt-In Path'),
+        '#required' => TRUE,
+        '#default_value' => dosomething_signup_variable_get($nid, 'mobilecommons_opt_in_beta'),
+      );
+    }
+  }
+  $form['actions']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save'),
+  );
+  return $form;
+}
+
+/**
+ * Submit handler for dosomething_signup_admin_config_form().
+ */
+function dosomething_signup_admin_config_form_submit($form, &$form_state) {
+  $values = $form_state['values'];
+  $sms_games = dosomething_campaign_get_sms_games();
+  if ($sms_games) {
+    foreach ($sms_games as $vars) {
+      $nid = $vars['nid'];
+      dosomething_signup_variable_set($nid, 'mobilecommons_opt_in_alpha', $values[$nid . '_alpha']);
+      dosomething_signup_variable_set($nid, 'mobilecommons_opt_in_beta', $values[$nid . '_beta']);
+    }
+  }
+  drupal_set_message(t("Configuration saved."));
+}
+
+/**
  * Settings form third party opt-in ids.
  */
 function dosomething_signup_optin_config_form($form, &$form_state) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -170,6 +170,42 @@ function dosomething_signup_schema() {
     ),
     'primary key' => array('nid'),
   );
+  $schema['dosomething_signup_variable'] = array(
+    'description' => 'Table of signup configuration variables.',
+    'fields' => array(
+      'id' => array(
+        'description' => 'Primary key.',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'entity_type' => array(
+        'description' => 'The entity type this data is attached to.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'entity_id' => array(
+        'description' => 'The entity id this data is attached to.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'name' => array(
+        'description' => 'The name of the variable.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+      ),
+      'value' => array(
+        'description' => 'The value of the variable.',
+        'type' => 'int',
+        'not null' => FALSE,
+      ),
+    ),
+    'primary key' => array('id'),
+  );
   return $schema;
 }
 
@@ -297,3 +333,16 @@ function dosomething_signup_update_7007() {
     ->execute();
 }
 
+/**
+ * Adds the dosomething_signup_variable table.
+ */
+function dosomething_signup_update_7008() {
+  $tbl_name = 'dosomething_signup_variable';
+  // Load schema to get table definition.
+  $schema = dosomething_signup_schema();
+  // If table not present:
+  if (!db_table_exists($tbl_name)) {
+    // Create it.
+    db_create_table($tbl_name, $schema[$tbl_name]);
+  }
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -173,12 +173,6 @@ function dosomething_signup_schema() {
   $schema['dosomething_signup_variable'] = array(
     'description' => 'Table of signup configuration variables.',
     'fields' => array(
-      'id' => array(
-        'description' => 'Primary key.',
-        'type' => 'serial',
-        'unsigned' => TRUE,
-        'not null' => TRUE,
-      ),
       'entity_type' => array(
         'description' => 'The entity type this data is attached to.',
         'type' => 'varchar',
@@ -204,7 +198,7 @@ function dosomething_signup_schema() {
         'not null' => FALSE,
       ),
     ),
-    'primary key' => array('id'),
+    'primary key' => array('entity_type', 'entity_id', 'name'),
   );
   return $schema;
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -9,6 +9,7 @@ include_once 'dosomething_signup.forms.inc';
 include_once 'dosomething_signup.signup_data_form.inc';
 include_once 'dosomething_signup.theme.inc';
 include_once 'includes/dosomething_signup.mobilecommons.inc';
+include_once 'includes/dosomething_signup.variable.inc';
 
 /**
  * Implements hook_menu().
@@ -19,8 +20,7 @@ function dosomething_signup_menu() {
   $items['admin/config/services/optins'] = array(
     'title' => t('Third Party Opt-Ins'),
     'description' => 'Admin form to manage custom opt-ins',
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('dosomething_signup_optin_config_form'),
+    'page callback' => 'dosomething_signup_opt_in_config_page',
     'access callback' => 'user_access',
     'access arguments' => array('administer third party communication'),
     'file' => 'dosomething_signup.admin.inc'

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.variable.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.variable.inc
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @file
+ * Provides custom variable get and set functions for DoSomething Signup.
+ */
+
+/**
+ * Returns value of given Signup variable name for given entity id/type.
+ */
+function dosomething_signup_variable_get($entity_id, $name, $entity_type = 'node') {
+  return db_select('dosomething_signup_variable', 'v')
+    ->fields('v', array('value'))
+    ->condition('entity_id', $entity_id)
+    ->condition('entity_type', $entity_type)
+    ->condition('name', $name)
+    ->execute()
+    ->fetchField(0);
+}
+
+/**
+ * Sets a given Signup variable name and value for given entity id/type.
+ */
+function dosomething_signup_variable_set($entity_id, $name, $value, $entity_type = 'node') {
+  // If an empty string was passed:
+  if (empty($value)) {
+    // Delete the record.
+    dosomething_signup_variable_del($entity_id, $name, $entity_type);
+    return;
+  }
+  try {
+     // Adds or updates variable value for variable $name and given $entity.
+    return db_merge('dosomething_signup_variable')
+      ->key(array(
+          'entity_type' => $entity_type,
+          'entity_id' => $entity_id,
+          'name' => $name,
+        ))
+      ->fields(array(
+          'entity_type' => $entity_type,
+          'entity_id' => $entity_id,
+          'name' => $name,
+          'value' => $value,
+      ))
+      ->execute();
+  }
+  catch (Exception $e) {
+    // Keep message general in case a user ever sees it.
+    drupal_set_message(t("There was an error processing your request."));
+    // Log the error.
+    watchdog('dosomething_signup', $e, array(), WATCHDOG_ERROR);
+  }
+}
+
+/**
+ * Deletes dosomething_signup_variable record for given entity type, id , and variable name.
+ */
+function dosomething_signup_variable_del($entity_id, $name, $entity_type = 'node') {
+  return db_delete('dosomething_signup_variable')
+    ->condition('entity_id', $entity_id)
+    ->condition('entity_type', $entity_type)
+    ->condition('name', $name)
+    ->execute();
+}


### PR DESCRIPTION
@angaither Can you pls review?

Creates a custom variable table and get/set functions for Signup third party values (and other potential settings as well).  Details in #2175.  

Configures admin form to set variables for SMS Games.  No changes yet to existing Campaigns (will be handled by #2258)

This allows us to begin work on actually sending the API request to Mobilecommons in the SMS Game.
