### PR TITLE
Add more fields to campaign cache payload

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -188,9 +188,15 @@ function dosomething_mbp_get_campaign_cache_payload($origin, $params = NULL) {
         'title' => $params['title'],
         'url' => $params['url'],
         'call_to_action' => $params['call_to_action'],
-        'cover_image_url' => $params['image_campaign_cover'],
+        'image_campaign_cover_markup' => $params['image_campaign_cover_markup'],
+        'do_it_title' => $params['do_it_title'],
+        'do_it_body' => $params['do_it_body'],
         'fact_problem' => $params['fact_problem'],
         'fact_solution' => $params['fact_solution'],
+        'high_season_start_timestamp' => $params['high_season_start_timestamp'],
+        'high_season_end_timestamp' => $params['high_season_end_timestamp'],
+        'low_season_start_timestamp' => $params['low_season_start_timestamp'],
+        'low_season_start_timestamp' => $params['low_season_start_timestamp'],
       );
       break;
 

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -259,8 +259,8 @@ function dosomething_mbp_campaign_request($action, $node) {
   $params['url'] = $url;
 
   $field = field_get_items('node', $node, 'field_call_to_action');
-  if (isset($field[LANGUAGE_NONE][0]['value'])) {
-    $params['call_to_action'] = $field[LANGUAGE_NONE][0]['value'];
+  if (isset($field[0]['value'])) {
+    $params['call_to_action'] = $field[0]['value'];
   }
 
   $field = field_get_items('node', $node, 'field_image_campaign_cover');

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -196,7 +196,7 @@ function dosomething_mbp_get_campaign_cache_payload($origin, $params = NULL) {
         'high_season_start_timestamp' => $params['high_season_start_timestamp'],
         'high_season_end_timestamp' => $params['high_season_end_timestamp'],
         'low_season_start_timestamp' => $params['low_season_start_timestamp'],
-        'low_season_start_timestamp' => $params['low_season_start_timestamp'],
+        'low_season_end_timestamp' => $params['low_season_end_timestamp'],
       );
       break;
 


### PR DESCRIPTION
Adds additional fields to campaign cache payload to be sent to mb-campaign-api:
- image_campaign_cover_markup
- do_it_title
- do_it_body
- high_season_start_timestamp
- high_season_end_timestamp
- low_season_start_timestamp
- low_season_start_timestamp
  for use in digest email messages.

Fixes #2622 
