### PR TITLE
Exclude forms.js because it was exploding. And seemingly useless.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
+++ b/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
@@ -46,6 +46,7 @@ exclude[js][] = 'misc/jquery.once.js'
 exclude[js][] = 'modules/contextual/contextual.js'
 exclude[js][] = 'modules/user/user.js'
 exclude[js][] = 'misc/textarea.js'
+exclude[js][] = 'misc/forms.js'
 
 ;css
 exclude[css][] = 'misc/vertical-tabs.css'


### PR DESCRIPTION
:+1: :space_invader: :beer: :bear: :beers: :soon: 
