### PR TITLE
Refactor get user field

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -111,7 +111,7 @@ function dosomething_campaign_run_preprocess_winners(&$vars, $nid) {
       $winners[$i]['uid'] = $winner[$entity_id]->field_user[LANGUAGE_NONE][0]['target_id'];
       // If there is no user, get the first name from the text field.
       if (!isset($winners[$i]['uid'])) {
-        $winners[$i]['fname'] = $winner[$entity_id]->field_winner_name[LANGUAGE_NONE][0]['value'];
+        $winners[$i]['fname'] = dosomething_user_get_field('field_first_name', user_load($winners[$i]['uid'], 'ucwords'));
       }
       // Else, grab the first name from the user account.
       else {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -124,7 +124,7 @@ function dosomething_signup_friends_form($form, &$form_state, $node, $num_friend
     '#type' => 'textfield',
     '#required' => TRUE,
     '#title' => 'Your Cell Number',
-    '#default_value' => dosomething_user_get_mobile(),
+    '#default_value' => dosomething_user_get_field('field_mobile'),
     '#attributes' => array(
       'data-validate' => 'phone',
       'data-validate-required' => '',

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -472,7 +472,7 @@ function dosomething_signup_get_mbp_params($account, $node) {
     'email' => $account->mail,
     'uid' => $account->uid,
     'first_name' => dosomething_user_get_field('field_first_name', $account),
-    'mobile' => dosomething_user_get_mobile($account),
+    'mobile' => dosomething_user_get_field('field_mobile', $account),
     'event_id' => $node->nid,
     'campaign_title' => $node->title,
     'campaign_link' => url(drupal_get_path_alias('node/' . $node->nid), array('absolute' => TRUE)),

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
@@ -60,7 +60,7 @@ function dosomething_signup_get_mobilecommons_vars($account, $lid, $title = NULL
     $args['person[first_name]'] = $first_name;
   }
   // Expected DOB format is YYYY-MM-DD.
-  if ($dob = dosomething_user_get_birthdate('Y-m-d', $account)) {
+  if ($dob = dosomething_user_get_field('field_birthdate', $account, 'Y-m-d')) {
     $args['person[date_of_birth]'] = $dob;
   }
   if (isset($title)) {

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
@@ -18,7 +18,7 @@ function dosomething_signup_mobilecommons_opt_in($account, $lid, $title = NULL) 
   if (!module_exists('mobilecommons')) { return; }
 
    // If user doesn't have mobile number, exit function.
-  $mobile = dosomething_user_get_mobile($account);
+  $mobile = dosomething_user_get_field('field_mobile', $account);
   if (!$mobile) {
     return FALSE;
   }
@@ -53,7 +53,7 @@ function dosomething_signup_mobilecommons_opt_in($account, $lid, $title = NULL) 
 function dosomething_signup_get_mobilecommons_vars($account, $lid, $title = NULL) {
   $args = array(
     'opt_in_path[]' => $lid,
-    'person[phone]' => dosomething_user_get_mobile($account),
+    'person[phone]' => dosomething_user_get_field('field_mobile', $account),
     'person[email]' => $account->mail,
   );
   if ($first_name = dosomething_user_get_field('field_first_name', $account)) {

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -349,7 +349,7 @@ function dosomething_user_new_user($form, &$form_state) {
       'email' => $account->mail,
       'uid' => $account->uid,
       'first_name' => dosomething_user_get_field('field_first_name', $account),
-      'birthdate' => dosomething_user_get_birthdate(),
+      'birthdate' => dosomething_user_get_field('field_birthdate', $account),
     );
     if (module_exists('dosomething_mbp')) {
       dosomething_mbp_request('user_register', $params);
@@ -375,7 +375,7 @@ function dosomething_user_is_under_thirteen($user = NULL) {
   if ($user == NULL) {
     global $user;
   }
-  $birthday = dosomething_user_get_birthdate(NULL, $user);
+  $birthday = dosomething_user_get_field('field_birthdate', $user);
   // Get the date 13 years ago today.
   $date_cutoff = strtotime('-13 years');
   if ($date_cutoff < $birthday) {
@@ -401,7 +401,7 @@ function dosomething_user_is_old_person($user = NULL) {
   if ($user == NULL) {
     global $user;
   }
-  $birthday = dosomething_user_get_birthdate(NULL, $user);
+  $birthday = dosomething_user_get_field('field_birthdate', $user);
   // Get the date 26 years ago today.
   $date_cutoff = strtotime('-26 years');
   return $date_cutoff > $birthday;

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -655,7 +655,7 @@ function dosomething_user_get_field($field_name, $account = NULL, $format = NULL
   // Check if there is a specifc function handler for that field, use that first.
   $handler = 'dosomething_user_get_' . $field_name;
   if (function_exists($handler)) {
-    return $handler($field_value, $format);
+    $field_value = ($format == NULL) ? $handler($field_value) : $handler($field_value, $format);
   }
   return $field_value;
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -673,15 +673,44 @@ function dosomething_user_get_field($field_name, $account = NULL, $format = NULL
  * @return mixed
  *   Returns NULL if not set, otherwise string.
  */
-function dosomething_user_get_field_first_name($field_value, $format) {
-  switch ($format) {
-    case 'ucwords':
-      return ucwords(strtolower($field_value));
-    case 'strtoupper':
-      return strtoupper($field_value);
-    case 'strtolower':
-      return strtolower($field_value);
-  }
+function dosomething_user_get_field_first_name($field_value, $format = 'ucwords') {
+  return dosomething_user_format_string($field_value, $format);
+}
+
+/**
+ * Returns a user's first name.
+ *
+ * @param object $account
+ *   The account to return value for.
+ * @param string $format
+ *   Optional- format to return.
+ *    strtolower, strtoupper, ucwords
+ *
+ * @return mixed
+ *   Returns NULL if not set, otherwise string.
+ */
+function dosomething_user_get_field_last_name($field_value, $format = 'ucwords') {
+  return dosomething_user_format_string($field_value, $format);
+}
+
+/**
+ * Helper function to format strings.
+ *
+ * @param string $string
+ *  The string to format
+ * @param string $format
+ *  The format that should be returned.
+ *    strtolower, strtoupper, ucwords
+ */
+function dosomething_user_format_string($string, $format) {
+    switch ($format) {
+      case 'ucwords':
+        return ucwords(strtolower($string));
+      case 'strtoupper':
+        return strtoupper($string);
+      case 'strtolower':
+        return strtolower($string);
+    }
 }
 
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -635,51 +635,74 @@ function dosomething_user_create_user_by_mobile($number) {
  *   The machine name of the field that stores value to return.
  * @param object $account
  *   The account to return value for. If NULL, uses global $user.
+ * @param string $format
+ *   Optional- format to return.
+ *    - Dates, http://www.php.net/manual/en/function.date.php.
+ *    - Strings uclower, strtolower, strtoupper.
  *
  * @return mixed
  *   Returns NULL if not set, otherwise whatever type of data the field stores.
  */
-function dosomething_user_get_field($field_name, $account = NULL) {
+function dosomething_user_get_field($field_name, $account = NULL, $format = NULL) {
   if ($account == NULL) {
     global $user;
     $account = $user;
   }
+
   $wrapper = entity_metadata_wrapper('user', $account);
-  return $wrapper->{$field_name}->value();
+  $field_value =  $wrapper->{$field_name}->value();
+
+  // Check if there is a specifc function handler for that field, use that first.
+  $handler = 'dosomething_user_get_' . $field_name;
+  if (function_exists($handler)) {
+    return $handler($field_value, $format);
+  }
+  return $field_value;
+
 }
 
 /**
- * Returns given user's mobile number.
+ * Returns a user's first name.
  *
  * @param object $account
- *   The account to return value for. If NULL, uses global $user.
+ *   The account to return value for.
+ * @param string $format
+ *   Optional- format to return.
+ *    strtolower, strtoupper, ucwords
  *
  * @return mixed
  *   Returns NULL if not set, otherwise string.
  */
-function dosomething_user_get_mobile($account = NULL) {
-  return dosomething_user_get_field('field_mobile', $account);
+function dosomething_user_get_field_first_name($field_value, $format) {
+  switch ($format) {
+    case 'ucwords':
+      return ucwords(strtolower($field_value));
+    case 'strtoupper':
+      return strtoupper($field_value);
+    case 'strtolower':
+      return strtolower($field_value);
+  }
 }
+
 
 /**
  * Returns given user's birthdate.
  *
+ * @param string $field_value
+ *   The value of the field from `dosomething_user_get_field` to format.
  * @param string $format
  *   Optional- format to return. http://www.php.net/manual/en/function.date.php.
  *   If NULL, the raw timestamp is returned.
- * @param object $account
- *   The account to return value for. If NULL, uses global $user.
  *
  * @return string
  *   Returns the date in specified $format.
  */
-function dosomething_user_get_birthdate($format = NULL, $account = NULL) {
-  $time = dosomething_user_get_field('field_birthdate', $account);
+function dosomething_user_get_field_birthdate($field_value, $format) {
   // If no format specified:
   if ($format == NULL) {
     // Return raw timestamp.
-    return $time;
+    return $field_value;
   }
   // Return date formatted per $format string.
-  return format_date($time, 'custom', $format);
+  return format_date($field_value, 'custom', $format);
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
@@ -27,14 +27,15 @@ function dosomething_user_preprocess_user_profile(&$variables) {
 
   // Collect User Account data.
   $user_profile = $variables['user_profile'];
+  $user = user_load($user_profile['uid']);
 
   $user_account['id']                  = isset($user_profile['uid']) ? $user_profile['uid'] : NULL;
   $user_account['username']            = isset($user_profile['username']) ? $user_profile['username'] : NULL;
   $user_account['email']               = isset($user_profile['mail']) ? $user_profile['mail'] : NULL;
-  $user_account['first_name']          = isset($user_profile['field_first_name']['#items'][0]['safe_value']) ? $user_profile['field_first_name']['#items'][0]['safe_value'] : NULL;
-  $user_account['last_name']           = isset($user_profile['field_last_name']['#items'][0]['safe_value']) ? $user_profile['field_last_name']['#items'][0]['safe_value'] : NULL;
-  $user_account['birthday']            = isset($user_profile['field_birthdate']['#items'][0]['value']) ? $user_profile['field_birthdate']['#items'][0]['value'] : NULL;
-  $user_account['mobile']              = isset($user_profile['field_mobile']['#items'][0]['safe_value']) ? $user_profile['field_mobile']['#items'][0]['safe_value'] : NULL;
+  $user_account['first_name']          = dosomething_user_get_field('field_first_name', $user, 'ucwords');
+  $user_account['last_name']           = dosomething_user_get_field('field_last_name', $user, 'ucwords');
+  $user_account['birthday']            = dosomething_user_get_field('field_birthdate', $user, 'F j, Y');
+  $user_account['mobile']              = dosomething_user_get_field('field_mobile', $user);
   $user_account['location']['country'] = isset($user_profile['field_address']['#items'][0]['country']) ? $user_profile['field_address']['#items'][0]['country'] : NULL;
   $user_account['location']['state']   = isset($user_profile['field_address']['#items'][0]['administrative_area']) ? $user_profile['field_address']['#items'][0]['administrative_area'] : NULL;
   $user_account['location']['city']    = isset($user_profile['field_address']['#items'][0]['locality']) ? $user_profile['field_address']['#items'][0]['locality'] : NULL;

--- a/lib/themes/dosomething/paraneue_dosomething/templates/user/user-profile.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/user/user-profile.tpl.php
@@ -120,7 +120,7 @@
         <?php endif; ?>
 
         <dt>Birthday:</dt>
-        <dd><?php print date('F j, Y', strtotime($user_account['birthday'])); ?></dd>
+        <dd><?php print $user_account['birthday']; ?></dd>
       </dl>
 
       <?php if (!empty($address)): ?>


### PR DESCRIPTION
## Overview

Refactoring calls to `dosomething_user_get_field`
## What does this PR do?
- Creates a generic `dosomething_user_get_field` function 
  - This function calls handlers if more specific formatting is needed
  - The handlers should not be called directly
## How to test
- Check out this PR
- Test out the user profile page for any oddities
- Manually `drush php-eval` functions to make sure the results are as expected, a few to test...
  - `drush php-eval "var_dump(dosomething_signup_get_mbp_params(user_load(10), node_load(84)));"`
  -  `drush php-eval "echo dosomething_user_is_under_thirteen(user_load(10))"`
  - `drush php-eval "echo dosomething_user_get_field('field_first_name', user_load(10), 'ucwords');"`

Bonus! Fixes #2606
