### PR TITLE
Intl: Allow overriding header logo.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -34,10 +34,17 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     $modifier_classes = 'black floating';
   }
 
+  $logo = NEUE_ASSET_PATH . '/assets/images/ds-logo.png';
+  if (theme_get_setting('header_logo_override')) {
+    $file = file_load(theme_get_setting('header_logo_override'));
+    if (!empty($file->uri)) {
+      $logo = file_create_url($file->uri);
+    }
+  }
   $navigation_vars = array(
     'base_path'        => $vars['base_path'],
     'modifier_classes' => $modifier_classes,
-    'logo'             => NEUE_ASSET_PATH . '/assets/images/ds-logo.png',
+    'logo'             => $logo,
     'front_page'       => $vars['front_page'],
     'logged_in'        => $vars['logged_in'],
     'search_box'       => $vars['search_box'],

--- a/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
+++ b/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
@@ -5,7 +5,6 @@ engine = phptemplate
 core = 7.x
 php = 5.2
 
-features[] = logo
 features[] = favicon
 features[] = name
 features[] = slogan

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -65,6 +65,23 @@ function _paraneue_dosomething_theme_settings_header(&$form, $form_state) {
     '#title' => t('Header'),
   );
 
+  $form['header']['logo'] = array(
+    '#type'        => 'fieldset',
+    '#title'       => t('Logo Override'),
+    '#collapsible' => TRUE,
+    '#collapsed'   => TRUE,
+  );
+  $form_logo = &$form['header']['logo'];
+  $form_logo['header_logo_override'] = array(
+    '#type'              => 'managed_file',
+    '#title'             => t('File'),
+    '#upload_location'   => file_default_scheme() . '://theme/',
+    '#default_value'     => theme_get_setting('header_logo_override'),
+    '#upload_validators' => array(
+      'file_validate_extensions' => array('png'),
+    ),
+  );
+
   $form['header']['who_we_are'] = array(
     '#type'        => 'fieldset',
     '#title'       => t('Who We Are?'),


### PR DESCRIPTION
#### What's this PR do?

Adds an option to override header logo.
![image](https://cloud.githubusercontent.com/assets/672669/3577491/3176538a-0b9d-11e4-971f-4bd85f6a2d8e.png)
#### How should this be manually tested?
- Open paraneue_dosomething [theme settings](http://localhost:8888/admin/appearance/settings/paraneue_dosomething)
- Upload a png to LOGO OVERRIDE → File, save form.
  Logo examples can be found [here](https://jira.dosomething.org/browse/DOS-11)
- Open frontpage and see the logo changed
- Open theme settings, click Remove on the left of LOGO OVERRIDE → File
- Open frontpage and make sure it's default logo
#### What are the relevant tickets?

Fixes [#DOS-11](https://jira.dosomething.org/browse/DOS-11)
