### PR TITLE
Fixes borked reference to helpers module

### DIFF
--- a/lib/profiles/dosomething/dosomething.make
+++ b/lib/profiles/dosomething/dosomething.make
@@ -43,10 +43,10 @@ projects[dosomething_helpers][download][source] = './lib/modules/dosomething/dos
 projects[dosomething_helpers][subdir] = "dosomething"
 
 ; Dosomething Home
-projects[dosomething_helpers][type] = "module"
-projects[dosomething_helpers][download][type] = local
-projects[dosomething_helpers][download][source] = './lib/modules/dosomething/dosomething_home'
-projects[dosomething_helpers][subdir] = "dosomething"
+projects[dosomething_home][type] = "module"
+projects[dosomething_home][download][type] = local
+projects[dosomething_home][download][source] = './lib/modules/dosomething/dosomething_home'
+projects[dosomething_home][subdir] = "dosomething"
 
 ; Dosomething Image
 projects[dosomething_image][type] = "module"


### PR DESCRIPTION
#### What's this PR do?

The reference to dosomething home is incorrect in the profile make file.  We never noticed this because we do symlink magic in the ds build script.  When running the installation you see this:

![screen shot 2014-06-04 at 5 06 42 pm](https://cloud.githubusercontent.com/assets/129360/3180027/5f2604e6-ec2c-11e3-9f52-42541b17cd02.png)
#### Where should the reviewer start?

https://github.com/desmondmorris/dosomething/blob/dev/lib/profiles/dosomething/dosomething.make#L39-L49
#### How should this be manually tested?

Run install.php from a fresh build sans "--install" and confirm that the error in the above screenshot does not appear
#### Any background context you want to provide?

Just trying to make the profile play nice.
