### PR TITLE
Drush command to create campaigns from JSON

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.drush.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.drush.inc
@@ -7,7 +7,10 @@ function dosomething_campaign_drush_command() {
   $items = array();
   // Name of the drush command.
   $items['create-campaign'] = array(
-    'description' => 'Creates a campaign node',
+    'description' => 'Creates a campaign node from given JSON file.',
+    'arguments' => array(
+      'filename' => 'Name of the file to read.'
+    ),
     'callback' => 'dosomething_campaign_drush_create_campaign',
   );
   return $items;
@@ -16,6 +19,13 @@ function dosomething_campaign_drush_command() {
 /**
  * Callback for create-campaign command.
  */
-function dosomething_campaign_drush_create_campaign() {
-  return "Hey there";
+function dosomething_campaign_drush_create_campaign($filename) {
+  if ($string = file_get_contents($filename)) {
+    $node = dosomething_campaign_create_node_from_json($string);
+    $message = "Created node nid " . $node->nid . ".";
+    return $message;
+  }
+  else {
+    return "Invalid filename.";
+  }
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.drush.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.drush.inc
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Implementation of hook_drush_command().
+ */
+function dosomething_campaign_drush_command() {
+  $items = array();
+  // Name of the drush command.
+  $items['create-campaign'] = array(
+    'description' => 'Creates a campaign node',
+    'callback' => 'dosomething_campaign_drush_create_campaign',
+  );
+  return $items;
+}
+
+/**
+ * Callback for create-campaign command.
+ */
+function dosomething_campaign_drush_create_campaign() {
+  return "Hey there";
+}

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.drush.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.drush.inc
@@ -6,20 +6,24 @@
 function dosomething_campaign_drush_command() {
   $items = array();
   // Name of the drush command.
-  $items['create-campaign'] = array(
+  $items['campaign-create'] = array(
     'description' => 'Creates a campaign node from given JSON file.',
     'arguments' => array(
-      'filename' => 'Name of the file to read.'
+      'filename' => 'Name of the JSON file to read.',
     ),
-    'callback' => 'dosomething_campaign_drush_create_campaign',
+    'required-arguments' => TRUE,
+    'callback' => 'dosomething_campaign_drush_campaign_create',
+    'examples' => array(
+      'drush campaign-create ../tests/campaign/campaign.json' => 'Creates a campaign node from contents of campaign.json.',
+    ),
   );
   return $items;
 }
 
 /**
- * Callback for create-campaign command.
+ * Callback for campaign-create command.
  */
-function dosomething_campaign_drush_create_campaign($filename) {
+function dosomething_campaign_drush_campaign_create($filename) {
   if ($string = file_get_contents($filename)) {
     $node = dosomething_campaign_create_node_from_json($string);
     $message = "Created node nid " . $node->nid . ".";

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -210,6 +210,38 @@ function dosomething_campaign_load($node, $public = FALSE) {
 }
 
 /**
+ * Creates and returns a campaign node from given JSON string.
+ */
+function dosomething_campaign_create_node_from_json($string) {
+  $data = json_decode($string);
+  $node = new stdClass();
+  $node->type = 'campaign';
+  $node->title = $data->title;
+  $filtered_text = array(
+    'call_to_action',
+    'items_needed',
+    'promoting_tips',
+    'solution_copy',
+    'solution_support',
+    'starter_statement',
+    'starter_statement_header',
+    'time_and_place',
+    'vips',
+  );
+  foreach ($filtered_text as $text_field) {
+    if (isset($data->{$text_field})) {
+      $field_name = 'field_' . $text_field;
+      $node->{$field_name}[LANGUAGE_NONE][0]['value'] = $data->{$text_field};
+      if ($text_field != 'call_to_action') {
+        $node->{$field_name}[LANGUAGE_NONE][0]['format'] = 'markdown';
+      }
+    }
+  }
+  node_save($node);
+  return $node;
+}
+
+/**
  * Returns a loaded campaign $node's field_campaign_type value.
  *
  * @param object $node

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -79,27 +79,16 @@ function dosomething_campaign_load($node, $public = FALSE) {
   $campaign->status = dosomething_campaign_get_campaign_status($node);
   $campaign->type = dosomething_campaign_get_campaign_type($node);
 
-  // Plain text fields.
-  $fields_plain_text = array(
-    'call_to_action',
-    'starter_statement_header',
-  );
-  foreach ($fields_plain_text as $property) {
+  // Plain text properties.
+  $plain_text = dosomething_campaign_get_property_names_plain_text();
+  foreach ($plain_text as $property) {
     $field_name = 'field_' . $property;
     $campaign->{$property} = $wrapper->{$field_name}->value();
   }
 
-  // Filtered text fields.
-  $fields_filtered_text = array(
-    'items_needed',
-    'promoting_tips',
-    'solution_copy',
-    'solution_support',
-    'starter_statement',
-    'time_and_place',
-    'vips',
-  );
-  foreach ($fields_filtered_text as $property) {
+  // Filtered text properties.
+  $filtered_text = dosomething_campaign_get_property_names_filtered_text();
+  foreach ($filtered_text as $property) {
     $field_name = 'field_' . $property;
     if ($value = $wrapper->{$field_name}->value()) {
       // Store filtered text.
@@ -217,30 +206,51 @@ function dosomething_campaign_create_node_from_json($string) {
   $node = new stdClass();
   $node->type = 'campaign';
   $node->title = $data->title;
-  $filtered_text = array(
-    'call_to_action',
-    'items_needed',
-    'promoting_tips',
-    'solution_copy',
-    'solution_support',
-    'starter_statement',
-    'starter_statement_header',
-    'time_and_place',
-    'vips',
-  );
+  // Set all plain text properties:
+  $plain_text = dosomething_campaign_get_property_names_plain_text();
+  foreach ($plain_text as $text_field) {
+    if (isset($data->{$text_field})) {
+      $field_name = 'field_' . $text_field;
+      $node->{$field_name}[LANGUAGE_NONE][0]['value'] = $data->{$text_field};
+    }
+  }
+  // Set all filtered text properties:
+  $filtered_text = dosomething_campaign_get_property_names_filtered_text();
   foreach ($filtered_text as $text_field) {
     if (isset($data->{$text_field})) {
       $field_name = 'field_' . $text_field;
       $node->{$field_name}[LANGUAGE_NONE][0]['value'] = $data->{$text_field};
-      if ($text_field != 'call_to_action') {
-        $node->{$field_name}[LANGUAGE_NONE][0]['format'] = 'markdown';
-      }
+      $node->{$field_name}[LANGUAGE_NONE][0]['format'] = 'markdown';
     }
   }
   node_save($node);
   return $node;
 }
 
+/**
+ * Returns array of campaign property names which contain plain text.
+ */
+function dosomething_campaign_get_property_names_plain_text() {
+  return array(
+    'call_to_action',
+    'starter_statement_header',
+  );
+}
+
+/**
+ * Returns array of campaign property names which contain filtered text.
+ */
+function dosomething_campaign_get_property_names_filtered_text() {
+  return array(
+    'items_needed',
+    'promoting_tips',
+    'solution_copy',
+    'solution_support',
+    'starter_statement',
+    'time_and_place',
+    'vips',
+  );
+}
 /**
  * Returns a loaded campaign $node's field_campaign_type value.
  *

--- a/tests/campaign/campaign.json
+++ b/tests/campaign/campaign.json
@@ -1,0 +1,7 @@
+{
+    "title": "Super Sweet Test Campaign",
+    "status": "active",
+    "type": "sms_game",
+    "call_to_action": "Challenge friends to stand up to testing sandwiches.",
+    "solution_support": "Sandwiches help self esteem and hunger."
+}


### PR DESCRIPTION
Fixes #2793

@sergii-tkachenko Would you mind reviewing?

cc @DFurnes 

Adds a drush command `drush campaign-create` to create a campaign node from a given JSON file, and adds said JSON file into the `tests/campaign` directory.

```
vagrant@dev:/var/www/vagrant/html$ drush campaign-create ../tests/campaign/campaign.json
Created node nid 1292.
```

The function and JSON files are minimal at the moment, just to get this up and running.  The idea here is that the Capser JS tests will read from the JSON file as well when checking for the presence of various fields, so we're not relying on content within the database as is, and hardcoding tests based on that content.
