### PR TITLE
Fix polaroid position.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -80,6 +80,14 @@
     }
   }
 
+  .container--do {
+    .polaroid {
+      position: absolute;
+      top: 117px;
+      left: 104%;
+    }
+  }
+
   .container--prove {
 
     .container__body {


### PR DESCRIPTION
Removed specific positioning rules (seen in diff) from the pattern in Neue and forgot to add them back in for this specific usage in the DS app codebase.
