### PR TITLE
Fact page intro

### DIFF
--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.features.field_instance.inc
@@ -299,7 +299,7 @@ function dosomething_fact_page_field_default_field_instances() {
     'label' => 'Intro',
     'required' => 0,
     'settings' => array(
-      'text_processing' => 0,
+      'text_processing' => 1,
       'user_register_form' => FALSE,
     ),
     'widget' => array(

--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.install
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.install
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @file
+ * Installation and schema hooks for dosomething_fact_page.module.
+ */
+
+/**
+ * Removes field_additional_text from Fact Page content type.
+ */
+function dosomething_fact_page_update_7001(&$sandbox) {
+  if ($instance = field_info_instance('node', 'field_additional_text', 'fact_page')) {
+    field_delete_instance($instance);
+  }
+}

--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
@@ -64,7 +64,6 @@ function dosomething_fact_page_preprocess_node(&$vars) {
         'intro_title',
         'intro',
         'call_to_action',
-        'additional_text',
       ),
       'image' => array(
         'intro_image',

--- a/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
@@ -30,6 +30,7 @@
         <?php if (isset($intro_title)): ?>
           <h2 class="container__title inline--alt-color"><?php print $intro_title; ?></h2>
         <?php endif; ?>
+        <?php print $intro; ?>
       </div>
     </section>
   <?php endif; ?>


### PR DESCRIPTION
- Changes `field_intro` to use markdown, displays in the template.
- Removes the `field_additional_text` field instance. This was used for including Sources as per the legacy 11 fact pages, but we are not using this field anymore and instead displaying the Sources linked to Facts.
