### PR TITLE
Move third-party signup variables into DS Helpers variables

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -585,28 +585,28 @@ function dosomething_campaign_get_recommended_campaign_nids($tid = NULL, $uid = 
 }
 
 /**
- * Returns all staff pick campaigns.
+ * Returns all staff pick standard Campaigns.
  *
  * @return array
  *  Array of nids and titles of all published/unpublished staff picks.
  */
 function dosomething_campaign_get_staff_picks() {
- $query = db_select('node', 'n')
-    ->fields('n', array('nid', 'title'))
-    ->condition('type', 'campaign');
-  $query->innerJoin('field_data_field_staff_pick', 'sp', 'sp.entity_id = n.nid');
-  $query->condition('field_staff_pick_value' , 1);
-  $results = $query->execute();
-
-  foreach($results as $key => $result) {
-    $staff_picks[$key]['nid'] = $result->nid;
-    $staff_picks[$key]['title'] = $result->title;
+  $staff_picks = array();
+  $query = new EntityFieldQuery();
+  $query->entityCondition('entity_type', 'node')
+    ->entityCondition('bundle', 'campaign')
+    ->fieldCondition('field_staff_pick', 'value', 1, '=')
+    ->fieldCondition('field_campaign_type', 'value', 'sms_game', '!=');
+  $result = $query->execute();
+  if (isset($result['node'])) {
+    $campaign_nids = array_keys($result['node']);
+    $campaigns = entity_load('node', $campaign_nids);
   }
-  if ($staff_picks) {
-    return $staff_picks;
+  foreach ($campaigns as $key => $node) {
+    $staff_picks[$key]['nid'] = $node->nid;
+    $staff_picks[$key]['title'] = $node->title;
   }
-  // If no staff picks, return null.
-  return NULL;
+  return $staff_picks;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.install
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.install
@@ -124,8 +124,19 @@ function dosomething_helpers_update_7003() {
       dosomething_helpers_set_variable($node, $variable, $value);
       // Delete the old variable.
       variable_del($name);
-      // @todo: Delete unused 'mailchimp_id' variables.
-      // @see https://github.com/DoSomething/dosomething/issues/1476
     }
+  }
+  // Last, cleanup unused 'mailchimp_id' variables that were never deleted.
+  // @see https://github.com/DoSomething/dosomething/issues/1476
+  // Grab all mailchimp_id variables.
+  $result = db_select('variable', 'v')
+    ->fields('v')
+    ->condition('name', '%' . db_like('mailchimp_id'), 'LIKE')
+    ->execute()
+    ->fetchAll();
+  // For each variable found:
+  foreach ($result as $record) {
+    $name = $record->name;
+    variable_del($name);
   }
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.install
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.install
@@ -114,7 +114,7 @@ function dosomething_helpers_update_7003() {
       // Get the numeric nid from the variable name.
       $nid = filter_var($name, FILTER_SANITIZE_NUMBER_INT);
       // Store its value.
-      $value = variable_get($name);e.
+      $value = variable_get($name);
       $node = node_load($nid);
       if ($variable == 'mobilecommons_id') {
         // Rename to keep consistent with SMS Game variable.

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.install
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.install
@@ -72,7 +72,7 @@ function dosomething_helpers_update_7002() {
     // Grab all variable records:
     $result = db_select('variable', 'v')
       ->fields('v')
-      ->condition('name', '%' . $variable . '%', 'LIKE')
+      ->condition('name', '%' . db_like($variable), 'LIKE')
       ->execute()
       ->fetchAll();
     // For each variable found:
@@ -87,6 +87,44 @@ function dosomething_helpers_update_7002() {
       dosomething_helpers_set_variable($node, $variable, $value);
       // Delete the old variable.
       variable_del($name);
+    }
+  }
+}
+
+/**
+ * Migrates campaign opt-in variables to the dosomething_helpers_variable table.
+ */
+function dosomething_helpers_update_7003() {
+  // Suffix of variables to migrate from the variable table.
+  $variables = array(
+    'mailchimp_group_name',
+    'mailchimp_grouping_id',
+    'mobilecommons_id',
+  );
+  foreach ($variables as $variable) {
+    // Grab all variable records that match.
+    $result = db_select('variable', 'v')
+      ->fields('v')
+      ->condition('name', '%' . db_like($variable), 'LIKE')
+      ->execute()
+      ->fetchAll();
+    // For each variable found:
+    foreach ($result as $record) {
+      $name = $record->name;
+      // Get the numeric nid from the variable name.
+      $nid = filter_var($name, FILTER_SANITIZE_NUMBER_INT);
+      // Store its value.
+      $value = variable_get($name);e.
+      $node = node_load($nid);
+      if ($variable == 'mobilecommons_id') {
+        // Rename to keep consistent with SMS Game variable.
+        $variable = 'mobilecommons_opt_in_path';
+      }
+      // Save it to the dosomething_helpers_variable table.
+      dosomething_helpers_set_variable($node, $variable, $value);
+      // Delete the old variable.
+      variable_del($name);
+      //@todo: Delete unused 'mailchimp_id' variables.
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.install
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.install
@@ -124,7 +124,8 @@ function dosomething_helpers_update_7003() {
       dosomething_helpers_set_variable($node, $variable, $value);
       // Delete the old variable.
       variable_del($name);
-      //@todo: Delete unused 'mailchimp_id' variables.
+      // @todo: Delete unused 'mailchimp_id' variables.
+      // @see https://github.com/DoSomething/dosomething/issues/1476
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -23,6 +23,28 @@ function dosomething_signup_opt_in_config_page() {
  * Form constructor for Signup opt-in configuration.
  */
 function dosomething_signup_admin_config_form($form, &$form_state) {
+  $form['staff_picks'] = array(
+    '#prefix' => '<h3>',
+    '#markup' => 'Staff Picks',
+    '#suffix' => '</h3>',
+  );
+  // Each staff pick could have a special opt-in for third party communications.
+  $staff_picks = dosomething_campaign_get_staff_picks();
+  if ($staff_picks) {
+    foreach ($staff_picks as $vars) {
+      dosomething_signup_optin_config_form_add_elements($form, $vars);
+    }
+  }
+  $form['campaign_groups'] = array(
+    '#prefix' => '<h3>',
+    '#markup' => 'Campaign Groups',
+    '#suffix' => '</h3>',
+  );
+  if ($campaign_groups = dosomething_helpers_get_node_vars('campaign_group')) {
+    foreach ($campaign_groups as $vars) {
+      dosomething_signup_optin_config_form_add_elements($form, $vars);
+    }
+  }
   $form['header'] = array(
     '#prefix' => '<h3>',
     '#markup' => 'SMS Games',
@@ -65,6 +87,18 @@ function dosomething_signup_admin_config_form($form, &$form_state) {
  */
 function dosomething_signup_admin_config_form_submit($form, &$form_state) {
   $values = $form_state['values'];
+  $variables = dosomething_signup_get_admin_config_campaign_variables();
+  $staff_picks = dosomething_campaign_get_staff_picks();
+  if ($staff_picks) {
+    foreach ($staff_picks as $vars) {
+      $nid = $vars['nid'];
+      $node = node_load($nid);
+      foreach ($variables as $name => $description) {
+        $value = $values[$nid . '_' . $name];
+        dosomething_helpers_set_variable($node, $name, $value);
+      }
+    }
+  }
   $sms_games = dosomething_campaign_get_sms_games();
   if ($sms_games) {
     foreach ($sms_games as $vars) {
@@ -80,6 +114,7 @@ function dosomething_signup_admin_config_form_submit($form, &$form_state) {
   }
   drupal_set_message(t("Configuration saved."));
 }
+
 
 /**
  * Settings form third party opt-in ids.
@@ -99,28 +134,6 @@ function dosomething_signup_optin_config_form($form, &$form_state) {
     '#title' => t('Mobile Commons Campaigns Opt-In'),
     '#default_value' => variable_get('dosomething_mobilecommons_campaign_general'),
   );
-  $form['staff_picks'] = array(
-    '#prefix' => '<h3>',
-    '#markup' => 'Staff Picks',
-    '#suffix' => '</h3>',
-  );
-  // Each staff pick could have a special opt-in for third party communications.
-  $staff_picks = dosomething_campaign_get_staff_picks();
-  if ($staff_picks) {
-    foreach ($staff_picks as $vars) {
-      dosomething_signup_optin_config_form_add_elements($form, $vars);
-    }
-  }
-  $form['campaign_groups'] = array(
-    '#prefix' => '<h3>',
-    '#markup' => 'Campaign Groups',
-    '#suffix' => '</h3>',
-  );
-  if ($campaign_groups = dosomething_helpers_get_node_vars('campaign_group')) {
-    foreach ($campaign_groups as $vars) {
-      dosomething_signup_optin_config_form_add_elements($form, $vars);
-    }
-  }
   return system_settings_form($form);
 }
 
@@ -130,10 +143,7 @@ function dosomething_signup_optin_config_form($form, &$form_state) {
 function dosomething_signup_optin_config_form_add_elements(&$form, $vars) {
   $nid = $vars['nid'];
   $title = $vars['title'];
-  $prefix = 'dosomething_signup_nid_' . $nid;
-  $mailchimp_grouping_id = $prefix . '_mailchimp_grouping_id';
-  $mailchimp_group_name = $prefix . '_mailchimp_group_name';
-  $mobilecommons_id = $prefix . '_mobilecommons_id';
+  $variables = dosomething_signup_get_admin_config_campaign_variables();
 
   // Create a fieldset for each campaign.
   $form[$nid] = array(
@@ -142,24 +152,22 @@ function dosomething_signup_optin_config_form_add_elements(&$form, $vars) {
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
+  // Loop through each variable it can contain:
+  foreach ($variables as $name => $description) {
+    // Create a form element for it.
+    $form[$nid][$nid . '_' . $name] = array(
+      '#type' => 'textfield',
+      '#title' => $name,
+      '#default_value' => dosomething_helpers_get_variable($nid, $name),
+      '#description' => $description,
+    );
+  }
+}
 
-  // Each campaign gets a mailchimp grouping_id/group_name & mobilecommons id.
-  $form[$nid][$mailchimp_grouping_id] = array(
-    '#type' => 'textfield',
-    '#title' => t('MailChimp Grouping ID'),
-    '#default_value' => variable_get($mailchimp_grouping_id),
-    '#description' => t('The numeric Grouping ID that the Group Name belongs to.'),
-  );
-  $form[$nid][$mailchimp_group_name] = array(
-    '#type' => 'textfield',
-    '#title' => t('MailChimp Group Name'),
-    '#default_value' => variable_get($mailchimp_group_name),
-    '#description' => t('The alphanumeric Interest Group name.'),
-  );
-  $form[$nid][$mobilecommons_id] = array(
-    '#type' => 'textfield',
-    '#title' => t('Mobile Commons Opt-In Path'),
-    '#default_value' => variable_get($mobilecommons_id),
-    '#description' => t("The numeric Mobilecommons opt-in path."),
+function dosomething_signup_get_admin_config_campaign_variables() {
+  return array(
+    'mailchimp_grouping_id' => t('The numeric Grouping ID for the Group Name'),
+    'mailchimp_group_name' => t('The alphanumeric Interest Group Name'),
+    'mobilecommons_opt_in_path' => t('The numeric Mobilecommons opt-in path'),
   );
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -88,6 +88,8 @@ function dosomething_signup_admin_config_form($form, &$form_state) {
 function dosomething_signup_admin_config_form_submit($form, &$form_state) {
   $values = $form_state['values'];
   $variables = dosomething_signup_get_admin_config_campaign_variables();
+
+  // Save staff pick helpers variables.
   $staff_picks = dosomething_campaign_get_staff_picks();
   if ($staff_picks) {
     foreach ($staff_picks as $vars) {
@@ -99,6 +101,20 @@ function dosomething_signup_admin_config_form_submit($form, &$form_state) {
       }
     }
   }
+
+  // Save Campaign Group helpers variables.
+  if ($campaign_groups = dosomething_helpers_get_node_vars('campaign_group')) {
+    foreach ($campaign_groups as $vars) {
+      $nid = $vars['nid'];
+      $node = node_load($nid);
+      foreach ($variables as $name => $description) {
+        $value = $values[$nid . '_' . $name];
+        dosomething_helpers_set_variable($node, $name, $value);
+      }
+    }
+  }
+
+  // Save SMS Games helpers variables.
   $sms_games = dosomething_campaign_get_sms_games();
   if ($sms_games) {
     foreach ($sms_games as $vars) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -57,7 +57,7 @@ function dosomething_signup_admin_config_form($form, &$form_state) {
       // Create a fieldset for each SMS Game.
       $form[$nid] = array(
         '#type' => 'fieldset',
-        '#title' => $vars['title'] . ' : NID ' . $nid,
+        '#title' => $vars['title'] . ' | NID ' . $nid,
         '#collapsible' => TRUE,
         '#collapsed' => TRUE,
       );
@@ -164,7 +164,7 @@ function dosomething_signup_optin_config_form_add_elements(&$form, $vars) {
   // Create a fieldset for each campaign.
   $form[$nid] = array(
     '#type' => 'fieldset',
-    '#title' => $title . ' : NID ' . $nid,
+    '#title' => $title . ' | NID ' . $nid,
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
@@ -180,6 +180,12 @@ function dosomething_signup_optin_config_form_add_elements(&$form, $vars) {
   }
 }
 
+/**
+ * Returns list of helper variables that a standard Campaign can implement.
+ *
+ * @return array
+ *   Associative array keyed by variable name.
+ */
 function dosomething_signup_get_admin_config_campaign_variables() {
   return array(
     'mailchimp_grouping_id' => t('The numeric Grouping ID for the Group Name'),

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -489,12 +489,10 @@ function dosomething_signup_get_mbp_params_campaign_group(&$params, $node) {
  */
 function dosomething_signup_get_mbp_params_mailchimp(&$params, $node) {
   $nid = $node->nid;
-  $prefix = 'dosomething_signup_nid_' . $nid;
-  // Variable may be set as empty string, so set empty string as default.
-  $grouping_id = variable_get($prefix . '_mailchimp_grouping_id', '');
-  $group_name = variable_get($prefix . '_mailchimp_group_name', '');
+  $grouping_id = dosomething_helpers_get_variable($nid, 'mailchimp_grouping_id');
+  $group_name = dosomething_helpers_get_variable($nid, 'mailchimp_group_name');
   // If a value is present for Mailchimp groups:
-  if (!empty($grouping_id) || !empty($group_name)) {
+  if (isset($grouping_id) && isset($group_name)) {
     // Add it into the mbp_request params.
     $params['mailchimp_grouping_id'] = $grouping_id;
     $params['mailchimp_group_name'] = $group_name;

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -340,11 +340,15 @@ function dosomething_signup_entity_insert($entity, $type) {
  * Sends third-party subscription requests for given $account and $node.
  */
 function dosomething_signup_third_party_subscribe($account, $node) {
+  $var_name  = 'mobilecommons_opt_in_path';
   // Is there an override set on this campaign?
-  $opt_in_override = variable_get('dosomething_signup_nid_' . $node->nid . '_mobilecommons_id');
-  $opt_in_general = variable_get('dosomething_mobilecommons_campaign_general');
+  $opt_in = dosomething_helpers_get_variable($node->nid, $var_name);
+  // If not:
+  if (!$opt_in) {
+    // Use general opt_in_path.
+    $opt_in = variable_get('dosomething_mobilecommons_campaign_general');
+  }
   // Opt-in to mobilecommons.
-  $opt_in = isset($opt_in_override) ? $opt_in_override : $opt_in_general;
   dosomething_signup_mobilecommons_opt_in($account, $opt_in, $node->title);
   // Send message broker request.
   dosomething_signup_mbp_request($account, $node);


### PR DESCRIPTION
Closes #2258
- Migrate the existing `variable` records for Campaigns and Campaign Groups into corresponding `dosomething_helpers_variable` records
- Update `dosomething_signup_third_party_subscribe` and `dosomething_signup_get_mbp_params_mailchimp` to get values from `dosomething_helpers` variables
- Update admin form to get/set helpers variables
- Alter `dosomething_campaigns_get_staff_picks` to filter out SMS Games (defined by the `field_campaign_type` field
