### PR TITLE
Adds dosomething_campaign_is_pitch_page

### DIFF
--- a/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.features.field_instance.inc
@@ -24,12 +24,6 @@ function dosomething_action_guide_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 7,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -69,12 +63,6 @@ function dosomething_action_guide_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 6,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -116,12 +104,6 @@ function dosomething_action_guide_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 8,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -169,12 +151,6 @@ function dosomething_action_guide_field_default_field_instances() {
         'type' => 'field_collection_view',
         'weight' => 5,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -211,12 +187,6 @@ function dosomething_action_guide_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 3,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -259,12 +229,6 @@ function dosomething_action_guide_field_default_field_instances() {
         ),
         'type' => 'entityreference_label',
         'weight' => 4,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -309,12 +273,6 @@ function dosomething_action_guide_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 2,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -354,12 +312,6 @@ function dosomething_action_guide_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 1,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
@@ -238,12 +238,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'entityreference_label',
         'weight' => 60,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -287,12 +281,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'taxonomy_term_reference_link',
         'weight' => 2,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 20,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -329,12 +317,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'list_default',
         'weight' => 21,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 3,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -374,13 +356,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 0,
-      ),
-      'pitch' => array(
-        'label' => 'hidden',
-        'module' => 'text',
-        'settings' => array(),
-        'type' => 'text_default',
-        'weight' => 1,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -426,12 +401,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'list_default',
         'weight' => 63,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -469,12 +438,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'taxonomy_term_reference_link',
         'weight' => 3,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 21,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -511,12 +474,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'link_default',
         'weight' => 17,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 7,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -576,12 +533,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'list_default',
         'weight' => 16,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 16,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -624,12 +575,6 @@ function dosomething_campaign_field_default_field_instances() {
         ),
         'type' => 'entityreference_label',
         'weight' => 8,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 22,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -676,12 +621,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'entityreference_label',
         'weight' => 9,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 23,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -726,12 +665,6 @@ function dosomething_campaign_field_default_field_instances() {
         ),
         'type' => 'entityreference_label',
         'weight' => 13,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 24,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -782,12 +715,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'field_collection_view',
         'weight' => 31,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -829,12 +756,6 @@ function dosomething_campaign_field_default_field_instances() {
         ),
         'type' => 'date_default',
         'weight' => 14,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 25,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -886,13 +807,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'entityreference_label',
         'weight' => 5,
       ),
-      'pitch' => array(
-        'label' => 'hidden',
-        'module' => 'entityreference',
-        'settings' => array(),
-        'type' => 'entityreference_entity_id',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -935,12 +849,6 @@ function dosomething_campaign_field_default_field_instances() {
         ),
         'type' => 'entityreference_label',
         'weight' => 38,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -987,12 +895,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'entityreference_label',
         'weight' => 50,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1036,12 +938,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'entityreference_label',
         'weight' => 49,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1082,12 +978,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'taxonomy_term_reference_link',
         'weight' => 53,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -1137,12 +1027,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 27,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 13,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1187,12 +1071,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'list_default',
         'weight' => 29,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 12,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1233,12 +1111,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 57,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1278,12 +1150,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'link_default',
         'weight' => 58,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -1344,12 +1210,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'date_default',
         'weight' => 15,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 17,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1396,12 +1256,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'file_default',
         'weight' => 35,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -1452,12 +1306,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'field_collection_view',
         'weight' => 61,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1496,12 +1344,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 43,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -1545,12 +1387,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 48,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1592,12 +1428,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 47,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -1641,12 +1471,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 46,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1689,12 +1513,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 45,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1735,12 +1553,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'taxonomy_term_reference_link',
         'weight' => 55,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1777,12 +1589,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'taxonomy_term_reference_link',
         'weight' => 54,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -1822,12 +1628,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 28,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 11,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -1871,12 +1671,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 44,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1916,12 +1710,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 52,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -1963,12 +1751,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 22,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 4,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -2008,12 +1790,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 23,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 9,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -2060,12 +1836,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'number_integer',
         'weight' => 34,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -2109,12 +1879,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 59,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -2157,12 +1921,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 37,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -2208,12 +1966,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'list_default',
         'weight' => 20,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 5,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -2254,12 +2006,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 24,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 10,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -2307,12 +2053,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'field_collection_view',
         'weight' => 33,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -2356,12 +2096,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'field_collection_view',
         'weight' => 32,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -2400,12 +2134,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'taxonomy_term_reference_link',
         'weight' => 4,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 19,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -2448,12 +2176,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 25,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 15,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -2500,12 +2222,6 @@ function dosomething_campaign_field_default_field_instances() {
         'type' => 'field_collection_view',
         'weight' => 62,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -2543,12 +2259,6 @@ function dosomething_campaign_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 26,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 14,
       ),
       'teaser' => array(
         'label' => 'above',

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -294,7 +294,7 @@ function dosomething_campaign_theme($existing, $type, $theme, $path) {
  * @see dosomething_campaign_entity_view_mode_alter().
  */
 function dosomething_campaign_node_view($node, $view_mode, $langcode) {
-  if ($node->type == 'campaign' && ($view_mode == 'full' || $view_mode == 'sms_game')) {
+  if ($node->type == 'campaign' && $view_mode == 'full') {
 
     // Add Zendesk form variable:
     if (module_exists('dosomething_zendesk')) {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -432,16 +432,6 @@ function dosomething_campaign_is_pitch_page($node) {
   return FALSE;
 }
 
-/**
- * Implements hook_entity_info_alter().
- */
-function dosomething_campaign_entity_info_alter(&$entity_info) {
-  $entity_info['node']['view modes']['pitch'] = array(
-    'label' => t('Pitch page'),
-    'custom settings' => TRUE,
-  );
-}
-
 /*
  * Implements hook_entity_view_mode_alter().
  *

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -405,6 +405,34 @@ function dosomething_campaign_get_campaign_type($node) {
 }
 
 /**
+ * For given campaign $node, determines if the pitch page should be displayed.
+ *
+ * @todo: Assumes the campaign is in a live state, for now.
+ * This logic will need to change when a campaign is in a closed state.
+ */
+function dosomething_campaign_is_pitch_page($node) {
+
+  // If not a campaign (e.g. SMS Game), no pitch page is needed.
+  if (dosomething_campaign_get_campaign_type($node) != 'campaign') {
+    return FALSE;
+  }
+
+  // Anonymous users are always shown pitch page.
+  if (!user_is_logged_in()) {
+    return TRUE;
+  }
+
+  // If the current user is not on staff and not signed up:
+  if ( (!dosomething_user_is_staff()) && (!dosomething_signup_exists($node->nid)) ) {
+    // Then return pitch page.
+    return TRUE;
+  }
+
+  // Default to FALSE.
+  return FALSE;
+}
+
+/**
  * Implements hook_entity_info_alter().
  */
 function dosomething_campaign_entity_info_alter(&$entity_info) {
@@ -423,27 +451,7 @@ function dosomething_campaign_entity_info_alter(&$entity_info) {
  */
 function dosomething_campaign_entity_view_mode_alter(&$view_mode, $context) {
   // Is this a campaign node?
-  if ($context['entity_type'] == 'node' && $context['entity']->type == 'campaign' && $view_mode == 'full') {
-
-    $node = $context['entity'];
-    // If SMS Game:
-    if (dosomething_campaign_get_campaign_type($node) == 'sms_game') {
-      // Exit out of function, don't need to check for pitch page.
-      return;
-    }
-
-    // If anonymous user:
-    if (!user_is_logged_in()) {
-      // Display pitch view mode.
-      $view_mode = 'pitch';
-      return;
-    }
-    // If the current user is not on staff, and not signed up for the campaign, show the pitch page.
-    if (!dosomething_user_is_staff()) {
-      if (!dosomething_signup_exists($node->nid)) {
-        $view_mode = 'pitch';
-      }
-    }
+  if ($context['entity_type'] == 'node' && $context['entity']->type == 'campaign') {
     // Is this a legacy campaign?
     if (module_exists('dosomething_legacy') && dosomething_legacy_check($node)) {
       if (dosomething_signup_exists($node->nid)) {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -41,7 +41,7 @@ function dosomething_campaign_preprocess_node(&$vars) {
   // Add inline css based on vars.
   dosomething_helpers_add_inline_css($vars);
 
-  if ($vars['view_mode'] == 'pitch') {
+  if (dosomething_campaign_is_pitch_page($node)) {
     // Use the pitch page template to theme.
     $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'] . '__pitch';
     // Gather vars for pitch page.

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
@@ -24,12 +24,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'taxonomy_term_reference_link',
         'weight' => 27,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -67,12 +61,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'list_default',
         'weight' => 29,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -109,12 +97,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 13,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -157,12 +139,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         ),
         'type' => 'entityreference_label',
         'weight' => 33,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -207,12 +183,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 14,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -252,12 +222,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 8,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -300,12 +264,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         ),
         'type' => 'entityreference_label',
         'weight' => 9,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -350,12 +308,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'taxonomy_term_reference_link',
         'weight' => 10,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -396,12 +348,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'settings' => array(),
         'type' => 'list_default',
         'weight' => 26,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -445,12 +391,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'settings' => array(),
         'type' => 'list_default',
         'weight' => 19,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -496,12 +436,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'field_collection_view',
         'weight' => 4,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -543,12 +477,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'field_collection_view',
         'weight' => 11,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -589,12 +517,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         ),
         'type' => 'date_default',
         'weight' => 25,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -646,12 +568,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'entityreference_label',
         'weight' => 22,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -693,12 +609,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'module' => 'text',
         'settings' => array(),
         'type' => 'text_default',
-        'weight' => 0,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
         'weight' => 0,
       ),
       'teaser' => array(
@@ -743,12 +653,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'entityreference_label',
         'weight' => 24,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -791,12 +695,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 1,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -843,12 +741,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'field_collection_view',
         'weight' => 12,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -884,12 +776,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 34,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -931,12 +817,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 16,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -977,12 +857,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 32,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1022,12 +896,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 31,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -1074,12 +942,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'number_integer',
         'weight' => 23,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1121,12 +983,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 17,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1166,12 +1022,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 21,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -1217,12 +1067,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'type' => 'list_default',
         'weight' => 28,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -1261,12 +1105,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'settings' => array(),
         'type' => 'taxonomy_term_reference_link',
         'weight' => 30,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -1307,12 +1145,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 20,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -1358,12 +1190,6 @@ function dosomething_campaign_group_field_default_field_instances() {
         ),
         'type' => 'field_collection_view',
         'weight' => 3,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.field_instance.inc
@@ -65,12 +65,6 @@ function dosomething_campaign_run_field_default_field_instances() {
         'type' => 'entityreference_label',
         'weight' => 1,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -113,12 +107,6 @@ function dosomething_campaign_run_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 2,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -165,12 +153,6 @@ function dosomething_campaign_run_field_default_field_instances() {
         ),
         'type' => 'field_collection_view',
         'weight' => 3,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.features.field_instance.inc
@@ -24,12 +24,6 @@ function dosomething_fact_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 1,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),

--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.features.field_instance.inc
@@ -24,12 +24,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 13,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -69,12 +63,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 7,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -116,12 +104,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'taxonomy_term_reference_link',
         'weight' => 11,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -160,12 +142,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'settings' => array(),
         'type' => 'link_default',
         'weight' => 8,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -223,12 +199,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'entityreference_label',
         'weight' => 1,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -274,12 +244,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'entityreference_label',
         'weight' => 2,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -323,12 +287,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 12,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -370,12 +328,6 @@ function dosomething_fact_page_field_default_field_instances() {
         ),
         'type' => 'entityreference_label',
         'weight' => 5,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -420,12 +372,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 4,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -466,12 +412,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'type' => 'taxonomy_term_reference_link',
         'weight' => 14,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -508,12 +448,6 @@ function dosomething_fact_page_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 3,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',

--- a/lib/modules/dosomething/dosomething_home/dosomething_home.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_home/dosomething_home.features.field_instance.inc
@@ -26,12 +26,6 @@ function dosomething_home_field_default_field_instances() {
         'type' => 'entityreference_label',
         'weight' => 1,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -73,12 +67,6 @@ function dosomething_home_field_default_field_instances() {
         'module' => 'text',
         'settings' => array(),
         'type' => 'text_default',
-        'weight' => 0,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
         'weight' => 0,
       ),
       'teaser' => array(

--- a/lib/modules/dosomething/dosomething_image/dosomething_image.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.features.field_instance.inc
@@ -24,12 +24,6 @@ function dosomething_image_field_default_field_instances() {
         'type' => 'taxonomy_term_reference_link',
         'weight' => 3,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -67,12 +61,6 @@ function dosomething_image_field_default_field_instances() {
           'image_style' => '',
         ),
         'type' => 'image',
-        'weight' => 0,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
         'weight' => 0,
       ),
       'teaser' => array(
@@ -125,12 +113,6 @@ function dosomething_image_field_default_field_instances() {
         'type' => 'image',
         'weight' => 1,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -181,12 +163,6 @@ function dosomething_image_field_default_field_instances() {
         'type' => 'image',
         'weight' => 2,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -234,12 +210,6 @@ function dosomething_image_field_default_field_instances() {
         'settings' => array(),
         'type' => 'taxonomy_term_reference_link',
         'weight' => 4,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.features.field_instance.inc
@@ -285,12 +285,6 @@ function dosomething_static_content_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 13,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -330,12 +324,6 @@ function dosomething_static_content_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 12,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -377,12 +365,6 @@ function dosomething_static_content_field_default_field_instances() {
         'type' => 'blockreference_default',
         'weight' => 17,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -419,12 +401,6 @@ function dosomething_static_content_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 5,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -465,12 +441,6 @@ function dosomething_static_content_field_default_field_instances() {
         'settings' => array(),
         'type' => 'link_default',
         'weight' => 14,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -532,12 +502,6 @@ function dosomething_static_content_field_default_field_instances() {
         'type' => 'field_collection_view',
         'weight' => 4,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -576,12 +540,6 @@ function dosomething_static_content_field_default_field_instances() {
         ),
         'type' => 'entityreference_label',
         'weight' => 7,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -626,12 +584,6 @@ function dosomething_static_content_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 10,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -673,12 +625,6 @@ function dosomething_static_content_field_default_field_instances() {
         ),
         'type' => 'entityreference_label',
         'weight' => 9,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -722,12 +668,6 @@ function dosomething_static_content_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 8,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -774,12 +714,6 @@ function dosomething_static_content_field_default_field_instances() {
         'type' => 'field_collection_view',
         'weight' => 16,
       ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
-      ),
       'teaser' => array(
         'label' => 'above',
         'settings' => array(),
@@ -815,12 +749,6 @@ function dosomething_static_content_field_default_field_instances() {
         'settings' => array(),
         'type' => 'text_default',
         'weight' => 11,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',
@@ -867,12 +795,6 @@ function dosomething_static_content_field_default_field_instances() {
         ),
         'type' => 'field_collection_view',
         'weight' => 15,
-      ),
-      'pitch' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 0,
       ),
       'teaser' => array(
         'label' => 'above',


### PR DESCRIPTION
Refs #2383

Major change is in `dosomething_campaign.module`:

Changes the preprocess logic to use the return of new function, `dosomething_campaign_is_pitch_page` instead of checking for `$view_mode == 'pitch'`.  The logic in `dosomething_campaign_is_pitch_page` is code moved out of `dosomething_campaign_entity_view_mode_alter`, as we look to not rely on view modes for any of this various Campaign type / state templating.
- Also removes `pitch` view_mode from content type field_instance.inc feature files.

@weerd Would you mind pulling down and test?
- Confirm that anon user sees pitch page
- Confirm that auth user not signed up also seses pitch page
- Confirm that auth user signed up sees full node
- Confirm that staff sees the full node regardless of signup status

This keeps things functional as cleanup continues to remove the custom view mode out of the codebase / features.  Up next will be removing everything out of the features - but this is the big functional change.
