### PR TITLE
Fixes #2256: ds build dies on Predis library clone

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -193,7 +193,7 @@ libraries[mobilecommons-php][download][url] = "https://github.com/DoSomething/mo
 
 ; Predis
 libraries[predis][download][type] = "git"
-libraries[predis][download][url] = "git@github.com:nrk/predis.git"
+libraries[predis][download][url] = "https://github.com/nrk/predis.git"
 
 ; Zendesk PHP
 libraries[zendesk][download][type] = "git"


### PR DESCRIPTION
#### What's this PR do?
- Updates Predis library URL
#### Where should the reviewer start?
1. **drupal-org.make** - https://github.com/mshmsh5000/dosomething/blob/2256_Git_predis_clone/lib/profiles/dosomething/drupal-org.make#L194
#### How should this be manually tested?
1.  Checkout my branch
2.  Run `bin/ds build`
#### Any background context you want to provide?

`bin/ds build` was dying, unable to clone this repo. Switching from the `git:` to `https:` protocol has fixed for me and [two other testers](https://github.com/DoSomething/dosomething/issues/2256).
#### What are the relevant tickets?

Fixes #2256
#### Screenshots (if appropriate)

![donkey](https://cloud.githubusercontent.com/assets/149811/3055981/bb0d890c-e1c6-11e3-90a2-16abc3889fc3.jpg)
