### PR TITLE
Move Submit Campaign form into a block

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -90,13 +90,6 @@ function dosomething_campaign_menu() {
     'access arguments' => array(1),
     'file' => 'dosomething_campaign.pages.inc',
   );
-  // Submit a campaign idea page.
-  $items['volunteer/hunt/campaign-form'] = array(
-    'title' => t('The Hunt: Create A Challenge'),
-    'page callback' => 'dosomething_campaign_submit_idea_page',
-    'access callback' => TRUE,
-    'file' => 'dosomething_campaign.pages.inc',
-  );
   return $items;
 }
 
@@ -107,6 +100,11 @@ function dosomething_campaign_block_info() {
   $blocks = array();
   $blocks['scholarship_list'] = array(
     'info' => t('DS Scholarships'),
+    //@todo: Remove and set to DRUPAL_CACHE_GLOBAL when done testing.
+    'cache' => DRUPAL_NO_CACHE,
+  );
+  $blocks['submit_campaign_idea'] = array(
+    'info' => t('DS Submit Campaign Idea'),
     //@todo: Remove and set to DRUPAL_CACHE_GLOBAL when done testing.
     'cache' => DRUPAL_NO_CACHE,
   );
@@ -122,6 +120,9 @@ function dosomething_campaign_block_view($delta = '') {
   switch ($delta) {
     case 'scholarship_list':
       $block['content']['#markup'] = dosomething_campaign_scholarship_block_content();
+      break;
+    case 'submit_campaign_idea':
+      $block['content']['#markup'] = theme('submit_campaign_idea');
       break;
   }
   return $block;

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
@@ -69,12 +69,3 @@ function dosomething_campaign_reportback_confirmation_page($node) {
     )
   );
 }
-
-/**
- * Page callback for campaigns/hunt/submit.
- *
- * @see dosomething_campaign_menu().
- */
-function dosomething_campaign_submit_idea_page() {
-  return theme('submit_campaign_idea');
-}

--- a/lib/themes/dosomething/paraneue_dosomething/templates/README.md
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/README.md
@@ -8,9 +8,16 @@ Campaign
 --------
 
 * `node--campaign.tpl.php` - Full node view of a campaign, a.k.a the Action Page
-* `node--campaign--pitch.tpl.php` - Pitch view mode of a campaign
+
+* `node--campaign--closed.tpl.php` - Displayed for a closed campaign
+
+* `node--campaign--pitch.tpl.php` - Pitch page display of a campaign
+
+* `node--campaign--sms-game.tpl.php` - Displayed for campaigns of type SMS Game
+
 * `reportback-confirmation.tpl.php` - Displayed after a user submits the campaign's reportback form.
 
+* `submit-campaign-idea.tpl.php` - Block content callback for the "DS Submit Campaign Idea" block, defined in DoSomething Campaign.  Displays a form which has been configured in Google Docs, to submit the data to the doc. The form redirect is defined from within the Google Doc.
 
 Reportback
 ----------

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/submit-campaign-idea.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/submit-campaign-idea.tpl.php
@@ -1,21 +1,6 @@
 <section class="mcc--googleform">
+  
     <div class="ss-form-container">
-      <div class="ss-top-of-page">
-        <div class="ss-form-heading">
-          <div class="ss-form-desc ss-no-ignore-whitespace">
-            <p>Here’s your chance to create a challenge for DoSomething.org’s The Hunt 2014! Your idea should be unique, accessible to young people around the country, and make a tangible impact. Submit this form by <strong>Friday, June 20</strong>.</p>
-            <div class="info-list">
-              <p>Some things to remember:</p>
-              <ul>
-                <li>Read the <a target="_blank" href="https://docs.google.com/a/dosomething.org/file/d/0B5fENCbpVZv9UHZGY1F3NnZ3MkVvR2h2OFhQek5RRnlRNXo4/edit">submission rules</a>.</li>
-                <li>All fields are required.</li>
-                <li>Questions? Email <a href="mailto:hunt@dosomething.org">hunt@dosomething.org</a></li>
-              </ul>
-            </div>
-          </div>
-          <hr class="ss-email-break" style="display:none;" />
-        </div>
-      </div>
 
       <script type="text/javascript">
         var submitted=false;


### PR DESCRIPTION
Fixes #2685 by removing the page calback to the Submit Campaign form.  

Moves the form into a custom block, to be embedded into Static Content for when we need it again.  I've tested creating a static content page and embedding the block, seems to look and work fine.

![static-content-view](https://cloud.githubusercontent.com/assets/1236811/3398795/f3361252-fd34-11e3-84ac-7fd1cc88e28e.png)
![static-content-edit](https://cloud.githubusercontent.com/assets/1236811/3398798/f85fea5a-fd34-11e3-8bf0-6034a71c1abe.png)
