### PR TITLE
Default page layout

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -6,6 +6,12 @@
 function paraneue_dosomething_preprocess_page(&$vars) {
   $vars['logo'] = NEUE_ASSET_PATH . '/assets/images/ds-logo.png';
 
+  // Add theme suggestion for page template based on node.
+  if (isset($vars['node']->type)) {
+    // If the content type's machine name is "my_machine_name" the file
+    // name will be "page--my-machine-name.tpl.php".
+    $vars['theme_hook_suggestions'][] = 'page__' . $vars['node']->type;
+  }
 
   // Get User Information
   $user_info = user_load($vars['user']->uid);
@@ -36,9 +42,19 @@ function paraneue_dosomething_preprocess_page(&$vars) {
   $node_type = menu_get_object()->type;
   if ($node_type == 'campaign_group' && array_key_exists('submitted_mcc', $_GET)) {
     drupal_set_message(t('Thanks! We\'ll be in touch soon with next steps. If you\'d like to submit more than one campaign idea, go for it!'));
+  // Header
+  // ------
+  $header_vars = array(
+    'title' => drupal_get_title(),
+  );
+
+  // If there's a subtitle field on this node, send it to the header
+  if(isset( $vars['node']->field_subtitle[LANGUAGE_NONE][0]['safe_value'] )) {
+    $header_vars['subtitle'] =  $vars['node']->field_subtitle[LANGUAGE_NONE][0]['safe_value'];
   }
 
   // Footer Output Setup
+  $vars['header'] = theme('header', $header_vars);
   $columns = array('first', 'second', 'third');
   $footer_links = array();
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -23,16 +23,23 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     $vars['user_identifier'] = $user_info->mail;
   }
 
-  // krumo($vars['user_identifier']);
+  // Navigation
+  // ----------
 
-  // Navigation Output Setup
+  // @TODO: We should be able to specify these (probably as independent toggles) on nodes.
+  $modifier_classes = 'white floating';
+  if(isset($vars['node']->type) && $vars['node']->type == "campaign") {
+    $modifier_classes = 'floating';
+  }
+
   $navigation_vars = array(
-    'base_path'       => $vars['base_path'],
-    'logo'            => $vars['logo'],
-    'front_page'      => $vars['front_page'],
-    'logged_in'       => $vars['logged_in'],
-    'search_box'      => $vars['search_box'],
-    'user_identifier' => dosomething_helpers_text_truncate($vars['user_identifier'], 8),
+    'base_path'        => $vars['base_path'],
+    'modifier_classes' => $modifier_classes,
+    'logo'             => NEUE_ASSET_PATH . '/assets/images/ds-logo.png',
+    'front_page'       => $vars['front_page'],
+    'logged_in'        => $vars['logged_in'],
+    'search_box'       => $vars['search_box'],
+    'user_identifier'  => dosomething_helpers_text_truncate($vars['user_identifier'], 8),
   );
 
   $vars['navigation'] = theme('navigation', $navigation_vars);

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -4,8 +4,6 @@
  * Implements theme_preprocess_page().
  */
 function paraneue_dosomething_preprocess_page(&$vars) {
-  $vars['logo'] = NEUE_ASSET_PATH . '/assets/images/ds-logo.png';
-
   // Add theme suggestion for page template based on node.
   if (isset($vars['node']->type)) {
     // If the content type's machine name is "my_machine_name" the file
@@ -13,7 +11,8 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     $vars['theme_hook_suggestions'][] = 'page__' . $vars['node']->type;
   }
 
-  // Get User Information
+  // User
+  // ----
   $user_info = user_load($vars['user']->uid);
 
   if (isset($user_info->field_first_name['und'][0]['safe_value'])) {
@@ -38,10 +37,6 @@ function paraneue_dosomething_preprocess_page(&$vars) {
 
   $vars['navigation'] = theme('navigation', $navigation_vars);
 
-  // Show Hunt MCC form confirmation if query string exists
-  $node_type = menu_get_object()->type;
-  if ($node_type == 'campaign_group' && array_key_exists('submitted_mcc', $_GET)) {
-    drupal_set_message(t('Thanks! We\'ll be in touch soon with next steps. If you\'d like to submit more than one campaign idea, go for it!'));
   // Header
   // ------
   $header_vars = array(
@@ -53,8 +48,11 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     $header_vars['subtitle'] =  $vars['node']->field_subtitle[LANGUAGE_NONE][0]['safe_value'];
   }
 
-  // Footer Output Setup
   $vars['header'] = theme('header', $header_vars);
+
+
+  // Footer
+  // ------
   $columns = array('first', 'second', 'third');
   $footer_links = array();
 
@@ -82,6 +80,15 @@ function paraneue_dosomething_preprocess_page(&$vars) {
       'links' => $footer_links
     )
   );
+
+
+  // Misc
+  // ----
+  // Show Hunt MCC form confirmation if query string exists
+  $node_type = menu_get_object()->type;
+  if ($node_type == 'campaign_group' && array_key_exists('submitted_mcc', $_GET)) {
+    drupal_set_message(t('Thanks! We\'ll be in touch soon with next steps. If you\'d like to submit more than one campaign idea, go for it!'));
+  }
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -11,8 +11,10 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     $vars['theme_hook_suggestions'][] = 'page__' . $vars['node']->type;
   }
 
-  // User
-  // ----
+  /**
+   * User Info
+   */
+
   $user_info = user_load($vars['user']->uid);
 
   if (isset($user_info->field_first_name['und'][0]['safe_value'])) {
@@ -23,8 +25,9 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     $vars['user_identifier'] = $user_info->mail;
   }
 
-  // Navigation
-  // ----------
+  /**
+   * Navigation
+   */
 
   // @TODO: We should be able to specify these (probably as independent toggles) on nodes.
   $modifier_classes = 'white floating';
@@ -44,8 +47,10 @@ function paraneue_dosomething_preprocess_page(&$vars) {
 
   $vars['navigation'] = theme('navigation', $navigation_vars);
 
-  // Header
-  // ------
+  /**
+   * Header
+   */
+
   $header_vars = array(
     'title' => drupal_get_title(),
   );
@@ -58,8 +63,10 @@ function paraneue_dosomething_preprocess_page(&$vars) {
   $vars['header'] = theme('header', $header_vars);
 
 
-  // Footer
-  // ------
+  /**
+   * Footer
+   */
+
   $columns = array('first', 'second', 'third');
   $footer_links = array();
 
@@ -89,8 +96,10 @@ function paraneue_dosomething_preprocess_page(&$vars) {
   );
 
 
-  // Misc
-  // ----
+  /**
+   * Miscellaneous
+   */
+
   // Show Hunt MCC form confirmation if query string exists
   $node_type = menu_get_object()->type;
   if ($node_type == 'campaign_group' && array_key_exists('submitted_mcc', $_GET)) {

--- a/lib/themes/dosomething/paraneue_dosomething/includes/theme.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/theme.inc
@@ -49,6 +49,11 @@ function paraneue_dosomething_theme() {
       'path' => PARANEUE_DS_PATH . '/templates/system/partials',
     ),
 
+    'header' => array(
+      'template' => 'header',
+      'path' => PARANEUE_DS_PATH . '/templates/system/partials',
+    ),
+
     'thumbnail' => array(
       'template' => 'thumbnail',
       'path' => PARANEUE_DS_PATH . '/templates/home/partials',

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -23,7 +23,7 @@
 
 // Content styles by section
 @import "content/auth";
-@import "content/home"; // new homepage
+@import "content/home";
 @import "content/campaign"; // @NOTE - parent partial that imports sub-partials
 @import "content/sources";
 @import "content/disclaimer";

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -24,6 +24,7 @@
 // Content styles by section
 @import "content/auth";
 @import "content/home";
+@import "content/chrome";
 @import "content/campaign"; // @NOTE - parent partial that imports sub-partials
 @import "content/sources";
 @import "content/disclaimer";

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -1,7 +1,5 @@
 // Higher level selector to access content outside of .campaign--wrapper
 body.node-type-campaign {
-  @include wrapper--nav-floating;
-
   // Action Guide within campaigns styles
   .node-action-guide {
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_chrome.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_chrome.scss
@@ -1,0 +1,33 @@
+// @TODO: These should be moved to Neue!
+// Applies styles to make nav text white
+.chrome--nav {
+  &.white {
+    .hamburger {
+      color: #fff !important;
+    }
+
+    a {
+      text-shadow: 0 1px 3px rgba(#000, 0.3);
+      color: #fff !important;
+    }
+
+    .secondary-nav input[type="search"] {
+      color: #fff;
+      border: 1px solid #fff;
+      box-shadow: 0 1px 3px rgba(#000, 0.3);
+      background-image: neue-image-url("search_light.png");
+
+      @include hidpi {
+        background-image: neue-image-url("search_light@2x.png");
+      }
+    }
+  }
+
+  // Applies styles to make nav float over content wrapper
+  &.floating {
+    position: absolute;
+    top: 0;
+    margin-bottom: 0;
+    z-index: 1;
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_fact-page.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_fact-page.scss
@@ -5,12 +5,7 @@
 
 // @TODO: Sync naming between SCSS files and tpl.php
 
-.node-type-fact-page {
-  background: $purple;
-
-  @include wrapper--nav-white;
-  @include wrapper--nav-floating;
-
+.node-type-fact {
   // @TODO: Sync with Dave/Maxwell on all 18px base font size for static content
   p {
     font-size: 18px;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_home.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_home.scss
@@ -1,8 +1,3 @@
-.node-type-home {
-  @include wrapper--nav-white;
-  @include wrapper--nav-floating;
-}
-
 .home--wrapper {
   background: #fff;
   overflow: hidden;
@@ -73,6 +68,7 @@
   background: #fff;
   text-align: center;
   overflow: hidden;
+  padding-top: 2rem;
 
   @include media($tablet) {
     @include span-columns(12);

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_search.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_search.scss
@@ -1,18 +1,6 @@
 .page-search {
-  // Generic wrapper for search content
-  .content {
-    width: 90%;
-    margin: 7rem auto 2rem;
-
-    @include media($tablet) {
-      width: 100%;
-      margin: 7rem auto 4rem;
-
-      @include span-columns(8);
-      @include shift(4);
-      float: none;
-    }
-  }
+  @include wrapper--nav-white;
+  @include wrapper--nav-floating;
 
   // Pagination styles
   .pager li {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_static.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_static.scss
@@ -2,13 +2,6 @@
 //  STATIC CONTENT
 // ----------------
 
-.node-type-static-content {
-  background: $purple;
-
-  @include wrapper--nav-white;
-  @include wrapper--nav-floating;
-}
-
 .static_content-wrapper {
   background: #fff;
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_user.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_user.scss
@@ -149,29 +149,3 @@
   }
 
 }
-
-
-// Forgot Password
-// @TODO: Let's fix this shit.
-.page-user-register, .page-user-password {
-  .chrome--nav {
-    position: static;
-
-    a {
-      color: $off-black !important;
-    }
-
-    .secondary-nav input[type="search"] {
-      color: $off-black !important;
-      background-image: neue-image-url("search_dark.png");
-      border: 1px solid $off-black;
-    }
-  }
-
-  main[role="main"] {
-    background: #fff;
-    max-width: 650px;
-    padding: 2rem;
-    margin: 20px auto 100px;
-  }
-}

--- a/lib/themes/dosomething/paraneue_dosomething/scss/helpers/_mixins.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/helpers/_mixins.scss
@@ -29,39 +29,11 @@
   };
 }
 
-// Applies styles to make nav text white
-@mixin wrapper--nav-white {
-  .chrome--nav {
-    .hamburger {
-      color: #fff !important;
-    }
-
-    a {
-      text-shadow: 0 1px 3px rgba(#000, 0.3);
-      color: #fff !important;
-    }
-
-    .secondary-nav input[type="search"] {
-      color: #fff;
-      border: 1px solid #fff;
-      box-shadow: 0 1px 3px rgba(#000, 0.3);
-      background-image: neue-image-url("search_light.png");
-
-      @include hidpi {
-        background-image: neue-image-url("search_light@2x.png");
-      }
-    }
-  }
-}
-
-// Applies styles to make nav float over content wrapper
 @mixin wrapper--nav-floating {
-  .chrome--nav {
-    position: absolute;
-    top: 0;
-    margin-bottom: 0;
-    z-index: 1;
-  }
+  @warn "This old mixin is deprecated!";
+}
+@mixin wrapper--nav-white {
+  @warn "This old mixin is deprecated!";
 }
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/page--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/page--campaign.tpl.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Generates minimal site-wide page chrome.
+ * @see https://drupal.org/node/1728148
+ **/
+
+?>
+
+<?php if (!empty($tabs['#primary'])): ?><nav class="admin--tabs"><?php print render($tabs); ?></nav><?php endif; ?>
+<?php print $messages; ?>
+
+<div class="chrome--wrapper">
+  <?php print $variables['navigation']; ?>
+
+  <main role="main">
+    <?php print render($page['content']); ?>
+  </main>
+
+  <?php print $variables['footer']; ?>
+</div>
+

--- a/lib/themes/dosomething/paraneue_dosomething/templates/home/page--home.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/home/page--home.tpl.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Generates site-wide page chrome.
+ * @see https://drupal.org/node/1728148
+ **/
+
+?>
+
+<?php if (!empty($tabs['#primary'])): ?><nav class="admin--tabs"><?php print render($tabs); ?></nav><?php endif; ?>
+<?php print $messages; ?>
+
+<div class="chrome--wrapper">
+  <?php print $variables['navigation']; ?>
+
+  <main role="main" class="container">
+    <?php print render($page['content']); ?>
+  </main>
+
+  <?php print $variables['footer']; ?>
+</div>
+

--- a/lib/themes/dosomething/paraneue_dosomething/templates/static_content/node--static_content.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/static_content/node--static_content.tpl.php
@@ -11,24 +11,6 @@
 <section class="static_content-wrapper">
   <article id="node-<?php print $node->nid; ?>" class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
 
-    <header role="banner" class="-basic<?php if (isset($sponsors[0]['display'])): print ' -sponsored'; endif; ?>">
-      <div class="wrapper">
-        <h1 class="__title"><?php print $title; ?></h1>
-        <?php if (isset($subtitle)): ?>
-        <h2 class="__subtitle"><?php print $subtitle; ?></h2>
-        <?php endif; ?>
-
-        <?php if (isset($sponsors[0]['display'])): ?>
-        <div class="sponsor">
-          <p class="__copy">Powered by</p>
-          <?php foreach ($sponsors as $key => $sponsor) :?>
-            <?php if (isset($sponsor['display'])): print $sponsor['display']; endif; ?>
-          <?php endforeach; ?>
-        </div>
-        <?php endif; ?>
-      </div>
-    </header>
-
     <?php if (isset($intro)): ?>
       <div class="intro-wrapper">
         <div class="intro<?php if (!isset($intro_title)): print ' no-title'; endif; ?>">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/static_content/page--static_content.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/static_content/page--static_content.tpl.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Generates minimal site-wide page chrome.
+ * @see https://drupal.org/node/1728148
+ **/
+
+?>
+
+<?php if (!empty($tabs['#primary'])): ?><nav class="admin--tabs"><?php print render($tabs); ?></nav><?php endif; ?>
+<?php print $messages; ?>
+
+<div class="chrome--wrapper">
+  <?php print $variables['navigation']; ?>
+  <?php print $variables['header']; ?>
+
+  <main role="main">
+    <?php print render($page['content']); ?>
+  </main>
+
+  <?php print $variables['footer']; ?>
+</div>
+

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/page.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/page.tpl.php
@@ -12,9 +12,12 @@
 
 <div class="chrome--wrapper">
   <?php print $variables['navigation']; ?>
+  <?php print $variables['header']; ?>
 
-  <main role="main">
-    <?php print render($page['content']); ?>
+  <main role="main" class="container">
+    <div class="wrapper">
+      <?php print render($page['content']); ?>
+    </div>
   </main>
 
   <?php print $variables['footer']; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/header.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/header.tpl.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Generates site-wide global page nav.
+ **/
+
+?>
+
+<header role="banner" class="-basic<?php if (isset($sponsors)): print ' -sponsored'; endif; ?>">
+  <div class="wrapper">
+    <h1 class="__title"><?php print $title; ?></h1>
+    <?php if (isset($subtitle)): ?>
+    <h2 class="__subtitle"><?php if (isset($subtitle)): print $subtitle; endif; ?></h2>
+    <?php endif; ?>
+
+    <?php if (isset($sponsors)): ?>
+    <div class="sponsor">
+      <p class="__copy">Powered by</p>
+      <?php foreach ($sponsors as $key => $sponsor) :?>
+        <?php if (isset($sponsor['display'])): print $sponsor['display']; endif; ?>
+      <?php endforeach; ?>
+    </div>
+    <?php endif; ?>
+  </div>
+</header>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/navigation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/navigation.tpl.php
@@ -6,7 +6,7 @@
 
 ?>
 
-<nav class="chrome--nav">
+<nav class="chrome--nav<?php if(isset($modifier_classes)): print ' ' . $modifier_classes; endif; ?>">
   <a class="logo" href="<?php print $base_path; ?>"><img src="<?php print $logo ?>" alt="DoSomething.org"></a>
   <a class="hamburger js-toggle-mobile-menu" href="#">&#xe606;</a>
   <div class="menu">


### PR DESCRIPTION
### Changes
- Sets a default page layout (with purple header & appropriate content margins), and adds theme suggestion to allow overriding page template by node type.
- Partializes "header" pattern to dry up that markup.
- Applies style classes directly to navigation in preprocess step, rather than styling based on `.node-type` page classes.

Fixes #1706. Also fixes #2198, fixes #2197, fixes #2164, and fixes #1949.
