### PR TITLE
Metatag tweaks

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -141,22 +141,6 @@ function dosomething_helpers_add_entityref_links(&$node, $fields) {
 }
 
 /**
- * Implements hook_preprocess_html().
- */
-function dosomething_helpers_preprocess_html(&$vars) {
-  $dmoz_meta_tag = array(
-    '#type' => 'html_tag',
-    '#tag' => 'meta',
-    '#attributes' => array(
-      'name' => 'robots',
-      'content' => 'NOODP'
-    )
-  );
-
-  drupal_add_html_head($dmoz_meta_tag, 'dmoz_meta_tag');
-}
-
-/**
  * Returns array of values of a field collection field.
  *
  * @param object $wrapper

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -7,7 +7,7 @@
 /**
  * Implements hook_preprocess_html().
  */
-function dosomething_helpers_preprocess_html(&$vars) {
+function dosomething_metatag_preprocess_html(&$vars) {
   // Prevent search engines from using DMOZ site descriptions.
   $dmoz_meta_tag = array(
     '#type' => 'html_tag',
@@ -18,6 +18,16 @@ function dosomething_helpers_preprocess_html(&$vars) {
     )
   );
   drupal_add_html_head($dmoz_meta_tag, 'dmoz_meta_tag');
+  // Verifies DS Pinterest account.
+  $pinterest_verify_tag = array(
+    '#type' => 'html_tag',
+    '#tag' => 'meta',
+    '#attributes' => array(
+      'name' => 'p:domain_verify',
+      'content' => '14e81c42e6c4ff0ca4ec7be173a4799f'
+    )
+  );
+  drupal_add_html_head($pinterest_verify_tag, 'pinterest_verify_tag');
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -5,6 +5,22 @@
  */
 
 /**
+ * Implements hook_preprocess_html().
+ */
+function dosomething_helpers_preprocess_html(&$vars) {
+  // Prevent search engines from using DMOZ site descriptions.
+  $dmoz_meta_tag = array(
+    '#type' => 'html_tag',
+    '#tag' => 'meta',
+    '#attributes' => array(
+      'name' => 'robots',
+      'content' => 'NOODP'
+    )
+  );
+  drupal_add_html_head($dmoz_meta_tag, 'dmoz_meta_tag');
+}
+
+/**
  * Implements hook_node_view().
  */
 function dosomething_metatag_node_view($node, $view_mode, $langcode) {


### PR DESCRIPTION
- Moves DMOZ tag into `dosomething_metags` instead of `dosomething_helpers`
- Adds a new tag to get our DoSomething Pinterest account verified
