### PR TITLE
Filter flagged reportbacks in totals

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -244,7 +244,7 @@ function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$fo
   if (isset($campaign_nid)) {
     // Get totals & language from the campaign.
     $signup_total_members = dosomething_signup_get_signup_total_by_nid($campaign_nid);
-    $reportback_quantity = dosomething_reportback_get_total_campaign_reportback_sums($campaign_nid);
+    $reportback_quantity = dosomething_reportback_get_reportback_total_by_nid($campaign_nid);
     $language = dosomething_reportback_get_noun_and_verb($campaign_nid);
 
     // Add the text to the form.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -917,6 +917,25 @@ function dosomething_reportback_get_total_campaign_reportback_sums($nid) {
 }
 
 /**
+ * Returns array of Reportback rbid's which have been flagged.
+ *
+ * @param int $nid
+ *   Node $nid.
+ *
+ * @return array
+ */
+function dosomething_reportback_get_flagged_rbids($nid) {
+  $query = db_select('flagging', 'f');
+  $query->join('dosomething_reportback', 'rb', 'rb.rbid = f.entity_id');
+  $query->fields('f', array('entity_id'));
+  // Filter flagging records for reportbacks only.
+  $query->condition('entity_type', 'reportback');
+  // Filter for the given $nid.
+  $query->condition('rb.nid', $nid);
+  return $query->execute()->fetchCol();
+}
+
+/**
  * Return the reportback noun & verb for a campaign.
  *
  * @param int $nid

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -898,18 +898,29 @@ function dosomething_reportback_get_total_campaign_reportbacks($nid) {
 }
 
 /**
- * Get the total quanity from the reportbacks for a camapgin.
+ * Get the total quantity from the reportbacks for a campaign.
  *
  * @param int $nid
  *   A campaign node id.
+ * @param bool $filter_flagged
+ *   Whether or not to exclude flagged reportback sums.
+ *
  * @return int $result
- *  The sum of all values in the `quantity` section from the reportback on a camapgin.
+ *  The sum of all values in the `quantity` section from the reportback on a campaign.
  *
  */
-function dosomething_reportback_get_total_campaign_reportback_sums($nid) {
+function dosomething_reportback_get_total_campaign_reportback_sums($nid, $filter_flagged = TRUE) {
   $query = db_select('dosomething_reportback', 'rb')
     ->fields('rb', array('quantity'))
     ->condition('nid', $nid);
+
+  if ($filter_flagged) {
+    // Find reportback rbid's that have been flagged for given $nid.
+    $flagged = dosomething_reportback_get_flagged_rbids($nid);
+    // Filter them out.
+    $query->condition('rbid', $flagged, 'NOT IN');
+  }
+
   $query->addExpression('SUM(quantity)', 'quantity');
   $result = $query->execute()->fetchAll();
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -881,38 +881,23 @@ function dosomething_reportback_get_gallery_vars($nid, $style = '300x300', $num_
   return $vars;
 }
 
-/*
- * Get the total number of campaign reportbacks.
- *
- * @param int $nid
- *   A campaign node id.
- * @return int $result
- *   The number of users who reportedback on a camapgin.
- */
-function dosomething_reportback_get_total_campaign_reportbacks($nid) {
-  $result = db_select('dosomething_reportback', 'rb')
-    ->fields('rb', array('rbid'))
-    ->condition('nid', $nid)
-    ->execute();
-  return $result->rowCount();
-}
-
 /**
- * Get the total quantity from the reportbacks for a campaign.
+ * Returns reportback total for a given node $nid.
  *
  * @param int $nid
- *   A campaign node id.
+ *   A node nid.
+ * @param string $type
+ *   Type of total to return.  Accepted values: 'quantity' or 'count'.
  * @param bool $filter_flagged
- *   Whether or not to exclude flagged reportback sums.
+ *   Whether or not to exclude flagged reportbacks.
  *
  * @return int $result
- *  The sum of all values in the `quantity` section from the reportback on a campaign.
- *
+ *  Either the total reportback count, or the sum of all reportback quantity values.
  */
-function dosomething_reportback_get_total_campaign_reportback_sums($nid, $filter_flagged = TRUE) {
-  $query = db_select('dosomething_reportback', 'rb')
-    ->fields('rb', array('quantity'))
-    ->condition('nid', $nid);
+function dosomething_reportback_get_reportback_total_by_nid($nid, $type = 'quantity', $filter_flagged = TRUE) {
+
+  // Select all reportbacks for given $nid.
+  $query = db_select('dosomething_reportback', 'rb')->condition('nid', $nid);
 
   if ($filter_flagged) {
     // Find reportback rbid's that have been flagged for given $nid.
@@ -921,10 +906,16 @@ function dosomething_reportback_get_total_campaign_reportback_sums($nid, $filter
     $query->condition('rbid', $flagged, 'NOT IN');
   }
 
-  $query->addExpression('SUM(quantity)', 'quantity');
-  $result = $query->execute()->fetchAll();
-
-  return $result[0]->quantity;
+  if ($type == 'quantity') {
+    $query->fields('rb', array('quantity'));
+    $query->addExpression('SUM(quantity)', 'quantity');
+    $result = $query->execute()->fetchAll();
+    return $result[0]->quantity;
+  }
+  elseif ($type == 'count') {
+    $query->fields('rb', array('rbid'));
+    return $query->execute()->rowCount();
+  }
 }
 
 /**


### PR DESCRIPTION
@angaither Please review.

Consolidates `dosomething_reportback_get_total_campaign_reportbacks` and `dosomething_reportback_get_total_campaign_reportback_sums` functions into a single `dosomething_reportback_get_reportback_total_by_nid` which accepts a total `$type` as a parameter.

Provides parameter to filter flagged reportbacks, which defaults to TRUE. 
