### PR TITLE
Attempt to disbale autocomplete.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -129,6 +129,7 @@ function dosomething_signup_friends_form($form, &$form_state, $node, $num_friend
       'data-validate' => 'phone',
       'data-validate-required' => '',
       'placeholder' => t('(555) 555-5555'),
+      'autocomplete' => 'off',
     ),
   );
   for ($i = 0; $i < $num_friends; $i++) {
@@ -144,6 +145,7 @@ function dosomething_signup_friends_form($form, &$form_state, $node, $num_friend
       '#attributes' => array(
         'data-validate' => 'phone',
         'placeholder' => t('(555) 555-5555'),
+        'autocomplete' => 'off',
       ),
     );
   }


### PR DESCRIPTION
Not 100% this will work to eliminate the autofilling of the multiple phone number fields we saw during user testing. This approach could work, but it's dependent on the browser actually paying attention to this attribute on the `<input>`. 

This seems to be a very browser specific and OS specific issue which is harder to address universally.

Resolves #2460

@DFurnes @aaronschachter 
