### PR TITLE
Fix drush aliases syntax error

### DIFF
--- a/provision/salt/roots/salt/dosomething/ds.aliases.drushrc.php
+++ b/provision/salt/roots/salt/dosomething/ds.aliases.drushrc.php
@@ -37,4 +37,3 @@ foreach ($countries as $country) {
    '%dump-dir' => '/tmp',
   );
 }
-r


### PR DESCRIPTION
@blisteringherb Please review.  Assuming this was just a typo?
