### PR TITLE
Refactoring Capistrano to work with multistage international

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@
 lock '3.1.0'
 
 set :application, 'beta.dosomething.org'
-set :repo_url, 'git@github.com:blisteringherb/dosomething.git'
+set :repo_url, 'git@github.com:DoSomething/dosomething.git'
 
 set :branch, "dev"
 if ENV['branch']

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@
 lock '3.1.0'
 
 set :application, 'beta.dosomething.org'
-set :repo_url, 'git@github.com:DoSomething/dosomething.git'
+set :repo_url, 'git@github.com:blisteringherb/dosomething.git'
 
 set :branch, "dev"
 if ENV['branch']

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,6 +23,17 @@ namespace :deploy do
     end
   end
 
+  task :shared_links do
+    on roles(:app) do |host|
+      execute "cd '#{release_path}/html/sites/default'; rm -rf files 2> /dev/null; ln -s #{shared_path}/files files"
+      execute "ln -s #{shared_path}/settings.#{stage}.php #{release_path}/html/sites/default/settings.#{stage}.php"
+      if :stage == 'staging'
+        execute "printf 'User-agent: *\nDisallow: /' > #{release_path}/html/robots.txt"
+      end
+    end
+  end
+
   after :updated, 'deploy:build'
+  after :build, 'deploy:shared_links'
 
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -26,7 +26,7 @@ namespace :deploy do
   task :shared_links do
     on roles(:app) do |host|
       execute "cd '#{release_path}/html/sites/default'; rm -rf files 2> /dev/null; ln -s #{shared_path}/files files"
-      execute "ln -s #{shared_path}/settings.#{stage}.php #{release_path}/html/sites/default/settings.#{stage}.php"
+      execute "ln -s #{shared_path}/settings.#{:stage}.php #{release_path}/html/sites/default/settings.#{:stage}.php"
       if :stage == 'staging'
         execute "printf 'User-agent: *\nDisallow: /' > #{release_path}/html/robots.txt"
       end

--- a/config/deploy/includes/international.rb
+++ b/config/deploy/includes/international.rb
@@ -1,6 +1,6 @@
 set :deploy_to, "/var/www/international.dosomething.org"
 
-case :stage
+case ENV['stage']
 when production
   role :app, %w{dosomething@dosomething@deploy.international.dosomething.org}
   server 'deploy.international.dosomething.org', user: 'dosomething', roles: %w{app}

--- a/config/deploy/includes/international.rb
+++ b/config/deploy/includes/international.rb
@@ -6,6 +6,6 @@ when production
   server 'deploy.international.dosomething.org', user: 'dosomething', roles: %w{app}
 
 when qa
-  role :app, %w{dosomething@10.241.0.33}
-  server '10.241.0.33', user: 'dosomething', roles: %w{app}
+  role :app, %w{dosomething@intl-qa}
+  server 'intl-qa', user: 'dosomething', roles: %w{app}
 end

--- a/config/deploy/includes/international.rb
+++ b/config/deploy/includes/international.rb
@@ -2,7 +2,7 @@ set :deploy_to, "/var/www/international.dosomething.org"
 
 case ENV['stage']
 when production
-  role :app, %w{dosomething@dosomething@deploy.international.dosomething.org}
+  role :app, %w{dosomething@deploy.international.dosomething.org}
   server 'deploy.international.dosomething.org', user: 'dosomething', roles: %w{app}
 
 when qa

--- a/config/deploy/includes/international.rb
+++ b/config/deploy/includes/international.rb
@@ -1,0 +1,11 @@
+set :deploy_to, "/var/www/international.dosomething.org"
+
+case :stage
+when production
+  role :app, %w{dosomething@dosomething@deploy.international.dosomething.org}
+  server 'deploy.international.dosomething.org', user: 'dosomething', roles: %w{app}
+
+when qa
+  role :app, %w{dosomething@10.241.0.33}
+  server '10.241.0.33', user: 'dosomething', roles: %w{app}
+end

--- a/config/deploy/international.rb
+++ b/config/deploy/international.rb
@@ -1,8 +1,4 @@
-set :deploy_to, "/var/www/international.dosomething.org"
-
-role :app, %w{dosomething@dosomething@deploy.international.dosomething.org}
-
-server 'deploy.international.dosomething.org', user: 'dosomething', roles: %w{app}
+require "includes/international"
 
 namespace :deploy do
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -3,16 +3,3 @@ set :deploy_to, "/var/www/beta.dosomething.org"
 role :app, %w{dosomething@10.241.0.26}
 
 server '10.241.0.26', user: 'dosomething', roles: %w{app}
-
-namespace :deploy do
-
-  task :shared_links do
-    on roles(:app) do |host|
-      execute "cd '#{release_path}/html/sites/default'; rm -rf files 2> /dev/null; ln -s #{shared_path}/files files"
-      execute "ln -s #{shared_path}/settings.production.php #{release_path}/html/sites/default/settings.production.php"
-    end
-  end
-
-  after :build, 'deploy:shared_links'
-
-end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,5 +1,5 @@
 set :deploy_to, "/var/www/beta.dosomething.org"
 
-role :app, %w{dosomething@beta.prod.test}
+role :app, %w{dosomething@beta-web1}
 
-server 'beta.prod.test', user: 'dosomething', roles: %w{app}
+server 'beta-web1', user: 'dosomething', roles: %w{app}

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,5 +1,5 @@
 set :deploy_to, "/var/www/beta.dosomething.org"
 
-role :app, %w{dosomething@10.241.0.26}
+role :app, %w{dosomething@beta.prod.test}
 
-server '10.241.0.26', user: 'dosomething', roles: %w{app}
+server 'beta.prod.test', user: 'dosomething', roles: %w{app}

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -3,19 +3,3 @@ set :deploy_to, "/var/www/qa-beta"
 role :app, %w{dosomething@blackangus.dosomething.org}
 
 server 'blackangus.dosomething.org', user: 'dosomething', roles: %w{app}
-
-namespace :deploy do
-
-  task :shared_links do
-    on roles(:app) do |host|
-      execute "cd '#{release_path}/html/sites/default'; sudo rm -rf files 2> /dev/null; sudo ln -s #{shared_path}/files files"
-      execute "cd '#{release_path}/html/sites/default'; sudo ln -s #{shared_path}/settings.qa.php"
-
-      execute "printf 'User-agent: *\nDisallow: /' > #{release_path}/html/robots.txt"
-      #execute "drush rsync @ds.staging:%files #{shared_path} -y"
-    end
-  end
-
-  after :build, 'deploy:shared_links'
-
-end

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,6 +1,6 @@
 set :deploy_to, "/var/www/beta.dosomething.org"
 
-role :app, %w{dosomething@10.241.0.22}
+role :app, %w{dosomething@beta.staging.test}
 
-server '10.241.0.22', user: 'dosomething', roles: %w{app}
+server 'beta.staging.test', user: 'dosomething', roles: %w{app}
 

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -4,18 +4,3 @@ role :app, %w{dosomething@10.241.0.22}
 
 server '10.241.0.22', user: 'dosomething', roles: %w{app}
 
-namespace :deploy do
-
-  task :shared_links do
-    on roles(:app) do |host|
-      execute "cd '#{release_path}/html/sites/default'; sudo rm -rf files 2> /dev/null; sudo ln -s #{shared_path}/files files"
-      execute "sudo ln -s #{shared_path}/settings.staging.php #{release_path}/html/sites/default/settings.staging.php"
-
-      # Prevent the robots
-      execute "printf 'User-agent: *\nDisallow: /' > #{release_path}/html/robots.txt"
-    end
-  end
-
-  after :build, 'deploy:shared_links'
-
-end

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,6 +1,6 @@
 set :deploy_to, "/var/www/beta.dosomething.org"
 
-role :app, %w{dosomething@beta.staging.test}
+role :app, %w{dosomething@staging}
 
-server 'beta.staging.test', user: 'dosomething', roles: %w{app}
+server 'staging', user: 'dosomething', roles: %w{app}
 

--- a/provision/salt/roots/salt/dosomething/ds.aliases.drushrc.php
+++ b/provision/salt/roots/salt/dosomething/ds.aliases.drushrc.php
@@ -9,3 +9,32 @@ $aliases['staging'] = array(
    '%files' => '/var/www/beta.dosomething.org/shared/files',
  ),
 );
+
+$aliases['international.prod'] = array(
+ 'uri' => 'default',
+ 'root' => '/var/www/international.dosomething.org/current/html',
+ 'remote-host' => '72.32.106.161',
+ 'remote-user' => 'dosomething',
+ 'path-aliases' => array(
+   '%files' => '/var/www/international.dosomething.org/shared/files',
+ ),
+);
+
+$countries = array(
+  'botswana',
+  'canada',
+  'congo',
+  'indonesia',
+  'nigeria',
+  'training',
+  'uk',
+);
+
+foreach ($countries as $country) {
+  $aliases[$country . '.prod'] = array(
+   'parent' => '@international.prod',
+   'uri' => $country,
+   '%dump-dir' => '/tmp',
+  );
+}
+r

--- a/provision/salt/roots/salt/dosomething/policy.drush.inc
+++ b/provision/salt/roots/salt/dosomething/policy.drush.inc
@@ -1,13 +1,15 @@
 <?php
 
 function drush_policy_sql_sync_validate($source = NULL, $destination = NULL) {
-  if ($destination == '@ds.staging') {
-    return drush_set_error('POLICY_DENY', dt('You cannot overwrite the staging db from here'));
-  }
+  dosomething_check_target($destination, 'db');
 }
 
 function drush_policy_core_rsync_validate($source, $destination, $additional_options = array()) {
-  if ($destination == '@ds.staging') {
-    return drush_set_error('POLICY_DENY', dt('You cannot overwrite the staging files from here'));
+  dosomething_check_target($destination, 'files');
+}
+
+function dosomething_check_target($destination, $asset) {
+  if (stristr($destination, '.prod')|| stristr($destination, '.staging')) {
+    return drush_set_error('POLICY_DENY', dt('You cannot overwrite the !destination !asset from here', array('!destination' => $destination, '!asset' => $asset)));
   }
 }


### PR DESCRIPTION
#### What's this PR do?
- Adding an include file to accommodate international staged deployments.
- Refactoring non-international stages to use the same shared_links code
- Adding aliases to support international prod pulls
- Refactoring and adding policies to drush to prevent issues with using international prod aliases
#### Where should the reviewer start?

The biggest changes are in the deploy.rb file.  All of the code that was in the individual stage deploy files was abstracted here to one shared_links task
#### How should this be manually tested?

This branch in this repo will have to be added to a new Jenkins job for testing.
#### Any background context you want to provide?

Because the international deployment is a multisite and multistage installation it requires more than just the one 'international' stage for Capistrano.  It seemed prudent while refactoring that to also refactor the other stage files and tasks.

@desmondmorris 
@mshmsh5000 
