### PR TITLE
SMS Game Tweaks

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -48,7 +48,7 @@ function dosomething_signup_friends_form($form, &$form_state, $node, $num_friend
   }
   $form['num_betas'] = array(
     '#type' => 'hidden',
-    '#default_value' => $num_betas,
+    '#default_value' => $num_friends,
     '#access' => FALSE,
   );
   $form['alpha_first_name'] = array(

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -630,7 +630,9 @@ function dosomething_signup_get_login_signup_nid() {
   if (isset($obj->type)) {
     switch ($obj->type) {
       case 'campaign':
-        return $obj->nid;
+        if (dosomething_campaign_get_campaign_type($obj) != 'sms_game') {
+          return $obj->nid;
+        }
         break;
       case 'campaign_group':
         // Should only signup on login if the signup form is displayed.


### PR DESCRIPTION
@angaither Can you please review?
- Fixes bug to set the form's `num_betas` hidden element correctly.  I changed the form constructor parameter to `$num_friends` but forgot to set this value in the hidden element.
- Prevents a signup from being created if a user logs in on a SMS Game Campaign node.
