### PR TITLE
truncated 'congrats' headline and added default purple text to totals copy

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-closed.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-closed.scss
@@ -21,6 +21,7 @@
     text-align: center;
 
     strong {
+      color: $purple;
       display: block;
       font-size: $font-largest;
       line-height: 1;

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
@@ -220,7 +220,7 @@
 
   <?php // CONGRATULATIONS TO... ////////////////////////////////////////////////////// ?>
   <section class="container container--congrats">
-    <h2 class="container__title banner"><span>Congratulations to&hellip;</span></h2>
+    <h2 class="container__title banner"><span>Congrats to&hellip;</span></h2>
     <div class="wrapper">
 
       <div class="container__body">


### PR DESCRIPTION
Fixes #2597, #2598, #2599, #2600
