### PR TITLE
Presignup form

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -22,6 +22,9 @@ function dosomething_campaign_run_preprocess_closed(&$vars) {
     dosomething_campaign_run_preprocess_text_vars($vars, $wrapper);
     dosomething_campaign_run_preprocess_winners($vars, $closed_run_nid);
     dosomething_campaign_run_preprocess_klout_gallery($vars, $closed_run_nid);
+    // Preprocess the presignup form.
+    $label = t("I'm interested");
+    dosomething_signup_preprocess_signup_button($vars, $label, $presignup = TRUE);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -6,6 +6,64 @@
  */
 
 /**
+ * Form constructor for user presignup form.
+ *
+ * @param int $nid
+ *   The node nid to presignup for.
+ * @param string $label
+ *   The label to display on the form submit button.
+ */
+function dosomething_signup_presignup_form($form, &$form_state, $nid, $label) {
+  $form['nid'] = array(
+    '#type' => 'hidden',
+    '#value' => $nid,
+    '#access' => FALSE,
+  );
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => $label,
+    '#attributes' => array(
+      'class' => array(
+        'btn',
+        'medium',
+      ),
+    ),
+  );
+  return $form;
+}
+
+/**
+ * Form submission handler for dosomething_signup_presignup_form().
+ *
+ * @see dosomething_signup_presignup_form()
+ */
+function dosomething_signup_presignup_form_submit($form, &$form_state) {
+  $nid = $form_state['values']['nid'];
+  // Create the presignup.
+  dosomething_signup_presignup_create($nid);
+  // Assuming this form always just lives on the campaign,
+  // Let's grab title this way instead of querying db.
+  $title = drupal_get_title();
+  drupal_set_message(dosomething_signup_get_presignup_confirm_msg($title));
+}
+
+/**
+ * Returns the confirmation message after submitting presignup form.
+ *
+ * @param string $title
+ *   The title of the presignup node.
+ *
+ * @return string
+ */
+function dosomething_signup_get_presignup_confirm_msg($title) {
+  $link = l(t('find a campaign'), 'campaigns');
+  return t("Sweet, we'll send you an email as soon as @title re-opens. In the meantime, !link you can do right now.", array(
+    '@title' => $title,
+    '!link' => $link,
+  ));
+}
+
+/**
  * Form constructor for a Friends signup form.
  *
  * @param int $nid

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -39,9 +39,9 @@ function dosomething_signup_presignup_form($form, &$form_state, $nid, $label) {
  */
 function dosomething_signup_presignup_form_submit($form, &$form_state) {
   $nid = $form_state['values']['nid'];
-  // Create the presignup.
-  dosomething_signup_presignup_create($nid);
-  // Assuming this form always just lives on the campaign,
+  // Handle user presignup.
+  dosomething_signup_user_presignup($nid);
+  // Assuming this form always just lives on the campaign.
   // Let's grab title this way instead of querying db.
   $title = drupal_get_title();
   drupal_set_message(dosomething_signup_get_presignup_confirm_msg($title));

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -696,3 +696,12 @@ function dosomething_signup_presignup_exists($nid) {
   global $user;
   return dosomething_signup_exists($nid, $user->uid, $presignup = TRUE);
 }
+
+/**
+ * Presignup the global $user for given $nid.
+ */
+function dosomething_signup_user_presignup($nid) {
+  // Create the presignup record.
+  dosomething_signup_presignup_create($nid);
+  // @todo: Mailchimp subscription.
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
@@ -15,13 +15,19 @@
  *   Node variables, passed from preprocess_node.  Must contain $vars['nid'].
  * @param string $label
  *   The label to display fon the button.
+ * @param string $presignup
+ *   Optional - If TRUE, get the presignup form, else regular signup form.
  */
-function dosomething_signup_preprocess_signup_button(&$vars, $label = "Sign Up") {
+function dosomething_signup_preprocess_signup_button(&$vars, $label = "Sign Up", $presignup = FALSE) {
   $label = t($label);
   // If user is logged in:
   if (user_is_logged_in()) {
+    $form_id = 'dosomething_signup_form';
+    if ($presignup) {
+      $form_id = 'dosomething_signup_presignup_form';
+    }
     // Render button as sign up form.
-    $vars['signup_button'] = drupal_get_form('dosomething_signup_form', $vars['nid'], $label);
+    $vars['signup_button'] = drupal_get_form($form_id, $vars['nid'], $label);
   }
   // Otherwise, for anonymous user:
   else {


### PR DESCRIPTION
@angaither Please review.

Refs #2449

Places a presignup form on the Campaign Closed template, and writes a presignup record upon submitting.

If a user clicks it over and over, they'll get the confirmation message but we'll only store the presignup once.

Sets up placeholder code for adding Mailchimp Presignup subscription: https://github.com/DoSomething/message_broker_producer/issues/35
