### PR TITLE
Load in jQuery using proper require function.ink hover

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/sources.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/sources.js
@@ -1,7 +1,7 @@
 define(function() {
   "use strict";
 
-  var $ = window.jQuery;
+  var $ = require("jquery");
 
   // Toggle visibility of fact sources
   $(".js-toggle-sources").on("click", function(e) {

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/tips.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/tips.js
@@ -1,7 +1,7 @@
 define(function() {
   "use strict";
 
-  var $ = window.jQuery;
+  var $ = require("jquery");
 
   // View other tips on click
   $(".js-show-tip").on("click", function(event) {

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/Campaign.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/Campaign.js
@@ -1,7 +1,7 @@
 define(function(require) {
   "use strict";
 
-  var $ = window.jQuery;
+  var $ = require("jquery");
   var _ = require("lodash");
   var campaignTplSrc =  require("text!finder/templates/campaign.tpl.html");
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/FormView.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/FormView.js
@@ -1,7 +1,7 @@
 define(function(require) {
   "use strict";
 
-  var $ = window.jQuery;
+  var $ = require("jquery");
   var _ = require("lodash");
   var ResultsView = require("finder/ResultsView");
   var SolrAdapter = require("finder/SolrAdapter");

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
@@ -1,7 +1,7 @@
 define(function(require) {
   "use strict";
 
-  var $ = window.jQuery;
+  var $ = require("jquery");
   var _ = require("lodash");
   var Campaign = require("finder/Campaign");
   var noResultsTplSrc = require("text!finder/templates/no-results.tpl.html");

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
@@ -1,7 +1,7 @@
 define(function(require) {
   "use strict";
 
-  var $ = window.jQuery;
+  var $ = require("jquery");
   var _ = require("lodash");
 
   // Create a callback function for caching the jsonp response.

--- a/lib/themes/dosomething/paraneue_dosomething/js/main.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/main.js
@@ -43,7 +43,7 @@ define("main", function(require) {
   "use strict";
 
   // Set $ global for jQuery
-  window.$ = require("jquery");
+  var $ = require("jquery");
 
   // load in jQuery plugins
   require("jquery-once");

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/address.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/address.js
@@ -1,7 +1,7 @@
 define(function(require) {
   "use strict";
 
-  var $ = window.jQuery;
+  var $ = require("jquery");
   var Validation= require("neue/validation");
 
   /** @NOTE: Temporary, testing out some new ideas. */


### PR DESCRIPTION
Loads in jQuery using proper `require()` function now that we're bundling everything through RequireJS. This also fixes an intermittent issue where jQuery dependency wasn't loading in time for finder code to be initialized.

For review: @DoSomething/front-end
