### PR TITLE
Services: User authentication

### DIFF
--- a/lib/modules/dosomething/dosomething_settings/README.md
+++ b/lib/modules/dosomething/dosomething_settings/README.md
@@ -5,16 +5,24 @@ Filter, File Entity, and Services.
 
 ## Services
 
-The `drupalapi` endpoint is defined at `api/v1`.  It is currently configured 
-to not use session information, so all requests will be done as an anonymous user.
+See https://github.com/DoSomething/dosomething/wiki/API for usage.
 
-### Retrieve a campaign
+The API is provided by the `drupalapi` Services endpoint, defined at `api/v1`.
+
+
+### Users
+
+User authentication is handled via Services User resources:
+* login
+* logout
+
+And the System resources:
+* connect
+
+
+### Nodes
 
 Currently we are only using the Node Retrieve resource, at alias `content`.
-
-**GET** `https://www.dosomething.org/api/v1/content/:nid`
-
-**nid** (int) Required. The Node nid to retrieve content for. 
 
 The `dosomething_settings_services_request_postprocess_alter` function is 
 postprocessing the Node resource's output to only return content for a given 
@@ -23,6 +31,12 @@ as defined in `dosomething_campaign_load`.
 
 If a non-campaign Node nid is passed, the response returned will be `false`.
 
-Since all requests are done as an anonymous user, the Node resource will 
-use our user permissions and not return unpublished campaigns for anonymous 
-users: `["Access denied for user anonymous"]`
+The Node resource will use our user permissions and not return unpublished 
+campaigns for anonymous or authenticated users:
+
+````
+["Access denied for user anonymous"]
+````
+
+If an editor or administrator were logged in via Services and accessed an 
+unpublished node, it would be returned. 

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.services.inc
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.services.inc
@@ -16,7 +16,9 @@ function dosomething_settings_default_services_endpoint() {
   $endpoint->name = 'drupalapi';
   $endpoint->server = 'rest_server';
   $endpoint->path = 'api/v1';
-  $endpoint->authentication = array();
+  $endpoint->authentication = array(
+    'services' => 'services',
+  );
   $endpoint->server_settings = array(
     'formatters' => array(
       'json' => TRUE,
@@ -42,6 +44,33 @@ function dosomething_settings_default_services_endpoint() {
       'operations' => array(
         'retrieve' => array(
           'enabled' => '1',
+        ),
+      ),
+    ),
+    'system' => array(
+      'actions' => array(
+        'connect' => array(
+          'enabled' => '1',
+        ),
+      ),
+    ),
+    'user' => array(
+      'actions' => array(
+        'login' => array(
+          'enabled' => '1',
+          'settings' => array(
+            'services' => array(
+              'resource_api_version' => '1.0',
+            ),
+          ),
+        ),
+        'logout' => array(
+          'enabled' => '1',
+          'settings' => array(
+            'services' => array(
+              'resource_api_version' => '1.0',
+            ),
+          ),
         ),
       ),
     ),


### PR DESCRIPTION
Enables Session authentication for our Services endpoint `drupalapi`, and also enables the User `login` and `logout` and System `connect` resources to begin work on a Reportback endpoint #2774

Updates DS Settings README to link to a new API wiki page, which will provide docs for all endpoints.  The README will now pertain to how we're configuring various Services module endpoints, whereas the wiki will provide URL's and example requests/responses.
