### PR TITLE
Check for `is_closed` before `is_pitch`

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -49,6 +49,8 @@ function dosomething_campaign_preprocess_node(&$vars) {
     // Use the campaign closed template to theme.
     $vars['theme_hook_suggestions'][] = 'node__campaign__closed';
     dosomething_campaign_run_preprocess_closed($vars);
+    // Preprocess common vars between all campaign types.
+    dosomething_campaign_preprocess_common_vars($vars, $wrapper);
     return;
   }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -41,17 +41,6 @@ function dosomething_campaign_preprocess_node(&$vars) {
   // Add inline css based on vars.
   dosomething_helpers_add_inline_css($vars);
 
-  if (dosomething_campaign_is_pitch_page($node)) {
-    // Use the pitch page template to theme.
-    $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'] . '__pitch';
-    // Gather vars for pitch page.
-    dosomething_campaign_preprocess_pitch_page($vars, $wrapper);
-    return;
-  }
-
-  // Preprocess common vars between all campaign types.
-  dosomething_campaign_preprocess_common_vars($vars, $wrapper);
-  
   // Check if current path is closed path.
   // @see dosomething_campaign_menu().
   $closed_path = 'node/' . $node->nid . '/closed';
@@ -62,6 +51,19 @@ function dosomething_campaign_preprocess_node(&$vars) {
     dosomething_campaign_run_preprocess_closed($vars);
     return;
   }
+
+  if (dosomething_campaign_is_pitch_page($node)) {
+    // Use the pitch page template to theme.
+    $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'] . '__pitch';
+    // Gather vars for pitch page.
+    dosomething_campaign_preprocess_pitch_page($vars, $wrapper);
+    return;
+  }
+
+  // Preprocess common vars between all campaign types.
+  dosomething_campaign_preprocess_common_vars($vars, $wrapper);
+
+
 
   if (dosomething_campaign_get_campaign_type($node) == 'sms_game') {
     // Use the SMS Game template to theme.


### PR DESCRIPTION
If a campaign is closed, we want to show that before we show the pitch page.
This is no code changes, just order changes.

![](https://i.chzbgr.com/maxW500/6487447296/hC8C2F3A6/)

Fixes #2486
