### PR TITLE
Bundle em up

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/bower.json
+++ b/lib/themes/dosomething/paraneue_dosomething/bower.json
@@ -30,6 +30,7 @@
     "unveil": "~1.3.0",
     "jquery-once": "~1.2.6",
     "respond": "~1.4.2",
-    "REM-unit-polyfill": "~1.2.3"
+    "REM-unit-polyfill": "~1.2.3",
+    "almond": "~0.2.9"
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/js/main.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/main.js
@@ -24,10 +24,6 @@ require.config({
     "rem-unit-polyfill": "../bower_components/REM-unit-polyfill/js/rem",
     "respond": "../bower_components/respond/dest/respond.min"
   },
-  excludeShallow: [
-    "respond",
-    "rem-unit-polyfill"
-  ],
   shim: {
     "jquery-once": { deps: ["jquery"] },
     "jquery-unveil": { deps: ["jquery"] },

--- a/lib/themes/dosomething/paraneue_dosomething/js/main.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/main.js
@@ -1,18 +1,12 @@
 /**
  * We configure RequireJS options, paths, and shims here.
  *
- *  - baseURL: Path where modules will be loaded from at runtime.
  *  - paths: Load any Bower components in here.
- *  - excludeShallow: Any components that should *not* be included
- *    in the minified production build. They will be loaded in on
- *    demand via the RequireJS loader.
  *  - shim: Shim any non-AMD scripts.
  *
  *  @see https://github.com/jrburke/r.js/blob/master/build/example.build.js
  */
 require.config({
-  include: "main",
-  includeRequire: "main",
   paths: {
     "jquery": "../bower_components/jquery/jquery",
     "jquery-once": "../bower_components/jquery-once/jquery.once",

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/build.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/build.js
@@ -1,8 +1,8 @@
 module.exports = function(grunt) {
   // The `build` task lints, tests, and compiles assets.
-  grunt.registerTask("build", ["clean:dist", "sass:compile", "copy:assets", "copy:js", "requirejs:dev"]);
+  grunt.registerTask("build", ["clean:dist", "sass:compile", "copy:assets", "requirejs:dev"]);
 
   // The `prod` build task is used when building for production. Since compiled assets
   // are ignored in version control, this is run in Continuous Integration on deploy.
-  grunt.registerTask("prod", ["clean:dist", "sass:compile", "cssmin:minify", "copy:assets", "copy:js", "requirejs:prod"]);
+  grunt.registerTask("prod", ["clean:dist", "sass:compile", "cssmin:minify", "copy:assets", "requirejs:prod"]);
 }

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/copy.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/copy.js
@@ -4,10 +4,5 @@ module.exports = {
       {expand: true, src: ["images/**"], dest: "dist/"},
       {expand: true, src: ["bower_components/**"], dest: "dist/"},
     ]
-  },
-  js: {
-    files: [
-      {expand: true, src: ["js/**"], dest: "dist/"},
-    ]
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/requirejs.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/requirejs.js
@@ -3,6 +3,7 @@ module.exports = {
     baseUrl: "js/",
     name: "../bower_components/almond/almond",
     mainConfigFile: "js/main.js",
+    include: "main",
     insertRequire: ["main"],
     optimize: "uglify2",
     preserveLicenseComments: false,

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/requirejs.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/requirejs.js
@@ -1,8 +1,9 @@
 module.exports = {
   options: {
     baseUrl: "js/",
-    name: "../bower_components/requirejs/require",
+    name: "../bower_components/almond/almond",
     mainConfigFile: "js/main.js",
+    insertRequire: ["main"],
     optimize: "uglify2",
     preserveLicenseComments: false,
     generateSourceMaps: true,

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/watch.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/watch.js
@@ -5,11 +5,7 @@ module.exports = {
   },
   js: {
     files: ["js/**/*.js", "tests/**/*.js"],
-    tasks: ["lint:js", "copy:js", "test:js"]
-  },
-  requirejs: {
-    files: ["js/main.js", "js/config.dev.js"],
-    tasks: ["uglify:dev"]
+    tasks: ["lint:js", "requirejs:dev", "test:js"]
   },
   assets: {
     files: ["assets/**/*", "bower_components/**/*"],

--- a/lib/themes/dosomething/paraneue_dosomething/tests/index.html
+++ b/lib/themes/dosomething/paraneue_dosomething/tests/index.html
@@ -14,12 +14,7 @@
         var TEST = true;
       </script>
 
-      <script type="text/javascript" charset="utf-8">
-        var require = {
-          baseUrl: "../js/"
-        };
-      </script>
-      <script data-main="main" src='../dist/app.js'></script>
+      <script src='../dist/app.js'></script>
       <!-- add any JS files under test (or put them in different .html files) -->
 
       <script src='lib/qunit-1.12.0.js'></script>


### PR DESCRIPTION
This should fix our issue lazy-loading in assets over CDN on IE8. Since we're bundling up most of the rest of our assets, it seems to make sense to just bundle everything outright to side-step the IE8 issues and save us the overhead of including the full RequireJS loader.

References #2347.
