### PR TITLE
SMS Game Helpers variables

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -82,6 +82,8 @@ function dosomething_helpers_get_variable_names() {
     'alt_bg_fid',
     'alt_color',
     'alt_image_campaign_cover_nid',
+    'mobilecommons_opt_in_path',
+    'mobilecommons_friends_opt_in_path',
     'signup_form_submit_label',
   );
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -19,6 +19,9 @@ function dosomething_signup_opt_in_config_page() {
   return $output;
 }
 
+/**
+ * Form constructor for Signup opt-in configuration.
+ */
 function dosomething_signup_admin_config_form($form, &$form_state) {
   $form['header'] = array(
     '#prefix' => '<h3>',
@@ -40,13 +43,13 @@ function dosomething_signup_admin_config_form($form, &$form_state) {
         '#type' => 'textfield',
         '#title' => t('Mobile Commons Alpha Opt-In Path'),
         '#required' => TRUE,
-        '#default_value' => dosomething_signup_variable_get($nid, 'mobilecommons_opt_in_path'),
+        '#default_value' => dosomething_helpers_get_variable($nid, 'mobilecommons_opt_in_path'),
       );
       $form[$nid][$nid . '_beta'] = array(
         '#type' => 'textfield',
         '#title' => t('Mobile Commons Beta Opt-In Path'),
         '#required' => TRUE,
-        '#default_value' => dosomething_signup_variable_get($nid, 'mobilecommons_friends_opt_in_path'),
+        '#default_value' => dosomething_helpers_get_variable($nid, 'mobilecommons_friends_opt_in_path'),
       );
     }
   }
@@ -66,8 +69,13 @@ function dosomething_signup_admin_config_form_submit($form, &$form_state) {
   if ($sms_games) {
     foreach ($sms_games as $vars) {
       $nid = $vars['nid'];
-      dosomething_signup_variable_set($nid, 'mobilecommons_opt_in_path', $values[$nid . '_alpha']);
-      dosomething_signup_variable_set($nid, 'mobilecommons_friends_opt_in_path', $values[$nid . '_beta']);
+      $node = node_load($nid);
+      $alpha_name = 'mobilecommons_opt_in_path';
+      $alpha_value = $values[$nid . '_alpha'];
+      $beta_name = 'mobilecommons_friends_opt_in_path';
+      $beta_value = $values[$nid . '_beta'];
+      dosomething_helpers_set_variable($node, $alpha_name, $alpha_value);
+      dosomething_helpers_set_variable($node, $beta_name, $beta_value);
     }
   }
   drupal_set_message(t("Configuration saved."));

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -95,8 +95,9 @@ function dosomething_signup_presignup_form_submit($form, &$form_state) {
  */
 function dosomething_signup_friends_form($form, &$form_state, $node, $num_friends = 3) {
   $nid = $node->nid;
-  $opt_in_path = dosomething_signup_variable_get($nid, 'mobilecommons_opt_in_path');
-  $friends_opt_in_path = dosomething_signup_variable_get($nid, 'mobilecommons_friends_opt_in_path');
+  $vars = dosomething_helpers_get_variables($node->nid);
+  $opt_in_path = $vars['mobilecommons_opt_in_path'];
+  $friends_opt_in_path = $vars['mobilecommons_friends_opt_in_path'];
  
   $form['nid'] = array(
     '#type' => 'hidden',

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -360,7 +360,7 @@ function dosomething_signup_update_7009() {
  */
 function dosomething_signup_update_7010() {
   // List of variables to migrate.
-  $opt_in = 'mobilecommons_opt_in_path',
+  $opt_in = 'mobilecommons_opt_in_path';
   $opt_in_friends = 'mobilecommons_friends_opt_in_path';
   // Grab all variable records:
   $result = db_select('dosomething_signup_variable', 'v')

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -170,36 +170,6 @@ function dosomething_signup_schema() {
     ),
     'primary key' => array('nid'),
   );
-  $schema['dosomething_signup_variable'] = array(
-    'description' => 'Table of signup configuration variables.',
-    'fields' => array(
-      'entity_type' => array(
-        'description' => 'The entity type this data is attached to.',
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => TRUE,
-        'default' => '',
-      ),
-      'entity_id' => array(
-        'description' => 'The entity id this data is attached to.',
-        'type' => 'int',
-        'not null' => TRUE,
-        'default' => 0,
-      ),
-      'name' => array(
-        'description' => 'The name of the variable.',
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => FALSE,
-      ),
-      'value' => array(
-        'description' => 'The value of the variable.',
-        'type' => 'int',
-        'not null' => FALSE,
-      ),
-    ),
-    'primary key' => array('entity_type', 'entity_id', 'name'),
-  );
   $schema['dosomething_signup_presignup'] = array(
     'description' => 'Table of user pre-signups.',
     'fields' => array(
@@ -367,14 +337,8 @@ function dosomething_signup_update_7007() {
  * Adds the dosomething_signup_variable table.
  */
 function dosomething_signup_update_7008() {
-  $tbl_name = 'dosomething_signup_variable';
-  // Load schema to get table definition.
-  $schema = dosomething_signup_schema();
-  // If table not present:
-  if (!db_table_exists($tbl_name)) {
-    // Create it.
-    db_create_table($tbl_name, $schema[$tbl_name]);
-  }
+  // Table removed.
+  // @see dosomething_signup_update_7010().
 }
 
 /**
@@ -389,4 +353,34 @@ function dosomething_signup_update_7009() {
     // Create it.
     db_create_table($tbl_name, $schema[$tbl_name]);
   }
+}
+
+/**
+ * Migrates and destroys dosomething_signup_variable table.
+ */
+function dosomething_signup_update_7010() {
+  // List of variables to migrate.
+  $opt_in = 'mobilecommons_opt_in_path',
+  $opt_in_friends = 'mobilecommons_friends_opt_in_path';
+  // Grab all variable records:
+  $result = db_select('dosomething_signup_variable', 'v')
+    ->fields('v')
+    ->execute()
+    ->fetchAll();
+  // For each variable found:
+  foreach ($result as $record) {
+    $name = $record->name;
+    if ($name == $opt_in || $name == $opt_in_friends) {
+      db_insert('dosomething_helpers_variable')
+        ->fields(array(
+          'entity_type' => 'node',
+          'bundle' => 'campaign',
+          'entity_id' => $record->entity_id,
+          'name' => $record->name,
+          'value' => $record->value,
+        ))
+        ->execute();
+    }
+  }
+  db_drop_table('dosomething_signup_variable');
 }


### PR DESCRIPTION
Refs #2258 

Migrates the `dosomething_signup_variable` table (which is currently only used to store opt_in paths for SMS Games) to `dosomething_helpers_variable` stuff.

Updates the SMS Game form accordingly.
