### PR TITLE
Cleanup dosomething_campaign_is_closed function

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -54,7 +54,7 @@ function dosomething_campaign_menu() {
     'title' => 'Closed',
     'page callback' => 'node_page_view',
     'page arguments' => array(1),
-    'access callback' => 'dosomething_campaign_is_closed',
+    'access callback' => '_dosomething_campaign_closed_page_access',
     'access arguments' => array(1),
     'type' => MENU_LOCAL_TASK,
     'weight' => 70,
@@ -181,6 +181,19 @@ function _dosomething_campaign_pitch_page_access($node) {
     }
   }
   return FALSE;
+}
+
+/*
+ * Determines whether a user has access to the closed page callback.
+ */
+function _dosomething_campaign_closed_page_access($node) {
+  // Staff only.
+  if (!dosomething_user_is_staff()) { return FALSE; }
+
+  // Only display closed page link if a campaign run exists for node.
+  $run_nid = dosomething_campaign_run_get_closed_run_nid($node->nid);
+  // Closed page available if this is a campaign node with a campaign run.
+  return ($node->type == 'campaign' && $run_nid);
 }
 
 /**
@@ -456,16 +469,7 @@ function dosomething_campaign_is_pitch_page($node) {
  */
 function dosomething_campaign_is_closed($node) {
   // Is the campaign status set to closed?
-  if ($node->field_campaign_status[LANGUAGE_NONE][0]['value'] == 'closed') {
-    return TRUE;
-  }
-  // Is a staff trying to preview the closed node?
-  if (dosomething_user_is_staff()) {
-    // Check if staff-only closed path.
-    // @see dosomething_campaign_menu().
-    return current_path() == 'node/' . $node->nid . '/closed';
-  }
-  return FALSE;
+  return $node->field_campaign_status[LANGUAGE_NONE][0]['value'] == 'closed';
 }
 
 /*

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -468,8 +468,10 @@ function dosomething_campaign_is_pitch_page($node) {
  * @return bool
  */
 function dosomething_campaign_is_closed($node) {
-  // Is the campaign status set to closed?
-  return $node->field_campaign_status[LANGUAGE_NONE][0]['value'] == 'closed';
+  if (isset($node->field_campaign_status[LANGUAGE_NONE][0]['value'])) {
+    return $node->field_campaign_status[LANGUAGE_NONE][0]['value'] == 'closed';
+  }
+  return FALSE;
 }
 
 /*

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -51,8 +51,12 @@ function dosomething_campaign_preprocess_node(&$vars) {
 
   // Preprocess common vars between all campaign types.
   dosomething_campaign_preprocess_common_vars($vars, $wrapper);
-
-  if (dosomething_campaign_is_closed($node)) {
+  
+  // Check if current path is closed path.
+  // @see dosomething_campaign_menu().
+  $closed_path = 'node/' . $node->nid . '/closed';
+  // If the campaign node is closed or we're on the closed path:
+  if (dosomething_campaign_is_closed($node) || current_path() == $closed_path) {
     // Use the campaign closed template to theme.
     $vars['theme_hook_suggestions'][] = 'node__campaign__closed';
     dosomething_campaign_run_preprocess_closed($vars);


### PR DESCRIPTION
@angaither Please review

Issue details in #2475 but this removes staff / current path checks out of `dosomething_campaign_is_closed` and into an access callback and check within the preprocess.

Without a proper access callback, and simply checking if `dosomething_campaign_is_closed`, the user will be presented with both the "View" and "Closed" tab when the campaign is actually closed.
