### PR TITLE
Account creation for Partner / Sponsors

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.features.field_instance.inc
@@ -240,7 +240,7 @@ function dosomething_user_field_default_field_instances() {
     'label' => 'Partner / Sponsor',
     'required' => 0,
     'settings' => array(
-      'user_register_form' => 0,
+      'user_register_form' => 1,
     ),
     'widget' => array(
       'active' => 1,


### PR DESCRIPTION
Fix for an old issue, when we created an account for H&M.

Displays the `user_partner` field on a user registration form, to allow for admin's to create an account for a partner in one form (vs needing to create and then go back to edit)

It will not display for users because of this line in `dosomething_user`: https://github.com/DoSomething/dosomething/blob/dev/lib/modules/dosomething/dosomething_user/dosomething_user.module#L187

i've tested with by creating a new user and confirmed it does not display on the register modal, on user/register, or within the edit profile form.
