### PR TITLE
SMS Game Signup Form

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -303,7 +303,7 @@ function dosomething_campaign_node_view($node, $view_mode, $langcode) {
 
     // Check if SMS Game:
     if (dosomething_campaign_get_campaign_type($node) == 'sms_game') {
-      $node->content['signup_form'] = drupal_get_form('dosomething_signup_alpha_beta_form', $node);
+      $node->content['signup_form'] = drupal_get_form('dosomething_signup_friends_form', $node);
       return;
     }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -40,13 +40,13 @@ function dosomething_signup_admin_config_form($form, &$form_state) {
         '#type' => 'textfield',
         '#title' => t('Mobile Commons Alpha Opt-In Path'),
         '#required' => TRUE,
-        '#default_value' => dosomething_signup_variable_get($nid, 'mobilecommons_opt_in_alpha'),
+        '#default_value' => dosomething_signup_variable_get($nid, 'mobilecommons_opt_in_path'),
       );
       $form[$nid][$nid . '_beta'] = array(
         '#type' => 'textfield',
         '#title' => t('Mobile Commons Beta Opt-In Path'),
         '#required' => TRUE,
-        '#default_value' => dosomething_signup_variable_get($nid, 'mobilecommons_opt_in_beta'),
+        '#default_value' => dosomething_signup_variable_get($nid, 'mobilecommons_friends_opt_in_path'),
       );
     }
   }
@@ -66,8 +66,8 @@ function dosomething_signup_admin_config_form_submit($form, &$form_state) {
   if ($sms_games) {
     foreach ($sms_games as $vars) {
       $nid = $vars['nid'];
-      dosomething_signup_variable_set($nid, 'mobilecommons_opt_in_alpha', $values[$nid . '_alpha']);
-      dosomething_signup_variable_set($nid, 'mobilecommons_opt_in_beta', $values[$nid . '_beta']);
+      dosomething_signup_variable_set($nid, 'mobilecommons_opt_in_path', $values[$nid . '_alpha']);
+      dosomething_signup_variable_set($nid, 'mobilecommons_friends_opt_in_path', $values[$nid . '_beta']);
     }
   }
   drupal_set_message(t("Configuration saved."));

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -6,14 +6,14 @@
  */
 
 /**
- * Form constructor for an Alpha/Beta signup form.
+ * Form constructor for a Friends signup form.
  *
  * @param int $nid
  *   Loaded $node that the form is being rendered on.
- * @param int $num_betas
- *   Number of inputs to provide for beta numbers.
+ * @param int $num_friends
+ *   Number of inputs to provide for friends' numbers.
  */
-function dosomething_signup_alpha_beta_form($form, &$form_state, $node, $num_betas = 3) {
+function dosomething_signup_friends_form($form, &$form_state, $node, $num_friends = 3) {
   $nid = $node->nid;
   $opt_in_path = dosomething_signup_variable_get($nid, 'mobilecommons_opt_in_path');
   $friends_opt_in_path = dosomething_signup_variable_get($nid, 'mobilecommons_friends_opt_in_path');
@@ -71,7 +71,7 @@ function dosomething_signup_alpha_beta_form($form, &$form_state, $node, $num_bet
       'placeholder' => t('Enter your mobile number'),
     ),
   );
-  for ($i = 0; $i < $num_betas; $i++) {
+  for ($i = 0; $i < $num_friends; $i++) {
     $form['beta_mobile_' .$i] = array(
       '#type' => 'textfield',
       '#attributes' => array(
@@ -91,11 +91,11 @@ function dosomething_signup_alpha_beta_form($form, &$form_state, $node, $num_bet
 }
 
 /**
- * Form validation handler for dosomething_signup_alpha_beta_form().
+ * Form validation handler for dosomething_signup_friends_form().
  *
  * Provides server-side checks for valid and duplicate numbers, cleans input format.
  */
-function dosomething_signup_alpha_beta_form_validate($form, &$form_state) {
+function dosomething_signup_friends_form_validate($form, &$form_state) {
   $values = $form_state['values'];
   // Text to display for invalid number format.
   $invalid_format_msg = t("Please provide a valid telephone number.");
@@ -141,16 +141,18 @@ function dosomething_signup_alpha_beta_form_validate($form, &$form_state) {
 }
 
 /**
- * Form submission handler for dosomething_signup_alpha_beta_form().
+ * Form submission handler for dosomething_signup_friends_form().
  *
  * Redirects user to the reportback confirmation page for given node.
  */
-function dosomething_signup_alpha_beta_form_submit($form, &$form_state) {
+function dosomething_signup_friends_form_submit($form, &$form_state) {
   $values = $form_state['values'];
   $nid = $values['nid'];
   if (user_is_logged_in()) {
     // Create a signup.
     dosomething_signup_create($nid);
+    // @todo: Save mobile and first name to user if not set.
+    // @see https://github.com/DoSomething/dosomething/issues/2274.
   }
   
   // Send opt_in request to Mobilecommons API.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -14,11 +14,33 @@
  *   Number of inputs to provide for beta numbers.
  */
 function dosomething_signup_alpha_beta_form($form, &$form_state, $node, $num_betas = 3) {
+  $nid = $node->nid;
+  $opt_in_path = dosomething_signup_variable_get($nid, 'mobilecommons_opt_in_path');
+  $friends_opt_in_path = dosomething_signup_variable_get($nid, 'mobilecommons_friends_opt_in_path');
+
   $form['nid'] = array(
     '#type' => 'hidden',
-    '#default_value' => $node->nid,
+    '#default_value' => $nid,
     '#access' => FALSE,
   );
+  // If we have opt-in paths set:
+  if ($opt_in_path && $friends_opt_in_path) {
+    // Add as hidden form elements.
+    $form['opt_in_path'] = array(
+      '#type' => 'hidden',
+      '#default_value' => $opt_in_path,
+      '#access' => FALSE,
+    );
+    $form['friends_opt_in_path'] = array(
+      '#type' => 'hidden',
+      '#default_value' => $friends_opt_in_path,
+      '#access' => FALSE,
+    );
+  }
+  else {
+    // Else set a warning message to inform staff to not expect any texts.
+    drupal_set_message(t("The opt-in paths for this SMS Game have not been configured."), "error");
+  }
   $form['num_betas'] = array(
     '#type' => 'hidden',
     '#default_value' => $num_betas,

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -23,6 +23,11 @@ function dosomething_signup_alpha_beta_form($form, &$form_state, $node, $num_bet
     '#default_value' => $nid,
     '#access' => FALSE,
   );
+  $form['title'] = array(
+    '#type' => 'hidden',
+    '#default_value' => $node->title,
+    '#access' => FALSE,
+  );
   // If we have opt-in paths set:
   if ($opt_in_path && $friends_opt_in_path) {
     // Add as hidden form elements.
@@ -147,6 +152,10 @@ function dosomething_signup_alpha_beta_form_submit($form, &$form_state) {
     // Create a signup.
     dosomething_signup_create($nid);
   }
+  
+  // Send opt_in request to Mobilecommons API.
+  dosomething_signup_mobilecommons_opt_in_friends($values);
+
   // Redirect to the reportback confirmation page.
   $confirmation_path = 'node/' . $values['nid'] . '/confirmation';
   $form_state['redirect'] = $confirmation_path;

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
@@ -68,3 +68,65 @@ function dosomething_signup_get_mobilecommons_vars($account, $lid, $title = NULL
   }
   return $args;
 }
+
+/**
+ * Sends a Mobilecommons API request to opt-in an alpha and betas.
+ *
+ * @param array $values
+ *   An array of form values sent from a Friends Signup Form.
+ *   @see dosomething_signup_friends_form().
+ *
+ * @return mixed
+ *   A Mobilecommons object, or FALSE if error.
+ */
+function dosomething_signup_get_mobilecommons_friends_vars($values) {
+  // Initialize arrays to send to the Mobilecommons API.
+  $args = array();
+  $friends = array();
+  $title = $values['title'];
+
+  // If user is logged in already:
+  if (user_is_logged_in()) {
+    // Use existing function to send existing data.
+    global $user;
+    $args = dosomething_signup_get_mobilecommons_vars($user, $values['opt_in_path'], $title);
+  }
+  // Else set relevant alpha values from the given $values.
+  else {
+    $args['opt_in_path[]'] = $values['opt_in_path'];
+    $args['person[phone]'] = $values['alpha_mobile'];
+    $args['person[first_name]'] = $values['alpha_name'];
+    $args['person[campaign_name]'] = $title;  
+  }
+  // Next set args for the friends.
+  for ($i = 0; $i < $values['num_betas']; $i++) {
+    if (!empty($values['beta_mobile_' . $i])) {
+      $friends[] = $values['beta_mobile_' . $i];
+    }
+  }
+  if (!empty($friends)) {
+    $args['friends_opt_in_path'] = $values['friends_opt_in_path'];
+  }
+  return array('args' => $args, 'friends' => $friends);
+}
+
+/**
+ * Sends a Mobilecommons API request to opt-in an alpha and betas.
+ *
+ * @param array $values
+ *   An array of form values sent from a Friends Signup Form.
+ *   @see dosomething_signup_friends_form().
+ *
+ * @return mixed
+ *   A Mobilecommons object, or FALSE if error.
+ */
+function dosomething_signup_mobilecommons_opt_in_friends($values) {
+  $vars = dosomething_signup_get_mobilecommons_friends_vars($values);
+  try {
+    return mobilecommons_request('opt_in_with_friends', $vars);
+  }
+  catch (Exception $e) {
+    // Log the error.
+    watchdog('dosomething_signup', $e, array(), WATCHDOG_ERROR);
+  }
+}


### PR DESCRIPTION
@angaither Can you please review?

Closes #2146
- Collects relevant alpha and beta form values and submits to Mobilecommons to opt-in everybody.  This will not be functional on the site until https://github.com/DoSomething/mobilecommons-php/issues/7 is resolved (will be submitting a pull request to close that issue shortly)
- Renames `dosomething_signup_alpha_beta_form` as `dosomething_signup_friends_form` to keep consistent with Mobilecommons API terminology 
- Renames `dosomething_signup_variable` names as `opt_in_path` and `friends_opt_in_path` to keep identical to Mobilecommons API parameters.
