### PR TITLE
Expose reportback fid after insert

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -437,18 +437,6 @@ function dosomething_reportback_set_field_values(&$entity, $values) {
 }
 
 /**
- * Implements hook_entity_insert().
- */
-function dosomething_reportback_entity_insert($entity, $type) {
-  if ($type == 'reportback') {
-    // Reload entity to grab the relevant node variables.
-    $reportback = reportback_load($entity->rbid);
-    // Pass it into mbp request.
-    dosomething_reportback_mbp_request($reportback);
-  }
-}
-
-/**
  * Returns the file destination for a new reportback file for given node $nid.
  *
  * @param string $filename
@@ -490,6 +478,10 @@ function dosomething_reportback_get_file_dest($name, $nid, $uid = NULL) {
  * Sends mbp request for a reportback.
  */
 function dosomething_reportback_mbp_request($entity) {
+  // This fid is the last file uploaded to the reportback.
+  // @see ReportbackEntity->save().
+  $inserted_fid = $entity->fid;
+
   if (module_exists('dosomething_user')) {
     $account = user_load($entity->uid);
     $params = array(

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -395,6 +395,10 @@ class ReportbackEntityController extends EntityAPIController {
     }
     // Log the write operation.
     $entity->insertLog($op);
+    // If this was an insert, send a Message Broker request.
+    if ($op == 'insert' && module_exists('dosomething_mbp')) {
+      dosomething_reportback_mbp_request($entity);
+    }
   }
 
   /**


### PR DESCRIPTION
The `ReportbackEntity->save()` adds the corresponding `dosomething_reportback_file` record after the entity is saved, in order to insert a record with the newly created `rbid`.  This is why the `hook_insert_entity` method was not finding any `fids` array when loading the reportback.

Unblocks #2718
cc @DeeZone @deadlybutter
