### PR TITLE
File Entity + Editorial Caption

### DIFF
--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.info
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.info
@@ -13,3 +13,4 @@ features[ctools][] = strongarm:strongarm:1
 features[features_api][] = api:2
 features[filter][] = markdown
 features[user_permission][] = use text format markdown
+features[variable][] = pathauto_file_pattern

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.strongarm.inc
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @file
+ * dosomething_settings.strongarm.inc
+ */
+
+/**
+ * Implements hook_strongarm().
+ */
+function dosomething_settings_strongarm() {
+  $export = array();
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'pathauto_file_pattern';
+  $strongarm->value = 'file/[file:fid]';
+  $export['pathauto_file_pattern'] = $strongarm;
+
+  return $export;
+}

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -33,6 +33,7 @@ dependencies[] = entityconnect
 dependencies[] = entityreference
 dependencies[] = features
 dependencies[] = field_collection
+dependencies[] = file_entity
 dependencies[] = i18n
 dependencies[] = libraries
 dependencies[] = link

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -34,6 +34,7 @@ dependencies[] = entityreference
 dependencies[] = features
 dependencies[] = field_collection
 dependencies[] = file_entity
+dependencies[] = flag
 dependencies[] = i18n
 dependencies[] = libraries
 dependencies[] = link

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -67,6 +67,10 @@ projects[field_group][subdir] = "contrib"
 projects[file_entity][version] = "2.0-alpha3"
 projects[file_entity][subdir] = "contrib"
 
+; Flag
+projects[flag][version] = "3.5"
+projects[flag][subdir] = "contrib"
+
 ; Google Analytics
 projects[google_analytics][version] = "1.4"
 projects[google_analytics][subdir] = "contrib"

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -63,6 +63,10 @@ projects[field_collection][subdir] = "contrib"
 projects[field_group][version] = "1.3"
 projects[field_group][subdir] = "contrib"
 
+; File Entity
+projects[file_entity][version] = "2.0-alpha3"
+projects[file_entity][subdir] = "contrib"
+
 ; Google Analytics
 projects[google_analytics][version] = "1.4"
 projects[google_analytics][subdir] = "contrib"


### PR DESCRIPTION
**UPDATE:**

Adds File Entity and Flag module into the repo.  Sets the pathauto alias for Files to `file/[fid]`, the File entity's default URI, which prevents `url_alias` from created when we upload files.

We'll use a Promoted Flag in order to promote Reportback Files to the Campaign Run gallery, and add a description field to the flag entity itself for a better editorial experience.  This PR adds Flag into the mix as well to allow development to begin on Dynamic Galleries.

---

**Original PR:**

Adds File Entity module into the DS profile in order to:
- Add an Editorial Caption field to the File Entity and link to edit file from Reportbacks view.
- Allow use of Flag module to promote Reportback Files to Campaign / Run galleries, refs #2356

Will add a comment with a gist I've been working on detailing out pros/cons, but wanted to open the PR first. 
## Screenshots

![Reportback File List](https://cloud.githubusercontent.com/assets/1236811/3223242/4c21871a-f020-11e3-9790-c91dff5350eb.png)
![Reportback File Edit](https://cloud.githubusercontent.com/assets/1236811/3223243/4c247362-f020-11e3-93c0-1ce78aa465f1.png)
![admin-content-files](https://cloud.githubusercontent.com/assets/1236811/3230293/66a2870c-f0a1-11e3-88cd-0a02e18e83a8.png)
