### PR TITLE
Adds reportback image markup to payload

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -128,6 +128,7 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
         'IMPACT_VERB' => $params['impact_verb'],
         'IMPACT_NUMBER' => $params['impact_number'],
         'IMPACT_NOUN' => $params['impact_noun'],
+        'CAMPAIGN_IMAGE_MARKUP' => $params['image_markup'],
       );
       break;
 

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -128,7 +128,7 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
         'IMPACT_VERB' => $params['impact_verb'],
         'IMPACT_NUMBER' => $params['impact_number'],
         'IMPACT_NOUN' => $params['impact_noun'],
-        'CAMPAIGN_IMAGE_MARKUP' => $params['image_markup'],
+        'REPORTBACK_IMAGE_MARKUP' => $params['image_markup'],
       );
       break;
 


### PR DESCRIPTION
Fixes #2838

Adds the campaign reportback image markup to the Message broker payload for the dashboad project.
