### PR TITLE
User presignup tweaks

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -30,6 +30,20 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#description' => t("This copy is displayed in every SMS Game. e.g. <em>Join 250,000 people who have played since 2012!</em>"),
     '#default_value' => variable_get('dosomething_campaign_sms_game_all_participants_copy'),
   );
+  // Closed variables.
+  $form['closed'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Closed Campaign'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['closed']['dosomething_campaign_presignup_callout_copy'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Presignup Form Callout Copy'),
+    '#required' => TRUE,
+    '#description' => t("Callout text displayed for the Presignup Form."),
+    '#default_value' => variable_get('dosomething_campaign_presignup_callout_copy'),
+  );
   return system_settings_form($form);
 }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
@@ -19,3 +19,11 @@ function dosomething_campaign_update_7002(&$sandbox) {
   $copy = "Join 250,000 people who have played since 2012!";
   variable_set('dosomething_campaign_sms_game_all_participants_copy', $copy);
 }
+
+/**
+ * Sets Closed Callout variable.
+ */
+function dosomething_campaign_update_7003(&$sandbox) {
+  $copy = "We'll hit you up when it re-opens";
+  variable_set('dosomething_campaign_presignup_callout_copy', $copy);
+}

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -45,7 +45,8 @@ function dosomething_campaign_run_preprocess_closed(&$vars) {
     if (!dosomething_signup_presignup_exists($vars['nid'])) {
        // Preprocess the presignup form.
       $label = variable_get('dosomething_campaign_run_signup_button_copy');
-      dosomething_signup_preprocess_signup_button($vars, $label, $presignup = TRUE);     
+      dosomething_signup_preprocess_signup_button($vars, $label, $presignup = TRUE);
+      $vars['presignup_callout'] = variable_get('dosomething_campaign_presignup_callout_copy');
     }
     // Preprocess the campaign reportback gallery.
     dosomething_campaign_preprocess_reportback_gallery($vars, '300x300', 3);

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -41,9 +41,12 @@ function dosomething_campaign_run_preprocess_closed(&$vars) {
     dosomething_campaign_run_preprocess_text_vars($vars, $wrapper);
     dosomething_campaign_run_preprocess_winners($vars, $closed_run_nid);
     dosomething_campaign_run_preprocess_klout_gallery($vars, $closed_run_nid);
-    // Preprocess the presignup form.
-    $label = variable_get('dosomething_campaign_run_signup_button_copy');
-    dosomething_signup_preprocess_signup_button($vars, $label, $presignup = TRUE);
+    // If user has not presigned up:
+    if (!dosomething_signup_presignup_exists($vars['nid'])) {
+       // Preprocess the presignup form.
+      $label = variable_get('dosomething_campaign_run_signup_button_copy');
+      dosomething_signup_preprocess_signup_button($vars, $label, $presignup = TRUE);     
+    }
     // Preprocess the campaign reportback gallery.
     dosomething_campaign_preprocess_reportback_gallery($vars, '300x300', 3);
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -41,26 +41,6 @@ function dosomething_signup_presignup_form_submit($form, &$form_state) {
   $nid = $form_state['values']['nid'];
   // Handle user presignup.
   dosomething_signup_user_presignup($nid);
-  // Assuming this form always just lives on the campaign.
-  // Let's grab title this way instead of querying db.
-  $title = drupal_get_title();
-  drupal_set_message(dosomething_signup_get_presignup_confirm_msg($title));
-}
-
-/**
- * Returns the confirmation message after submitting presignup form.
- *
- * @param string $title
- *   The title of the presignup node.
- *
- * @return string
- */
-function dosomething_signup_get_presignup_confirm_msg($title) {
-  $link = l(t('find a campaign'), 'campaigns');
-  return t("Sweet, we'll send you an email as soon as @title re-opens. In the meantime, !link you can do right now.", array(
-    '@title' => $title,
-    '!link' => $link,
-  ));
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -558,6 +558,23 @@ function dosomething_signup_set_signup_message($title = NULL) {
 }
 
 /**
+ * Returns the confirmation message after submitting presignup form.
+ *
+ * @param string $title
+ *   The title of the presignup node.
+ *
+ * @return string
+ */
+function dosomething_signup_set_presignup_message($title) {
+  $link = l(t('find a campaign'), 'campaigns');
+  $message = t("Sweet, we'll send you an email as soon as @title re-opens. In the meantime, !link you can do right now.", array(
+    '@title' => $title,
+    '!link' => $link,
+  ));
+  drupal_set_message($message);
+}
+
+/**
  * Returns array of campaign nid's that a user has signed up for.
  *
  * @param int $uid
@@ -704,6 +721,10 @@ function dosomething_signup_user_presignup($nid) {
   // Create the presignup record.
   dosomething_signup_presignup_create($nid);
   // @todo: Mailchimp subscription.
+  // For now, we know the presignup always lives on the node we're presigning up for.
+  $title = drupal_get_title();
+  // Set the confirmation message.
+  dosomething_signup_set_presignup_message($title);
 }
 
 /*

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
@@ -27,9 +27,9 @@
         <div class="__signup">
           <?php print render($signup_button); ?>
 
-          <?php if (isset($scholarship)): ?>
+          <?php if (isset($presignup_callout)): ?>
           <div class="scholarship-callout -below -pitch">
-            <p class="copy"><?php print $scholarship; ?></p>
+            <p class="copy"><?php print $presignup_callout; ?></p>
           </div>
           <?php endif; ?>
         </div>


### PR DESCRIPTION
@angaither Please review.
- Sets the presignup confirm message upon user login/presignup.
- Hides presignup form if you're logged in and presigned up.
- Displays "We'll hit you up" text instead of the scholarship amount in the Presignup Form Callout, stores copy in a variable
