### PR TITLE
Pulls image lazy-loading for tiles out of the campaign finder.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
@@ -57,13 +57,6 @@ define(function(require) {
         // it doesn't have to be passed in as an argument to the init().
         clearFormAction();
       });
-
-      // Lazy-load in images
-      ResultsView.$blankSlateDiv.find("img").unveil(200, function() {
-        $(this).load(function() {
-          this.style.opacity = 1;
-        });
-      });
     },
 
     /**

--- a/lib/themes/dosomething/paraneue_dosomething/js/main.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/main.js
@@ -50,6 +50,7 @@ define("main", function(require) {
   require("validation/reportback");
   require("validation/address");
   require("Analytics");
+  require("tiles");
 
   $(function() {
     if( $(".js-finder-form").length ) {

--- a/lib/themes/dosomething/paraneue_dosomething/js/tiles.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/tiles.js
@@ -1,0 +1,13 @@
+define(function(require) {
+  "use strict";
+
+  var $ = require("jquery");
+
+  // Lazy-load in tile images
+  $(".tile").find("img").unveil(200, function() {
+    $(this).load(function() {
+      this.style.opacity = 1;
+    });
+  });
+
+});


### PR DESCRIPTION
Tiles with an [Unveil](http://luis-almeida.github.io/unveil/) lazy-loaded `data-src` image should now work properly when included outside of the campaign finder. (Fixes issue with international sites.)
