### PR TITLE
Campaign header image

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -149,7 +149,12 @@ function dosomething_campaign_load($node) {
   $campaign->image_cover = NULL;
   if ($image_cover = $wrapper->field_image_campaign_cover->value()) {
     $campaign->image_cover['nid'] = (int) $image_cover->nid;
-    $campaign->image_cover['is_dark_image'] = (int) $image_cover->field_dark_image[LANGUAGE_NONE][0]['value'];
+    // Initalize as 0.
+    $campaign->image_cover['is_dark_image'] = 0;
+    // If is_dark_image field value exists:
+    if (isset($image_cover->field_dark_image[LANGUAGE_NONE][0]['value'])) {
+      $campaign->image_cover['is_dark_image'] = (int) $image_cover->field_dark_image[LANGUAGE_NONE][0]['value'];
+    }
   }
 
   // Set image_header property.
@@ -157,8 +162,13 @@ function dosomething_campaign_load($node) {
   if (isset($campaign->variables['alt_image_campaign_cover_nid'])) {
     // Set the nid to the overridden value.
     $campaign->image_header['nid'] = (int) $campaign->variables['alt_image_campaign_cover_nid'];
+    // Initalize as 0.
+    $campaign->image_header['is_dark_image'] = 0;
+    // Load the alt image node.
     $alt_image = node_load($campaign->image_header['nid']);
-    $campaign->image_header['is_dark_image'] = (int) $alt_image->field_dark_image[LANGUAGE_NONE][0]['value'];
+    if (isset($alt_image->field_dark_image[LANGUAGE_NONE][0]['value'])) {
+      $campaign->image_header['is_dark_image'] = (int) $alt_image->field_dark_image[LANGUAGE_NONE][0]['value'];
+    }
   }
   // Else if no override:
   else {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -330,9 +330,10 @@ function dosomething_campaign_get_campaign_block_vars($nid, $image_size = '740x4
  * Implements hook_preprocess_page().
  */
 function dosomething_campaign_preprocess_page(&$vars) {
-  if ($vars['node']->type == 'campaign') {
-    $cover_image_nid = $vars['node']->field_image_campaign_cover[LANGUAGE_NONE][0]['target_id'];
-    $cover_image_dark_background = node_load($cover_image_nid)->field_dark_image[LANGUAGE_NONE][0]['value'];
+  if (isset($vars['node']) && $vars['node']->type == 'campaign') {
+
+    $campaign = dosomething_campaign_load($vars['node']);
+    $cover_image_dark_background = $campaign->image_header['is_dark_image'];
 
     // The usual default for navigation is white.
     // If image *doesn't* have a dark background, use black.

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -159,6 +159,9 @@ function dosomething_helpers_format_partners_list(&$vars) {
   $vars['formatted_partners'] = $formatted_partners;
 }
 
+/**
+ * Sets hero_image variables based on image_header / Cover Image field.
+ */
 function dosomething_helpers_preprocess_hero_images(&$vars) {
   // If the Campaign class is available:
   if (isset($vars['campaign'])) {
@@ -170,14 +173,9 @@ function dosomething_helpers_preprocess_hero_images(&$vars) {
   }
 
   if ($hero_nid) {
-    $vars['hero_image_l'] = dosomething_image_get_themed_image($hero_nid, 'landscape', '1440x810');
-    $vars['hero_image_m'] = dosomething_image_get_themed_image($hero_nid, 'square', '768x768');
-    $vars['hero_image_l_url'] = dosomething_image_get_themed_image_url($hero_nid, 'landscape', '1440x810');
-    $vars['hero_image_m_url'] = dosomething_image_get_themed_image_url($hero_nid, 'square', '768x768');
+    $vars['hero_image']['desktop'] = dosomething_image_get_themed_image_url($hero_nid, 'landscape', '1440x810');
+    $vars['hero_image']['mobile'] = dosomething_image_get_themed_image_url($hero_nid, 'square', '768x768');
   }
-
-  isset($vars['hero_image_m_url']) ? $vars['hero_image']['mobile'] = $vars['hero_image_m_url'] : NULL ;
-  isset($vars['hero_image_l_url']) ? $vars['hero_image']['desktop'] = $vars['hero_image_l_url'] : NULL ;
 }
 
 /**


### PR DESCRIPTION
Alters `dosomething_campaign_preprocess_page` to check the Campaign class's `image_header` property, which will be set based on the `field_image_campaign_cover` value, or the overridden value found in `field_variables`, which closes #2676

Fixes PHP warnings in #2578

Also removes unused variables from campaign preprocessing.
