### PR TITLE
Migrate custom variables into dosomething_helpers_variables

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.install
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.install
@@ -62,3 +62,31 @@ function dosomething_helpers_update_7001() {
     db_create_table($tbl_name, $schema[$tbl_name]);
   }
 }
+
+/**
+ * Migrates alt_bf_fid, alt_color variables to the dosomething_helpers_variable table.
+ */
+function dosomething_helpers_update_7002() {
+  $variables = array('alt_bg_fid', 'alt_color');
+  foreach ($variables as $variable) {
+    // Grab all variable records:
+    $result = db_select('variable', 'v')
+      ->fields('v')
+      ->condition('name', '%' . $variable . '%', 'LIKE')
+      ->execute()
+      ->fetchAll();
+    // For each variable found:
+    foreach ($result as $record) {
+      $name = $record->name;
+      // Get the numeric nid from the variable name.
+      $nid = filter_var($name, FILTER_SANITIZE_NUMBER_INT);
+      // Store its value.
+      $value = variable_get($name);
+      // Save it to the dosomething_helpers_variable table for the node.
+      $node = node_load($nid);
+      dosomething_helpers_set_variable($node, $variable, $value);
+      // Delete the old variable.
+      variable_del($name);
+    }
+  }
+}

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -371,17 +371,6 @@ function dosomething_helpers_form_extras(&$form, &$form_state) {
   );
 
   if ($type == 'campaign') {
-
-    // Alt bg pattern variable.
-    $alt_bg_fid = $prefix . 'alt_bg_fid';
-    $form['custom']['styles'][$alt_bg_fid] = array(
-      '#type' => 'managed_file',
-      '#title' => t('Alt background pattern'),
-      '#default_value' => variable_get($alt_bg_fid),
-      //@todo: /campaigns/[nid] directory?
-      '#upload_location' => 'public://',
-    );
-
     $form['custom']['optins'] = array(
       '#type' => 'fieldset',
       '#title' => t('Third Party Opt-ins'),
@@ -389,7 +378,6 @@ function dosomething_helpers_form_extras(&$form, &$form_state) {
       '#collapsible' => TRUE,
       '#collapsed' => TRUE,
     );
-
     $form['custom']['optins']['mailchimp_grouping_id'] = array(
       '#type' => 'textfield',
       '#title' => t('MailChimp Grouping ID'),

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -195,10 +195,10 @@ function dosomething_helpers_preprocess_custom_vars(&$vars) {
     }
   }
   else {
-    // Get prefix to check for custom node styles variables.
-    $prefix = dosomething_helpers_get_custom_var_prefix($vars['type'], $vars['nid']);
-    // Check for custom alt color.
-    $alt_color = variable_get($prefix . 'alt_color', NULL);
+    $custom_vars = dosomething_helpers_get_variables($vars['nid']);
+     if ($custom_vars['alt_color']) {
+      $alt_color = $custom_vars['alt_color'];
+    }
   }
 
   if (isset($alt_color)) {

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -185,17 +185,28 @@ function dosomething_helpers_preprocess_hero_images(&$vars) {
  *   Node variables, passed from preprocess_node.
  */
 function dosomething_helpers_preprocess_custom_vars(&$vars) {
-  // Get prefix to check for custom node styles variables.
-  $prefix = dosomething_helpers_get_custom_var_prefix($vars['type'], $vars['nid']);
-  // Check for custom alt color.
-  $alt_color = variable_get($prefix . 'alt_color');
-  if (!empty($alt_color)) {
+  if ($vars['type'] == 'campaign') {
+    $campaign = $vars['campaign'];
+    if ($campaign->variables['alt_color']) {
+      $alt_color = $campaign->variables['alt_color'];
+    }
+    if ($campaign->variables['alt_bg_fid']) {
+      $fid = $campaign->variables['alt_bg_fid'];
+    }
+  }
+  else {
+    // Get prefix to check for custom node styles variables.
+    $prefix = dosomething_helpers_get_custom_var_prefix($vars['type'], $vars['nid']);
+    // Check for custom alt color.
+    $alt_color = variable_get($prefix . 'alt_color', NULL);
+  }
+
+  if (isset($alt_color)) {
     // Sanitize value for sanity's sake.
     $vars['alt_color'] = strip_tags($alt_color);
   }
   // Check for alt background File fid.
-  $fid = variable_get($prefix . 'alt_bg_fid');
-  if (!empty($fid)) {
+  if (isset($fid)) {
     $file = file_load($fid);
     $vars['alt_bg_src'] = file_create_url($file->uri);
   }


### PR DESCRIPTION
Issue description in #2726.  

Moves all the node specific `dosomething_campaign` and `dosomething_campaign_run` variables into the `dosomething_helpers_variable` for Alt Color and Alt BG Fid.
