### PR TITLE
On login submit, sign the user up for the correct campaign state.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -428,7 +428,14 @@ function dosomething_user_login_submit($form, &$form_state) {
     $nid = $form['nid']['#value'];
     // Signup global user for node $nid.
     if (module_exists('dosomething_signup')) {
-      dosomething_signup_user_signup($nid);
+      // First check if the campaign is closed.
+      $campaign = node_load($nid);
+      if (dosomething_campaign_is_closed($campaign)) {
+        dosomething_signup_user_presignup($nid);
+      }
+      else {
+        dosomething_signup_user_signup($nid);
+      }
     }
   }
   // After all logins redirect to page user was just on.


### PR DESCRIPTION
Check to see if campaign is closed, if so 'presignup' else signup.

This currently works for logged in users. Will probably also worked for anon users once #2486 is fixed.

Fixes #2472
