### PR TITLE
Sms gaming

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -5,6 +5,28 @@
  */
 
 /**
+ * Form constructor for campaign admin config form.
+ *
+ * @see dosomething_campaign_menu()
+ */
+function dosomething_campaign_admin_config_form($form, &$form_state) {
+  $form['sms_game'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('SMS Games'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['sms_game']['dosomething_campaign_sms_game_all_participants_copy'] = array(
+    '#type' => 'textarea',
+    '#required' => TRUE,
+    '#title' => t('Total participants in all SMS Games copy'),
+    '#description' => t("This copy is displayed in every SMS Game. e.g. <em>Join 250,000 people who have played since 2012!</em>"),
+    '#default_value' => variable_get('dosomething_campaign_sms_game_all_participants_copy'),
+  );
+  return system_settings_form($form);
+}
+
+/**
  * Page callback for campaign admin custom settings page.
  *
  * @param object $node

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -10,11 +10,18 @@
  * @see dosomething_campaign_menu()
  */
 function dosomething_campaign_admin_config_form($form, &$form_state) {
+  // SMS Game variables.
   $form['sms_game'] = array(
     '#type' => 'fieldset',
     '#title' => t('SMS Games'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
+  );
+  $form['sms_game']['dosomething_campaign_sms_game_signup_friends_form_button_text'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Signup Friends Form Button Label'),
+    '#description' => t("Text displayed on the Signup Friends Form.  Defaults to <em>Share</em> if not set."),
+    '#default_value' => variable_get('dosomething_campaign_sms_game_signup_friends_form_button_text'),
   );
   $form['sms_game']['dosomething_campaign_sms_game_all_participants_copy'] = array(
     '#type' => 'textarea',

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -17,11 +17,11 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $form['sms_game']['dosomething_campaign_sms_game_signup_friends_form_button_text'] = array(
+  $form['sms_game']['dosomething_campaign_sms_game_signup_friends_form_button_copy'] = array(
     '#type' => 'textfield',
     '#title' => t('Signup Friends Form Button Label'),
     '#description' => t("Text displayed on the Signup Friends Form.  Defaults to <em>Share</em> if not set."),
-    '#default_value' => variable_get('dosomething_campaign_sms_game_signup_friends_form_button_text'),
+    '#default_value' => variable_get('dosomething_campaign_sms_game_signup_friends_form_button_copy'),
   );
   $form['sms_game']['dosomething_campaign_sms_game_all_participants_copy'] = array(
     '#type' => 'textarea',

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
@@ -11,3 +11,11 @@
 function dosomething_campaign_update_7001(&$sandbox) {
   field_delete_field('field_psa');
 }
+
+/**
+ * Sets new variable value.
+ */
+function dosomething_campaign_update_7002(&$sandbox) {
+  $copy = "Join 250,000 people who have played since 2012!";
+  variable_set('dosomething_campaign_sms_game_all_participants_copy', $copy);
+}

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -30,7 +30,7 @@ function dosomething_campaign_menu() {
   $items = array();
   // Admin campaign status page.
   $items['admin/config/dosomething/dosomething_campaign'] = array(
-    'title' => t('Campaign settings'),
+    'title' => 'Campaign settings',
     'description' => 'Admin form to set campaign variables.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_campaign_admin_config_form'),

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -29,6 +29,17 @@ function dosomething_campaign_form_campaign_node_form_alter(&$form, &$form_state
 function dosomething_campaign_menu() {
   $items = array();
   // Admin campaign status page.
+  $items['admin/config/dosomething/dosomething_campaign'] = array(
+    'title' => t('Campaign settings'),
+    'description' => 'Admin form to set campaign variables.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_campaign_admin_config_form'),
+    'access callback' => 'user_access',
+    'access arguments' => array('administer modules'),
+    'type' => MENU_LOCAL_TASK,
+    'file' => 'dosomething_campaign.admin.inc',
+  );
+  // Admin campaign status page.
   $items['admin/content/campaign-status'] = array(
     'title' => t('Campaign status'),
     'description' => 'Admin page to display campaign node information.',

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -75,7 +75,9 @@ function dosomething_signup_friends_form($form, &$form_state, $node, $num_friend
   $nid = $node->nid;
   $opt_in_path = dosomething_signup_variable_get($nid, 'mobilecommons_opt_in_path');
   $friends_opt_in_path = dosomething_signup_variable_get($nid, 'mobilecommons_friends_opt_in_path');
-
+  // Load "all participants" copy.
+  $all_participants_copy = variable_get('dosomething_campaign_sms_game_all_participants_copy');
+ 
   $form['nid'] = array(
     '#type' => 'hidden',
     '#default_value' => $nid,
@@ -129,6 +131,7 @@ function dosomething_signup_friends_form($form, &$form_state, $node, $num_friend
   );
   $form['group2'] = array(
     '#type' => 'fieldset',
+    '#prefix' => $all_participants_copy,
     '#attributes' => array(
       'class' => array('-columned second-group'),
     ),
@@ -160,11 +163,13 @@ function dosomething_signup_friends_form($form, &$form_state, $node, $num_friend
       ),
     );
   }
+  // Check if varaible is set for the Friends Form submit button label.
+  $label = variable_get('dosomething_campaign_sms_game_signup_friends_form_button_text', t('Share'));
   $form['actions'] = array(
     '#type' => 'actions',
     'submit' => array(
       '#type' => 'submit',
-      '#value' => t('Share'),
+      '#value' => $label,
     ),
   );
   return $form;

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -164,7 +164,7 @@ function dosomething_signup_friends_form($form, &$form_state, $node, $num_friend
     );
   }
   // Check if varaible is set for the Friends Form submit button label.
-  $label = variable_get('dosomething_campaign_sms_game_signup_friends_form_button_text', t('Share'));
+  $label = variable_get('dosomething_campaign_sms_game_signup_friends_form_button_copy', t('Share'));
   $form['actions'] = array(
     '#type' => 'actions',
     'submit' => array(


### PR DESCRIPTION
Fixes #2538 

Introduces variables to set copy in the Signup Friends Form on SMS Games, and outputs them within the form.

![sms-game-admin](https://cloud.githubusercontent.com/assets/1236811/3301974/91711518-f630-11e3-9df0-50d0dd7acacc.png)
.
