### PR TITLE
Source maps for SCSS, optional un-minified builds on production

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
+++ b/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
@@ -2,6 +2,9 @@
 "use strict";
 
 module.exports = function(grunt) {
+  // measures the time each task takes
+  require('time-grunt')(grunt);
+
   // Load tasks from `/tasks`
   grunt.loadTasks('tasks');
 

--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -23,7 +23,7 @@
     "load-grunt-config": "^0.8.0",
     "glob": "^3.2.9",
     "path": "^0.4.9",
-    "grunt-contrib-clean": "^0.5.0"
+    "grunt-contrib-clean": "^0.5.0",
     "time-grunt": "^0.3.1"
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-sass": "~0.9.0",
+    "grunt-sass": "~0.12.1",
     "grunt-contrib-cssmin": "~0.7.0",
     "grunt-contrib-coffee": "~0.7.0",
     "grunt-contrib-uglify": "~0.2.4",

--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -24,5 +24,6 @@
     "glob": "^3.2.9",
     "path": "^0.4.9",
     "grunt-contrib-clean": "^0.5.0"
+    "time-grunt": "^0.3.1"
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
+++ b/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
@@ -14,6 +14,7 @@ features[] = secondary_menu
 
 ; Settings
 settings[use_cdn_assets] = 0
+settings[use_minified_assets] = 1
 settings[show_campaign_finder] = 0
 settings[show_sponsors] = 1
 

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/build.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/build.js
@@ -1,8 +1,8 @@
 module.exports = function(grunt) {
   // The `build` task lints, tests, and compiles assets.
-  grunt.registerTask("build", ["clean:dist", "sass:compile", "copy:assets", "requirejs:dev"]);
+  grunt.registerTask("build", ["clean:dist", "copy:assets", "copy:source", "sass:prod", "requirejs:debug"]);
 
   // The `prod` build task is used when building for production. Since compiled assets
   // are ignored in version control, this is run in Continuous Integration on deploy.
-  grunt.registerTask("prod", ["clean:dist", "sass:compile", "cssmin:minify", "copy:assets", "requirejs:prod"]);
+  grunt.registerTask("prod", ["clean:dist", "copy:assets", "copy:source", "sass:dev", "sass:prod", "requirejs:dev", "requirejs:prod"]);
 }

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/copy.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/copy.js
@@ -4,5 +4,11 @@ module.exports = {
       {expand: true, src: ["images/**"], dest: "dist/"},
       {expand: true, src: ["bower_components/**"], dest: "dist/"},
     ]
+  },
+  source: {
+    files: [
+      {expand: true, src: ["scss/**"], dest: "dist/"},
+      {expand: true, src: ["js/**"], dest: "dist/"},
+    ]
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/requirejs.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/requirejs.js
@@ -1,42 +1,55 @@
 module.exports = {
   options: {
+    out: "dist/app.min.js",
     baseUrl: "js/",
     name: "../bower_components/almond/almond",
     mainConfigFile: "js/main.js",
     include: "main",
     insertRequire: ["main"],
-    optimize: "uglify2",
     preserveLicenseComments: false,
     generateSourceMaps: true,
-    out: "dist/app.js"
+    optimize: "uglify2",
+    uglify2: {
+      compress: {
+        dead_code: true,
+        drop_debugger: true,
+        drop_console: true,
+        global_defs: {
+          DEBUG: false
+        }
+      }
+    }
   },
-  dev: {
+  debug: {
+    // Override DEBUG global to be true on "dev" builds
     options: {
       uglify2: {
-        output: {
-          beautify: true
-        },
         compress: {
+          drop_debugger: false,
+          drop_console: false,
           global_defs: {
             DEBUG: true
           }
+        },
+      }
+    }
+  },
+  dev: {
+    // Create a "beautified" copy of the production build
+    options: {
+      out: "dist/app.js",
+      generateSourceMaps: false,
+      uglify2: {
+        output: {
+          comments: true,
+          beautify: true
         },
         mangle: false
       }
     }
   },
   prod: {
-    options: {
-      uglify2: {
-        compress: {
-          dead_code: true,
-          drop_debugger: true,
-          drop_console: true,
-          global_defs: {
-            DEBUG: false
-          }
-        }
-      }
-    }
+    // Uses all default settings
+    // (minifies code, drops console/debuggers, & mangles variable names)
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/sass.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/sass.js
@@ -1,11 +1,22 @@
 module.exports = {
-  compile: {
+  dev: {
     files: {
-      "dist/app.css": "scss/app.scss",
-      "dist/ie.css": "scss/ie.scss"
+      "dist/app.css": "dist/scss/app.scss",
+      "dist/ie.css": "dist/scss/ie.scss"
     },
     options: {
+      outputStyle: "nested",
       sourceComments: "normal"
+    }
+  },
+  prod: {
+    files: {
+      "dist/app.min.css": "dist/scss/app.scss",
+      "dist/ie.min.css": "dist/scss/ie.scss"
+    },
+    options: {
+      outputStyle: "compressed",
+      sourceComments: "map"
     }
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/template.php
+++ b/lib/themes/dosomething/paraneue_dosomething/template.php
@@ -10,6 +10,15 @@ if(theme_get_setting('use_cdn_assets')) {
   define('DS_ASSET_PATH', '/' . PARANEUE_DS_PATH . '/dist');
 }
 
+// Determine whether to use minified script or not
+if(theme_get_setting('use_minified_assets')) {
+  define('DS_STYLE_PATH', DS_ASSET_PATH . '/app.min.css');
+  define('DS_JAVASCRIPT_PATH', DS_ASSET_PATH . '/app.min.js');
+} else {
+  define('DS_STYLE_PATH', DS_ASSET_PATH . '/app.css');
+  define('DS_JAVASCRIPT_PATH', DS_ASSET_PATH . '/app.js');
+}
+
 // Define asset directory paths
 define('LIB_ASSET_PATH', DS_ASSET_PATH . '/bower_components');
 define('NEUE_ASSET_PATH', LIB_ASSET_PATH . '/neue');

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -17,7 +17,7 @@
   <script type="text/javascript" src="<?php print NEUE_ASSET_PATH; ?>/js/vendor/modernizr.js"></script>
 
   <link rel="stylesheet" href="<?php print NEUE_ASSET_PATH; ?>/neue.css" type="text/css" />
-  <link rel="stylesheet" href="<?php print DS_ASSET_PATH;; ?>/app.css" type="text/css" />
+  <link rel="stylesheet" href="<?php print DS_STYLE_PATH; ?>" type="text/css" />
   <?php print $styles; ?>
 
   <!--[if lte IE 8]>
@@ -41,12 +41,7 @@
   <?php print $page_top; ?>
   <?php print $page; ?>
 
-  <script type="text/javascript" charset="utf-8">
-    var require = {
-      baseUrl: "<?php print DS_ASSET_PATH; ?>/js/"
-    };
-  </script>
-  <script type="text/javascript" data-main="main" src="<?php print DS_ASSET_PATH; ?>/app.js"></script>
+  <script type="text/javascript" src="<?php print DS_JAVASCRIPT_PATH; ?>"></script>
   <?php print $scripts; ?>
   <?php print $page_bottom; ?>
 </body>

--- a/lib/themes/dosomething/paraneue_dosomething/tests/index.html
+++ b/lib/themes/dosomething/paraneue_dosomething/tests/index.html
@@ -14,7 +14,7 @@
         var TEST = true;
       </script>
 
-      <script src='../dist/app.js'></script>
+      <script src='../dist/app.min.js'></script>
       <!-- add any JS files under test (or put them in different .html files) -->
 
       <script src='lib/qunit-1.12.0.js'></script>

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -13,8 +13,16 @@ function paraneue_dosomething_form_system_theme_settings_alter(&$form, $form_sta
   $form['theme_settings']['use_cdn_assets'] = array(
     '#type' => 'checkbox',
     '#title' => t('Use CDN Assets'),
-    '#description' => t('Will use versiond assets hosted on Akamai CDN, generated when tagging deploy. On local development machines, this defaults to the latest assets on the CDN.'),
+    '#description' => t('Will use versioned assets hosted on Akamai CDN, generated when tagging deploy. On local development machines, this defaults to the latest assets on the CDN.'),
     '#default_value' => theme_get_setting('use_cdn_assets')
+  );
+
+
+  $form['theme_settings']['use_minified_assets'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Minify Assets'),
+    '#description' => t('Will use minified assets. Uncheck this if debugging in a browser without source maps. (Unminified assets are only built for production.)'),
+    '#default_value' => theme_get_setting('use_minified_assets')
   );
 
   $form['feature_flags'] = array(


### PR DESCRIPTION
### Changes:
- Adds source maps for SCSS (yay, Grunt-Sass v0.12!)
- Option to use un-minified builds on production (for debugging in IE8 or other older browsers).
- Adds Time-Grunt to benchmark how long tasks take.
