### PR TITLE
Create a function to determine if current site is an international affiliate.

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -119,3 +119,12 @@ $conf['locale_custom_strings_en'][''] = array(
  );
 
 $conf['optimizely_id'] = '747623297';
+
+/**
+ * DoSomething specific settings.
+ */
+// Determines whether current site is an international affiliate.
+// @todo: set this variable to TRUE for international affiliate.
+// e.g. in_array($hostname, $affiliates);
+// @see https://github.com/DoSomething/dosomething/pull/2809
+$conf['dosomething_is_affiliate'] = FALSE;

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
@@ -25,3 +25,13 @@ function dosomething_settings_services_request_postprocess_alter($controller, $a
     }
   }
 }
+
+/**
+ * Determines whether current site is an international affiliate.
+ *
+ * @return bool
+ *   TRUE for international affiliates.
+ */
+function dosomething_settings_is_affiliate() {
+  return (bool) variable_get('dosomething_is_affiliate', FALSE);
+}


### PR DESCRIPTION
#### What's this PR do?
- Creates a variable in settings.php to determine if current site is an international affiliate
- Create a helper function returning if current site is an international affiliate
#### Todo

Set the variable to TRUE for international affiliate, e.g. `in_array($hostname, $affiliates);`
Reference: #2809 
#### What are the relevant tickets?

Fixes [#DOS-76](https://jira.dosomething.org/browse/DOS-76)
