### PR TITLE
removed capitalization from winners text and fixed vertical centering on tablet

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-closed.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-closed.scss
@@ -107,9 +107,15 @@
     margin-top: 3rem;
   }
 
-  // Galleries following a <h3>
+  // Items following a gallery
+
+
   h3 + .gallery {
-    margin-top: 2.5rem;
+    margin-top: 1.5rem;
+  }
+
+  .-psa {
+    margin-bottom: 3rem;
   }
 
   // This introduces a new gallery pattern with floated image
@@ -142,6 +148,10 @@
           @include span-columns(8 of 12);
         }
       }
+    }
+
+    &.-mention + h3 {
+      margin-top: 0;
     }
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-closed.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-closed.scss
@@ -20,10 +20,6 @@
     position: relative;
     text-align: center;
 
-    p {
-      text-transform: capitalize;
-    }
-
     strong {
       display: block;
       font-size: $font-largest;
@@ -53,11 +49,21 @@
         padding: 0 2rem;
       }
 
+      strong {
+        margin-top: 1.4rem;
+      }
+
       &.-columned {
         @include span-columns(6 of 12);
         min-height: 138px;
         margin-right: 0;
       }
+    }
+
+    @include media($desktop) {
+      strong {
+        margin-top: 0;
+      } 
     }
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
@@ -147,7 +147,7 @@
 
         <div class="container__body">
 
-          <div class="__row">
+          <div class="__row -psa">
             <div <?php if (isset($psa)): ?>class="-columned -odd"<?php endif; ?>>
               <?php if (isset($additional_text_title)): ?>
               <h3 class="inline--alt-color"><?php print $additional_text_title; ?></h3>


### PR DESCRIPTION
Removes auto caps on winners text and vertical alignment of the content of each column
