### PR TITLE
Grouped Campaign Alt Color

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -43,9 +43,6 @@ function dosomething_campaign_preprocess_node(&$vars) {
       dosomething_helpers_preprocess_partners_vars($vars);
     }
 
-    // Preprocess any custom campaign variables.
-    dosomething_campaign_preprocess_custom_vars($vars);
-
     // Add inline css based on vars.
     dosomething_helpers_add_inline_css($vars);
 
@@ -69,29 +66,6 @@ function dosomething_campaign_preprocess_node(&$vars) {
       // Preprocess the vars for the campaign action page.
       dosomething_campaign_preprocess_action_page($vars, $wrapper);
     }
-  }
-}
-
-/**
- * Preprocesses variables for any custom settings.
- *
- * @param array $vars
- *   Node variables, passed from preprocess_node.
- */
-function dosomething_campaign_preprocess_custom_vars(&$vars) {
-  // Get prefix to check for custom campaign variables.
-  $prefix = dosomething_helpers_get_custom_var_prefix('campaign', $vars['nid']);
-  // Check for custom alt color.
-  $alt_color = variable_get($prefix . 'alt_color');
-  if (!empty($alt_color)) {
-    // Sanitize value for sanity's sake.
-    $vars['alt_color'] = strip_tags($alt_color);
-  }
-  // Check for alt background File fid.
-  $fid = variable_get($prefix . 'alt_bg_fid');
-  if (!empty($fid)) {
-    $file = file_load($fid);
-    $vars['alt_bg_src'] = file_create_url($file->uri);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
@@ -76,9 +76,6 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
     // Hero Images.
     dosomething_helpers_preprocess_hero_images($vars);
 
-    // Preprocess any custom campaign variables.
-    dosomething_campaign_preprocess_custom_vars($vars);
-
     // Add inline css based on vars.
     dosomething_helpers_add_inline_css($vars);
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -166,12 +166,38 @@ function dosomething_helpers_preprocess_hero_images(&$vars) {
 }
 
 /**
+ * Preprocesses variables for any custom settings.
+ *
+ * @param array $vars
+ *   Node variables, passed from preprocess_node.
+ */
+function dosomething_helpers_preprocess_custom_vars(&$vars) {
+  // Get prefix to check for custom node styles variables.
+  $prefix = dosomething_helpers_get_custom_var_prefix($vars['type'], $vars['nid']);
+  // Check for custom alt color.
+  $alt_color = variable_get($prefix . 'alt_color');
+  if (!empty($alt_color)) {
+    // Sanitize value for sanity's sake.
+    $vars['alt_color'] = strip_tags($alt_color);
+  }
+  // Check for alt background File fid.
+  $fid = variable_get($prefix . 'alt_bg_fid');
+  if (!empty($fid)) {
+    $file = file_load($fid);
+    $vars['alt_bg_src'] = file_create_url($file->uri);
+  }
+}
+
+/**
  * Adds inline css into HEAD based on current state of vars.
  *
  * @param array $vars
  *   Node variables, passed from preprocess_node.
  */
 function dosomething_helpers_add_inline_css(&$vars) {
+  // Preprocess custom vars to see if any inline css needed.
+  dosomething_helpers_preprocess_custom_vars($vars);
+
   // Check for alt_color variable.
   if (isset($vars['alt_color'])) {
     $alt_color = 'color: #' .  $vars['alt_color'] . ' !important;';

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
@@ -161,7 +161,7 @@
 
         <?php foreach ($galleries as $gallery): ?>
           <?php if (isset($gallery['title'])): ?>
-            <h2 class="__title"><?php print $gallery['title']; ?></h2>
+            <h2 class="__title inline--alt-color"><?php print $gallery['title']; ?></h2>
           <?php endif; ?>
           <ul class="gallery -triad">
             <?php foreach ($gallery['items'] as $gallery_item): ?>


### PR DESCRIPTION
@angaither @weerd please review.
#### What's this PR do?

Adds a Grouped Campaign's alt_color variable into inline CSS in the `<HEAD>` markup.
#### Where should the reviewer start?

1.`dosomething_helpers_add_inline_css`
#### How should this be manually tested?
1.  Check out my branch
2.  Set the alt color for a Grouped Campaign node
3. Verify the H2 color changes
4. Set the alt color for a Campaign node
5. Verify the H2 color changes
6. Verify that a different campaign has normal color.
#### Any background context you want to provide?

Adding the `dosomething_campaign_preprocess_custom_vars` function didn't do the trick here: https://github.com/DoSomething/dosomething/pull/2283/files#diff-0e259d21c6440ea2681ced1bd67ae238R80
because it's hardcoded to find custom variables with `campaign` in the variable name.

The `preprocess_custom_vars` function is only used for the sake of the `dosomething_helpers_add_inline_css` function (formerly called `dosomething_campaign_add_inline_css` before it was moved into `dosomething_helpers`) , so i've just created a new function `dosomething_helpers_preprocess_custom_vars` which gets the custom vars by node type, and then is called from within `dosomething_helpers_add_inline_css`

TL;DR Just make one call to `dosomething_helpers_add_inline_css` to add the relevant inline CSS for styles variable overrides.
#### What are the relevant tickets?

Fixes #2041
#### Screenshots

![screen shot 2014-05-22 at 3 40 47 pm](https://cloud.githubusercontent.com/assets/1236811/3059229/1c9d5fae-e1e9-11e3-86ec-f82cd05688c8.png)
