### PR TITLE
Don't display Custom Settings page on SMS Game

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -150,7 +150,7 @@ function dosomething_campaign_admin_paths() {
  * Page access callback for admin custom settings form.
  */
 function dosomething_campaign_admin_custom_settings_page_access($node) {
-  return ($node->type == 'campaign' && dosomething_user_is_staff());
+  return ($node->type == 'campaign' && dosomething_user_is_staff() && dosomething_campaign_get_campaign_type($node) == 'campaign');
 }
 
 /*


### PR DESCRIPTION
@angaither Please review.

The custom settings page houses the Signup Data Form and Reportback Field configuration forms, which don't apply to a SMS Game. Don't display for SMS Games.
