### PR TITLE
Add campaign totals to help text

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -212,13 +212,13 @@ function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$fo
   $campaign_nid = $form['#node']->field_campaigns[LANGUAGE_NONE][0]['target_id'];
   if (isset($campaign_nid)) {
     // Get totals & language from the campaign.
-    $reportback_total_members = dosomething_reportback_get_total_campaign_reportbacks($campaign_nid);
+    $signup_total_members = dosomething_signup_get_signup_total_by_nid($campaign_nid);
     $reportback_quantity = dosomething_reportback_get_total_campaign_reportback_sums($campaign_nid);
     $language = dosomething_reportback_get_noun_and_verb($campaign_nid);
 
     // Add the text to the form.
     // @TODO: why doesn't this work in the ['#description'] place?
-    $form['field_total_participants'][LANGUAGE_NONE]['#suffix'] = '<div class="description">' . $reportback_total_members . ' members have reported back. </div>';
+    $form['field_total_participants'][LANGUAGE_NONE]['#suffix'] = '<div class="description">' . $signup_total_members . ' members have signed up. </div>';
     $form['field_total_quantity'][LANGUAGE_NONE]['#suffix'] = '<div class="description">' . $reportback_quantity . ' ' .$language->noun . ' ' . $language->verb . ' have been reported back. </div>';
   }
 

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -204,7 +204,23 @@ function dosomething_campaign_run_add_campaign_run_info(&$form, &$form_state) {
 /**
  * Implements hook_form_NODE_TYPE_alter().
  */
-function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, $form_state, $form_id) {
+function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$form_state, $form_id) {
+  // Add title help text.
   $form['title']['#description'] = t('The title is not user facing, it just helps when searching for content. Suggestion: Use campaign name and year campaign ended (i.e. Comeback Clothes 2014).');
+
+  // If the campaign nid is set let's add some help text!
+  $campaign_nid = $form['#node']->field_campaigns[LANGUAGE_NONE][0]['target_id'];
+  if (isset($campaign_nid)) {
+    // Get totals & language from the campaign.
+    $reportback_total_members = dosomething_reportback_get_total_campaign_reportbacks($campaign_nid);
+    $reportback_quantity = dosomething_reportback_get_total_campaign_reportback_sums($campaign_nid);
+    $language = dosomething_reportback_get_noun_and_verb($campaign_nid);
+
+    // Add the text to the form.
+    // @TODO: why doesn't this work in the ['#description'] place?
+    $form['field_total_participants'][LANGUAGE_NONE]['#suffix'] = '<div class="description">' . $reportback_total_members . ' members have reported back. </div>';
+    $form['field_total_quantity'][LANGUAGE_NONE]['#suffix'] = '<div class="description">' . $reportback_quantity . ' ' .$language->noun . ' ' . $language->verb . ' have been reported back. </div>';
+  }
+
   drupal_add_css(drupal_get_path('module', 'dosomething_campaign_run') . '/campaign_run_node.css');
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -144,7 +144,7 @@ function dosomething_reportback_form_alter(&$form, &$form_state) {
   if ($form['#form_id'] == 'flag_confirm') {
     // Displays the image to be promoted/unpromoted.
     // @todo: Add a check to see if this is the promoted flag.  Fine for now
-    // since we only have one flag in the system. 
+    // since we only have one flag in the system.
     $fid = $form['entity_id']['#value'];
     $form['image'] = array(
       '#markup' => dosomething_image_get_themed_image_by_fid($fid, '300x300'),
@@ -782,6 +782,7 @@ function dosomething_reportback_get_reportback_field_info($nid, $name = NULL) {
 }
 
 /**
+<<<<<<< HEAD
  * Returns flagging_id, fids, rbid's for given $nid ordered by field_weight.
  *
  * @param int $nid
@@ -800,7 +801,7 @@ function dosomething_reportback_get_gallery_item_ids($nid, $num_items = NULL) {
     JOIN dosomething_reportback_file rbf ON flagging.entity_id = rbf.fid
     JOIN dosomething_reportback rb ON rb.rbid = rbf.rbid
     JOIN file_managed file ON file.fid = rbf.fid
-    LEFT OUTER JOIN field_data_field_weight weight 
+    LEFT OUTER JOIN field_data_field_weight weight
       ON weight.entity_id = flagging_id AND weight.entity_type = 'flagging'
     WHERE nid = :nid
     ORDER BY field_weight_value";
@@ -847,4 +848,39 @@ function dosomething_reportback_get_gallery_vars($nid, $style = '300x300', $num_
     }
   }
   return $vars;
+}
+
+/*
+ * Get the total number of campaign reportbacks.
+ *
+ * @param int $nid
+ *   A campaign node id.
+ * @return int $result
+ *   The number of users who reportedback on a camapgin.
+ */
+function dosomething_reportback_get_total_campaign_reportbacks($nid) {
+  $result = db_select('dosomething_reportback', 'rb')
+    ->fields('rb', array('rbid'))
+    ->condition('nid', $nid)
+    ->execute();
+  return $result->rowCount();
+}
+
+/**
+ * Get the total quanity from the reportbacks for a camapgin.
+ *
+ * @param int $nid
+ *   A campaign node id.
+ * @return int $result
+ *  The sum of all values in the `quantity` section from the reportback on a camapgin.
+ *
+ */
+function dosomething_reportback_get_total_campaign_reportback_sums($nid) {
+  $query = db_select('dosomething_reportback', 'rb')
+    ->fields('rb', array('quantity'))
+    ->condition('nid', $nid);
+  $query->addExpression('SUM(quantity)', 'quantity');
+  $result = $query->execute()->fetchAll();
+
+  return $result[0]->quantity;
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -782,7 +782,6 @@ function dosomething_reportback_get_reportback_field_info($nid, $name = NULL) {
 }
 
 /**
-<<<<<<< HEAD
  * Returns flagging_id, fids, rbid's for given $nid ordered by field_weight.
  *
  * @param int $nid

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -884,3 +884,22 @@ function dosomething_reportback_get_total_campaign_reportback_sums($nid) {
 
   return $result[0]->quantity;
 }
+
+/**
+ * Return the reportback noun & verb for a campaign.
+ *
+ * @param int $nid
+ *   A campaign node id.
+ * @return obj $results
+ *   An object containing reportback noun & verb
+ */
+function dosomething_reportback_get_noun_and_verb($nid) {
+  $query = db_select('field_data_field_reportback_noun', 'noun')
+    ->condition('noun.entity_id', $nid);
+  $query->addField('noun', 'field_reportback_noun_value', 'noun');
+  $query->addField('verb', 'field_reportback_verb_value', 'verb');
+  $query->join('field_data_field_reportback_verb', 'verb', 'noun.entity_id = verb.entity_id');
+  $results = $query->execute()->fetch();
+
+  return $results;
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -353,7 +353,7 @@ function dosomething_signup_views_data() {
 function dosomething_signup_entity_insert($entity, $type) {
   // If not a signup, exit out of function.
   if ($type != 'signup') { return; }
-  
+
   $account = user_load($entity->uid);
   $node = node_load($entity->nid);
 
@@ -426,7 +426,7 @@ function dosomething_signup_user_signup($nid, $account = NULL) {
     }
 
     // Set default signup message if we're still in this function.
-    dosomething_signup_set_signup_message($node->title);      
+    dosomething_signup_set_signup_message($node->title);
   }
 }
 
@@ -704,4 +704,20 @@ function dosomething_signup_user_presignup($nid) {
   // Create the presignup record.
   dosomething_signup_presignup_create($nid);
   // @todo: Mailchimp subscription.
+}
+
+/*
+ * Get the total number of campaign signups.
+ *
+ * @param int $nid
+ *   A campaign node id.
+ * @return int $result
+ *   The number of users who signedup for a camapgin.
+ */
+function dosomething_signup_get_signup_total_by_nid($nid) {
+  $result = db_select('dosomething_signup', 's')
+    ->fields('s', array('sid'))
+    ->condition('nid', $nid)
+    ->execute();
+  return $result->rowCount();
 }


### PR DESCRIPTION
Calculates the totals of reportbacks and the quantity of reportbacks and adds it to the campaign run form.
![](http://cl.ly/image/0h1U431W2W2X/Screen%20Shot%202014-06-16%20at%204.40.24%20PM.png)

Fixes #2480
