### PR TITLE
Changing Campaign fields to markdown

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
@@ -1975,7 +1975,7 @@ function dosomething_campaign_field_default_field_instances() {
     'label' => 'Supporting Statement on the Solution',
     'required' => 0,
     'settings' => array(
-      'text_processing' => 0,
+      'text_processing' => 1,
       'user_register_form' => FALSE,
     ),
     'widget' => array(

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -82,7 +82,6 @@ function dosomething_campaign_load($node, $public = FALSE) {
   // Plain text fields.
   $fields_plain_text = array(
     'call_to_action',
-    'solution_support',
     'starter_statement_header',
   );
   foreach ($fields_plain_text as $property) {
@@ -95,6 +94,7 @@ function dosomething_campaign_load($node, $public = FALSE) {
     'items_needed',
     'promoting_tips',
     'solution_copy',
+    'solution_support',
     'starter_statement',
     'time_and_place',
     'vips',

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
@@ -77,7 +77,6 @@ features[field_group][] = group_do_it|node|campaign|form
 features[field_group][] = group_incentives|node|campaign|form
 features[field_group][] = group_know_it|node|campaign|form
 features[field_group][] = group_location_finder|node|campaign|form
-features[field_group][] = group_overrides|node|campaign|form
 features[field_group][] = group_partners|node|campaign|form
 features[field_group][] = group_prep_it|node|campaign|form
 features[field_group][] = group_report_back|node|campaign|form

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
@@ -62,27 +62,31 @@ function dosomething_campaign_update_7006() {
   $format = 'markdown';
 
   // Find all campaigns.
-  $result = db_select('node', 'n')
-    ->fields('n', array('nid'))
-    ->condition('type', 'campaign')
-    ->execute();
+  $query = db_select('node', 'n');
+  $query->addField('n', 'nid');
+  $query->condition('type', 'campaign');
+  $result = $query->execute();
 
   // Foreach campaign:
   foreach ($result as $record) {
     $nid = $record->nid;
+    $args = array(
+      '%nid' => $nid, 
+      '@format' => $format,
+    );
     $node = node_load($nid);
     $updated = FALSE;
     if (isset($node->field_post_step_copy[LANGUAGE_NONE])) {
       $node->field_post_step_copy[LANGUAGE_NONE][0]['format'] = $format;
       $updated = TRUE;
-      $msg = 'Nid ' . $nid . ' field_post_step_copy updated to ' . $format;
-      watchdog('dosomething_campaign', $msg);
+      $msg = 'Nid %nid field_post_step_copy updated to @format.';
+      watchdog('dosomething_campaign', $msg, $args);
     }
     if (isset($node->field_solution_support[LANGUAGE_NONE])) {
       $node->field_solution_support[LANGUAGE_NONE][0]['format'] = $format;
       $updated = TRUE;
-      $msg = 'Nid ' . $nid . ' field_solution_support updated to ' . $format;
-      watchdog('dosomething_campaign', $msg);
+      $msg = 'Nid %nid field_post_step_copy updated to @format.';
+      watchdog('dosomething_campaign', $msg, $args);
     }
     if ($updated) {
       node_save($node);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
@@ -54,3 +54,38 @@ function dosomething_campaign_update_7005(&$sandbox) {
   field_delete_field('field_variable_value');
   field_delete_field('field_variables');
 }
+
+/**
+ * Updates field_post_step_copy and field_solution_support values to markdown.
+ */
+function dosomething_campaign_update_7006() {
+  $format = 'markdown';
+
+  // Find all campaigns.
+  $result = db_select('node', 'n')
+    ->fields('n', array('nid'))
+    ->condition('type', 'campaign')
+    ->execute();
+
+  // Foreach campaign:
+  foreach ($result as $record) {
+    $nid = $record->nid;
+    $node = node_load($nid);
+    $updated = FALSE;
+    if (isset($node->field_post_step_copy[LANGUAGE_NONE])) {
+      $node->field_post_step_copy[LANGUAGE_NONE][0]['format'] = $format;
+      $updated = TRUE;
+      $msg = 'Nid ' . $nid . ' field_post_step_copy updated to ' . $format;
+      watchdog('dosomething_campaign', $msg);
+    }
+    if (isset($node->field_solution_support[LANGUAGE_NONE])) {
+      $node->field_solution_support[LANGUAGE_NONE][0]['format'] = $format;
+      $updated = TRUE;
+      $msg = 'Nid ' . $nid . ' field_solution_support updated to ' . $format;
+      watchdog('dosomething_campaign', $msg);
+    }
+    if ($updated) {
+      node_save($node);
+    }
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -66,7 +66,7 @@
               <?php endif; ?>
 
               <?php if (isset($campaign->solution_support)): ?>
-                <p><?php print $campaign->solution_support; ?></p>
+                <?php print $campaign->solution_support; ?>
               <?php endif; ?>
 
             <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -86,7 +86,7 @@
               <?php endif; ?>
 
               <?php if (isset($campaign->solution_support)): ?>
-                <p><?php print $campaign->solution_support; ?></p>
+                <?php print $campaign->solution_support; ?>
               <?php endif; ?>
 
             <?php endif; ?>


### PR DESCRIPTION
Changes the `text_processing` for `field_solution_support` to use filtered text.

Updates all current `field_solution_support` and `field_post_step_copy` values to use Markdown.

How to test:
- Pull this branch down
- Run `drush -y fr dosomething_campaign` to change the text format for Solution Support
- Run `drush updb` to bulk update the field values.
