### PR TITLE
Fixes #2389: Updates Salt config to copy Vagrant shared dir internally

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ Vagrant.configure("2") do |config|
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
   config.vm.provider "virtualbox" do |v|
-    v.customize ["modifyvm", :id, "--memory", 1024]
+    v.customize ["modifyvm", :id, "--memory", 3072]
   end
 
   # SSH Agent forwarding
@@ -12,6 +12,10 @@ Vagrant.configure("2") do |config|
 
   ## For masterless, mount your salt file root
   config.vm.synced_folder "provision/salt/roots/", "/srv/"
+
+  # SSHFS -- reverse mount from within Vagrant box
+  config.sshfs.paths = { "/var/www/vagrant" => "../dosomething-mount" }
+  # config.sshfs.username = "alternateuser"
 
   # Bare Apache httpd (http and https)
   config.vm.network :forwarded_port, guest: 8888, host: 8888
@@ -23,7 +27,7 @@ Vagrant.configure("2") do |config|
   config.vm.network :forwarded_port, guest: 6081, host: 9999
 
   # Tomcat with Jenkins and Solr
-  config.vm.network :forwarded_port, guest: 9090, host: 11111
+  # config.vm.network :forwarded_port, guest: 9090, host: 11111
 
   ## Use all the defaults:
   config.vm.provision :salt do |salt|

--- a/provision/salt/roots/salt/apache2/vhost-ssl.conf
+++ b/provision/salt/roots/salt/apache2/vhost-ssl.conf
@@ -2,24 +2,16 @@
 <VirtualHost _default_:8889>
 	ServerAdmin webmaster@localhost
 
-	DocumentRoot /vagrant/html
+	DocumentRoot /var/www/vagrant/html
 	<Directory />
 		Options FollowSymLinks
 		AllowOverride None
 	</Directory>
-	<Directory /vagrant/html/>
+	<Directory /var/www/vagrant/html/>
 		Options Indexes FollowSymLinks MultiViews
 		AllowOverride All
 		Order allow,deny
 		allow from all
-	</Directory>
-
-	ScriptAlias /cgi-bin/ /usr/lib/cgi-bin/
-	<Directory "/usr/lib/cgi-bin">
-		AllowOverride None
-		Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
-		Order allow,deny
-		Allow from all
 	</Directory>
 
 	ErrorLog ${APACHE_LOG_DIR}/error.log

--- a/provision/salt/roots/salt/apache2/vhost.conf
+++ b/provision/salt/roots/salt/apache2/vhost.conf
@@ -1,12 +1,12 @@
 <VirtualHost *:8888>
 	ServerAdmin webmaster@localhost
 
-	DocumentRoot /vagrant/html
+	DocumentRoot /var/www/vagrant/html
 	<Directory />
 		Options FollowSymLinks
 		AllowOverride None
 	</Directory>
-	<Directory /vagrant/html>
+	<Directory /var/www/vagrant/html>
 		Options Indexes FollowSymLinks MultiViews
 		AllowOverride All
 		Order allow,deny

--- a/provision/salt/roots/salt/dosomething.sls
+++ b/provision/salt/roots/salt/dosomething.sls
@@ -17,4 +17,11 @@ ssh-host-access:
     - user: vagrant
     - group: vagrant
 
+webroot-internal:
+  cmd.run:
+    - name: 'tar czf /var/www/vagrant.tgz /vagrant ; cd /var/www ; tar xzf vagrant.tgz ; rm vagrant.tgz'
+    - unless: test -d /var/www/vagrant
+    - require:
+      - pkg: apache2
+
 {% endif %}

--- a/provision/salt/roots/salt/lamp-drupal.sls
+++ b/provision/salt/roots/salt/lamp-drupal.sls
@@ -57,12 +57,12 @@ apache2-env:
   file.managed:
     - name: /etc/apache2/envvars
     - source: salt://apache2/envvars
+    - require:
+      - pkg: apache2
 
 apache2:
   pkg:
     - installed
-    - require:
-      - file: apache2-env
   file.managed:
     - name: /etc/apache2/ports.conf
     - source: salt://apache2/ports.conf

--- a/provision/salt/roots/salt/top.sls
+++ b/provision/salt/roots/salt/top.sls
@@ -3,7 +3,6 @@ base:
     - utils
     - lamp-drupal
     - ssl
-    - selenium
     - install
     - composer
     - node


### PR DESCRIPTION
Updates Apache vhost files. Also fixes and order of operations issue that was preventing apache2 from getting installed in the first place.

ALSO removes the Selenium package, which is a bunch of crap we don't need in here anymore.
