### PR TITLE
Salt: provision latest stable git. Fixes #1427.

### DIFF
--- a/provision/salt/roots/salt/utils.sls
+++ b/provision/salt/roots/salt/utils.sls
@@ -14,7 +14,13 @@ python-pip:
 
 git:
   pkg:
-    - installed
+    - latest
+
+git-repo:
+  pkgrepo.managed:
+    - ppa: git-core/ppa
+    - require_in:
+      - pkg: git
 
 vim:
   pkg:


### PR DESCRIPTION
- Add PPA to last stable git release by [“Ubuntu Git Maintainers” team](https://launchpad.net/~git-core/+archive/ppa?field.series_filter=precise).
- Setup git package to always upgrade to the latest version.

To upgrade your existing vagrant just run `vagrant provision`.
