### PR TITLE
SMS report back for #ImABoss

### DIFF
--- a/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.keywords.inc
+++ b/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.keywords.inc
@@ -9,3 +9,4 @@ $keywords['start-campaign-transition'] = 'dosomething_sms_start_campaign_transit
 $keywords['sms-game-paths'] = 'dosomething_sms_game_paths';
 $keywords['comeback-clothes-reportback'] = 'dosomething_sms_comeback_clothes_reportback';
 $keywords['thumbwars-reportback'] = 'dosomething_sms_thumbwars_reportback';
+$keywords['imaboss-reportback'] = 'dosomething_sms_imaboss_reportback';

--- a/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.workflows.inc
+++ b/lib/modules/dosomething/dosomething_sms/workflows/dosomething_sms.workflows.inc
@@ -193,3 +193,59 @@ $activity->name = 'end';
 $activity->inputs = array('submit_reportback');
 
 $workflows[$workflow->name] = $workflow;
+
+/**
+ * Report back for Fifth Harmony #ImABoss 2014.
+ */
+$workflow = new ConductorWorkflow();
+$workflow->wid = 'new';
+$workflow->name = 'dosomething_sms_imaboss_reportback';
+$workflow->title = 'Fifth Harmony #ImABoss 2014 Report Back';
+$workflow->api_version = '1.0';
+
+$activity = $workflow->newActivity('start');
+$activity->name = 'start';
+$activity->outputs = array('ask_picture');
+
+$activity = $workflow->newActivity('mms_prompt');
+$activity->name = 'ask_picture';
+$activity->inputs = array('start');
+$activity->outputs = array('ask_quantity');
+$activity->noMmsResponse = 168597;
+
+$activity = $workflow->newActivity('mobilecommons_opt_in_prompt');
+$activity->name = 'ask_quantity';
+$activity->inputs = array('ask_picture');
+$activity->outputs = array('ask_why_participated');
+$activity->optInPathId = 168599;
+
+$activity = $workflow->newActivity('mobilecommons_opt_in_prompt');
+$activity->name = 'ask_why_participated';
+$activity->inputs = array('ask_quantity');
+$activity->outputs = array('strip_signature');
+$activity->optInPathId = 168601;
+
+$activity = $workflow->newActivity('sms_strip_signature');
+$activity->name = 'strip_signature';
+$activity->inputs = array('ask_why_participated');
+$activity->outputs = array('submit_reportback');
+
+$activity = $workflow->newActivity('dosomething_sms_submit_reportback');
+$activity->name = 'submit_reportback';
+$activity->inputs = array('strip_signature');
+$activity->outputs = array('end');
+$activity->nid = 2401; // #ImABoss node id
+$activity->mmsContext = 'ask_picture:mms';
+$activity->propertyToContextMap = array(
+  'quantity' => 'ask_quantity:message',
+  'why_participated' => 'ask_why_participated:message',
+);
+$activity->optInPathId = 168589;
+$activity->optOutCampaignId = 126961;
+$activity->mobileCommonsCompletedCampaignId = 126963;
+
+$activity = $workflow->newActivity('end');
+$activity->name = 'end';
+$activity->inputs = array('submit_reportback');
+
+$workflows[$workflow->name] = $workflow;


### PR DESCRIPTION
Same deal as the report backs from before.

mData endpoint setup to POST to `dosomething.org/dosomething_sms/imaboss-reportback`. The only real thing to note is `$activity->nid = 2401;` which should be the #ImABoss node id.

Tested stepping through the SMS flow on my local by posting requests at the endpoint to mimic Mobile Commons requests.
