### PR TITLE
Removed index lookup in field_transactional_email_copy value

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -498,8 +498,7 @@ function dosomething_signup_get_mbp_params_campaign(&$params, $node) {
 function dosomething_signup_get_mbp_params_campaign_group(&$params, $node) {
   if ($node->type == 'campaign_group') {
     $wrapper = entity_metadata_wrapper('node', $node);
-    $transactional_email_copy_values = $wrapper->field_transactional_email_copy->value();
-    $params['transactional_email_copy'] = $transactional_email_copy_values['value'];
+    $params['transactional_email_copy'] = $wrapper->field_transactional_email_copy->value();
   }
 }
 


### PR DESCRIPTION
Fixes #2269

No need to use `['value']` when using `entity_metadata_wrapper`.
