### PR TITLE
Hotfix to get Fact pages back

### DIFF
--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.install
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.install
@@ -14,59 +14,29 @@ function dosomething_fact_page_update_7001(&$sandbox) {
 }
 
 /**
- * Imports existing field_facts data into the field_fact_collection field.
+ * Sets a variable to indicate that the fact_collections have not been imported yet.
  */
 function dosomething_fact_page_update_7002(&$sandbox) {
-  // Revert all Fact Page feature components to add field_fact_collection.
-  $feature = features_get_features('dosomething_fact_page');
-  $components = array_keys($feature->info['features']);
-  features_revert(array('dosomething_fact_page' => $components));
-
-  // Get all Fact Page node nid's.
-  $fact_pages = dosomething_helpers_get_node_vars('fact_page');
-  // If no Fact Page nodes:
-  if (empty($fact_pages)) {
-    // Nothing to do here, exit.
-    return;
-  }
-
-  // Loop through all fact page nodes.
-  foreach ($fact_pages as $fact_page) {
-
-    // Load the Fact Page node.
-    $node = node_load($fact_page['nid']);
-
-    // If no field_facts set:
-    if (!isset($node->field_facts[LANGUAGE_NONE][0])) {
-      // Skip to next $fact_page node.
-      continue;
-    }
-
-    // Loop through all field_facts values.
-    foreach ($node->field_facts[LANGUAGE_NONE] as $fact_node) {
-      $fact_nid = $fact_node['target_id'];
-      // Initialize a new field_fact_collection field_collection_item entity.
-      $fc_item = entity_create('field_collection_item', array(
-        'field_name' => 'field_fact_collection',
-      ));
-      // Set its host entity to our stored Fact Page $node.
-      $fc_item->setHostEntity('node', $node);
-      // Set the Fact entityreference to our stored $fact_nid.
-      $fc_item->field_fact[LANGUAGE_NONE][0]['target_id'] = $fact_nid;
-      $fc_item->save();
-    }
-
-    // Save the parent Fact Page $node.
-    node_save($node);
-
-  }
+  variable_set('dosomething_fact_page_fact_collection_imported', FALSE);
 }
 
 /**
  * Removes field_facts from Fact Page content type.
+ *
+ * To be run once features have been reverted and field_fact_collection exists.
  */
-function dosomething_fact_page_update_7003(&$sandbox) {
-  if ($instance = field_info_instance('node', 'field_facts', 'fact_page')) {
-    field_delete_instance($instance);
-  }
-}
+// function dosomething_fact_page_update_7003(&$sandbox) {
+//   $is_imported = variable_get('dosomething_fact_page_fact_collection_imported');
+//   $import_status = FALSE;
+//   if ($is_imported == FALSE) {
+//     $import_status = dosomething_fact_page_import_fact_collections();
+//   }
+//   // If the import was successful, drop the field_facts:
+//   if ($import_status) {
+//     // If field_facts exists on the fact_page node:
+//     if ($instance = field_info_instance('node', 'field_facts', 'fact_page')) {
+//       // Remove it.
+//       field_delete_instance($instance);
+//     }
+//   }
+// }

--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
@@ -95,7 +95,19 @@ function dosomething_fact_page_preprocess_node(&$vars) {
       }
     }
 
-    $values = dosomething_fact_page_get_fact_collection_vars($vars['node']);
+    // @todo: Remove this conditional once fact_collection has been imported.
+    // If the fact collections have been imported:
+    if (variable_get('dosomething_fact_page_fact_collection_imported') == TRUE) {
+      // Get values from field_fact_collection.
+      $values = dosomething_fact_page_get_fact_collection_vars($vars['node']);
+    }
+    // Else if not imported yet:
+    else {
+      $node = entity_metadata_wrapper('node', $vars['node']);
+      // Get values from the field_facts field.
+      $values = dosomething_fact_get_fact_field_vars($node->field_facts);
+    }
+
     $vars['facts'] = $values['facts'];
     $vars['sources'] = $values['sources'];
   }
@@ -213,4 +225,65 @@ function dosomething_fact_page_get_fact_page_list_links() {
     return $results;
   }
   return NULL;
+}
+
+/**
+ * Imports values from field_facts into field_fact_collection foreach Fact Page.
+ *
+ * This is a one-time script that needs to be run once the field_fact_collection
+ * has been added to the content type via features-revert.
+ */
+function dosomething_fact_page_import_fact_collections() {
+  // If the fact collections have been imported already:
+  if (variable_get('dosomething_fact_page_fact_collection_imported') == TRUE) {
+    // Don't do anything.
+    return;
+  }
+
+  // Get all Fact Page node nid's.
+  $fact_pages = dosomething_helpers_get_node_vars('fact_page');
+  // If no Fact Page nodes:
+  if (empty($fact_pages)) {
+    // Nothing to do here, exit.
+    return;
+  }
+
+  // Loop through all fact page nodes.
+  foreach ($fact_pages as $fact_page) {
+
+    // Load the Fact Page node.
+    $node = node_load($fact_page['nid']);
+
+    // If a field_fact_collection doesn't exist, this will fail.
+    if (!isset($node->field_fact_collection)) {
+      return FALSE;
+    }
+
+    // If no field_facts set:
+    if (!isset($node->field_facts[LANGUAGE_NONE][0])) {
+      // Skip to next $fact_page node.
+      continue;
+    }
+
+    // Loop through all field_facts values.
+    foreach ($node->field_facts[LANGUAGE_NONE] as $fact_node) {
+      $fact_nid = $fact_node['target_id'];
+      // Initialize a new field_fact_collection field_collection_item entity.
+      $fc_item = entity_create('field_collection_item', array(
+        'field_name' => 'field_fact_collection',
+      ));
+      // Set its host entity to our stored Fact Page $node.
+      $fc_item->setHostEntity('node', $node);
+      // Set the Fact entityreference to our stored $fact_nid.
+      $fc_item->field_fact[LANGUAGE_NONE][0]['target_id'] = $fact_nid;
+      $fc_item->save();
+    }
+
+    // Save the parent Fact Page $node.
+    node_save($node);
+
+  }
+  // Indicate that the fact_collections have been imported.
+  variable_set('dosomething_fact_page_fact_collection_imported', TRUE);
+  return variable_get('dosomething_fact_page_fact_collection_imported');
 }


### PR DESCRIPTION
PR #2789 seems to have failed because `dosomething_fact_page_update_7002` did not properly revert the `dosomething_fact_page` feature, which adds the `field_fact_collection` that we're attempting to import the `field_facts` data into.

not sure why it worked locally for me and @sergii-tkachenko but i'd rather not chance it on the prod site.

Instead of trying to do it all the field-adding and importing in one shot, this PR sets a `dosomething_fact_page_fact_collection_imported` to `FALSE` to indicate that the fact collections have not been imported, and to use the existing field fact values.

Comments out `dosomething_fact_page_update_7003` because that's the code we'll need once features are reverted and the field collection is added, in order to finally close out #2674 for good.
