### PR TITLE
Campaign status solr

### DIFF
--- a/lib/modules/dosomething/dosomething_search/dosomething_search.views_default.inc
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.views_default.inc
@@ -79,6 +79,12 @@ function dosomething_search_views_default_views() {
   $handler->display->display_options['filters']['ss_field_search_image_300x300']['table'] = 'apachesolr__solr';
   $handler->display->display_options['filters']['ss_field_search_image_300x300']['field'] = 'ss_field_search_image_300x300';
   $handler->display->display_options['filters']['ss_field_search_image_300x300']['value'] = '[* TO *]';
+    /* Filter criterion: Apache Solr: sm_field_campaign_status */
+  $handler->display->display_options['filters']['sm_field_campaign_status']['id'] = 'sm_field_campaign_status';
+  $handler->display->display_options['filters']['sm_field_campaign_status']['table'] = 'apachesolr__solr';
+  $handler->display->display_options['filters']['sm_field_campaign_status']['field'] = 'sm_field_campaign_status';
+  $handler->display->display_options['filters']['sm_field_campaign_status']['operator'] = '!=';
+  $handler->display->display_options['filters']['sm_field_campaign_status']['value'] = 'closed';
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
@@ -34,7 +34,7 @@ define(function(require) {
 
     // This would be awesome with an object key:value, but Solr allows multiple of the same key
     defaultQuery: [
-      "fq=bundle:[campaign TO campaign_group]",
+      "fq=-sm_field_campaign_status:(closed) bundle:[campaign TO campaign_group]",
       //"fq=ss_field_search_image:[* TO *]",
       "wt=json",
       "indent=false",


### PR DESCRIPTION
Hiding closed campaigns from the /campaigns page and the finder.  Closed campaigns will still be visible in search.

Fixes #2377
