### PR TITLE
Remove SMS Game required check on Signup Admin Config Form

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -63,13 +63,11 @@ function dosomething_signup_admin_config_form($form, &$form_state) {
       $form[$nid][$nid . '_alpha'] = array(
         '#type' => 'textfield',
         '#title' => t('Mobile Commons Alpha Opt-In Path'),
-        '#required' => TRUE,
         '#default_value' => dosomething_helpers_get_variable($nid, 'mobilecommons_opt_in_path'),
       );
       $form[$nid][$nid . '_beta'] = array(
         '#type' => 'textfield',
         '#title' => t('Mobile Commons Beta Opt-In Path'),
-        '#required' => TRUE,
         '#default_value' => dosomething_helpers_get_variable($nid, 'mobilecommons_friends_opt_in_path'),
       );
     }


### PR DESCRIPTION
Per request in #2792 - removes the mandatory check for SMS Games' alpha/beta opt-ins.

The form will display the warning message if they are not set, as this is done within `dosomething_signup_friends_form`
