### PR TITLE
Remove deprecated Fact Page import variables and functions

### DIFF
--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.install
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.install
@@ -29,7 +29,9 @@ function dosomething_fact_page_update_7003(&$sandbox) {
   $is_imported = variable_get('dosomething_fact_page_fact_collection_imported');
   $import_status = FALSE;
   if ($is_imported == FALSE) {
-    $import_status = dosomething_fact_page_import_fact_collections();
+    // This function has been removed from the codebase.
+    // @see https://github.com/DoSomething/dosomething/pull/2797.
+    // $import_status = dosomething_fact_page_import_fact_collections();
   }
   // If the import was successful, drop the field_facts:
   if ($import_status) {
@@ -39,4 +41,11 @@ function dosomething_fact_page_update_7003(&$sandbox) {
       field_delete_instance($instance);
     }
   }
+}
+
+/**
+ * Deletes deprecated variable used for importing field_fact_collection values.
+ */
+function dosomething_fact_page_update_7004() {
+  variable_del('dosomething_fact_page_fact_collection_imported');
 }

--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
@@ -95,19 +95,7 @@ function dosomething_fact_page_preprocess_node(&$vars) {
       }
     }
 
-    // @todo: Remove this conditional once fact_collection has been imported.
-    // If the fact collections have been imported:
-    if (variable_get('dosomething_fact_page_fact_collection_imported') == TRUE) {
-      // Get values from field_fact_collection.
-      $values = dosomething_fact_page_get_fact_collection_vars($vars['node']);
-    }
-    // Else if not imported yet:
-    else {
-      $node = entity_metadata_wrapper('node', $vars['node']);
-      // Get values from the field_facts field.
-      $values = dosomething_fact_get_fact_field_vars($node->field_facts);
-    }
-
+    $values = dosomething_fact_page_get_fact_collection_vars($vars['node']);
     $vars['facts'] = $values['facts'];
     $vars['sources'] = $values['sources'];
   }
@@ -225,65 +213,4 @@ function dosomething_fact_page_get_fact_page_list_links() {
     return $results;
   }
   return NULL;
-}
-
-/**
- * Imports values from field_facts into field_fact_collection foreach Fact Page.
- *
- * This is a one-time script that needs to be run once the field_fact_collection
- * has been added to the content type via features-revert.
- */
-function dosomething_fact_page_import_fact_collections() {
-  // If the fact collections have been imported already:
-  if (variable_get('dosomething_fact_page_fact_collection_imported') == TRUE) {
-    // Don't do anything.
-    return;
-  }
-
-  // Get all Fact Page node nid's.
-  $fact_pages = dosomething_helpers_get_node_vars('fact_page');
-  // If no Fact Page nodes:
-  if (empty($fact_pages)) {
-    // Nothing to do here, exit.
-    return;
-  }
-
-  // Loop through all fact page nodes.
-  foreach ($fact_pages as $fact_page) {
-
-    // Load the Fact Page node.
-    $node = node_load($fact_page['nid']);
-
-    // If a field_fact_collection doesn't exist, this will fail.
-    if (!isset($node->field_fact_collection)) {
-      return FALSE;
-    }
-
-    // If no field_facts set:
-    if (!isset($node->field_facts[LANGUAGE_NONE][0])) {
-      // Skip to next $fact_page node.
-      continue;
-    }
-
-    // Loop through all field_facts values.
-    foreach ($node->field_facts[LANGUAGE_NONE] as $fact_node) {
-      $fact_nid = $fact_node['target_id'];
-      // Initialize a new field_fact_collection field_collection_item entity.
-      $fc_item = entity_create('field_collection_item', array(
-        'field_name' => 'field_fact_collection',
-      ));
-      // Set its host entity to our stored Fact Page $node.
-      $fc_item->setHostEntity('node', $node);
-      // Set the Fact entityreference to our stored $fact_nid.
-      $fc_item->field_fact[LANGUAGE_NONE][0]['target_id'] = $fact_nid;
-      $fc_item->save();
-    }
-
-    // Save the parent Fact Page $node.
-    node_save($node);
-
-  }
-  // Indicate that the fact_collections have been imported.
-  variable_set('dosomething_fact_page_fact_collection_imported', TRUE);
-  return variable_get('dosomething_fact_page_fact_collection_imported');
 }


### PR DESCRIPTION
@sergii-tkachenko Can you please review?

Refs #2674 and #2797

Now that the `field_facts` data has been imported into `field_fact_collection` and has been removed from the Fact Page content type, this PR gets rid of all the code we don't need anymore (and don't want lingering around as a function which someone could potentially call)
