### PR TITLE
More campaign class

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -16,10 +16,25 @@
  *   - type (string). 'campaign' | 'sms_game'
  *
  *   - call_to_action (string). Plain text.
+ *   - fact_problem (array)
+ *       - fact (string) HTML.
+ *   - fact_solution (array)
+ *       - fact (string) HTML.
+ *   - fact_sources (array)
+ *        Contains composite sources of fact_problem and fact_solution.
  *   - high_season_end (string). Date string.
  *   - high_season_start (string). Date string.
+ *   - items_needed (string). HTML.
  *   - low_season_end (string). Date string.
  *   - low_season_start (string). Date string.
+ *   - primary_cause (array)
+ *       - tid (int)
+ *       - name (string)
+ *   - promoting_tips (string). HTML.
+ *   - solution_copy (string). HTML.
+ *   - solution_support (string). Plain text.
+ *   - starter_statement (string). HTML.
+ *   - starter_statement_header (string). Plain text.
  *   - time_and_place (string). HTML.
  *   - vips (string). HTML.
  *
@@ -61,6 +76,9 @@ function dosomething_campaign_load($node) {
     if ($value = $wrapper->{$field_name}->value()) {
       // Store filtered text.
       $campaign->{$property} = $value['safe_value'];
+    }
+    else {
+      $campaign->{$property} = NULL;
     }
   }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -16,6 +16,10 @@
  *   - type (string). 'campaign' | 'sms_game'
  *
  *   - call_to_action (string). Plain text.
+ *   - high_season_end (string). Date string.
+ *   - high_season_start (string). Date string.
+ *   - low_season_end (string). Date string.
+ *   - low_season_start (string). Date string.
  *   - time_and_place (string). HTML.
  *   - vips (string). HTML.
  *
@@ -33,18 +37,18 @@ function dosomething_campaign_load($node) {
   $campaign->type = dosomething_campaign_get_campaign_type($node);
 
   // Plain text fields.
-  $plain_text = array(
+  $fields_plain_text = array(
     'call_to_action',
     'solution_support',
     'starter_statement_header',
   );
-  foreach ($plain_text as $property) {
+  foreach ($fields_plain_text as $property) {
     $field_name = 'field_' . $property;
     $campaign->{$property} = $wrapper->{$field_name}->value();
   }
 
   // Filtered text fields.
-  $filtered_text = array(
+  $fields_filtered_text = array(
     'items_needed',
     'promoting_tips',
     'solution_copy',
@@ -52,7 +56,7 @@ function dosomething_campaign_load($node) {
     'time_and_place',
     'vips',
   );
-  foreach ($filtered_text as $property) {
+  foreach ($fields_filtered_text as $property) {
     $field_name = 'field_' . $property;
     if ($value = $wrapper->{$field_name}->value()) {
       // Store filtered text.
@@ -65,6 +69,25 @@ function dosomething_campaign_load($node) {
   if ($primary_cause = $wrapper->field_primary_cause->value()) {
     $campaign->primary_cause['tid'] = $primary_cause->tid;
     $campaign->primary_cause['name'] = $primary_cause->name;
+  }
+
+  // Date fields.
+  $campaign->high_season_start = NULL;
+  $campaign->high_season_end = NULL;
+  $campaign->low_season_start = NULL;
+  $campaign->low_season_end = NULL;
+  $fields_date = array(
+    'high_season',
+    'low_season',
+  );
+  foreach ($fields_date as $property) {
+    $field_name = 'field_' . $property;
+    if ($value = $wrapper->{$field_name}->value()) {
+      $start_property = $property . '_start';
+      $campaign->{$start_property} = $value['value'];
+      $end_property = $property . '_end';
+      $campaign->{$end_property} = $value['value2'];
+    }
   }
 
   // Fact fields.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -7,7 +7,18 @@
 /**
  * Returns a scaled down version of a campaign loaded $node.
  *
- * @return $obj
+ * @return object
+ *   Available properties:
+ *
+ *   - nid: (int)
+ *   - title: (string)
+ *   - status (string). 'active' | 'closed'
+ *   - type (string). 'campaign' | 'sms_game'
+ *
+ *   - call_to_action (string). Plain text.
+ *   - time_and_place (string). HTML.
+ *   - vips (string). HTML.
+ *
  */
 function dosomething_campaign_load($node) {
   if ($node->type != 'campaign') { return FALSE; }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -20,8 +20,6 @@ function dosomething_campaign_preprocess_node(&$vars) {
     $vars['scholarship'] = '$' . number_format($scholarship, 0, '', ',') . ' Scholarship';
   }
 
-  $vars['cta'] = $wrapper->field_call_to_action->value();
-
   // Timing.
   $display_date = $wrapper->field_display_end_date->value();
   // Check if there is a value in the date field.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -84,8 +84,6 @@ function dosomething_campaign_preprocess_node(&$vars) {
  */
 function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
   $vars['issue'] = $wrapper->field_issue->value()->name;
-  $vars['solution_copy'] = $wrapper->field_solution_copy->value();
-  $vars['solution_support'] = $wrapper->field_solution_support->value();
   $vars['faq'] = dosomething_helpers_get_field_collection_values($wrapper, 'field_faq');
   dosomething_campaign_preprocess_facts_vars($vars, $wrapper);
   dosomething_campaign_preprocess_media_vars($vars, $wrapper);

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -306,4 +306,4 @@ function dosomething_mbp_campaign_request($action, $node) {
   $params = dosomething_mbp_get_campaign_request_params($node);
   // Send request.
   dosomething_mbp_request($action, $params);
-} 
+}

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -235,18 +235,15 @@ function dosomething_mbp_node_update($node) {
   }
 }
 
-/*
- * Collect and format values from campaign $node submissions and populate
- * $params. The function responsible for ultimately triggering the request to
- * produce a Message Broker caching transaction for campaign content creation
- * and updates.
+/**
+ * Collects and format values from campaign $node and returns a $params array.
  *
- * @param string $action
- *   Type of mbp request
  * @param object $node
- *   Submitted values for campaign
+ *   A loaded campaign $node.
+ *
+ * @return array
  */
-function dosomething_mbp_campaign_request($action, $node) {
+function dosomething_mbp_get_campaign_request_params($node) {
 
   $params = array();
   $params = array(
@@ -283,18 +280,30 @@ function dosomething_mbp_campaign_request($action, $node) {
   if (isset($campaign->fact_solution)) {
     $params['fact_solution'] = $campaign->fact_solution['fact'];
   }
-
-  $field = field_get_items('node', $node, 'field_high_season');
-  if (isset($field[0]['value'])) {
-    $params['high_season_start_timestamp'] = strtotime($field[0]['value']);
-    $params['high_season_end_timestamp'] = strtotime($field[0]['value2']);
+  if (isset($campaign->high_season_start)) {
+    $params['high_season_start_timestamp'] = strtotime($campaign->high_season_start);
+    $params['high_season_end_timestamp'] = strtotime($campaign->high_season_end);
   }
-
-  $field = field_get_items('node', $node, 'field_low_season');
-  if (isset($field[0]['value'])) {
-    $params['low_season_start_timestamp'] = strtotime($field[0]['value']);
-    $params['low_season_end_timestamp'] = strtotime($field[0]['value2']);
+  if (isset($campaign->low_season_start)) {
+    $params['low_season_start_timestamp'] = strtotime($campaign->low_season_start);
+    $params['low_season_end_timestamp'] = strtotime($campaign->low_season_end);
   }
-
-  dosomething_mbp_request($action, $params);
+  return $params; 
 }
+
+/**
+ * The function responsible for ultimately triggering the request to
+ * produce a Message Broker caching transaction for campaign content creation
+ * and updates.
+ *
+ * @param string $action
+ *   Type of mbp request
+ * @param object $node
+ *   Submitted values for campaign
+ */
+function dosomething_mbp_campaign_request($action, $node) {
+  // Get the params to send to Message Broker from given $node.
+  $params = dosomething_mbp_get_campaign_request_params($node);
+  // Send request.
+  dosomething_mbp_request($action, $params);
+} 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
@@ -3,8 +3,8 @@
  * Returns the HTML for the Campaign Closed page.
  *
  * Available Variables
+ * - $campaign: A campaign object. @see dosomething_campaign_load()
  * - $title: Title for the campaign closed page (string).
- * - $cta: Call To Action for the campaign closed page (string).
  * - $classes: Additional classes passed for output (string).
  * - $presignup_callout: Call to action (string).
  * - $sponsors: List of sponsors (array).
@@ -21,7 +21,7 @@
   <header role="banner" class="-hero <?php print $classes; ?>">
     <div class="wrapper">
       <h1 class="__title"><?php print $title; ?></h1>
-      <h2 class="__subtitle"><?php print $cta; ?></h2>
+      <h2 class="__subtitle"><?php print $campaign->call_to_action; ?></h2>
 
       <?php if (isset($signup_button)): ?>
         <div class="__signup">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -56,17 +56,17 @@
           </div>
 
           <div class="-columned -col-last">
-            <?php if (isset($campaign->fact_solution) || isset($solution_copy)): ?>
+            <?php if (isset($campaign->fact_solution) || isset($campaign->solution_copy)): ?>
                 <h3 class="inline--alt-color">The Solution</h3>
 
               <?php if (isset($campaign->fact_solution)): ?>
                 <p><?php print $campaign->fact_solution['fact']; ?><sup><?php print $campaign->fact_solution['footnotes']; ?></sup></p>
-              <?php elseif (isset($solution_copy)): ?>
-                <?php print $solution_copy['safe_value']; ?>
+              <?php elseif (isset($campaign->solution_copy)): ?>
+                <?php print $campaign->solution_copy; ?>
               <?php endif; ?>
 
-              <?php if (isset($solution_support)): ?>
-                <p><?php print $solution_support; ?></p>
+              <?php if (isset($campaign->solution_support)): ?>
+                <p><?php print $campaign->solution_support; ?></p>
               <?php endif; ?>
 
             <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -15,7 +15,7 @@
   <header role="banner" class="-hero <?php print $classes; ?>">
     <div class="wrapper">
       <h1 class="__title"><?php print $title; ?></h1>
-      <h2 class="__subtitle"><?php print $cta; ?></h2>
+      <h2 class="__subtitle"><?php print $campaign->call_to_action; ?></h2>
 
       <?php if (isset($end_date)): ?><p class="__date"><?php print $end_date; ?></p><?php endif; ?>
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -76,17 +76,17 @@
           </div>
 
           <div class="-columned -even -col-last">
-            <?php if (isset($campaign->fact_solution) || isset($solution_copy)): ?>
+            <?php if (isset($campaign->fact_solution) || isset($campaign->solution_copy)): ?>
               <h3 class="inline--alt-color">The Solution</h3>
 
               <?php if (isset($campaign->fact_solution)): ?>
                 <p><?php print $campaign->fact_solution['fact']; ?><sup><?php print $campaign->fact_solution['footnotes']; ?></sup></p>
-              <?php elseif (isset($solution_copy)): ?>
-                <?php print $solution_copy['safe_value']; ?>
+              <?php elseif (isset($campaign->solution_copy)): ?>
+                <?php print $campaign->solution_copy; ?>
               <?php endif; ?>
 
-              <?php if (isset($solution_support)): ?>
-                <p><?php print $solution_support; ?></p>
+              <?php if (isset($campaign->solution_support)): ?>
+                <p><?php print $campaign->solution_support; ?></p>
               <?php endif; ?>
 
             <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -3,7 +3,7 @@
  * Returns the HTML for the Campaign Action page.
  *
  * Available Variables
- * - $fact_problem:
+ * - $campaign: A campaign object. @see dosomething_campaign_load()
  * - $end_date: End date for the campaign (string).
  * - $scholarship: Scholarship amount (string).
  * - $classes: Additional classes passed for output (string).
@@ -15,7 +15,7 @@
   <header role="banner" class="-hero <?php print $classes; ?>">
     <div class="wrapper">
       <h1 class="__title"><?php print $title; ?></h1>
-      <h2 class="__subtitle"><?php print $cta; ?></h2>
+      <h2 class="__subtitle"><?php print $campaign->call_to_action; ?></h2>
 
       <?php if (isset($end_date)): ?><p class="__date"><?php print $end_date; ?></p><?php endif; ?>
 


### PR DESCRIPTION
@angaither @DeeZone Could you please review?
- Adds high season and low season start / end properties, and uses them for `dosomething_mbp_campaign_request`.
- Adds a `dosomething_mbp_get_campaign_request_params` function to return the expected `$params` array based on a campaign node. Calls this function within  `dosomething_mbp_campaign_request`.  This was added to make testing the `$params` output easier.
- Replaces `$cta`, `$solution_copy`, `$solution_support` tpl variables with relevant `$campaign` properties.
