### PR TITLE
Removes SMS Game view mode

### DIFF
--- a/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.features.field_instance.inc
@@ -30,12 +30,6 @@ function dosomething_action_guide_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -77,12 +71,6 @@ function dosomething_action_guide_field_default_field_instances() {
         'weight' => 6,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -130,12 +118,6 @@ function dosomething_action_guide_field_default_field_instances() {
         'weight' => 8,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -193,12 +175,6 @@ function dosomething_action_guide_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -237,12 +213,6 @@ function dosomething_action_guide_field_default_field_instances() {
         'weight' => 3,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -291,12 +261,6 @@ function dosomething_action_guide_field_default_field_instances() {
         'weight' => 4,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -351,12 +315,6 @@ function dosomething_action_guide_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -398,12 +356,6 @@ function dosomething_action_guide_field_default_field_instances() {
         'weight' => 1,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
@@ -244,12 +244,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -299,12 +293,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 20,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -347,12 +335,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'hidden',
         'weight' => 3,
-      ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -399,12 +381,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 1,
-      ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -456,12 +432,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -505,12 +475,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 21,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -553,12 +517,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'hidden',
         'weight' => 7,
-      ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -624,12 +582,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 16,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -678,12 +630,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'hidden',
         'weight' => 22,
-      ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -736,12 +682,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 23,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -792,12 +732,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'hidden',
         'weight' => 24,
-      ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -854,12 +788,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -907,12 +835,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'hidden',
         'weight' => 25,
-      ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -971,12 +893,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'entityreference_entity_id',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1021,12 +937,6 @@ function dosomething_campaign_field_default_field_instances() {
         'weight' => 38,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -1083,12 +993,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1138,12 +1042,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1186,12 +1084,6 @@ function dosomething_campaign_field_default_field_instances() {
         'weight' => 53,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -1251,12 +1143,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 13,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1307,12 +1193,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 12,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1359,12 +1239,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1406,12 +1280,6 @@ function dosomething_campaign_field_default_field_instances() {
         'weight' => 58,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -1482,12 +1350,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 17,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1536,12 +1398,6 @@ function dosomething_campaign_field_default_field_instances() {
         'weight' => 35,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -1602,12 +1458,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1648,12 +1498,6 @@ function dosomething_campaign_field_default_field_instances() {
         'weight' => 43,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -1707,12 +1551,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1756,12 +1594,6 @@ function dosomething_campaign_field_default_field_instances() {
         'weight' => 47,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -1815,12 +1647,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1864,12 +1690,6 @@ function dosomething_campaign_field_default_field_instances() {
         'weight' => 45,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -1921,12 +1741,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1965,12 +1779,6 @@ function dosomething_campaign_field_default_field_instances() {
         'weight' => 54,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -2021,12 +1829,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 11,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -2070,12 +1872,6 @@ function dosomething_campaign_field_default_field_instances() {
         'weight' => 44,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -2127,12 +1923,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -2178,12 +1968,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'hidden',
         'weight' => 4,
-      ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -2231,12 +2015,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 9,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -2283,12 +2061,6 @@ function dosomething_campaign_field_default_field_instances() {
         'weight' => 34,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -2343,12 +2115,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -2393,12 +2159,6 @@ function dosomething_campaign_field_default_field_instances() {
         'weight' => 37,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -2454,12 +2214,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 5,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -2506,12 +2260,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'hidden',
         'weight' => 10,
-      ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -2560,12 +2308,6 @@ function dosomething_campaign_field_default_field_instances() {
         'weight' => 33,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -2620,12 +2362,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -2670,12 +2406,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'hidden',
         'weight' => 19,
-      ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -2724,12 +2454,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'hidden',
         'weight' => 15,
-      ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -2782,12 +2506,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -2831,12 +2549,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'hidden',
         'weight' => 14,
-      ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -417,20 +417,19 @@ function dosomething_campaign_entity_info_alter(&$entity_info) {
 /*
  * Implements hook_entity_view_mode_alter().
  *
- * When a campaign node is viewed in full, this function checks both signup status
- * and the node's field_campaign_type to determine what view_mode to set.
+ * Sets "pitch" view_mode for campaign nodes based on user signup status.
  *
  * This function also handles redirects to legacy nodes.
  */
 function dosomething_campaign_entity_view_mode_alter(&$view_mode, $context) {
   // Is this a campaign node?
   if ($context['entity_type'] == 'node' && $context['entity']->type == 'campaign' && $view_mode == 'full') {
+
     $node = $context['entity'];
-    // Find the campaign type.
-    $campaign_type = dosomething_campaign_get_campaign_type($node);
     // If SMS Game:
-    if ($campaign_type == 'sms_game') {
-      return 'full';
+    if (dosomething_campaign_get_campaign_type($node) == 'sms_game') {
+      // Exit out of function, don't need to check for pitch page.
+      return;
     }
 
     // If anonymous user:

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -219,7 +219,7 @@ function dosomething_campaign_reportback_confirmation_page_access($node) {
   if (dosomething_campaign_get_campaign_type($node) == 'sms_game') {
     return TRUE;
   }
-  
+
   // Else only grant if the user has reported back on this campaign.
   if (user_is_logged_in() && module_exists('dosomething_reportback') && dosomething_reportback_exists($node->nid)) {
     return TRUE;
@@ -360,7 +360,7 @@ function dosomething_campaign_add_signup_data_form_vars(&$node) {
     $node->content['signup_data_form'] = array(
       '#markup' => $config['old_people_copy'],
     );
-    // By exiting out of function now, we don't check to set the 
+    // By exiting out of function now, we don't check to set the
     // required_signup_data_form variable, meaning Old People will never be
     // auto prompted.
     return;
@@ -389,7 +389,7 @@ function dosomething_campaign_add_signup_data_form_vars(&$node) {
  *   A loaded campaign node.
  *
  * @return mixed
- *   If node type == campaign, returns string value of field_campaign_type. 
+ *   If node type == campaign, returns string value of field_campaign_type.
  *     - Defaults to 'campaign' if value is not set.
  *   Else returns FALSE.
  */
@@ -406,16 +406,10 @@ function dosomething_campaign_get_campaign_type($node) {
 
 /**
  * Implements hook_entity_info_alter().
- *
- * Defines the custom Pitch and SMS Game view modes.
  */
 function dosomething_campaign_entity_info_alter(&$entity_info) {
   $entity_info['node']['view modes']['pitch'] = array(
     'label' => t('Pitch page'),
-    'custom settings' => TRUE,
-  );
-  $entity_info['node']['view modes']['sms_game'] = array(
-    'label' => t('Sms game'),
     'custom settings' => TRUE,
   );
 }
@@ -423,7 +417,7 @@ function dosomething_campaign_entity_info_alter(&$entity_info) {
 /*
  * Implements hook_entity_view_mode_alter().
  *
- * When a campaign node is viewed in full, this function checks both signup status 
+ * When a campaign node is viewed in full, this function checks both signup status
  * and the node's field_campaign_type to determine what view_mode to set.
  *
  * This function also handles redirects to legacy nodes.
@@ -436,9 +430,9 @@ function dosomething_campaign_entity_view_mode_alter(&$view_mode, $context) {
     $campaign_type = dosomething_campaign_get_campaign_type($node);
     // If SMS Game:
     if ($campaign_type == 'sms_game') {
-      $view_mode = 'sms_game';
-      return;
+      return 'full';
     }
+
     // If anonymous user:
     if (!user_is_logged_in()) {
       // Display pitch view mode.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -11,62 +11,58 @@
 function dosomething_campaign_preprocess_node(&$vars) {
   if ($vars['type'] != 'campaign') { return; }
 
-  // View modes which need preprocessing.
-  $view_modes = array('pitch', 'full', 'sms_game');
+  $node = menu_get_object();
+  $wrapper = entity_metadata_wrapper('node', $node);
 
-  if (in_array($vars['view_mode'], $view_modes)) {
-
-    $node = menu_get_object();
-    $wrapper = entity_metadata_wrapper('node', $node);
-
-    $scholarship = $wrapper->field_scholarship_amount->value();
-    if (isset($scholarship)) {
-      $vars['scholarship'] = '$' . number_format($scholarship, 0, '', ',') . ' Scholarship';
-    }
-
-    $vars['cta'] = $wrapper->field_call_to_action->value();
-
-    // Timing.
-    $display_date = $wrapper->field_display_end_date->value();
-    // Check if there is a value in the date field.
-    $high_season = $wrapper->field_high_season->value();
-    if ($display_date == 1 && isset($high_season)) {
-      $end_date = date('F d', $wrapper->field_high_season->value2->value());
-      $vars['end_date'] = 'Ends ' . $end_date;
-    }
-
-    // Hero Images.
-    dosomething_helpers_preprocess_hero_images($vars);
-
-    if (!empty($vars['field_partners'])) {
-      // Sets partners, sponsors, and partner_info arrays if present.
-      dosomething_helpers_preprocess_partners_vars($vars);
-    }
-
-    // Add inline css based on vars.
-    dosomething_helpers_add_inline_css($vars);
-
-    if ($vars['view_mode'] == 'pitch') {
-      // Use the pitch page template to theme.
-      $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'] . '__pitch';
-      // Gather vars for pitch page.
-      dosomething_campaign_preprocess_pitch_page($vars, $wrapper);
-      return;
-    }
-    
-    // Preprocess common vars between all campaign types.
-    dosomething_campaign_preprocess_common_vars($vars, $wrapper);
-
-    if ($vars['view_mode'] == 'sms_game') {
-      // Use the pitch page template to theme.
-      $vars['theme_hook_suggestions'][] = 'node__campaign__sms_game';
-      dosomething_campaign_preprocess_sms_game($vars, $wrapper);
-    }
-    elseif ($vars['view_mode'] == 'full'){
-      // Preprocess the vars for the campaign action page.
-      dosomething_campaign_preprocess_action_page($vars, $wrapper);
-    }
+  $scholarship = $wrapper->field_scholarship_amount->value();
+  if (isset($scholarship)) {
+    $vars['scholarship'] = '$' . number_format($scholarship, 0, '', ',') . ' Scholarship';
   }
+
+  $vars['cta'] = $wrapper->field_call_to_action->value();
+
+  // Timing.
+  $display_date = $wrapper->field_display_end_date->value();
+  // Check if there is a value in the date field.
+  $high_season = $wrapper->field_high_season->value();
+  if ($display_date == 1 && isset($high_season)) {
+    $end_date = date('F d', $wrapper->field_high_season->value2->value());
+    $vars['end_date'] = 'Ends ' . $end_date;
+  }
+
+  // Hero Images.
+  dosomething_helpers_preprocess_hero_images($vars);
+
+  if (!empty($vars['field_partners'])) {
+    // Sets partners, sponsors, and partner_info arrays if present.
+    dosomething_helpers_preprocess_partners_vars($vars);
+  }
+
+  // Add inline css based on vars.
+  dosomething_helpers_add_inline_css($vars);
+
+  if ($vars['view_mode'] == 'pitch') {
+    // Use the pitch page template to theme.
+    $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'] . '__pitch';
+    // Gather vars for pitch page.
+    dosomething_campaign_preprocess_pitch_page($vars, $wrapper);
+    return;
+  }
+
+  // Preprocess common vars between all campaign types.
+  dosomething_campaign_preprocess_common_vars($vars, $wrapper);
+
+  if (dosomething_campaign_get_campaign_type($node) == 'sms_game') {
+    // Use the SMS Game template to theme.
+    $vars['theme_hook_suggestions'][] = 'node__campaign__sms_game';
+    dosomething_campaign_preprocess_sms_game($vars, $wrapper);
+    return;
+  }
+
+  // Preprocess the vars for the campaign action page.
+  dosomething_campaign_preprocess_action_page($vars, $wrapper);
+
+
 }
 
 /**
@@ -259,7 +255,7 @@ function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
   else {
     // Pass it as a param to display on the signup button.
     dosomething_signup_preprocess_signup_button($vars, $label);
-  }  
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
@@ -30,12 +30,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -74,12 +68,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'weight' => 29,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -128,12 +116,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -177,12 +159,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'weight' => 33,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -237,12 +213,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -284,12 +254,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'weight' => 8,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -338,12 +302,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'weight' => 9,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -398,12 +356,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -446,12 +398,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'weight' => 26,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -501,12 +447,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'weight' => 19,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -562,12 +502,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -615,12 +549,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -663,12 +591,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'weight' => 25,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -730,12 +652,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -780,12 +696,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'weight' => 0,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -839,12 +749,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -889,12 +793,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'weight' => 1,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -951,12 +849,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -994,12 +886,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'weight' => 34,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -1051,12 +937,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1103,12 +983,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1150,12 +1024,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'weight' => 31,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -1212,12 +1080,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1265,12 +1127,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1312,12 +1168,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'weight' => 21,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -1373,12 +1223,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1419,12 +1263,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'weight' => 30,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -1476,12 +1314,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1528,12 +1360,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'weight' => 3,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.field_instance.inc
@@ -71,12 +71,6 @@ function dosomething_campaign_run_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -121,12 +115,6 @@ function dosomething_campaign_run_field_default_field_instances() {
         'weight' => 2,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -179,12 +167,6 @@ function dosomething_campaign_run_field_default_field_instances() {
         'weight' => 3,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.features.field_instance.inc
@@ -30,12 +30,6 @@ function dosomething_fact_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),

--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.features.field_instance.inc
@@ -30,12 +30,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -77,12 +71,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'weight' => 7,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -134,12 +122,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -180,12 +162,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'weight' => 8,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -253,12 +229,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -305,12 +275,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'weight' => 2,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -365,12 +329,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -414,12 +372,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'weight' => 5,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -474,12 +426,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -526,12 +472,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -570,12 +510,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'weight' => 3,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',

--- a/lib/modules/dosomething/dosomething_home/dosomething_home.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_home/dosomething_home.features.field_instance.inc
@@ -32,12 +32,6 @@ function dosomething_home_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -82,12 +76,6 @@ function dosomething_home_field_default_field_instances() {
         'weight' => 0,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',

--- a/lib/modules/dosomething/dosomething_image/dosomething_image.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.features.field_instance.inc
@@ -30,12 +30,6 @@ function dosomething_image_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -76,12 +70,6 @@ function dosomething_image_field_default_field_instances() {
         'weight' => 0,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -143,12 +131,6 @@ function dosomething_image_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -205,12 +187,6 @@ function dosomething_image_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -260,12 +236,6 @@ function dosomething_image_field_default_field_instances() {
         'weight' => 4,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.features.field_instance.inc
@@ -291,12 +291,6 @@ function dosomething_static_content_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -338,12 +332,6 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 12,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -395,12 +383,6 @@ function dosomething_static_content_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -439,12 +421,6 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 5,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -491,12 +467,6 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 14,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -568,12 +538,6 @@ function dosomething_static_content_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -614,12 +578,6 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 7,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -674,12 +632,6 @@ function dosomething_static_content_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -723,12 +675,6 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 9,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -778,12 +724,6 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 8,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -840,12 +780,6 @@ function dosomething_static_content_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
-      'sms_game' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -883,12 +817,6 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 11,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -941,12 +869,6 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 15,
       ),
       'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
-      'sms_game' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',


### PR DESCRIPTION
Fixes #2349 in a hardcore way. It's because #2349 is some kind of crazy bug where there is a difference in the `$vars['field_image_campaign_cover']` array structure between the two different view modes, `full` and `sms_game`.

The cleanest solution here is to get rid of the view mode altogether.  We don't need it.  All we need to do is suggest a different theme template file based on the Campaign Type instead of looking for a `sms_game` view mode, which is seen here: https://github.com/aaronschachter/dosomething/compare/view_mode_no_more?expand=1#diff-f3920561a5ca7c40913d6f8452fb9c0fR55
## How to test:
- Pull down this branch and `drush -y fra`
- Verify Campaign Cover Images display for:
  - SMS Games
  - Campaigns
  - Grouped Campaigns
## History

The majority of these changes are removing the custom `sms_game` view mode entirely from the site, which means updating all the Features definitions to get rid of it.  

The fact that the `sms_game` view mode exists in Features on all of these content types we don't use it for is a good indicator that we're not using it correctly.

The history here is that the Campaign started as a custom Entity, and not a node.  We used a Pitch entity view for the Campaign entity, and it seemed to work fine to keep it for when we made the switch from defining Campaigns as custom entities instead of Nodes.

Little did we realize that the Pitch view mode was being exported for all field isntances for other content types too (since we started the Campaign node type as one of the first ones).  Will open a separate issue to do the same for Pitch view mode, it should just be handled via serving a different `theme_hook_suggestions` based on the Campaign Type and User Signup status.
