### PR TITLE
Zendesk Form variables

### DIFF
--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
@@ -45,6 +45,26 @@ function dosomething_zendesk_config_form($form, &$form_state)  {
     '#description' => t('Do not share this token publicly.'),
     '#default_value' => variable_get('dosomething_zendesk_token', ''),
   );
+  $form['copy'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Form copy'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['copy']['dosomething_zendesk_form_header'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Form Header'),
+    '#description' => t("Copy displayed in the form header."),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_zendesk_form_header'),
+  );
+  $form['copy']['dosomething_zendesk_form_body_label'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Textarea Label'),
+    '#description' => t("Label displayed above the textarea."),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_zendesk_form_body_label'),
+  );
   return system_settings_form($form);
 }
 

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.install
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.install
@@ -32,3 +32,12 @@ function dosomething_zendesk_update_7001(&$sandbox) {
     }
   }
 }
+
+/**
+ * Populates Zendesk form variables.
+ */
+function dosomething_zendesk_update_7002(&$sandbox) {
+  $copy = "Enter your question below. Please be as specific as possible. If you are having a technical issue, please make sure to provide detailed steps (click by click) on how you encountered the problem, so our developers can re-create the issue.";
+  variable_set('dosomething_zendesk_form_header', $copy);
+  variable_set('dosomething_zendesk_form_body_label', "Your Question");
+}

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -138,7 +138,7 @@ function dosomething_zendesk_form($form, &$form_state, $node = NULL)  {
   $form['body'] = array(
     '#type' => 'textarea',
     '#required' => TRUE,
-    '#title' => t('Your Question'),
+    '#title' => t(variable_get('dosomething_zendesk_form_body_label')),
   );
   $form['submit'] = array(
     '#type' => 'submit',

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -143,14 +143,30 @@ function paraneue_dosomething_preprocess_node(&$vars) {
   /**
    * Info Bar
    */
+
+  // Initialize info_bar_vars with variable that will always be set:
   $zendesk_form_header = t(variable_get('dosomething_zendesk_form_header'));
   $info_bar_vars = array(
-    'zendesk_form'       => $vars['zendesk_form'],
     'zendesk_form_header' => $zendesk_form_header,
-    'sponsors'           => $vars['sponsors'],
-    'formatted_partners' => $vars['formatted_partners'],
   );
-
+  // List $vars variable names to pass to info bar:
+  $info_var_names = array(
+    'formatted_partners',
+    'sponsors',
+    'zendesk_form',
+  );
+  // Loop through the variable names:
+  foreach ($info_var_names as $variable) {
+    // If the vars is set for this variable name:
+    if (isset($vars[$variable])) {
+      // Store its value.
+      $value = $vars[$variable];
+    }
+    else {
+      $value = NULL;
+    }
+    $info_bar_vars[$variable] = $value;
+  }
   $vars['info_bar'] = theme('info_bar', $info_bar_vars);
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -157,15 +157,12 @@ function paraneue_dosomething_preprocess_node(&$vars) {
   );
   // Loop through the variable names:
   foreach ($info_var_names as $variable) {
+    $info_bar_vars[$variable] = NULL;
     // If the vars is set for this variable name:
     if (isset($vars[$variable])) {
       // Store its value.
-      $value = $vars[$variable];
+      $info_bar_vars[$variable] = $vars[$variable];
     }
-    else {
-      $value = NULL;
-    }
-    $info_bar_vars[$variable] = $value;
   }
   $vars['info_bar'] = theme('info_bar', $info_bar_vars);
 }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -143,9 +143,10 @@ function paraneue_dosomething_preprocess_node(&$vars) {
   /**
    * Info Bar
    */
-
+  $zendesk_form_header = t(variable_get('dosomething_zendesk_form_header'));
   $info_bar_vars = array(
     'zendesk_form'       => $vars['zendesk_form'],
+    'zendesk_form_header' => $zendesk_form_header,
     'sponsors'           => $vars['sponsors'],
     'formatted_partners' => $vars['formatted_partners'],
   );

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
@@ -14,7 +14,7 @@
       Questions? <a href="#" data-modal-href="#modal-contact-form">Contact Us</a>
       <div data-modal id="modal-contact-form" class="modal--contact" role="dialog">
         <h2 class="banner">Contact Us</h2>
-        <p>Enter your question below. Please be as specific as possible.</p>
+        <p><?php print $zendesk_form_header; ?></p>
         <?php print render($zendesk_form); ?>
       </div>
     </div>


### PR DESCRIPTION
Stores the Form's' header and label text values as variables.

Also fixes lots of undefined errors for campaigns and/or nodes that do not have the `$vars` set.  cough, @weerd 
## Screenshots

![zendesk_form](https://cloud.githubusercontent.com/assets/1236811/3574222/aac1054a-0b7b-11e4-9c82-0d5dc783689c.png)

![zendesk_admin](https://cloud.githubusercontent.com/assets/1236811/3574216/a3bd0136-0b7b-11e4-9b5a-7b4eb5311029.png)
