### PR TITLE
Setting and fetching tier.  Capistrano doesn't automatically provide it

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -26,7 +26,7 @@ namespace :deploy do
   task :shared_links do
     on roles(:app) do |host|
       execute "cd '#{release_path}/html/sites/default'; rm -rf files 2> /dev/null; ln -s #{shared_path}/files files"
-      execute "ln -s #{shared_path}/settings.#{:stage}.php #{release_path}/html/sites/default/settings.#{:stage}.php"
+      execute "ln -s #{shared_path}/settings.#{fetch(:deploy_env)}.php #{release_path}/html/sites/default/settings.#{fetch(:deploy_env)}.php"
       if :stage == 'staging'
         execute "printf 'User-agent: *\nDisallow: /' > #{release_path}/html/robots.txt"
       end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,5 +1,7 @@
 set :deploy_to, "/var/www/beta.dosomething.org"
 
+set :deploy_env, "production"
+
 role :app, %w{dosomething@beta-web1}
 
 server 'beta-web1', user: 'dosomething', roles: %w{app}

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,5 +1,7 @@
 set :deploy_to, "/var/www/qa-beta"
 
+set :deploy_env, "qa"
+
 role :app, %w{dosomething@blackangus.dosomething.org}
 
 server 'blackangus.dosomething.org', user: 'dosomething', roles: %w{app}

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,5 +1,7 @@
 set :deploy_to, "/var/www/beta.dosomething.org"
 
+set :deploy_env, "stage"
+
 role :app, %w{dosomething@staging}
 
 server 'staging', user: 'dosomething', roles: %w{app}


### PR DESCRIPTION
The symlinks for production aren't working properly after deployment because Capistrano doesn't automatically provide :stage as a variable.  This code will explicitly set and fetch the values for the deploy_env for production, qa, and staging.  The symlinking process is different for international.
