### PR TITLE
Fixes #2497: Uses private subnet IPs for stage/prod deploy

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,8 +1,8 @@
 set :deploy_to, "/var/www/beta.dosomething.org"
 
-role :app, %w{dosomething@98.129.111.169}
+role :app, %w{dosomething@10.241.0.26}
 
-server '98.129.111.169', user: 'dosomething', roles: %w{app}
+server '10.241.0.26', user: 'dosomething', roles: %w{app}
 
 namespace :deploy do
 

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,8 +1,8 @@
 set :deploy_to, "/var/www/beta.dosomething.org"
 
-role :app, %w{dosomething@staging.beta.dosomething.org}
+role :app, %w{dosomething@10.241.0.22}
 
-server 'staging.beta.dosomething.org', user: 'dosomething', roles: %w{app}
+server '10.241.0.22', user: 'dosomething', roles: %w{app}
 
 namespace :deploy do
 


### PR DESCRIPTION
Requires the deploying server to be either on the private subnet, or to have access (i.e., via VPN).
