### PR TITLE
Remove bower copy task that was causing trouble with old configs.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/copy.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/copy.js
@@ -2,7 +2,6 @@ module.exports = {
   assets: {
     files: [
       {expand: true, src: ["images/**"], dest: "dist/"},
-      {expand: true, src: ["bower_components/**"], dest: "dist/"},
     ]
   },
   source: {


### PR DESCRIPTION
Fixes issue with old configs still copying the (no longer created) `paraneue_dosomething/bower_components` directory and overwriting updated dependencies in `paraneue_dosomething/dist/bower_components`.

References @32ba920f3f20eb9e044d5f793b766b7ae88954cf.
