### PR TITLE
Salt Provisioning: fix apache2/php.ini provisioning.

### DIFF
--- a/provision/salt/roots/salt/lamp-drupal.sls
+++ b/provision/salt/roots/salt/lamp-drupal.sls
@@ -13,11 +13,6 @@ php5-pkgs:
       - php5-gd
       - php5-memcache
       - php-apc
-  file.managed:
-    - name: /etc/php5/apache2/php.ini
-    - source: salt://php5/apache2/php.ini
-    - require:
-      - pkg: php5-pkgs
 
 php5-cli-config:
   file.managed:
@@ -105,6 +100,11 @@ libapache2-mod-php5:
     - installed
     - require:
       - pkg: apache2
+  file.managed:
+    - name: /etc/php5/apache2/php.ini
+    - source: salt://php5/apache2/php.ini
+    - require:
+      - pkg: php5-pkgs
 
 memcached:
   pkg:


### PR DESCRIPTION
Currently vagrant provisioning does not override system php.ini file for apache2 with the one provided by `lamp-drupal` salt state tree.
The reason for that is a logic error in `lamp-drupal.sls`. It was assumed that `/etc/php5/apache2/php.ini` is provided by `php5` package, however, it is provided by `libapache2-mod-php5`.
Thus salt-managed php.ini is copied too early so it gets overridden by the default version when `libapache2-mod-php5` package is being installed.
This commit corrects that by making `libapache2-mod-php5` responsible of managing `php5/apache2/php.ini`.
