### PR TITLE
Updates to preprocess to fix header in default pages.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -47,6 +47,25 @@ function paraneue_dosomething_preprocess_page(&$vars) {
   $vars['navigation'] = theme('navigation', $navigation_vars);
 
 
+  krumo($vars);
+  krumo($vars['node']);
+
+  /**
+   * Header
+   */
+
+  $header_vars = array(
+    'title' => drupal_get_title(),
+  );
+
+  // If there's a subtitle field on this node, send it to the header
+  if(isset( $vars['node']->field_subtitle[LANGUAGE_NONE][0]['safe_value'] )) {
+    $header_vars['subtitle'] =  $vars['node']->field_subtitle[LANGUAGE_NONE][0]['safe_value'];
+  }
+
+  $vars['header'] = theme('header', $header_vars);
+
+
   /**
    * Footer
    */
@@ -111,23 +130,6 @@ function paraneue_dosomething_preprocess_node(&$vars) {
     // Set these here to remove db calls from tpl files
     $vars['show_campaign_finder'] = theme_get_setting('show_campaign_finder');
     $vars['show_sponsors'] = theme_get_setting('show_sponsors');
-  }
-
-  elseif ($type === "static_content" || $type === "fact_page") {
-    /**
-     * Header
-     */
-
-    $header_vars = array(
-      'title' => $vars['title'],
-    );
-
-    // If there's a subtitle field on this node, send it to the header
-    if(isset( $vars['node']->field_subtitle[LANGUAGE_NONE][0]['safe_value'] )) {
-      $header_vars['subtitle'] =  $vars['node']->field_subtitle[LANGUAGE_NONE][0]['safe_value'];
-    }
-
-    $vars['header'] = theme('header', $header_vars);
   }
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -47,9 +47,6 @@ function paraneue_dosomething_preprocess_page(&$vars) {
   $vars['navigation'] = theme('navigation', $navigation_vars);
 
 
-  krumo($vars);
-  krumo($vars['node']);
-
   /**
    * Header
    */

--- a/lib/themes/dosomething/paraneue_dosomething/templates/static_content/node--static_content.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/static_content/node--static_content.tpl.php
@@ -11,7 +11,8 @@
 
 <article id="node-<?php print $node->nid; ?>" class="static <?php print $classes; ?> clearfix"<?php print $attributes; ?>>
 
-  <?php print $variables['header']; ?>
+  <?php //@TODO: Aiming to add this back in once a better solution is found for default pages. ?>
+  <?php //print $variables['header']; ?>
 
   <div class="wrapper">
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/static_content/page--static_content.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/static_content/page--static_content.tpl.php
@@ -11,6 +11,7 @@
 
 <div class="chrome--wrapper">
   <?php print $variables['navigation']; ?>
+  <?php print $variables['header']; ?>
 
   <main role="main">
     <?php print render($page['content']); ?>


### PR DESCRIPTION
@DFurnes @angaither 

Everything worked great except on default pages where the header disappears since there is no node output.

Aiming to find a different solution to be able to output the header in the static node tpl. This works for now.
