### PR TITLE
Metatag defaults for abstract/description

### DIFF
--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.features.metatag.inc
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.features.metatag.inc
@@ -18,10 +18,10 @@ function dosomething_metatag_metatag_export_default() {
         'value' => '[current-page:title] | [site:name]',
       ),
       'description' => array(
-        'value' => '',
+        'value' => 'America\'s largest organization for youth volunteering opportunities, with 2,500,000 members and counting.',
       ),
       'abstract' => array(
-        'value' => '',
+        'value' => 'America\'s largest organization for youth volunteering opportunities, with 2,500,000 members and counting.',
       ),
       'keywords' => array(
         'value' => '',
@@ -73,6 +73,99 @@ function dosomething_metatag_metatag_export_default() {
       'revisit-after' => array(
         'value' => '',
         'period' => '',
+      ),
+      'twitter:card' => array(
+        'value' => '',
+      ),
+      'twitter:site' => array(
+        'value' => '',
+      ),
+      'twitter:site:id' => array(
+        'value' => '',
+      ),
+      'twitter:creator' => array(
+        'value' => '',
+      ),
+      'twitter:creator:id' => array(
+        'value' => '',
+      ),
+      'twitter:url' => array(
+        'value' => '',
+      ),
+      'twitter:title' => array(
+        'value' => '',
+      ),
+      'twitter:description' => array(
+        'value' => '',
+      ),
+      'twitter:image' => array(
+        'value' => '',
+      ),
+      'twitter:image:width' => array(
+        'value' => '',
+      ),
+      'twitter:image:height' => array(
+        'value' => '',
+      ),
+      'twitter:image0' => array(
+        'value' => '',
+      ),
+      'twitter:image1' => array(
+        'value' => '',
+      ),
+      'twitter:image2' => array(
+        'value' => '',
+      ),
+      'twitter:image3' => array(
+        'value' => '',
+      ),
+      'twitter:player' => array(
+        'value' => '',
+      ),
+      'twitter:player:width' => array(
+        'value' => '',
+      ),
+      'twitter:player:height' => array(
+        'value' => '',
+      ),
+      'twitter:player:stream' => array(
+        'value' => '',
+      ),
+      'twitter:player:stream:content_type' => array(
+        'value' => '',
+      ),
+      'twitter:app:id:iphone' => array(
+        'value' => '',
+      ),
+      'twitter:app:id:ipad' => array(
+        'value' => '',
+      ),
+      'twitter:app:id:googleplay' => array(
+        'value' => '',
+      ),
+      'twitter:app:url:iphone' => array(
+        'value' => '',
+      ),
+      'twitter:app:url:ipad' => array(
+        'value' => '',
+      ),
+      'twitter:app:country' => array(
+        'value' => '',
+      ),
+      'twitter:app:url:googleplay' => array(
+        'value' => '',
+      ),
+      'twitter:label1' => array(
+        'value' => '',
+      ),
+      'twitter:data1' => array(
+        'value' => '',
+      ),
+      'twitter:label2' => array(
+        'value' => '',
+      ),
+      'twitter:data2' => array(
+        'value' => '',
       ),
     ),
   );


### PR DESCRIPTION
Setting the abstract/description in the homepage node is not setting the metatags when viewing the homepage. Didn't realize that this stuff was being reverted upon every deployment when I marked https://github.com/DoSomething/dosomething/issues/2343#issuecomment-47233342 as done.

I think we added Twitter Cards module after we initially created this module, hence all the new exportables.
