### PR TITLE
Check for logged in user before submitting reportback form

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -365,6 +365,14 @@ function dosomething_reportback_form($form, &$form_state, $entity) {
  * Validation callback for dosomething_reportback_form().
  */
 function dosomething_reportback_form_validate($form, &$form_state) {
+  // If user session no longer exists:
+  if (!user_is_logged_in()) {
+    // Tell them that.
+    drupal_set_message(t("You are no longer logged in. Please log in."), 'error');
+    // Redirect to the original node.
+    // Without this, the user is redirected to the confirmation page.
+    drupal_goto('node/' . $form_state['values']['nid']);
+  }
   // Validate uploaded file.
   dosomething_reportback_form_validate_file($form, $form_state);
 }


### PR DESCRIPTION
We've had a few reportbacks with uid 0, which can be replicated by navigating to a campaign while logged in. From a different tab, log out.  Then go back to the original tab with the campaign and submit the reportback. The reportback is submitted to uid 0.

This fixes that and prevents the submission from happening.

![screen shot 2014-06-13 at 1 34 19 pm](https://cloud.githubusercontent.com/assets/1236811/3273200/9df13f32-f321-11e3-8add-89fa99edb3dc.png)
