### PR TITLE
Flagged reportback

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.features.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.features.inc
@@ -16,6 +16,34 @@ function dosomething_reportback_views_api($module = NULL, $api = NULL) {
  */
 function dosomething_reportback_flag_default_flags() {
   $flags = array();
+  // Exported flag: "Flagged Reportback".
+  $flags['flagged_reportback'] = array(
+    'entity_type' => 'reportback',
+    'title' => 'Flagged Reportback',
+    'global' => 1,
+    'types' => array(),
+    'flag_short' => 'Flag reportback',
+    'flag_long' => 'Flag this reportback',
+    'flag_message' => 'Reportback flagged.',
+    'unflag_short' => 'Unflag reportback',
+    'unflag_long' => 'Unflag this reportback',
+    'unflag_message' => 'Removed reportback flag.',
+    'unflag_denied_text' => '',
+    'link_type' => 'confirm',
+    'weight' => 0,
+    'show_in_links' => array(),
+    'show_as_field' => FALSE,
+    'show_on_form' => FALSE,
+    'access_author' => '',
+    'show_contextual_link' => FALSE,
+    'flag_confirmation' => 'Flag reportback',
+    'unflag_confirmation' => 'Remove reportback flag',
+    'api_version' => 3,
+    'module' => 'dosomething_reportback',
+    'locked' => array(
+      0 => 'name',
+    ),
+  );
   // Exported flag: "Promoted".
   $flags['promoted'] = array(
     'entity_type' => 'file',

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
@@ -17,6 +17,7 @@ features[features_api][] = api:2
 features[field_base][] = field_weight
 features[field_instance][] = flagging-promoted-field_image_description
 features[field_instance][] = flagging-promoted-field_weight
+features[flag][] = flagged_reportback
 features[flag][] = promoted
 features[user_permission][] = delete any reportback
 features[user_permission][] = delete own reportback

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -141,14 +141,33 @@ function dosomething_reportback_menu() {
  * Implements hook_form_alter().
  */
 function dosomething_reportback_form_alter(&$form, &$form_state) {
-  if ($form['#form_id'] == 'flag_confirm') {
-    // Displays the image to be promoted/unpromoted.
-    // @todo: Add a check to see if this is the promoted flag.  Fine for now
-    // since we only have one flag in the system.
-    $fid = $form['entity_id']['#value'];
-    $form['image'] = array(
-      '#markup' => dosomething_image_get_themed_image_by_fid($fid, '300x300'),
-    );
+  // Only alter the flag_confirm form, provided by Flag module.
+  if ($form['#form_id'] != 'flag_confirm') { return; }
+
+  // The flag we're confirming:
+  $flag_name = $form['#flag']->name;
+  // The entity_id of whatever we're flagging.
+  $entity_id = $form['entity_id']['#value'];
+
+  switch ($flag_name) {
+
+    case 'promoted':
+      // Displays the image to be promoted/unpromoted.
+      $form['image'] = array(
+        '#markup' => dosomething_image_get_themed_image_by_fid($entity_id, '300x300'),
+      );
+      break;
+
+    case 'flagged_reportback':
+      $reportback = reportback_load($entity_id);
+      // Displays the reportback to be flagged:
+      $form['reportback'] = array(
+        '#prefix' => '<hr />',
+        '#markup' => render(dosomething_reportback_view_entity($reportback)),
+        '#weight' => 500,
+      );
+      break;
+
   }
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
@@ -133,6 +133,14 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['relationships']['flag_content_rel']['required'] = 0;
   $handler->display->display_options['relationships']['flag_content_rel']['flag'] = 'promoted';
   $handler->display->display_options['relationships']['flag_content_rel']['user_scope'] = 'any';
+  /* Relationship: Flags: flagged_reportback */
+  $handler->display->display_options['relationships']['flag_content_rel_1']['id'] = 'flag_content_rel_1';
+  $handler->display->display_options['relationships']['flag_content_rel_1']['table'] = 'dosomething_reportback';
+  $handler->display->display_options['relationships']['flag_content_rel_1']['field'] = 'flag_content_rel';
+  $handler->display->display_options['relationships']['flag_content_rel_1']['label'] = 'RB Flag';
+  $handler->display->display_options['relationships']['flag_content_rel_1']['required'] = 0;
+  $handler->display->display_options['relationships']['flag_content_rel_1']['flag'] = 'flagged_reportback';
+  $handler->display->display_options['relationships']['flag_content_rel_1']['user_scope'] = 'any';
   /* Field: Reportbacks: Reportback image fid */
   $handler->display->display_options['fields']['fid']['id'] = 'fid';
   $handler->display->display_options['fields']['fid']['table'] = 'dosomething_reportback_file';
@@ -193,6 +201,13 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['fields']['ops']['relationship'] = 'flag_content_rel';
   $handler->display->display_options['fields']['ops']['label'] = '';
   $handler->display->display_options['fields']['ops']['element_label_colon'] = FALSE;
+  /* Field: Flags: Flag link */
+  $handler->display->display_options['fields']['ops_1']['id'] = 'ops_1';
+  $handler->display->display_options['fields']['ops_1']['table'] = 'flagging';
+  $handler->display->display_options['fields']['ops_1']['field'] = 'ops';
+  $handler->display->display_options['fields']['ops_1']['relationship'] = 'flag_content_rel_1';
+  $handler->display->display_options['fields']['ops_1']['label'] = '';
+  $handler->display->display_options['fields']['ops_1']['element_label_colon'] = FALSE;
   /* Contextual filter: Reportback: Node nid */
   $handler->display->display_options['arguments']['nid']['id'] = 'nid';
   $handler->display->display_options['arguments']['nid']['table'] = 'dosomething_reportback';
@@ -245,6 +260,27 @@ function dosomething_reportback_views_default_views() {
     6 => 0,
     7 => 0,
   );
+  /* Filter criterion: Flags: Flagged */
+  $handler->display->display_options['filters']['flagged']['id'] = 'flagged';
+  $handler->display->display_options['filters']['flagged']['table'] = 'flagging';
+  $handler->display->display_options['filters']['flagged']['field'] = 'flagged';
+  $handler->display->display_options['filters']['flagged']['relationship'] = 'flag_content_rel_1';
+  $handler->display->display_options['filters']['flagged']['value'] = '0';
+  $handler->display->display_options['filters']['flagged']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['flagged']['expose']['operator_id'] = '';
+  $handler->display->display_options['filters']['flagged']['expose']['label'] = 'Flagged';
+  $handler->display->display_options['filters']['flagged']['expose']['operator'] = 'flagged_op';
+  $handler->display->display_options['filters']['flagged']['expose']['identifier'] = 'flagged';
+  $handler->display->display_options['filters']['flagged']['expose']['required'] = TRUE;
+  $handler->display->display_options['filters']['flagged']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+    6 => 0,
+    7 => 0,
+    8 => 0,
+  );
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');
@@ -275,6 +311,7 @@ function dosomething_reportback_views_default_views() {
     t('User'),
     t('Image'),
     t('flag'),
+    t('RB Flag'),
     t('Fid'),
     t('Rbid'),
     t('.'),
@@ -286,6 +323,7 @@ function dosomething_reportback_views_default_views() {
     t(','),
     t('All'),
     t('Reportbacks: %1'),
+    t('Flagged'),
     t('Page'),
   );
   $export['node_reportbacks'] = $view;


### PR DESCRIPTION
@angaither Can you please review?
## Overview

This PR lays the groundwork down for basic flagging.
- Adds a `flagged_reportback` Flag, to be associated with Reportback entities
- Adds a link to flag/unflag reportbacks in the `node_reportbacks` view.
- Adds a filter to display all non-flagged or flagged reportbacks. Defaults to non-flagged.
- Displays the reportback entity within the flag confirmation form.
## Coming up
- Storing reason for flagging
- Deleting reportback files when necessary 
## Screenshots

![reportback-view-flagged](https://cloud.githubusercontent.com/assets/1236811/3359879/3044c246-faed-11e3-974d-1d901c7d69b8.png)

![reportback-flag-form](https://cloud.githubusercontent.com/assets/1236811/3359874/28dcb14e-faed-11e3-9c19-0d26aab561cd.png)
