### PR TITLE
Updated source toggle js to accomodate fact page source markup

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/sources.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/sources.js
@@ -6,7 +6,7 @@ define(function() {
   var $sources = $(".sources") || null;
 
   if ($sources) {
-    var $list = $sources.find("ul");
+    var $list = $sources.find("ul, div:first");
 
     // Hide the fact sources list if present.
     $list.hide();


### PR DESCRIPTION
The markup for sources is unique for Facts because it's type is string versus an array in all other scenarios, therefore the JS had to be modified to accommodate.
