### PR TITLE
Checking for field existence before getting value

### DIFF
--- a/lib/modules/dosomething/dosomething_search/dosomething_search.module
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.module
@@ -122,11 +122,14 @@ function dosomething_search_apachesolr_index_document_build_node(ApacheSolrDocum
 
     $node = entity_metadata_wrapper('node', $entity);
     foreach (array('high_season', 'low_season') as $season) {
-      $value = $node->{"field_" . $season}->value();
-      if (isset($value)) {
-        $now = time();
-        if ($now >= $node->{"field_" . $season}->value->value() && $now <= $node->{"field_" . $season}->value2->value()) {
-          $document->setField("bs_{$season}", 'true');
+      $field = $node->{"field_" . $season};
+      if (isset($field)) {
+        $value = $field->value();
+        if (isset($value)) {
+          $now = time();
+          if ($now >= $node->{"field_" . $season}->value->value() && $now <= $node->{"field_" . $season}->value2->value()) {
+            $document->setField("bs_{$season}", 'true');
+          }
         }
       }
     }


### PR DESCRIPTION
- When indexing a grouped campaign make sure that the fields
  exist before calling value()
