### PR TITLE
Fixing broken indexing because of missing low_season field

### DIFF
--- a/lib/modules/dosomething/dosomething_search/dosomething_search.module
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.module
@@ -122,9 +122,8 @@ function dosomething_search_apachesolr_index_document_build_node(ApacheSolrDocum
 
     $node = entity_metadata_wrapper('node', $entity);
     foreach (array('high_season', 'low_season') as $season) {
-      $field = $node->{"field_" . $season};
-      if (isset($field)) {
-        $value = $field->value();
+      if (isset($node->{"field_" . $season})) {
+        $value = $node->{"field_" . $season}->value();
         if (isset($value)) {
           $now = time();
           if ($now >= $node->{"field_" . $season}->value->value() && $now <= $node->{"field_" . $season}->value2->value()) {


### PR DESCRIPTION
- Low season field doesn't exist on the grouped campaigns content
  type so it causes an entity field error if indexing tries to
  check that field's value

Fixes #2267
