### PR TITLE
Presignup table

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -200,6 +200,42 @@ function dosomething_signup_schema() {
     ),
     'primary key' => array('entity_type', 'entity_id', 'name'),
   );
+  $schema['dosomething_signup_presignup'] = array(
+    'description' => 'Table of user pre-signups.',
+    'fields' => array(
+      'sid' => array(
+        'description' => 'Primary key.',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'uid' => array(
+        'description' => 'The {users}.uid that signed up.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'nid' => array(
+        'description' => 'The {node}.nid that the user has signed up for.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'timestamp' => array(
+        'description' => 'The Unix timestamp when the signup was submitted.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+    ),
+    'primary key' => array('sid'),
+    'unique keys' => array(
+      'uid-nid' => array('uid', 'nid'),
+    ),
+    'indexes' => array(
+      'uid' => array('uid'),
+    ),
+  );
   return $schema;
 }
 
@@ -332,6 +368,20 @@ function dosomething_signup_update_7007() {
  */
 function dosomething_signup_update_7008() {
   $tbl_name = 'dosomething_signup_variable';
+  // Load schema to get table definition.
+  $schema = dosomething_signup_schema();
+  // If table not present:
+  if (!db_table_exists($tbl_name)) {
+    // Create it.
+    db_create_table($tbl_name, $schema[$tbl_name]);
+  }
+}
+
+/**
+ * Adds dosomething_signup_presignup table.
+ */
+function dosomething_signup_update_7009() {
+  $tbl_name = 'dosomething_signup_presignup';
   // Load schema to get table definition.
   $schema = dosomething_signup_schema();
   // If table not present:

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -103,6 +103,7 @@ function dosomething_signup_admin_paths() {
   );
   return $paths;
 }
+
 /**
  * Insert a user signup.
  *
@@ -177,16 +178,22 @@ function dosomething_signup_delete_signup($nid, $uid = NULL) {
  * @param int $uid
  *   Optional - the user uid of signup record to check.
  *   If not given, uses global $user->uid.
+ * @param string $presignup
+ *   Optional - If true, query the presignups table, not regular signups.
  *
  * @return mixed
  *   The sid of signup exists, FALSE if it doesn't exist.
  */
-function dosomething_signup_exists($nid, $uid = NULL) {
+function dosomething_signup_exists($nid, $uid = NULL, $presignup = FALSE) {
   if ($uid == NULL) {
     global $user;
     $uid = $user->uid;
   }
-  $result = db_select('dosomething_signup', 's')
+  $signup_tbl = 'dosomething_signup';
+  if ($presignup) {
+    $signup_tbl = 'dosomething_signup_presignup';
+  }
+  $result = db_select($signup_tbl, 's')
     ->condition('uid', $uid)
     ->condition('nid', $nid)
     ->fields('s', array('sid'))
@@ -654,4 +661,38 @@ function dosomething_signup_get_login_signup_nid() {
     }
   }
   return NULL;
+}
+
+/**
+ * Insert a pre-signup for the global $user.
+ *
+ * @param int $nid
+ *   The node nid the user has pre-signed up for.
+ *
+ * @return mixed
+ *   The sid of the newly inserted signup, or FALSE if error.
+ */
+function dosomething_signup_presignup_create($nid) {
+  // If a pre-signup does not exist already:
+  if (!dosomething_signup_presignup_exists($nid)) {
+    global $user;
+    // Insert one.
+    $sid = db_insert('dosomething_signup_presignup')
+      ->fields(array(
+        'nid' => $nid,
+        'uid' => $user->uid,
+        'timestamp' =>  REQUEST_TIME,
+      ))
+      ->execute();
+  }
+}
+
+/**
+ * Checks if a pre-signup exists for given $nid for global $user.
+ *
+ * @return bool
+ */
+function dosomething_signup_presignup_exists($nid) {
+  global $user;
+  return dosomething_signup_exists($nid, $user->uid, $presignup = TRUE);
 }


### PR DESCRIPTION
@angaither Please review.

Used for storing pre-signups when a campaign is in a closed state.

Closes #2463
