### PR TITLE
Filter current campaign from confirmation results

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -522,12 +522,12 @@ function dosomething_campaign_is_closed($node) {
  * @param int $uid
  *   Optional - The user $uid to recommend campaigns for.
  * @param int $limit
- *   Optional - The amount of campaigns to return, defaults to 3.
+ *   Optional - The amount of campaigns to return.
  *
  * @return array
  *  An array of node nid's.
  */
-function dosomething_campaign_get_recommended_campaign_nids($tid = NULL, $uid = NULL, $limit = 3) {
+function dosomething_campaign_get_recommended_campaign_nids($tid = NULL, $uid = NULL, $limit = 4) {
   if ($uid == NULL) {
     global $user;
     $uid = $user->uid;

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
@@ -26,14 +26,22 @@ function dosomething_campaign_reportback_confirmation_page($node) {
   $back_to_campaign_link = l($campaign_link_title, 'node/' . $node->nid, array('html' => TRUE));
   // Store current node's primary cause tid.
   $tid = $wrapper->field_primary_cause->getIdentifier();
-  // Get recommended campaign nids for term $tid and current user.
-  $rec_nids = dosomething_campaign_get_recommended_campaign_nids($tid);
+  // Get 4 recommended campaign nids for term $tid and current user.
+  $rec_nids = dosomething_campaign_get_recommended_campaign_nids($tid, NULL, 4);
   // Initalize array to store reccomended campaign vars.
   $rec_vars = array();
   // Loop through rec_nids to load relevant variables.
   foreach ($rec_nids as $nid) {
-    $rec_vars[] = dosomething_campaign_get_campaign_block_vars($nid);
+    // Make sure $nid returned isn't the current $node's $nid.
+    // This could happen for a SMS Game, where the confirmation page can be
+    // viewed by anonymous user, so we don't have a signup to filter out.
+    if ($nid != $node->nid) {
+      $rec_vars[] = dosomething_campaign_get_campaign_block_vars($nid);
+    }
   }
+  // We only want to display 3 campaigns blocks - we might have 4.
+  $rec_vars = array_slice($rec_vars, 0, 3);
+  // Returned themed reportback confirmation page.
   return theme('reportback_confirmation', array(
     'page_title' => dosomething_campaign_reportback_confirmation_page_title($node),
     'copy' => $wrapper->field_reportback_confirm_msg->value(),

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_profile.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_profile.inc
@@ -33,7 +33,7 @@ function dosomething_user_user_view($account, $view_mode, $langcode) {
 
 
   // Output recommended campaigns.
-  $rec_nids = dosomething_campaign_get_recommended_campaign_nids('', $account->uid, 4);
+  $rec_nids = dosomething_campaign_get_recommended_campaign_nids('', $account->uid);
   $recommended = array();
 
   foreach ($rec_nids as $delta => $nid) {


### PR DESCRIPTION
@angaither Can you please review?

Because an anonymous user can submit the Friends form for SMS Game nid X, the confirmation page could potentially display the campaign X as a recommended campaign since there is no signup to filter by.

This PR makes changes to the recommendation page callback to filter out the current campaign NID from results.
