### PR TITLE
Sms Game tweaks

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -148,12 +148,24 @@ function dosomething_signup_friends_form_validate($form, &$form_state) {
 function dosomething_signup_friends_form_submit($form, &$form_state) {
   $values = $form_state['values'];
   $nid = $values['nid'];
+
   if (user_is_logged_in()) {
     // Create a signup.
     dosomething_signup_create($nid);
     // @todo: Save mobile and first name to user if not set.
     // @see https://github.com/DoSomething/dosomething/issues/2274.
   }
+
+  // Check if an account exists for the given alpha mobile.
+  // An anonymous user is able to submit the form, but they may still have an account.
+  if ($account = dosomething_user_get_user_by_mobile($values['alpha_mobile'])) {
+    // Create a signup for the account.
+    // If $account happens to be the logged in user, it's okay.
+    // dosomething_signup_create will check if a signup exists before creating.
+    dosomething_signup_create($nid, $account->uid);
+
+  }
+
   
   // Send opt_in request to Mobilecommons API.
   dosomething_signup_mobilecommons_opt_in_friends($values);

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -349,6 +349,15 @@ function dosomething_signup_entity_insert($entity, $type) {
   
   $account = user_load($entity->uid);
   $node = node_load($entity->nid);
+
+  // If this is a SMS Game Campaign node:
+  if (module_exists('dosomething_campaign') && dosomething_campaign_get_campaign_type($node) == 'sms_game') {
+    // Third party subscription is handled elsewhere,
+    // @see dosomething_signup_friends_form_submit.
+    // Exit out of function.
+    return;
+  }
+
   // Send relevant third-party subscribe requests.
   dosomething_signup_third_party_subscribe($account, $node);
 
@@ -630,7 +639,7 @@ function dosomething_signup_get_login_signup_nid() {
   if (isset($obj->type)) {
     switch ($obj->type) {
       case 'campaign':
-        if (dosomething_campaign_get_campaign_type($obj) != 'sms_game') {
+        if (module_exists('dosomething_campaign') && dosomething_campaign_get_campaign_type($obj) != 'sms_game') {
           return $obj->nid;
         }
         break;


### PR DESCRIPTION
- Submitting SMS Game form creates a signup for the account which belongs to alpha number, if an account exists. Regardless of logged in or not.
- Don't send transactionals for SMS Game form submitting.
