### PR TITLE
I18N: add nid autocomplete to about us page link setting.

### DIFF
--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -29,6 +29,7 @@ dependencies[] = ctools
 dependencies[] = date
 dependencies[] = diff
 dependencies[] = entity
+dependencies[] = entity_autocomplete
 dependencies[] = entityconnect
 dependencies[] = entityreference
 dependencies[] = features

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -43,6 +43,10 @@ projects[diff][subdir] = "contrib"
 projects[entity][version] = "1.5"
 projects[entity][subdir] = "contrib"
 
+; Entity Autocomplete
+projects[entity_autocomplete][version] = "1.0-beta3"
+projects[entity_autocomplete][subdir] = "contrib"
+
 ; Entity Connect
 projects[entityconnect][version] = "1.0-rc1"
 projects[entityconnect][subdir] = "contrib"

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -71,14 +71,17 @@ function _paraneue_dosomething_theme_settings_header(&$form, $form_state) {
     '#collapsible' => TRUE,
     '#collapsed'   => TRUE,
   );
-  $form['header']['who_we_are']['header_who_we_are_text'] = array(
+
+  $form_who_we_are = &$form['header']['who_we_are'];
+  $form_who_we_are['header_who_we_are_text'] = array(
     '#type'          => 'textfield',
     '#title'         => 'Text',
     '#default_value' => theme_get_setting('header_who_we_are_text'),
   );
   $form['header']['who_we_are']['header_who_we_are_link'] = array(
-    '#type'          => 'textfield',
-    '#title'         => 'Link to Page',
+    '#type'          => 'entity_autocomplete',
+    '#title'         => 'Link to',
+    '#bundles'       => array('static_content'),
     '#default_value' => theme_get_setting('header_who_we_are_link'),
   );
 }


### PR DESCRIPTION
#### What's this PR do?

Adds [Entity Autocomplete](https://www.drupal.org/project/entity_autocomplete) (2,362 sites using this module / 17,851 downloads) functionality to selecting a link for 'about us' page.
##### Current UI

![image](https://cloud.githubusercontent.com/assets/672669/3544748/3d64704e-0870-11e4-9382-f7e78d9576b2.png)
##### Using Entity Autocomplete

It is already limited to Static Content pages only:
![image](https://cloud.githubusercontent.com/assets/672669/3544617/bf8bd96a-086e-11e4-840c-09a653fc068c.png)
Field with selected node:
![image](https://cloud.githubusercontent.com/assets/672669/3544840/191e515e-0871-11e4-8d83-9e2de7114676.png)
#### How should this be manually tested?
- Open http://localhost:8888/admin/appearance/settings/paraneue_dosomething
- Start typing into Header → Who We Are? → Link to page
#### What are the relevant tickets?

[DOS-12](https://jira.dosomething.org/browse/DOS-12)
