### PR TITLE
Partner modal videos

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -106,6 +106,14 @@ function dosomething_helpers_preprocess_partners_vars(&$vars) {
   // Preprocess partner info modals.
   if (isset($vars['partner_info'])) {
     foreach ($vars['partner_info'] as $delta => $info) {
+      // If video field is set:
+      if (!empty($info['video'])) {
+        $vars['partner_info'][$delta]['video'] = theme('dosomething_video_embed', array(
+          'field' => $info['video'],
+          'width' => 550,
+          'height' => 300,
+        ));
+      }
       // If image landscape field is set:
       $image_node = $info['image'];
       if (!empty($image_node->field_image_landscape)) {

--- a/lib/modules/dosomething/dosomething_helpers/modal-links.tpl.php
+++ b/lib/modules/dosomething/dosomething_helpers/modal-links.tpl.php
@@ -47,7 +47,8 @@
       <a href="#" class="js-close-modal modal-close-button white">×</a>
       <h2 class="banner">We &lt;3 <?php print $partner['name']; ?></h2>
       <?php print $partner['copy']; ?>
-      <?php if (isset($partner['image'])): print $partner['image']; endif; ?>
+      <?php if (isset($partner['video'])): print $partner['video']; ?>
+      <?php elseif (isset($partner['image'])): print $partner['image']; endif; ?>
       <a href="#" class="js-close-modal">Back to main page</a>
     </script>
   <?php endforeach; ?>


### PR DESCRIPTION
@angaither Please review.

Outputs the video field in a Partner Info field collection if set.  This issue was a backlog issue for a while since we didn't need it for Comeback Clothes, but need it for the Hunt.  So here it is.  No fending necessary!

![sponsor-video](https://cloud.githubusercontent.com/assets/1236811/3060567/ef6fea00-e1f8-11e3-9001-b8f9c35f1bbf.png)
