### PR TITLE
Fixes for IE8 polyfill issues with CDN assets

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -4,7 +4,7 @@
  * Implements theme_preprocess_page().
  */
 function paraneue_dosomething_preprocess_page(&$vars) {
-  $vars['logo'] = $vars['base_path'] . NEUE_PATH . '/assets/images/ds-logo.png';
+  $vars['logo'] = NEUE_ASSET_PATH . '/assets/images/ds-logo.png';
 
 
   // Get User Information
@@ -23,6 +23,7 @@ function paraneue_dosomething_preprocess_page(&$vars) {
   // Navigation Output Setup
   $navigation_vars = array(
     'base_path'       => $vars['base_path'],
+    'logo'            => $vars['logo'],
     'front_page'      => $vars['front_page'],
     'logged_in'       => $vars['logged_in'],
     'search_box'      => $vars['search_box'],

--- a/lib/themes/dosomething/paraneue_dosomething/js/main.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/main.js
@@ -14,9 +14,7 @@ require.config({
     "neue": "../bower_components/neue/js",
     "mailcheck": "../bower_components/mailcheck/src/mailcheck",
     "lodash": "../bower_components/lodash/dist/lodash",
-    "text": "../bower_components/requirejs-text/text",
-    "rem-unit-polyfill": "../bower_components/REM-unit-polyfill/js/rem",
-    "respond": "../bower_components/respond/dest/respond.min"
+    "text": "../bower_components/requirejs-text/text"
   },
   shim: {
     "jquery-once": { deps: ["jquery"] },
@@ -42,10 +40,6 @@ define("main", function(require) {
   // let's get going
   var Finder = require("finder/Finder");
   var Features = require("utils/Features");
-
-  // Load polyfills
-  if(!Features.mediaQueries) require("respond");
-  if(!Features.remUnits) require("rem-unit-polyfill");
 
   // Initialize modules on load
   require("neue/main");

--- a/lib/themes/dosomething/paraneue_dosomething/js/respond.custom.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/respond.custom.js
@@ -1,0 +1,334 @@
+/*! Respond.js v1.4.0: min/max-width media query polyfill. (c) Scott Jehl. MIT Lic. j.mp/respondjs  */
+(function( w ){
+
+	"use strict";
+
+	//exposed namespace
+	var respond = {};
+	w.respond = respond;
+
+	//define update even in native-mq-supporting browsers, to avoid errors
+	respond.update = function(){};
+
+	//define ajax obj
+	var requestQueue = [];
+
+  // attempt to use XMLHttpRequest, if not use XDomainRequest
+  var ajax = function( url, callback ) {
+    try {
+        var xhr = getXMLHttpRequest();
+        xhr.open('GET', url, true);
+        xhr.send();
+
+        xhr.onreadystatechange = new function() {
+            if (xhr.readyState === 4) {
+              callback(xhr.responseText);
+            }
+        };
+     } catch (e) {
+        if ( window.XDomainRequest ) {
+          var xdr = new XDomainRequest();
+          xdr.open('get', url);
+          xdr.onload = function() {
+            callback(xdr.responseText);
+          };
+          xdr.onerror = function() {
+            return false; // xdr load fail
+          };
+          xdr.send();
+        }
+     }
+  };
+
+	//expose for testing
+	respond.ajax = ajax;
+	respond.queue = requestQueue;
+
+	// expose for testing
+	respond.regex = {
+		media: /@media[^\{]+\{([^\{\}]*\{[^\}\{]*\})+/gi,
+		keyframes: /@(?:\-(?:o|moz|webkit)\-)?keyframes[^\{]+\{(?:[^\{\}]*\{[^\}\{]*\})+[^\}]*\}/gi,
+		urls: /(url\()['"]?([^\/\)'"][^:\)'"]+)['"]?(\))/g,
+		findStyles: /@media *([^\{]+)\{([\S\s]+?)$/,
+		only: /(only\s+)?([a-zA-Z]+)\s?/,
+		minw: /\([\s]*min\-width\s*:[\s]*([\s]*[0-9\.]+)(px|em)[\s]*\)/,
+		maxw: /\([\s]*max\-width\s*:[\s]*([\s]*[0-9\.]+)(px|em)[\s]*\)/
+	};
+
+	//expose media query support flag for external use
+	respond.mediaQueriesSupported = w.matchMedia && w.matchMedia( "only all" ) !== null && w.matchMedia( "only all" ).matches;
+
+	//if media queries are supported, exit here
+	if( respond.mediaQueriesSupported ){
+		return;
+	}
+
+	//define vars
+	var doc = w.document,
+		docElem = doc.documentElement,
+		mediastyles = [],
+		rules = [],
+		appendedEls = [],
+		parsedSheets = {},
+		resizeThrottle = 30,
+		head = doc.getElementsByTagName( "head" )[0] || docElem,
+		base = doc.getElementsByTagName( "base" )[0],
+		links = head.getElementsByTagName( "link" ),
+
+		lastCall,
+		resizeDefer,
+
+		//cached container for 1em value, populated the first time it's needed
+		eminpx,
+
+		// returns the value of 1em in pixels
+		getEmValue = function() {
+			var ret,
+				div = doc.createElement('div'),
+				body = doc.body,
+				originalHTMLFontSize = docElem.style.fontSize,
+				originalBodyFontSize = body && body.style.fontSize,
+				fakeUsed = false;
+
+			div.style.cssText = "position:absolute;font-size:1em;width:1em";
+
+			if( !body ){
+				body = fakeUsed = doc.createElement( "body" );
+				body.style.background = "none";
+			}
+
+			// 1em in a media query is the value of the default font size of the browser
+			// reset docElem and body to ensure the correct value is returned
+			docElem.style.fontSize = "100%";
+			body.style.fontSize = "100%";
+
+			body.appendChild( div );
+
+			if( fakeUsed ){
+				docElem.insertBefore( body, docElem.firstChild );
+			}
+
+			ret = div.offsetWidth;
+
+			if( fakeUsed ){
+				docElem.removeChild( body );
+			}
+			else {
+				body.removeChild( div );
+			}
+
+			// restore the original values
+			docElem.style.fontSize = originalHTMLFontSize;
+			if( originalBodyFontSize ) {
+				body.style.fontSize = originalBodyFontSize;
+			}
+
+
+			//also update eminpx before returning
+			ret = eminpx = parseFloat(ret);
+
+			return ret;
+		},
+
+		//enable/disable styles
+		applyMedia = function( fromResize ){
+			var name = "clientWidth",
+				docElemProp = docElem[ name ],
+				currWidth = doc.compatMode === "CSS1Compat" && docElemProp || doc.body[ name ] || docElemProp,
+				styleBlocks	= {},
+				lastLink = links[ links.length-1 ],
+				now = (new Date()).getTime();
+
+			//throttle resize calls
+			if( fromResize && lastCall && now - lastCall < resizeThrottle ){
+				w.clearTimeout( resizeDefer );
+				resizeDefer = w.setTimeout( applyMedia, resizeThrottle );
+				return;
+			}
+			else {
+				lastCall = now;
+			}
+
+			for( var i in mediastyles ){
+				if( mediastyles.hasOwnProperty( i ) ){
+					var thisstyle = mediastyles[ i ],
+						min = thisstyle.minw,
+						max = thisstyle.maxw,
+						minnull = min === null,
+						maxnull = max === null,
+						em = "em";
+
+					if( !!min ){
+						min = parseFloat( min ) * ( min.indexOf( em ) > -1 ? ( eminpx || getEmValue() ) : 1 );
+					}
+					if( !!max ){
+						max = parseFloat( max ) * ( max.indexOf( em ) > -1 ? ( eminpx || getEmValue() ) : 1 );
+					}
+
+					// if there's no media query at all (the () part), or min or max is not null, and if either is present, they're true
+					if( !thisstyle.hasquery || ( !minnull || !maxnull ) && ( minnull || currWidth >= min ) && ( maxnull || currWidth <= max ) ){
+						if( !styleBlocks[ thisstyle.media ] ){
+							styleBlocks[ thisstyle.media ] = [];
+						}
+						styleBlocks[ thisstyle.media ].push( rules[ thisstyle.rules ] );
+					}
+				}
+			}
+
+			//remove any existing respond style element(s)
+			for( var j in appendedEls ){
+				if( appendedEls.hasOwnProperty( j ) ){
+					if( appendedEls[ j ] && appendedEls[ j ].parentNode === head ){
+						head.removeChild( appendedEls[ j ] );
+					}
+				}
+			}
+			appendedEls.length = 0;
+
+			//inject active styles, grouped by media type
+			for( var k in styleBlocks ){
+				if( styleBlocks.hasOwnProperty( k ) ){
+					var ss = doc.createElement( "style" ),
+						css = styleBlocks[ k ].join( "\n" );
+
+					ss.type = "text/css";
+					ss.media = k;
+
+					//originally, ss was appended to a documentFragment and sheets were appended in bulk.
+					//this caused crashes in IE in a number of circumstances, such as when the HTML element had a bg image set, so appending beforehand seems best. Thanks to @dvelyk for the initial research on this one!
+					head.insertBefore( ss, lastLink.nextSibling );
+
+					if ( ss.styleSheet ){
+						ss.styleSheet.cssText = css;
+					}
+					else {
+						ss.appendChild( doc.createTextNode( css ) );
+					}
+
+					//push to appendedEls to track for later removal
+					appendedEls.push( ss );
+				}
+			}
+		},
+		//find media blocks in css text, convert to style blocks
+		translate = function( styles, href, media ){
+			var qs = styles.replace( respond.regex.keyframes, '' ).match( respond.regex.media ),
+				ql = qs && qs.length || 0;
+
+			//try to get CSS path
+			href = href.substring( 0, href.lastIndexOf( "/" ) );
+
+			var repUrls = function( css ){
+					return css.replace( respond.regex.urls, "$1" + href + "$2$3" );
+				},
+				useMedia = !ql && media;
+
+			//if path exists, tack on trailing slash
+			if( href.length ){ href += "/"; }
+
+			//if no internal queries exist, but media attr does, use that
+			//note: this currently lacks support for situations where a media attr is specified on a link AND
+				//its associated stylesheet has internal CSS media queries.
+				//In those cases, the media attribute will currently be ignored.
+			if( useMedia ){
+				ql = 1;
+			}
+
+			for( var i = 0; i < ql; i++ ){
+				var fullq, thisq, eachq, eql;
+
+				//media attr
+				if( useMedia ){
+					fullq = media;
+					rules.push( repUrls( styles ) );
+				}
+				//parse for styles
+				else{
+					fullq = qs[ i ].match( respond.regex.findStyles ) && RegExp.$1;
+					rules.push( RegExp.$2 && repUrls( RegExp.$2 ) );
+				}
+
+				eachq = fullq.split( "," );
+				eql = eachq.length;
+
+				for( var j = 0; j < eql; j++ ){
+					thisq = eachq[ j ];
+					mediastyles.push( {
+						media : thisq.split( "(" )[ 0 ].match( respond.regex.only ) && RegExp.$2 || "all",
+						rules : rules.length - 1,
+						hasquery : thisq.indexOf("(") > -1,
+						minw : thisq.match( respond.regex.minw ) && parseFloat( RegExp.$1 ) + ( RegExp.$2 || "" ),
+						maxw : thisq.match( respond.regex.maxw ) && parseFloat( RegExp.$1 ) + ( RegExp.$2 || "" )
+					} );
+				}
+			}
+
+			applyMedia();
+		},
+
+		//recurse through request queue, get css text
+		makeRequests = function(){
+			if( requestQueue.length ){
+				var thisRequest = requestQueue.shift();
+
+				ajax( thisRequest.href, function( styles ){
+					translate( styles, thisRequest.href, thisRequest.media );
+					parsedSheets[ thisRequest.href ] = true;
+
+					// by wrapping recursive function call in setTimeout
+					// we prevent "Stack overflow" error in IE7
+					w.setTimeout(function(){ makeRequests(); },0);
+				} );
+			}
+		},
+
+		//loop stylesheets, send text content to translate
+		ripCSS = function(){
+
+			for( var i = 0; i < links.length; i++ ){
+				var sheet = links[ i ],
+				href = sheet.href,
+				media = sheet.media,
+				isCSS = sheet.rel && sheet.rel.toLowerCase() === "stylesheet";
+
+				//only links plz and prevent re-parsing
+				if( !!href && isCSS && !parsedSheets[ href ] ){
+					// selectivizr exposes css through the rawCssText expando
+					if (sheet.styleSheet && sheet.styleSheet.rawCssText) {
+						translate( sheet.styleSheet.rawCssText, href, media );
+						parsedSheets[ href ] = true;
+					} else {
+							// IE7 doesn't handle urls that start with '//' for ajax request
+							// manually add in the protocol
+							if ( href.substring(0,2) === "//" ) { href = w.location.protocol + href; }
+							requestQueue.push( {
+								href: href,
+								media: media
+							} );
+					}
+				}
+			}
+			makeRequests();
+		};
+
+	//translate CSS
+	ripCSS();
+
+	//expose update for re-running respond later on
+	respond.update = ripCSS;
+
+	//expose getEmValue
+	respond.getEmValue = getEmValue;
+
+	//adjust on resize
+	function callMedia(){
+		applyMedia( true );
+	}
+
+	if( w.addEventListener ){
+		w.addEventListener( "resize", callMedia, false );
+	}
+	else if( w.attachEvent ){
+		w.attachEvent( "onresize", callMedia );
+	}
+})(this);

--- a/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
+++ b/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
@@ -13,7 +13,7 @@ features[] = main_menu
 features[] = secondary_menu
 
 ; Settings
-settings[use_cdn_assets] = 0
+settings[asset_path] = ''
 settings[use_minified_assets] = 1
 settings[show_campaign_finder] = 0
 settings[show_sponsors] = 1

--- a/lib/themes/dosomething/paraneue_dosomething/template.php
+++ b/lib/themes/dosomething/paraneue_dosomething/template.php
@@ -4,8 +4,10 @@
 define('PARANEUE_DS_PATH', drupal_get_path('theme', 'paraneue_dosomething'));
 
 // If ds_version is set, use CDN assets
-if(theme_get_setting('use_cdn_assets')) {
-  define('DS_ASSET_PATH', 'https://dosomething-a.akamaihd.net/sites/default/files/assets/' . variable_get('ds_version', 'latest'));
+if(theme_get_setting('asset_path')) {
+  $cdn_path = theme_get_setting('asset_path');
+  $cdn_path = str_replace('{ds_version}', variable_get('ds_version', 'latest'), $cdn_path);
+  define('DS_ASSET_PATH', $cdn_path);
 } else {
   define('DS_ASSET_PATH', '/' . PARANEUE_DS_PATH . '/dist');
 }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -26,7 +26,7 @@
 
       <script type="text/javascript" src="<?php print LIB_ASSET_PATH; ?>/html5shiv/dist/html5shiv.min.js"></script>
       <script type="text/javascript" src="<?php print LIB_ASSET_PATH; ?>/respond/dest/respond.min.js"></script>
-      <script type="text/javascript" src="<?php print LIB_ASSET_PATH; ?>/REM-unit-polyfill/js/rem.min.js"></script>
+      <script type="text/javascript" src="<?php print DS_ASSET_PATH ?>/js/respond.custom.js"></script>
   <![endif]-->
 
   <link rel="shortcut icon" href="<?php print NEUE_ASSET_PATH; ?>/assets/images/favicon.ico">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -23,7 +23,10 @@
   <!--[if lte IE 8]>
       <link type="text/css" rel="stylesheet" href="<?php print NEUE_ASSET_PATH; ?>/ie.css" media="all" />
       <link type="text/css" rel="stylesheet" href="<?php print DS_ASSET_PATH; ?>/ie.css" media="all" />
-      <script type="text/javascript" src="<?php print LIB_ASSET_PATH; ?>/html5shiv/dist/html5shiv.js"></script>
+
+      <script type="text/javascript" src="<?php print LIB_ASSET_PATH; ?>/html5shiv/dist/html5shiv.min.js"></script>
+      <script type="text/javascript" src="<?php print LIB_ASSET_PATH; ?>/respond/dest/respond.min.js"></script>
+      <script type="text/javascript" src="<?php print LIB_ASSET_PATH; ?>/REM-unit-polyfill/js/rem.min.js"></script>
   <![endif]-->
 
   <link rel="shortcut icon" href="<?php print NEUE_ASSET_PATH; ?>/assets/images/favicon.ico">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/navigation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/navigation.tpl.php
@@ -7,7 +7,7 @@
 ?>
 
 <nav class="chrome--nav">
-  <a class="logo" href="<?php print $base_path; ?>"><img src="<?php print NEUE_ASSET_PATH; ?>/assets/images/ds-logo.png" alt="DoSomething.org"></a>
+  <a class="logo" href="<?php print $base_path; ?>"><img src="<?php print $logo ?>" alt="DoSomething.org"></a>
   <a class="hamburger js-toggle-mobile-menu" href="#">&#xe606;</a>
   <div class="menu">
     <ul class="primary-nav">

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -9,19 +9,17 @@ function paraneue_dosomething_form_system_theme_settings_alter(&$form, $form_sta
       '#weight'=> -19
   );
 
-
-  $form['theme_settings']['use_cdn_assets'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Use CDN Assets'),
-    '#description' => t('Will use versioned assets hosted on Akamai CDN, generated when tagging deploy. On local development machines, this defaults to the latest assets on the CDN.'),
-    '#default_value' => theme_get_setting('use_cdn_assets')
+  $form['theme_settings']['asset_path'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Asset Path'),
+    '#description' => t('Path to load assets from. The <code>{ds_version}</code> string can be used to include the current <code>ds_version</code> value, or "latest" if not set. If left blank, assets will be loaded from the local theme folder.'),
+    '#default_value' => theme_get_setting('asset_path')
   );
-
 
   $form['theme_settings']['use_minified_assets'] = array(
     '#type' => 'checkbox',
     '#title' => t('Minify Assets'),
-    '#description' => t('Will use minified assets. Uncheck this if debugging in a browser without source maps. (Unminified assets are only built for production.)'),
+    '#description' => t('Will use minified assets. Uncheck this if debugging in a browser without source maps. <strong>(Unminified assets are only created in production builds.)</strong>'),
     '#default_value' => theme_get_setting('use_minified_assets')
   );
 


### PR DESCRIPTION
### Changes:
- Fixes #2347 with forked version of Respond.js that includes support for XDomainRequest. (See [lines 17 - 41](https://github.com/DFurnes/dosomething/blob/7b855edb4244b5357cc5de3337ac9ba7f0071da1/lib/themes/dosomething/paraneue_dosomething/js/respond.custom.js#L17-L41) and [lines 294 - 310](https://github.com/DFurnes/dosomething/blob/7b855edb4244b5357cc5de3337ac9ba7f0071da1/lib/themes/dosomething/paraneue_dosomething/js/respond.custom.js#L294-L310) for changes from the [original source](https://github.com/scottjehl/Respond/blob/master/src/respond.js)).
- Allow arbitrary CDN asset path setting (allows use of HTTP asset URLs on staging).
- Moves polyfills into IE8 conditional comments because it just makes things easier.
