### PR TITLE
Fixes SMS Game header image

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -36,7 +36,7 @@ function dosomething_campaign_preprocess_node(&$vars) {
     }
 
     // Hero Images.
-    dosomething_helpers_preprocess_hero_images($vars);
+    dosomething_helpers_preprocess_hero_images($vars, $wrapper);
 
     if (!empty($vars['field_partners'])) {
       // Sets partners, sponsors, and partner_info arrays if present.
@@ -53,7 +53,7 @@ function dosomething_campaign_preprocess_node(&$vars) {
       dosomething_campaign_preprocess_pitch_page($vars, $wrapper);
       return;
     }
-    
+
     // Preprocess common vars between all campaign types.
     dosomething_campaign_preprocess_common_vars($vars, $wrapper);
 
@@ -259,7 +259,7 @@ function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
   else {
     // Pass it as a param to display on the signup button.
     dosomething_signup_preprocess_signup_button($vars, $label);
-  }  
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
@@ -27,7 +27,7 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
 
     $vars['campaigns'] = dosomething_campaign_group_get_campaigns($vars['node']);
 
-    // If there are no published campaigns, 
+    // If there are no published campaigns,
     // Display pre_launch vars and remove campaigns from vars.
     if (!isset($vars['campaigns']['published'])) {
       $template_vars['text'][] = 'pre_launch_copy';
@@ -74,7 +74,7 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
     }
 
     // Hero Images.
-    dosomething_helpers_preprocess_hero_images($vars);
+    dosomething_helpers_preprocess_hero_images($vars, $wrapper);
 
     // Add inline css based on vars.
     dosomething_helpers_add_inline_css($vars);
@@ -130,7 +130,7 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
     if (!empty($modal_items)) {
       $vars['modals'] = theme('modal_links', array('modals' => $modal_items));
     }
-    
+
   }
 }
 
@@ -177,7 +177,7 @@ function dosomething_campaign_group_get_campaigns($campaign_group_node) {
 
       if ((int)$status === 1) {
         $campaigns['published'][] = $campaign;
-      } 
+      }
       else {
         $campaigns['unpublished'][] = $campaign;
       }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -160,7 +160,7 @@ function dosomething_helpers_format_partners_list(&$vars) {
 }
 
 /**
- * Handles preprocessing Cover Images.
+ * Handles preprocessing hero_images vars.
  */
 function dosomething_helpers_preprocess_hero_images(&$vars, $wrapper) {
 
@@ -171,10 +171,12 @@ function dosomething_helpers_preprocess_hero_images(&$vars, $wrapper) {
   if (!$hero_image) { return; }
 
   $hero_nid = $hero_image->nid;
-  $vars['hero_image_l'] = dosomething_image_get_themed_image($hero_nid, 'landscape', '1440x810');
-  $vars['hero_image_m'] = dosomething_image_get_themed_image($hero_nid, 'square', '768x768');
-  $vars['hero_image_l_url'] = dosomething_image_get_themed_image_url($hero_nid, 'landscape', '1440x810');
-  $vars['hero_image_m_url'] = dosomething_image_get_themed_image_url($hero_nid, 'square', '768x768');
+  $large = '1440x810';
+  $medium = '768x768';
+  $vars['hero_image_l'] = dosomething_image_get_themed_image($hero_nid, 'landscape', $large);
+  $vars['hero_image_m'] = dosomething_image_get_themed_image($hero_nid, 'square', $medium);
+  $vars['hero_image_l_url'] = dosomething_image_get_themed_image_url($hero_nid, 'landscape', $large);
+  $vars['hero_image_m_url'] = dosomething_image_get_themed_image_url($hero_nid, 'square', $medium);
 
   isset($vars['hero_image_m_url']) ? $vars['hero_image']['mobile'] = $vars['hero_image_m_url'] : NULL ;
   isset($vars['hero_image_l_url']) ? $vars['hero_image']['desktop'] = $vars['hero_image_l_url'] : NULL ;
@@ -201,7 +203,6 @@ function dosomething_helpers_preprocess_custom_vars(&$vars) {
     $file = file_load($fid);
     $vars['alt_bg_src'] = file_create_url($file->uri);
   }
-
 }
 
 /**
@@ -211,7 +212,6 @@ function dosomething_helpers_preprocess_custom_vars(&$vars) {
  *   Node variables, passed from preprocess_node.
  */
 function dosomething_helpers_add_inline_css(&$vars) {
-
   // Preprocess custom vars to see if any inline css needed.
   dosomething_helpers_preprocess_custom_vars($vars);
 
@@ -243,5 +243,4 @@ function dosomething_helpers_add_inline_css(&$vars) {
 
     drupal_add_css($style_alt_background, $option['type'] = 'inline');
   }
-
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -3,7 +3,7 @@
 /**
  * Implements hook_theme_registry_alter()
  *
- * Modules registered in dosomething_helpers_modules will 
+ * Modules registered in dosomething_helpers_modules will
  * have their paths added to the theme registry so that they
  * can store reference entity type templates within the module.
 **/
@@ -159,15 +159,22 @@ function dosomething_helpers_format_partners_list(&$vars) {
   $vars['formatted_partners'] = $formatted_partners;
 }
 
-function dosomething_helpers_preprocess_hero_images(&$vars) {
-  // Hero Images.
-  if (isset($vars['field_image_campaign_cover'][0])) {
-    $hero_nid = $vars['field_image_campaign_cover'][0]['entity']->nid;
-    $vars['hero_image_l'] = dosomething_image_get_themed_image($hero_nid, 'landscape', '1440x810');
-    $vars['hero_image_m'] = dosomething_image_get_themed_image($hero_nid, 'square', '768x768');
-    $vars['hero_image_l_url'] = dosomething_image_get_themed_image_url($hero_nid, 'landscape', '1440x810');
-    $vars['hero_image_m_url'] = dosomething_image_get_themed_image_url($hero_nid, 'square', '768x768');
-  }
+/**
+ * Handles preprocessing Cover Images.
+ */
+function dosomething_helpers_preprocess_hero_images(&$vars, $wrapper) {
+
+  // Use entity_metadata_wrapper to handle field language issues.
+  // @see https://github.com/DoSomething/dosomething/issues/2349.
+  $hero_image = $wrapper->field_image_campaign_cover->value();
+  // If no hero image set, exit out of function.
+  if (!$hero_image) { return; }
+
+  $hero_nid = $hero_image->nid;
+  $vars['hero_image_l'] = dosomething_image_get_themed_image($hero_nid, 'landscape', '1440x810');
+  $vars['hero_image_m'] = dosomething_image_get_themed_image($hero_nid, 'square', '768x768');
+  $vars['hero_image_l_url'] = dosomething_image_get_themed_image_url($hero_nid, 'landscape', '1440x810');
+  $vars['hero_image_m_url'] = dosomething_image_get_themed_image_url($hero_nid, 'square', '768x768');
 
   isset($vars['hero_image_m_url']) ? $vars['hero_image']['mobile'] = $vars['hero_image_m_url'] : NULL ;
   isset($vars['hero_image_l_url']) ? $vars['hero_image']['desktop'] = $vars['hero_image_l_url'] : NULL ;
@@ -194,6 +201,7 @@ function dosomething_helpers_preprocess_custom_vars(&$vars) {
     $file = file_load($fid);
     $vars['alt_bg_src'] = file_create_url($file->uri);
   }
+
 }
 
 /**
@@ -203,6 +211,7 @@ function dosomething_helpers_preprocess_custom_vars(&$vars) {
  *   Node variables, passed from preprocess_node.
  */
 function dosomething_helpers_add_inline_css(&$vars) {
+
   // Preprocess custom vars to see if any inline css needed.
   dosomething_helpers_preprocess_custom_vars($vars);
 
@@ -234,4 +243,5 @@ function dosomething_helpers_add_inline_css(&$vars) {
 
     drupal_add_css($style_alt_background, $option['type'] = 'inline');
   }
+
 }


### PR DESCRIPTION
@weerd Mind testing this fix locally?

Can test by pulling down this branch, and confirming that the Campaign Cover Image displays for:
- SMS Games
- Campaigns
- Grouped Campaigns

As mentioned in the issue, https://github.com/DoSomething/dosomething/issues/2349#issuecomment-44606427, this bug is kinda nuts.  The different `view_modes` have different `$vars['field_image_campaign_cover]` array keys, causing the conditional in `dosomething_helpers_preprocess_hero_images` to fail for the `sms_game` view mode.

This PR changes the function to use values returned from the `EntityMetaDataWrapper` stop the bleed, but this seems to open possibilities for other weird language issues in other fields where the `$vars` arrays could be different among view_modes.  

I'm beginning to think instead of defining custom view modes, all we might need is just different tpl and preprocess functions based on the Campaign type and "view" (pitch, closed).  Going to look into this a bit.
