### PR TITLE
A campaign class

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -44,18 +44,22 @@ function dosomething_campaign_load($node) {
   foreach ($filtered_text as $property) {
     $field_name = 'field_' . $property;
     if ($value = $wrapper->{$field_name}->value()) {
-      // Store raw input (without markup).
-      $campaign->{$property} = $value['value'];
+      // Store filtered text.
+      $campaign->{$property} = $value['safe_value'];
     }
   }
 
   // Taxonomy fields.
+  $campaign->primary_cause = NULL;
   if ($primary_cause = $wrapper->field_primary_cause->value()) {
     $campaign->primary_cause['tid'] = $primary_cause->tid;
     $campaign->primary_cause['name'] = $primary_cause->name;
   }
 
   // Fact fields.
+  $campaign->fact_problem = NULL;
+  $campaign->fact_solution = NULL;
+  $campaign->fact_sources = NULL;
   // Collect multiple fact fields values as fact and sources variables.
   $fact_fields = array('field_fact_problem', 'field_fact_solution');
   $fact_vars = dosomething_fact_get_mutiple_fact_field_vars($wrapper->nid->value(), $fact_fields);
@@ -114,7 +118,7 @@ function dosomething_campaign_get_campaign_status($node) {
   if (!isset($node->field_campaign_status[LANGUAGE_NONE][0]['value'])) {
     return 'active';
   }
-  return $node->field_campaign_type[LANGUAGE_NONE][0]['value'];
+  return $node->field_campaign_status[LANGUAGE_NONE][0]['value'];
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -54,6 +54,22 @@ function dosomething_campaign_load($node) {
     $campaign->primary_cause['tid'] = $primary_cause->tid;
     $campaign->primary_cause['name'] = $primary_cause->name;
   }
+
+  // Fact fields.
+  // Collect multiple fact fields values as fact and sources variables.
+  $fact_fields = array('field_fact_problem', 'field_fact_solution');
+  $fact_vars = dosomething_fact_get_mutiple_fact_field_vars($wrapper->nid->value(), $fact_fields);
+  if (!empty($fact_vars)) {
+    if (isset($fact_vars['facts']['field_fact_problem'])) {
+      $campaign->fact_problem = $fact_vars['facts']['field_fact_problem'];
+    }
+    if (isset($fact_vars['facts']['field_fact_solution'])) {
+      $campaign->fact_solution = $fact_vars['facts']['field_fact_solution'];
+    }
+    // Store all sources from fields as a sources array.
+    $campaign->fact_sources  = $fact_vars['sources'];
+  }
+
   return $campaign;
 }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -5,6 +5,103 @@
  */
 
 /**
+ * Returns a scaled down version of a campaign loaded $node.
+ *
+ * @return $obj
+ */
+function dosomething_campaign_load($node) {
+  if ($node->type != 'campaign') { return FALSE; }
+
+  // Load the entity metadata wrapper for easy value getting.
+  $wrapper = entity_metadata_wrapper('node', $node);
+
+  $campaign = new stdClass();
+  $campaign->nid = $node->nid;
+  $campaign->title = $node->title;
+  $campaign->status = dosomething_campaign_get_campaign_status($node);
+  $campaign->type = dosomething_campaign_get_campaign_type($node);
+
+  // Plain text fields.
+  $plain_text = array(
+    'call_to_action',
+    'solution_support',
+    'starter_statement_header',
+  );
+  foreach ($plain_text as $property) {
+    $field_name = 'field_' . $property;
+    $campaign->{$property} = $wrapper->{$field_name}->value();
+  }
+
+  // Filtered text fields.
+  $filtered_text = array(
+    'items_needed',
+    'promoting_tips',
+    'solution_copy',
+    'starter_statement',
+    'time_and_place',
+    'vips',
+  );
+  foreach ($filtered_text as $property) {
+    $field_name = 'field_' . $property;
+    if ($value = $wrapper->{$field_name}->value()) {
+      // Store raw input (without markup).
+      $campaign->{$property} = $value['value'];
+    }
+  }
+
+  // Taxonomy fields.
+  if ($primary_cause = $wrapper->field_primary_cause->value()) {
+    $campaign->primary_cause['tid'] = $primary_cause->tid;
+    $campaign->primary_cause['name'] = $primary_cause->name;
+  }
+  return $campaign;
+}
+
+/**
+ * Returns a loaded campaign $node's field_campaign_type value.
+ *
+ * @param object $node
+ *   A loaded campaign node.
+ *
+ * @return mixed
+ *   If node type == campaign, returns string value of field_campaign_type.
+ *     - Defaults to 'campaign' if value is not set.
+ *   Else returns FALSE.
+ */
+function dosomething_campaign_get_campaign_type($node) {
+  // Sanity check to make sure this is a campaign.
+  if ($node->type != 'campaign') { return FALSE; }
+
+  // Return campaign by default if no value is set.
+  if (!isset($node->field_campaign_type[LANGUAGE_NONE][0]['value'])) {
+    return 'campaign';
+  }
+  return $node->field_campaign_type[LANGUAGE_NONE][0]['value'];
+}
+
+/**
+ * Returns a loaded campaign $node's field_campaign_status value.
+ *
+ * @param object $node
+ *   A loaded campaign node.
+ *
+ * @return mixed
+ *   If node type == campaign, returns string value of field_campaign_status.
+ *     - Defaults to 'active' if value is not set.
+ *   Else returns FALSE.
+ */
+function dosomething_campaign_get_campaign_status($node) {
+  // Sanity check to make sure this is a campaign.
+  if ($node->type != 'campaign') { return FALSE; }
+
+  // Return active by default if no value is set.
+  if (!isset($node->field_campaign_status[LANGUAGE_NONE][0]['value'])) {
+    return 'active';
+  }
+  return $node->field_campaign_type[LANGUAGE_NONE][0]['value'];
+}
+
+/**
  * Returns variables for campaigns with field_campaign_type.
  *
  * @return array

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -472,28 +472,6 @@ function dosomething_campaign_add_signup_data_form_vars(&$node) {
 }
 
 /**
- * Returns a loaded campaign $node's field_campaign_type value.
- *
- * @param object $node
- *   A loaded campaign node.
- *
- * @return mixed
- *   If node type == campaign, returns string value of field_campaign_type.
- *     - Defaults to 'campaign' if value is not set.
- *   Else returns FALSE.
- */
-function dosomething_campaign_get_campaign_type($node) {
-  // Sanity check to make sure this is a campaign.
-  if ($node->type != 'campaign') { return FALSE; }
-
-  // Return campaign by default if no value is set.
-  if (!isset($node->field_campaign_type[LANGUAGE_NONE][0]['value'])) {
-    return 'campaign';
-  }
-  return $node->field_campaign_type[LANGUAGE_NONE][0]['value'];
-}
-
-/**
  * For given campaign $node, determines if the pitch page should be displayed.
  *
  * @todo: Assumes the campaign is in a live state, for now.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -12,6 +12,7 @@ function dosomething_campaign_preprocess_node(&$vars) {
   if ($vars['type'] != 'campaign') { return; }
 
   $node = menu_get_object();
+  $vars['campaign'] = dosomething_campaign_load($node);
   $wrapper = entity_metadata_wrapper('node', $node);
 
   $scholarship = $wrapper->field_scholarship_amount->value();
@@ -112,19 +113,6 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
  * Preprocesses variables for facts fields.
  */
 function dosomething_campaign_preprocess_facts_vars(&$vars, &$wrapper) {
-  // Collect multiple fact fields values as fact and sources variables.
-  $fact_fields = array('field_fact_problem', 'field_fact_solution');
-  $fact_vars = dosomething_fact_get_mutiple_fact_field_vars($wrapper->nid->value(), $fact_fields);
-  if (!empty($fact_vars)) {
-    if (isset($fact_vars['facts']['field_fact_problem'])) {
-      $vars['fact_problem'] = $fact_vars['facts']['field_fact_problem'];
-    }
-    if (isset($fact_vars['facts']['field_fact_solution'])) {
-      $vars['fact_solution'] = $fact_vars['facts']['field_fact_solution'];
-    }
-    // Store all sources from fields as a sources array.
-    $vars['fact_sources'] = $fact_vars['sources'];
-  }
   // Check for additional facts in field_facts.
   if ($wrapper->field_facts->count() > 0) {
     $vars['more_facts'] = dosomething_fact_get_fact_field_vars($wrapper->field_facts);

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -253,14 +253,14 @@ function dosomething_mbp_campaign_request($action, $node) {
     'nid' => $node->nid,
     'title' => $node->title,
   );
+  $campaign = dosomething_campaign_load($node);
 
   $url = 'http://dosomething.org/' . drupal_lookup_path('alias', "node/" .
     $node->nid);
   $params['url'] = $url;
 
-  $field = field_get_items('node', $node, 'field_call_to_action');
-  if (isset($field[0]['value'])) {
-    $params['call_to_action'] = $field[0]['value'];
+  if (isset($campaign->call_to_action)) {
+    $params['call_to_action'] = $campaign->call_to_action;
   }
 
   $field = field_get_items('node', $node, 'field_image_campaign_cover');
@@ -277,18 +277,11 @@ function dosomething_mbp_campaign_request($action, $node) {
     $params['do_it_body'] = $do_it_enitity[$do_it_prestep_target_id]->field_compound_text_copy[LANGUAGE_NONE][0]['value'];
   }
 
-  $field = field_get_items('node', $node, 'field_fact_problem');
-  if (isset($field[0]['target_id'])) {
-    $fact_problem_target_id = $field[0]['target_id'];
-    $fact_problem_node = node_load($fact_problem_target_id);
-    $params['fact_problem'] = $fact_problem_node->title;
+  if (isset($campaign->fact_problem)) {
+    $params['fact_problem'] = $campaign->fact_problem['fact'];
   }
-
-  $field = field_get_items('node', $node, 'field_fact_solution');
-  if (isset($field[0]['target_id'])) {
-    $fact_solution_target_id = $field[0]['target_id'];
-    $fact_solution_node = node_load($fact_problem_target_id);
-    $params['fact_solution'] = $fact_solution_node->title;
+  if (isset($campaign->fact_solution)) {
+    $params['fact_solution'] = $campaign->fact_solution['fact'];
   }
 
   $field = field_get_items('node', $node, 'field_high_season');

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -39,9 +39,9 @@
 
         <div class="container__body">
           <div class="-columned">
-            <?php if (isset($fact_problem)): ?>
+            <?php if (isset($campaign->fact_problem)): ?>
             <h3 class="inline--alt-color">The Problem</h3>
-            <p><?php print $fact_problem['fact']; ?><sup><?php print $fact_problem['footnotes']; ?></sup></p>
+            <p><?php print $campaign->fact_problem['fact']; ?><sup><?php print $campaign->fact_problem['footnotes']; ?></sup></p>
             <?php endif; ?>
 
             <?php if (isset($psa)): ?>
@@ -80,11 +80,11 @@
         </div>
 
 
-        <?php if (isset($fact_sources)): ?>
+        <?php if (isset($campaign->fact_sources)): ?>
         <section class="sources">
           <h3 class="__title js-toggle-sources">Sources</h3>
           <ul class="__body legal">
-            <?php foreach ($fact_sources as $key => $source): ?>
+            <?php foreach ($campaign->fact_sources as $key => $source): ?>
               <li><sup><?php print ($key + 1); ?></sup> <?php print $source; ?></li>
             <?php endforeach; ?>
           </ul>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -56,11 +56,11 @@
           </div>
 
           <div class="-columned -col-last">
-            <?php if (isset($fact_solution) || isset($solution_copy)): ?>
+            <?php if (isset($campaign->fact_solution) || isset($solution_copy)): ?>
                 <h3 class="inline--alt-color">The Solution</h3>
 
-              <?php if (isset($fact_solution)): ?>
-                <p><?php print $fact_solution['fact']; ?><sup><?php print $fact_solution['footnotes']; ?></sup></p>
+              <?php if (isset($campaign->fact_solution)): ?>
+                <p><?php print $campaign->fact_solution['fact']; ?><sup><?php print $campaign->fact_solution['footnotes']; ?></sup></p>
               <?php elseif (isset($solution_copy)): ?>
                 <?php print $solution_copy['safe_value']; ?>
               <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -76,11 +76,11 @@
           </div>
 
           <div class="-columned -even -col-last">
-            <?php if (isset($fact_solution) || isset($solution_copy)): ?>
+            <?php if (isset($campaign->fact_solution) || isset($solution_copy)): ?>
               <h3 class="inline--alt-color">The Solution</h3>
 
-              <?php if (isset($fact_solution)): ?>
-                <p><?php print $fact_solution['fact']; ?><sup><?php print $fact_solution['footnotes']; ?></sup></p>
+              <?php if (isset($campaign->fact_solution)): ?>
+                <p><?php print $campaign->fact_solution['fact']; ?><sup><?php print $campaign->fact_solution['footnotes']; ?></sup></p>
               <?php elseif (isset($solution_copy)): ?>
                 <?php print $solution_copy['safe_value']; ?>
               <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -58,9 +58,9 @@
 
         <div class="container__body">
           <div class="-columned -odd">
-            <?php if (isset($fact_problem)): ?>
+            <?php if (isset($campaign->fact_problem)): ?>
             <h3 class="inline--alt-color">The Problem</h3>
-            <p><?php print $fact_problem['fact']; ?><sup><?php print $fact_problem['footnotes']; ?></sup></p>
+            <p><?php print $campaign->fact_problem['fact']; ?><sup><?php print $campaign->fact_problem['footnotes']; ?></sup></p>
             <?php endif; ?>
 
             <?php // If there's a PSA image or video, output it in this column, otherwise output the modals list if it exists. ?>
@@ -100,11 +100,11 @@
           </div>
         </div>
 
-        <?php if (isset($fact_sources)): ?>
+        <?php if (isset($campaign->fact_sources)): ?>
         <section class="sources">
           <h3 class="__title js-toggle-sources">Sources</h3>
           <ul class="__body legal">
-            <?php foreach ($fact_sources as $key => $source): ?>
+            <?php foreach ($campaign->fact_sources as $key => $source): ?>
               <li><sup><?php print ($key + 1); ?></sup> <?php print $source; ?></li>
             <?php endforeach; ?>
           </ul>


### PR DESCRIPTION
This PR is the start of an idea I've discussed with a few devs in our team: a Campaign class to provide a simplified version of a loaded campaign node.

The idea here is moving all the preprocess / entity reference logic all into one class constructor, so there are standard variables we can use site wide, vs always needing to drill down into field arrays and loading reference nodes.  This Campaign class would be the object would be returned in a Campaign Content API GET request (vs all of the crazy field array stuff a Services node GET request would return).

I've made changes in two places to demonstrate how it could possibly simplify things: the campaign preprocess for Fact Problem and Fact Solution, and the message broker campaign cache request for Fact Problem and Fact Solution.

If we're on board with this approach, we can keep working on the class, and standardize the Campaign variable getting stuff site-wide.  This PR mainly for visibility and to open to discussion on pros and cons of this approach.. we can slowly migrate different fields into the campaign object, vs. needing to do all at once.
