### PR TITLE
Polyfill fixes

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/helpers/_mixins.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/helpers/_mixins.scss
@@ -12,12 +12,12 @@
 
 // Helper to generate image URLs
 @function image-url($url) {
-  @return url("/profiles/dosomething/themes/dosomething/paraneue_dosomething/dist/images/#{$url}");
+  @return url("images/#{$url}");
 }
 
 // Helper to generate Neue URLs
 @function neue-image-url($url) {
-  @return url("/profiles/dosomething/themes/dosomething/paraneue_dosomething/bower_components/neue/assets/images/#{$url}");
+  @return url("bower_components/neue/assets/images/#{$url}");
 }
 
 // @TODO: Temporary mixin for homepage sprites (from old world)

--- a/lib/themes/dosomething/paraneue_dosomething/template.php
+++ b/lib/themes/dosomething/paraneue_dosomething/template.php
@@ -2,6 +2,7 @@
 
 // Define theme directory path
 define('PARANEUE_DS_PATH', drupal_get_path('theme', 'paraneue_dosomething'));
+define('LOCAL_ASSET_PATH', '/' . PARANEUE_DS_PATH . '/dist');
 
 // If ds_version is set, use CDN assets
 if(theme_get_setting('asset_path')) {
@@ -9,7 +10,7 @@ if(theme_get_setting('asset_path')) {
   $cdn_path = str_replace('{ds_version}', variable_get('ds_version', 'latest'), $cdn_path);
   define('DS_ASSET_PATH', $cdn_path);
 } else {
-  define('DS_ASSET_PATH', '/' . PARANEUE_DS_PATH . '/dist');
+  define('DS_ASSET_PATH', LOCAL_ASSET_PATH);
 }
 
 // Determine whether to use minified script or not
@@ -22,8 +23,8 @@ if(theme_get_setting('use_minified_assets')) {
 }
 
 // Define asset directory paths
-define('LIB_ASSET_PATH', DS_ASSET_PATH . '/bower_components');
-define('NEUE_ASSET_PATH', LIB_ASSET_PATH . '/neue');
+define('VENDOR_ASSET_PATH', DS_ASSET_PATH . '/bower_components');
+define('NEUE_ASSET_PATH', VENDOR_ASSET_PATH . '/neue');
 
 // Theme includes
 require_once PARANEUE_DS_PATH . '/includes/bootstrap.inc';

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -29,6 +29,11 @@
       <link type="text/css" rel="stylesheet" href="<?php print DS_ASSET_PATH; ?>/ie.css" media="all" />
 
       <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/html5shiv/dist/html5shiv.min.js"></script>
+
+      <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/respond/dest/respond.min.js"></script>
+      <link href="<?php print VENDOR_ASSET_PATH; ?>/respond/cross-domain/respond-proxy.html" id="respond-proxy" rel="respond-proxy" />
+      <link href="<?php print LOCAL_ASSET_PATH; ?>/bower_components/respond/cross-domain/respond.proxy.gif" id="respond-redirect" rel="respond-redirect" />
+      <script type="text/javascript" src="<?php print LOCAL_ASSET_PATH; ?>/bower_components/respond/cross-domain/respond.proxy.js"></script>
   <![endif]-->
 
   <link rel="shortcut icon" href="<?php print NEUE_ASSET_PATH; ?>/assets/images/favicon.ico">
@@ -43,11 +48,6 @@
   <?php print $page; ?>
 
   <!--[if lte IE 8]>
-      <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/respond/dest/respond.min.js"></script>
-      <link href="<?php print VENDOR_ASSET_PATH; ?>/respond/cross-domain/respond-proxy.html" id="respond-proxy" rel="respond-proxy" />
-      <link href="<?php print LOCAL_ASSET_PATH; ?>/bower_components/respond/cross-domain/respond.proxy.gif" id="respond-redirect" rel="respond-redirect" />
-      <script type="text/javascript" src="<?php print LOCAL_ASSET_PATH; ?>/bower_components/respond/cross-domain/respond.proxy.js"></script>
-
       <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/REM-unit-polyfill/js/rem.min.js"></script>
   <![endif]-->
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -28,14 +28,11 @@
       <link type="text/css" rel="stylesheet" href="<?php print NEUE_ASSET_PATH; ?>/ie.css" media="all" />
       <link type="text/css" rel="stylesheet" href="<?php print DS_ASSET_PATH; ?>/ie.css" media="all" />
 
-      <script type="text/javascript" src="<?php print LIB_ASSET_PATH; ?>/html5shiv/dist/html5shiv.min.js"></script>
-      <script type="text/javascript" src="<?php print LIB_ASSET_PATH; ?>/respond/dest/respond.min.js"></script>
-      <script type="text/javascript" src="<?php print DS_ASSET_PATH ?>/js/respond.custom.js"></script>
+      <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/html5shiv/dist/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="shortcut icon" href="<?php print NEUE_ASSET_PATH; ?>/assets/images/favicon.ico">
   <link rel="apple-touch-icon-precomposed" href="<?php print NEUE_ASSET_PATH; ?>/assets/images/apple-touch-icon-precomposed.png">
-
 
   <?php print $head; ?>
 </head>
@@ -45,9 +42,17 @@
   <?php print $page_top; ?>
   <?php print $page; ?>
 
+  <!--[if lte IE 8]>
+      <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/respond/dest/respond.min.js"></script>
+      <link href="<?php print VENDOR_ASSET_PATH; ?>/respond/cross-domain/respond-proxy.html" id="respond-proxy" rel="respond-proxy" />
+      <link href="<?php print LOCAL_ASSET_PATH; ?>/bower_components/respond/cross-domain/respond.proxy.gif" id="respond-redirect" rel="respond-redirect" />
+      <script type="text/javascript" src="<?php print LOCAL_ASSET_PATH; ?>/bower_components/respond/cross-domain/respond.proxy.js"></script>
+
+      <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/REM-unit-polyfill/js/rem.min.js"></script>
+  <![endif]-->
+
   <script type="text/javascript" src="<?php print DS_JAVASCRIPT_PATH; ?>"></script>
   <?php print $scripts; ?>
   <?php print $page_bottom; ?>
 </body>
-
 </html>


### PR DESCRIPTION
- Uses cross-domain proxy for Respond.js.
- Move polyfills to end of body to prevent DOM not loaded issues.
- Rename `LIB_ASSET_PATH` to `VENDOR_ASSET_PATH` to be a bit clearer.
