### PR TITLE
Reportback API endpoint

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -738,3 +738,34 @@ function dosomething_reportback_get_noun_and_verb($nid) {
 
   return $results;
 }
+
+/**
+ * Implementation of hook_services_resources().
+ */
+function dosomething_reportback_services_resources() {
+  $resources = array();
+  $resources['reportback'] = array(
+    'operations' => array(
+      'retrieve' => array(
+        'help' => 'Retrieve a reportback.',
+        'file' => array(
+          'type' => 'inc',
+          'module' => 'dosomething_reportback',
+          'name' => 'resources/dosomething_reportback.resource'
+        ),
+        'callback' => '_dosomething_reportback_resource_retrieve',
+        'args' => array(
+          array(
+            'name' => 'rbid',
+            'optional' => FALSE,
+            'source' => array('path' => 0),
+            'type' => 'int',
+            'description' => 'The rbid of the reportback to retrieve.',
+          ),
+        ),
+        'access callback' => '_dosomething_reportback_resource_access',
+      ),
+    ),
+  );
+  return $resources;
+}

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -437,6 +437,32 @@ function dosomething_reportback_set_field_values(&$entity, $values) {
 }
 
 /**
+ * Saves a reportback file for a given $uid and $nid from file $url.
+ *
+ * @param int $nid
+ *   The node nid that this reportback file is associated with.
+ * @param int $uid
+ *   The users uid that this reportback file is associated with.
+ * @param string $url
+ *   The url of the file to save.
+ *
+ * @return mixed
+ *   A file object if save is successful, FALSE if not.
+ */
+function dosomething_reportback_save_file_from_url($nid, $uid, $url) {
+  // Get the location for where file should be saved to.
+  $dest = dosomething_reportback_get_file_dest(basename($url), $nid, $uid);
+  // Download and save file to that location.
+  $file_contents = file_get_contents($url);
+  $file = file_save_data($file_contents, $dest);
+  // Save UID and permanent status.
+  $file->uid = $uid;
+  $file->status = FILE_STATUS_PERMANENT;
+  file_save($file);
+  return $file;
+}
+
+/**
  * Returns the file destination for a new reportback file for given node $nid.
  *
  * @param string $filename
@@ -751,7 +777,7 @@ function dosomething_reportback_services_resources() {
         'file' => array(
           'type' => 'inc',
           'module' => 'dosomething_reportback',
-          'name' => 'resources/dosomething_reportback.resource'
+          'name' => 'resources/dosomething_reportback.resource',
         ),
         'callback' => '_dosomething_reportback_resource_retrieve',
         'args' => array(
@@ -764,6 +790,55 @@ function dosomething_reportback_services_resources() {
           ),
         ),
         'access callback' => '_dosomething_reportback_resource_access',
+      ),
+    ),
+    'actions' => array(
+      'save' => array(
+        'help'   => 'Creates or updates a reportback for given uid and nid.',
+        'file' => array(
+          'type' => 'inc',
+          'module' => 'dosomething_reportback',
+          'name' => 'resources/dosomething_reportback.resource',
+        ),
+        'callback' => '_dosomething_reportback_resource_save',
+        'access callback' => '_dosomething_reportback_resource_access',
+        'args' => array(
+          array(
+            'name' => 'uid',
+            'optional' => FALSE,
+            'source' => array('data' => 'uid'),
+            'description' => t('The uid of the user reporting back.'),
+            'type' => 'int',
+          ),
+          array(
+            'name' => 'nid',
+            'optional' => FALSE,
+            'source' => array('data' => 'nid'),
+            'description' => t('The nid of node the user is reporting back for.'),
+            'type' => 'int',
+          ),
+          array(
+            'name' => 'quantity',
+            'optional' => FALSE,
+            'source' => array('data' => 'quantity'),
+            'description' => t('The reportback quantity.'),
+            'type' => 'int',
+          ),
+          array(
+            'name' => 'why_participated',
+            'optional' => FALSE,
+            'source' => array('data' => 'why_participated'),
+            'description' => t('The reportback reason.'),
+            'type' => 'int',
+          ),
+          array(
+            'name' => 'file_url',
+            'optional' => FALSE,
+            'source' => array('data' => 'file_url'),
+            'description' => t('The URL of the reportback image.'),
+            'type' => 'string',
+          ),
+        ),
       ),
     ),
   );

--- a/lib/modules/dosomething/dosomething_reportback/resources/dosomething_reportback.resource.inc
+++ b/lib/modules/dosomething/dosomething_reportback/resources/dosomething_reportback.resource.inc
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @file
+ * Code for DoSomething Reportback Services resources.
+ *
+ * @see dosomething_reportback_services_resources()
+ */
+
+/**
+ * Access callback for Reportback resources.
+ */
+function _dosomething_reportback_resource_access() {
+  global $user;
+  // For now, only admins can access any reportback resources.
+  return in_array('administrator', $user->roles);
+}
+
+/**
+ * Callback for Reportback resource retrieve.
+ */
+function _dosomething_reportback_resource_retrieve($rbid) {
+  if ($reportback = reportback_load($rbid)) {
+    return get_object_vars($reportback);
+  }
+  else {
+    return FALSE;
+  }
+}
+

--- a/lib/modules/dosomething/dosomething_reportback/resources/dosomething_reportback.resource.inc
+++ b/lib/modules/dosomething/dosomething_reportback/resources/dosomething_reportback.resource.inc
@@ -27,3 +27,28 @@ function _dosomething_reportback_resource_retrieve($rbid) {
   }
 }
 
+/**
+ * Callback for Reportback resource save.
+ */
+function _dosomething_reportback_resource_save($uid, $nid, $quantity, $why_participated, $file_url) {
+  // Create a file from the $file_url.
+  $file = dosomething_reportback_save_file_from_url($nid, $uid, $file_url);
+  if (!$file) {
+    return FALSE;
+  }
+  // @todo: Move this logic into dosomething_reportback_save().
+  $rbid = dosomething_reportback_exists($nid, $uid);
+  if (!$rbid) {
+    $rbid = 0;
+  }
+  // Prepare values for save.
+  $values = array(
+    'rbid' => $rbid,
+    'uid' => $uid,
+    'nid' => $nid,
+    'quantity' => $quantity,
+    'why_participated' => $why_participated,
+    'fid' => $file->fid,
+  );
+  return dosomething_reportback_save($values);
+}

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.services.inc
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.services.inc
@@ -47,6 +47,13 @@ function dosomething_settings_default_services_endpoint() {
         ),
       ),
     ),
+    'reportback' => array(
+      'operations' => array(
+        'retrieve' => array(
+          'enabled' => '1',
+        ),
+      ),
+    ),
     'system' => array(
       'actions' => array(
         'connect' => array(

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.services.inc
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.services.inc
@@ -53,6 +53,11 @@ function dosomething_settings_default_services_endpoint() {
           'enabled' => '1',
         ),
       ),
+      'actions' => array(
+        'save' => array(
+          'enabled' => '1',
+        ),
+      ),
     ),
     'system' => array(
       'actions' => array(


### PR DESCRIPTION
Right now, this will only work for when the logged in user (via `api/v1/user/login`) is an administrator. 

cc @jonuy 

 This PR opens the door to building out SMS Reportbacks within the DS mData rResponder repo, and to eventually move all SMS Reportback functionality out of the Drupal app.  Instead the mData repo would post reportback data to the `reportback/save` endpoint.  The mData app would just login as an administrator (we could create an account like `machines@dosomething.org`, or build out Token based authentication.

Will update the API wiki when this is merged:

**GET** `www.dosomething.org/api/v1/reportback/:rbid` -- Returns reportback content for a given reportback rbid.

**POST** `www.dosomething.org/api/v1/reportback/save` -- Creates or updates a reportback based on given uid and nid in the data:
- nid
- uid
- quantity
- why_participated
- file_url -- an Image URL to save as a file and associate with the reportback

**Note: This will not work yet with campaigns that require custom reportback fields.
