### PR TITLE
Added a pre-commit hook to check for common mistakes.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -223,6 +223,9 @@ function symlinks {
   echo 'Linking themes'
   rm -rf "$WEB_PATH/profiles/dosomething/themes/dosomething/paraneue_dosomething"
   ln -s "$LIB_PATH/themes/dosomething/paraneue_dosomething" "$WEB_PATH/profiles/dosomething/themes/dosomething/paraneue_dosomething"
+
+  echo 'Add git pre-commit hook'
+  ln -s "../../hooks/pre-commit" ".git/hooks/pre-commit"
 }
 
 #=== FUNCTION ==================================================================

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+
+
+user = ENV["USER"]
+error_found = false
+
+# "Forbidden" regular expressions
+FORBIDDEN_STRINGS = [
+  />>>>>>/,    # Git conflict markers
+  /<<<<<</,    # ''
+  /dpm/,         # drupal debug statements
+  /krumo/,
+  /dsm/,
+]
+
+full_diff = `git diff --cached --`
+
+full_diff.scan(%r{^\+\+\+ b/(.+)\n@@.*\n([\s\S]*?)(?:^diff|\z)}).each do |file, diff|
+  changed_code_for_file = diff.split("\n").select { |x| x.start_with?("+") }.join("\n")
+  changed_lines_for_file = diff.split("\n").select { |x| x.start_with?("+") }
+  dir = File.dirname(file)
+
+  # Scan for "forbidden" calls
+  FORBIDDEN_STRINGS.each do |re|
+    if changed_code_for_file.match(re)
+      puts %{Error: git pre-commit hook forbids committing "#{$1 || $&}" to #{file}\n--------------}
+      error_found = true
+    end
+  end
+end
+
+
+# Finally, report errors
+if error_found
+  puts "To commit anyway, use --no-verify"
+  exit 1
+end


### PR DESCRIPTION
## What does this PR do?
- adds in pre-commit hooks that fire before committing
- adds the symlinked git hook into the `ds build` task
## What are we checking for?
- git conflicts to be committed
- drupal debug code (`dsm`, `dpm`, `krumo`)
## How do I test this?
- pull down this code
- add some `dpm`s
- `git commit`
- you will see this error

```
Error: git pre-commit hook forbids committing "dpm" to hooks/pre-commit
--------------
To commit anyway, use --no-verify
```

The code was generously provided by [this man](https://github.com/bobgilmore/githooks)
