### PR TITLE
Add npm-debug.log to gitignore. Fixes #2447.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ docs
 doxy.sh
 Doxyfile
 node_modules
+npm-debug.log
 Gemfile.lock
 lib/themes/dosomething/paraneue_dosomething/dist/
 lib/themes/dosomething/paraneue_dosomething/bower_components/


### PR DESCRIPTION
:secret: 
