### PR TITLE
DoSomething config admin menu group

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -17,6 +17,22 @@ function dosomething_helpers_ctools_plugin_api($module = NULL, $api = NULL) {
 }
 
 /**
+ * Implements hook_menu().
+ */
+function dosomething_helpers_menu() {
+  $items['admin/config/dosomething'] = array(
+    'title' => 'DoSomething config',
+    'description' => 'Configuration for DoSomething custom functionality.',
+    'page callback' => 'system_admin_menu_block_page',
+    'access arguments' => array('access administration pages'),
+    'file' => 'system.admin.inc',
+    'file path' => drupal_get_path('module', 'system'),
+  );
+  return $items;
+}
+
+
+/**
  * Wrapper function for Drupal's ip_address function.
  *
  * Because varnish only likes to expose its own IP, and 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -17,7 +17,7 @@ include_once 'includes/dosomething_signup.variable.inc';
 function dosomething_signup_menu() {
   $items = array();
 
-  $items['admin/config/services/optins'] = array(
+  $items['admin/config/dosomething/optins'] = array(
     'title' => t('Third Party Opt-Ins'),
     'description' => 'Admin form to manage custom opt-ins',
     'page callback' => 'dosomething_signup_opt_in_config_page',

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -43,7 +43,7 @@ function dosomething_user_menu() {
     'file' => 'dosomething_user_valid_address.inc'
   );
 
-  $items['admin/config/services/ups-api-settings'] = array(
+  $items['admin/config/dosomething/ups-api-settings'] = array(
     'title' => t('UPS API Configuration'),
     'description' => t('UPS integration that provices address validation'),
     'page callback' => 'drupal_get_form',

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -11,8 +11,8 @@ define('DOSOMETHING_ZENDESK_FIELD_ID_IP_ADDRESS', 22583120);
  */
 function dosomething_zendesk_menu() {
   $items = array();
-  $items['admin/config/services/dosomething_zendesk'] = array(
-    'title' => 'DoSomething Zendesk settings',
+  $items['admin/config/dosomething/dosomething_zendesk'] = array(
+    'title' => 'Zendesk settings',
     'description' => 'Manage Zendesk settings.',
     'page callback' => 'dosomething_zendesk_admin_page',
     'access arguments' => array('administer modules'),


### PR DESCRIPTION
Creates a `admin/config/dosomething` menu to place our custom configuration forms.

![screen shot 2014-06-13 at 1 08 09 pm](https://cloud.githubusercontent.com/assets/1236811/3272877/908fd12c-f31d-11e3-973b-4a1e2b4e063e.png)
