### PR TITLE
Rem no more

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/bower.json
+++ b/lib/themes/dosomething/paraneue_dosomething/bower.json
@@ -20,7 +20,7 @@
     "tests"
   ],
   "dependencies": {
-    "neue": "DoSomething/neue#~4.0.0",
+    "neue": "DoSomething/neue#~4.1.0",
     "jquery": "1.8.3",
     "mailcheck": "~1.0.3",
     "html5shiv": "~3.7.0",
@@ -30,7 +30,6 @@
     "unveil": "~1.3.0",
     "jquery-once": "~1.2.6",
     "respond": "~1.4.2",
-    "REM-unit-polyfill": "~1.2.3",
     "almond": "~0.2.9"
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_auth.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_auth.scss
@@ -1,7 +1,7 @@
 .auth--login {
   .form-actions {
     text-align: center;
-    margin: 1rem 0;
+    margin: 18px 0;
   }
 }
 
@@ -12,14 +12,14 @@
 
   .form-actions {
     text-align: center;
-    margin: 1rem 0;
+    margin: 18px 0;
   }
 
   .field-name-field-first-name {
     @include media($tablet) {
       float: left;
       width: 50%;
-      padding-right: 0.5rem;
+      padding-right: 9px;
       @include box-sizing(border-box);
     }
   }
@@ -28,7 +28,7 @@
     @include media($tablet) {
       float: left;
       width: 50%;
-      padding-left: 0.5rem;
+      padding-left: 9px;
       @include box-sizing(border-box);
     }
   }
@@ -36,15 +36,15 @@
 
 .auth--header {
   text-align: center;
-  padding: 0 1rem;
+  padding: 0 18px;
   color: $purple;
 
   @include media($tablet) {
-    padding: 0 3rem;
+    padding: 0 54px;
   }
 }
 
 .auth--toggle-link {
   text-align: center;
-  margin: 1rem 0;
+  margin: 18px 0;
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-closed.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-closed.scss
@@ -6,7 +6,7 @@
   [role="banner"] {
     &.-hero {
       .__subtitle {
-        margin-bottom: 1.5rem;
+        margin-bottom: 27px;
         margin-top: 0;
       }
     }
@@ -17,7 +17,7 @@
   // total quantity donated
   // @TODO: move to neue
   .statistic {
-    padding: 0.5rem 0;
+    padding: 9px 0;
     position: relative;
     text-align: center;
 
@@ -45,14 +45,14 @@
     }
 
     @include media($tablet) {
-      margin-top: 1rem;
+      margin-top: 18px;
 
       .statistic__body {
-        padding: 0 2rem;
+        padding: 0 36px;
       }
 
       strong {
-        margin-top: 1.4rem;
+        margin-top: 25px;
       }
 
       &.-columned {
@@ -70,13 +70,13 @@
   }
 
   .statistic + .statistic {
-    margin-top: 1.7rem;
-    padding-top: 2rem;
+    margin-top: 30px;
+    padding-top: 36px;
 
     @include media($tablet) {
       border-left: 2px solid #989898;
-      margin-top: 1rem;
-      padding-top: 0.5rem;
+      margin-top: 18px;
+      padding-top: 9px;
     }
 
     &:before {
@@ -105,19 +105,19 @@
   }
 
   .intro {
-    margin-bottom: 0.5rem;
-    margin-top: 2.5rem;
+    margin-bottom: 9px;
+    margin-top: 45px;
   }
 
   // Items following a gallery
 
 
   h3 + .gallery {
-    margin-top: 1.5rem;
+    margin-top: 27px;
   }
 
   .-psa {
-    margin-bottom: 3rem;
+    margin-bottom: 54px;
   }
 
   // This introduces a new gallery pattern with floated image
@@ -173,7 +173,7 @@
           }
         }
       }
-    }    
+    }
 
     &.-mention + h3 {
       margin-top: 0;
@@ -185,7 +185,7 @@
         // Added wrapper to force minimum height so content below lines up on each <li>
         // @TODO: update pattern in neue
         .__media {
-          margin-bottom: 1rem;
+          margin-bottom: 18px;
           min-height: 75px;
 
           img {
@@ -198,7 +198,7 @@
   }
 
   div + .gallery {
-    margin-top: 2.5rem;
+    margin-top: 45px;
   }
 
   // Winners
@@ -209,7 +209,7 @@
 
     h4 {
       color: #444;
-      margin-bottom: 1rem;
+      margin-bottom: 18px;
       text-transform: capitalize;
     }
   }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -18,11 +18,11 @@
 
 .campaign--action .container--prove,
 .campaign--sms .container--do {
-  background: $purple image-url("campaign-pattern-default.png") repeat center 3.5rem;
-  padding-bottom: 7rem;
+  background: $purple image-url("campaign-pattern-default.png") repeat center 63px;
+  padding-bottom: 126px;
 
   @include media($tablet) {
-    padding-bottom: 5rem;
+    padding-bottom: 90px;
   }
 }
 
@@ -82,7 +82,7 @@
       }
 
       @include media($tablet) {
-        left: 9.5rem;
+        left: 170px;
         bottom: -20px;
         width: 256px;
 
@@ -123,7 +123,7 @@
     h3 {
       color: #fff;
       font-size: $font-large;
-      margin-bottom: 1.5rem;
+      margin-bottom: 27px;
     }
 
     p, a {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_confirmation.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_confirmation.scss
@@ -18,16 +18,16 @@ body.page-node-confirmation {
 
   .header-wrapper {
     @include header-gradient();
-    padding: 8rem 1rem 0;
+    padding: 144px 18px 0;
     @include row;
     @include media($tablet) {
-      padding: 7rem 0 0;
+      padding: 126px 0 0;
     }
   }
 
   // Set gutters on mobile
   .cta-wrapper, .gallery-wrapper {
-    padding: 1rem;
+    padding: 18px;
     @include row;
     @include media($tablet) {
       padding: 0;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_container.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_container.scss
@@ -6,7 +6,7 @@
   }
 
   > .wrapper {
-    padding: 1rem;
+    padding: 18px;
     position: relative;
     @include clearfix();
 
@@ -14,11 +14,11 @@
       @include span-columns(12);
       @include shift(2);
       float: none;
-      padding: 1rem 0;
+      padding: 18px 0;
     }
 
     @include media($desktop) {
-      padding: 1.5rem 0;
+      padding: 27px 0;
     }
   }
 
@@ -26,20 +26,20 @@
   // but makes dictating extra padding on first item easy @_@
   &:first-of-type {
     > .wrapper {
-      padding-top: 2rem;
+      padding-top: 36px;
     }
 
     // If this is the first .container but has a header that's a .banner, then don't add the extra padding.
     .container__title + .wrapper {
-      padding-top: 1.5rem;
+      padding-top: 27px;
     }
   }
 
   > .gallery {
-    padding: 1rem 0;
+    padding: 18px 0;
 
     @include media($desktop) {
-      padding: 1.5rem 0;
+      padding: 27px 0;
     }
   }
 
@@ -54,7 +54,7 @@
   }
 
   .-columned + .-columned {
-    margin-top: 1rem;
+    margin-top: 18px;
 
     @include media($tablet) {
       margin-top: 0;
@@ -70,11 +70,11 @@
 
   p + .__row,
   .__row + .__row {
-    margin-top: 1.5rem;
+    margin-top: 27px;
   }
 
   p + .tabbed {
-    margin-top: 1.5rem;
+    margin-top: 27px;
   }
 }
 
@@ -82,14 +82,14 @@
 // Styles for Container Titles.
 .container__title {
   line-height: 1.1;
-  margin: 0 0 1rem;  // @TODO: remove margins. Should be done globally!
+  margin: 0 0 18px;  // @TODO: remove margins. Should be done globally!
 
   &.banner {
     margin-bottom: 0;
-    padding: .75rem 1rem;
+    padding: 14px 18px;
 
     @include media($tablet) {
-      padding: .75rem 0;
+      padding: 14px 0;
     }
 
     > span {
@@ -103,7 +103,7 @@
   }
 
   @include media($tablet) {
-    margin-bottom: 1.5rem;
+    margin-bottom: 27px;
   }
 }
 
@@ -122,7 +122,7 @@
 
   h3 {
     color: $purple;
-    margin-bottom: 0.5rem;
+    margin-bottom: 9px;
   }
 
   p {
@@ -137,7 +137,7 @@
   // <p> tags following other items.
   p + p,
   ul + p {
-    margin-top: 1.5rem;
+    margin-top: 27px;
   }
 
   ul {
@@ -147,28 +147,28 @@
   // Items following a <p> tag.
   p + ul,
   p + aside {
-    margin-top: 1.5rem;
+    margin-top: 27px;
   }
 
   // Items following a list, <ul> or <ol>
   ul + h3,
   ol + h3 {
-    margin-top: 1.5rem;
+    margin-top: 27px;
   }
 
   p + .btn {
-    margin-top: 0.75rem;
+    margin-top: 14px;
   }
 
   // Form items inside Container Body.
   form {
-    padding-top: 1rem;
+    padding-top: 18px;
     position: relative;
   }
 
   .form-actions {
     clear: both;
-    padding-top: 1rem;
+    padding-top: 18px;
 
     @include media($tablet) {
       text-align: left;
@@ -178,17 +178,17 @@
   .media {
     &.-inline {
       float: none;
-      margin-bottom: 1.5rem;
+      margin-bottom: 27px;
 
       @include media($desktop) {
-        margin-left: 2.5rem;
+        margin-left: 45px;
         float: right;
       }
     }
   }
 
   .polaroid + p {
-    margin-top: 1.5rem;
+    margin-top: 27px;
 
     @include media($tablet) {
       margin-top: 0;
@@ -248,11 +248,11 @@
     background-color: #111;
 
     > .wrapper {
-      padding: 0.5rem 1rem;
+      padding: 9px 18px;
     }
 
     .__tagline {
-      font-size: 0.9rem;
+      font-size: 16px;
       margin: 0;
       text-align: center;
     }
@@ -267,7 +267,7 @@
   .container__body {
 
     p + .tabbed {
-      margin-top: 0.5rem;
+      margin-top: 9px;
     }
 
   }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_disclaimer.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_disclaimer.scss
@@ -1,4 +1,4 @@
 .disclaimer {
   clear: both;
-  padding-top: 2rem;
+  padding-top: 36px;
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_explore-campaigns.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_explore-campaigns.scss
@@ -8,7 +8,7 @@
 
   // Set gutters on mobile
   .content-wrapper {
-    padding: 0 1rem;
+    padding: 0 18px;
   }
 
   // @TODO: Default content page headers -- same as campaign template -- abstract this
@@ -35,11 +35,11 @@
   }
 
   .view-content {
-    margin: 2rem auto;
+    margin: 36px auto;
 
     .search-result {
       text-align: center;
-      margin-bottom: 3rem;
+      margin-bottom: 54px;
 
       @include media($tablet) {
         // @TODO: Something's messed up here

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_fact-page.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_fact-page.scss
@@ -15,12 +15,21 @@
 // Styles for Facts Listing page
 .container--facts-list {
   h3 {
-    margin-bottom: 0.5rem;
+    margin-bottom: 9px;
   }
 }
 
 .fact-page {
   background: #fff;
+
+  // @TODO: Temporary until refactor! (06.20.2014)
+  .cta {
+    &.-simple {
+      background-color: transparent;
+      border: 0 none;
+      margin-top: 27px;
+    }
+  }
 
   h2, h3, h4 {
     color: $purple;
@@ -32,11 +41,11 @@
   }
 
   li {
-    margin-bottom: 1.5rem;
+    margin-bottom: 27px;
 
     // When number of facts > 5, call to action is placed within the 5th <li>
     .cta {
-      margin-top: 1.5rem;
+      margin-top: 27px;
       padding-left: 0;
       padding-right: 0;
     }
@@ -44,7 +53,7 @@
 
   // Set gutters on mobile
   .intro-wrapper, .facts-wrapper, .sources-wrapper {
-    padding: 1rem;
+    padding: 18px;
 
     @include row;
 
@@ -67,7 +76,7 @@
 
   .facts-wrapper {
     @include media($tablet) {
-      margin-top: 1.5rem;
+      margin-top: 27px;
     }
   }
 
@@ -75,7 +84,7 @@
     .__title {
       @include media($tablet) {
         font-size: $font-largest;  // Slightly smaller font-size, since 11 Facts titles are title-case.
-        margin: 1.5rem 0;
+        margin: 27px 0;
       }
     }
   }
@@ -93,6 +102,6 @@
   }
 
   .sources {
-    margin-bottom: 1rem;
+    margin-bottom: 18px;
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_home.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_home.scss
@@ -7,14 +7,14 @@
   @include row;
   @include header-gradient;
   background-size: cover;
-  padding: 5.5rem 0 2rem;
+  padding: 100px 0 36px;
 
   @include media($tablet) {
-    padding-top: 7rem;
+    padding-top: 126px;
   }
 
   .header {
-    margin-bottom: 1rem;
+    margin-bottom: 18px;
     @include row;
     // TODO: Possibly rethink the mobile grid to allow for thinner gutters.
     @include span-columns(7);
@@ -31,27 +31,27 @@
       font-size: $font-larger;
       font-weight: $weight-bold;
       line-height: 1.1;
-      margin: 1.5rem 0 0.5rem;
+      margin: 27px 0 9px;
       text-align: center;
 
       @include visually-hidden();
 
       @include media($tablet) {
         @include visually-restored();
-        margin: 1.5rem 0;
+        margin: 27px 0;
       }
 
       @include media($desktop) {
-        font-size: 3rem;
+        font-size: 54px;
       }
     }
 
     .subtitle {
       color: #fff;
-      font-size: 1.5rem;
+      font-size: 27px;
       font-weight: normal;
       line-height: 1.2;
-      margin: 0 0 0.6rem;
+      margin: 0 0 10px;
       text-align: center;
 
       @include media($tablet) {
@@ -68,7 +68,7 @@
   background: #fff;
   text-align: center;
   overflow: hidden;
-  padding-top: 2rem;
+  padding-top: 36px;
 
   @include media($tablet) {
     @include span-columns(12);
@@ -86,7 +86,7 @@
     background-size: 175px 160px;
     width: 50px;
     height: 35px;
-    margin: 0 1rem;
+    margin: 0 18px;
 
     @include media($tablet) {
       background-size: 350px 320px;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_membership-callout.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_membership-callout.scss
@@ -3,7 +3,7 @@
 
   .__copy {
     display: inline-block;
-    padding: 1rem 0.5rem;
+    padding: 18px 9px;
     position: relative;
 
     @include media($tablet) {
@@ -12,7 +12,7 @@
 
     p {
       color: #000;
-      font: 1.5rem/1.3 $font-handwritten, cursive;
+      font: 27px/1.3 $font-handwritten, cursive;
       letter-spacing: 0.03em;
       line-height: 1.1;
       margin: 0;
@@ -37,7 +37,7 @@
 
   // Class indicates callout is positioned below item it's pointing at.
   &.-below {
-    padding-top: 1rem;
+    padding-top: 18px;
 
     .__copy {
 
@@ -84,7 +84,7 @@
 
 
   &.-right {
-    left: 8rem; // Default value: override this value for specific scenarios.
+    left: 144px; // Default value: override this value for specific scenarios.
     bottom: 0;
     position: absolute;
 
@@ -115,7 +115,7 @@
   // Class applies to a callout that starts below or above an item on mobile, but then switches to positon to the right of item.
   &.-dynamic-right {
     @include media($tablet) {
-      left: 8rem;  // Default value: override this value for specific scenarios.
+      left: 144px;  // Default value: override this value for specific scenarios.
       padding-top: 0;
       position: absolute;
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-address.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-address.scss
@@ -2,18 +2,18 @@
   .modal-content.modal--signup-data {
     .form-actions {
       text-align: center;
-      margin-top: 1rem;
+      margin-top: 18px;
     }
 
     .form-item-user-address-locality {
       width: 50%;
-      padding-right: 1rem;
+      padding-right: 18px;
       margin-right: 0;
     }
 
     .form-item-user-address-administrative-area {
       width: 50%;
-      padding-right: 1rem;
+      padding-right: 18px;
       padding-right: 0;
       margin-right: 0;
     }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-reportback.scss
@@ -53,7 +53,7 @@
       max-height: 200px;
       background: $light-gray;
       border: 5px solid #fff;
-      margin: 0.25rem 1rem;
+      margin: 4px 18px;
     }
 
     .submitted-image {
@@ -76,7 +76,7 @@
 
     .form-type-radio {
       clear: both;
-      margin-bottom: 0.25rem;
+      margin-bottom: 4px;
       overflow: auto;
 
       input[type="radio"] {
@@ -86,7 +86,7 @@
       label {
         clear: none;
         float: left;
-        margin: 0 0 0 0.25rem;
+        margin: 0 0 0 4px;
         width: auto;
       }
     }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_polaroid.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_polaroid.scss
@@ -6,7 +6,7 @@
     height: 210px;
     left: 104%;
     position: absolute;
-    top: 6.5rem;
+    top: 117px;
     width: 180px;
 
     @include transform(rotate(-3deg));

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_search.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_search.scss
@@ -5,6 +5,6 @@
   // Pagination styles
   .pager li {
     display: inline-block;
-    padding: 0 1rem 0 0;
+    padding: 0 18px 0 0;
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_sources.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_sources.scss
@@ -1,6 +1,6 @@
 .sources {
   clear: both;
-  padding-top: 2rem;
+  padding-top: 36px;
   word-wrap: break-word;
 
   ul {
@@ -9,7 +9,7 @@
     padding: 0;
 
     li + li {
-      margin-top: 0.5rem;
+      margin-top: 9px;
     }
   }
 
@@ -28,7 +28,7 @@
 
 
   .__body {
-    padding-top: 1rem;
+    padding-top: 18px;
   }
 
 }
@@ -37,7 +37,7 @@
 // @TODO: Temporary Styles until the Modals are refactored (2014.06.24)
 .modal {
   .sources {
-    padding-bottom: 1rem;
+    padding-bottom: 18px;
     padding-top: 0;
   }
 }
@@ -47,11 +47,11 @@
 .sources-wrapper {
 
   @include media($tablet) {
-    margin-bottom: 1rem;
+    margin-bottom: 18px;
   }
 
   .sources {
-    padding: 0 0 1.5rem;
+    padding: 0 0 27px;
 
     @include media($tablet) {
       padding-bottom: 0;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_static.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_static.scss
@@ -8,16 +8,16 @@
   .header-wrapper {
     @include header-gradient();
     @include header-typography();
-    padding: 8rem 1rem 0;
+    padding: 144px 18px 0;
     @include row;
     @include media($tablet) {
-      padding: 8rem 0 0;
+      padding: 144px 0 0;
     }
   }
 
   // Set gutters on mobile
   .intro-wrapper, .additional-text-wrapper, .gallery-wrapper {
-    padding: 1rem;
+    padding: 18px;
     @include row;
     @include media($tablet) {
       padding: 0;
@@ -38,7 +38,7 @@
   }
 
   .intro-wrapper + .cta {
-    margin-top: 1.7rem;
+    margin-top: 30px;
   }
 
   .intro-wrapper + .additional-text-wrapper {
@@ -48,11 +48,11 @@
   }
 
   .intro {
-    margin-top: 1.5rem;
-    margin-bottom: 0.5rem;
+    margin-top: 27px;
+    margin-bottom: 9px;
 
     &.no-title {
-      margin-top: 3rem;
+      margin-top: 54px;
     }
 
     .intro-content {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_tabbed.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_tabbed.scss
@@ -12,7 +12,7 @@
   padding: 0;
 
   li {
-    margin-top: 1.5rem;
+    margin-top: 27px;
 
     &:first-child {
       margin-top: 0;
@@ -23,7 +23,7 @@
 .tab {
   .__title {
     font-weight: $weight-bold;
-    margin-bottom: 0.5rem;
+    margin-bottom: 9px;
   }
 }
 
@@ -78,7 +78,7 @@
   .tabs__body {
     li {
       margin-top: 0;
-      padding: 1rem;
+      padding: 18px;
     }
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_user.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_user.scss
@@ -39,7 +39,7 @@
   }
 
   #user-profile-form {
-    padding: 7rem 0 2rem;
+    padding: 126px 0 36px;
 
     @include span-columns(7);
     @include shift(0.5);
@@ -85,7 +85,7 @@
     }
 
     > .wrapper {
-      padding: 1.5rem 1rem;
+      padding: 27px 18px;
 
       @include media($tablet) {
         padding-left: 0;
@@ -120,7 +120,7 @@
   }
 
   dl {
-    padding-right: 1rem;
+    padding-right: 18px;
 
     @include clearfix();
 
@@ -129,18 +129,18 @@
       @include omega();
     }
 
-    margin-bottom: 1rem;
+    margin-bottom: 18px;
   }
 
   dt, dd {
     float: left;
-    margin-bottom: 0.5rem;
+    margin-bottom: 9px;
   }
 
   dt {
     clear: both;
     font-weight: $weight-bold;
-    padding-right: 0.5rem;
+    padding-right: 9px;
   }
 
   .btn {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_waypoints.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_waypoints.scss
@@ -16,7 +16,7 @@
     a {
       display: block;
       line-height: 1;
-      padding: 1rem 0.5rem;
+      padding: 18px 9px;
       position: relative;
       text-decoration: none;
     }
@@ -32,7 +32,7 @@
 
   @include media($desktop) {
     position: absolute;
-    top: 6.5rem;
+    top: 117px;
     width: 120px;
     z-index: 100;
   }
@@ -52,7 +52,7 @@
       text-transform: uppercase;
 
       @include media($desktop) {
-        padding: 0.75rem 1rem;
+        padding: 14px 18px;
       }
 
       &:hover {
@@ -75,7 +75,7 @@
     z-index: 100;
 
     @include media($desktop) {
-      top: 3rem;
+      top: 54px;
     }
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_hunt-mcc.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_hunt-mcc.scss
@@ -17,13 +17,13 @@
     }
 
     ul {
-      margin-bottom: 1.5rem;
+      margin-bottom: 27px;
     }
   }
 
   .ss-form-question {
     clear: both;
-    margin-bottom: 1rem;
+    margin-bottom: 18px;
     @include clearfix;
 
     &.-compact {
@@ -33,11 +33,11 @@
         width: 50%;
 
         &.-alpha {
-          padding-right: 0.5rem;
+          padding-right: 9px;
         }
 
         &.-beta {
-          padding-left: 0.5rem;
+          padding-left: 9px;
         }
       }
     }
@@ -51,7 +51,7 @@
   }
 
   .ss-form-desc {
-    margin-bottom: 2rem;
+    margin-bottom: 36px;
   }
 
   .required-message {
@@ -71,11 +71,11 @@
   }
 
   .ss-choice-item label {
-    margin: 0.25em 0;
+    margin: 4px 0;
   }
 
   .ss-q-other-container {
-    padding-left: 1.25rem;
+    padding-left: 22px;
 
     input {
       max-width: 400px;
@@ -94,8 +94,8 @@
 
   .ss-secondary-text {
     color: $med-gray;
-    font-size: 0.9rem;
-    padding-bottom: 1rem;
+    font-size: 16px;
+    padding-bottom: 18px;
   }
 
   // These should be hidden since we're not running Google's JS
@@ -104,7 +104,7 @@
   }
 
   .ss-navigate {
-    margin-bottom: 2rem;
+    margin-bottom: 36px;
 
     table {
       margin: 0 auto;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/finder.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/finder.scss
@@ -8,17 +8,11 @@
 
 //   @include media($tablet) {
 //     @include visually-restored();
-//     margin-bottom: 1rem;
+//     margin-bottom: 18px;
 //   }
 // }
 
 .finder--form {
-  p {
-    margin: 0;
-    font-size: $font-small;
-    font-weight: normal;
-  }
-
   input[type="checkbox"] {
     left: -40px;
     position: absolute;
@@ -30,23 +24,19 @@
     float: none;
     display: block;
     height: auto;
-    font-size: 0.8em;
+    font-size: 14px;
     font-weight: $weight-normal;
     left: 0;
     line-height: 1.2;
     margin: 0;
-    padding: 0.75rem 0.5rem;
+    padding: 14px 9px;
     position: relative;
     cursor: pointer;
-
-    // TODO: Pop this animatione effect into Neue?
-    -webkit-transition: left .1s linear;
-    -moz-transition: left .1s linear;
-    transition: left .1s linear;
+    @include transition(left .1s linear);
 
     @include media($tablet) {
-      padding-bottom: 0.1rem;
-      padding-top: 0.1rem;
+      padding-bottom: 4px;
+      padding-top: 4px;
     }
   }
 
@@ -61,7 +51,7 @@
 
   .dropdown {
     background: #fff;
-    margin-bottom: 1rem;
+    margin-bottom: 18px;
 
     @include media($tablet) {
       margin-bottom: 0;
@@ -88,7 +78,6 @@
     li {
       display: block;
       overflow: hidden;
-      padding: 0.1rem 0;
       position: relative;
       @include prefixer(column-break-inside, avoid, webkit moz spec);
 
@@ -104,7 +93,7 @@
     .caret-toggle {
       color: $purple;
       cursor: pointer;
-      padding: .6rem 1rem;
+      padding: 10px 18px;
     }
 
     .__title {
@@ -112,35 +101,36 @@
       font-weight: $weight-bold;
       line-height: 1;
       margin: 0;
-      padding: 0 0 0.25rem 1.5rem;
+      padding: 0 0 4px 27px;
 
       &:before {
         position: absolute;
         z-index: 1; // fixes display issue with css3 columns in below container
-        left: -0.25rem;
-        top: -0.5rem;
+        left: -4px;
+        top: -9px;
         content: "\e609";
         font-size: 32px;
         @include icomoon-icon;
         @include transform(rotate(-90deg));
-        @include transition-property(transform);
-        @include transition-duration(0.25s);
+        @include transition(transform 0.25s);
       }
     }
 
     .__question {
       color: $med-gray;
+      font-size: 14px;
       line-height: 1;
-      padding-left: 1.5rem;
+      padding-left: 27px;
+      margin: 0;
     }
 
     .dropdown-menu {
       display: none;
-      padding: 0 1rem .6rem;
+      padding: 0 18px 10px;
 
       ul {
         overflow: hidden;
-        padding-left: 1rem;
+        padding-left: 18px;
       }
     }
 
@@ -157,7 +147,7 @@
   }
 
   .two-col {
-    padding-left: 1rem;
+    padding-left: 18px;
 
     @include media(550px) {
       -moz-column-count: 2;
@@ -174,7 +164,7 @@
 
   .campaign-search {
     text-align: center;
-    margin-top: 1.5rem;
+    margin-top: 27px;
 
     @include media($tablet) {
       display: none;
@@ -183,7 +173,7 @@
 
   .error {
     clear: both;
-    // margin-top: 1rem;
+    // margin-top: 18px;
   }
 }
 
@@ -243,7 +233,7 @@
     width: 100%;
 
     > .wrapper {
-      padding: 2rem 1rem;
+      padding: 36px 18px;
       @include span-columns(7);
       @include shift(0.5);
     }
@@ -255,7 +245,7 @@
     .message {
       font-size: $font-large;
       line-height: 1.2;
-      margin-bottom: 0.5rem;
+      margin-bottom: 9px;
 
       @include media($tablet) {
         font-size: $font-larger;
@@ -308,7 +298,7 @@
       position: absolute;
       bottom: 0;
       width: 100%;
-      padding: 2rem 1rem 1rem;
+      padding: 36px 18px 18px;
 
       background: image-url("black-50.png");
       @include linear-gradient(transparent, #000);
@@ -322,7 +312,7 @@
 
       p {
         color: #fff;
-        font-size: 0.9rem;
+        font-size: 16px;
         font-weight: $weight-normal;
         line-height: 1.2;
         margin-bottom: 0;
@@ -337,13 +327,13 @@
       z-index: 1;
       background: $yellow;
       color: #000;
-      font-size: 0.75rem;
+      font-size: 14px;
       font-weight: $weight-sbold;
       text-transform: uppercase;
       padding: 0.2em 0.5em;
 
       @include media($tablet) {
-        font-size: 1rem;
+        font-size: 18px;
       }
     }
   }
@@ -352,7 +342,7 @@
     clear: both;
     background: #fff;
     text-align: center;
-    padding: 1rem;
+    padding: 18px;
 
     @include row;
   }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/helpers/_mixins.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/helpers/_mixins.scss
@@ -49,15 +49,15 @@
 @mixin header-typography() {
   .title {
     color: #fff;
-    font-size: 2rem;
+    font-size: 36px;
     line-height: 1;
     text-align: center;
-    margin: 0 0 0.5rem;
+    margin: 0 0 9px;
 
     @include media($tablet) {
       font-size: $font-hero;
       text-align: left;
-      margin: 0 0 0.5rem;
+      margin: 0 0 9px;
     }
   }
 
@@ -66,13 +66,13 @@
     font-size: $font-regular;
     font-weight: normal;
     line-height: 1.5;
-    margin: 0 0 0.5rem;
+    margin: 0 0 9px;
     text-align: center;
 
 
     @include media($tablet) {
       font-size: $font-medium;
-      margin-bottom: 1.5rem;
+      margin-bottom: 27px;
       text-align: left;
     }
   }
@@ -90,7 +90,7 @@
   background-color: lighten($light-gray, 10%);
   border-bottom: 2px solid $light-gray;
   border-top: 2px solid $light-gray;
-  padding: 1rem;
+  padding: 18px;
   @include row;
   @include media($tablet) {
     padding: 0;
@@ -98,13 +98,13 @@
 
   .cta {
     text-align: center;
-    padding: 2rem 0;
+    padding: 36px 0;
 
     h3 {
       color: $copy-color;
       font-size: $font-medium;
       font-weight: $weight-sbold;
-      margin: 0 0 0.5rem;
+      margin: 0 0 9px;
     }
 
     @include media($tablet) {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/overrides/_drupal.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/overrides/_drupal.scss
@@ -5,8 +5,8 @@
 // Quick and dirty fix for "Remove Signup" form being hidden
 // behind nav. @TODO Remove me when we fix "non-themed" template
 #dosomething-signup-node-unsignup-form {
-  padding-top: 8rem;
-  padding-bottom: 2rem;
+  padding-top: 144px;
+  padding-bottom: 36px;
   max-width: 600px;
   margin: 0 auto;
 }
@@ -41,7 +41,7 @@
 .admin--tabs .tabs {
   background: $light-gray;
   background-image: image-url("admin-panel.png");
-  padding: 1rem 0;
+  padding: 18px 0;
 }
 
 // @TODO: Remove date.css to override this more cleanly

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -47,10 +47,6 @@
   <?php print $page_top; ?>
   <?php print $page; ?>
 
-  <!--[if lte IE 8]>
-      <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/REM-unit-polyfill/js/rem.min.js"></script>
-  <![endif]-->
-
   <script type="text/javascript" src="<?php print DS_JAVASCRIPT_PATH; ?>"></script>
   <?php print $scripts; ?>
   <?php print $page_bottom; ?>


### PR DESCRIPTION
Replace `rem` units with `pixels`, removing our need for the polyfill on IE8. References DoSomething/neue#309.
