### PR TITLE
DS Build: Force revert all Features

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -165,7 +165,7 @@ function build {
   drush --script-path=../bin/ php-script enable_modules.php
 
   echo 'Reverting Features'
-  drush fl | grep 'Overridden' | awk '{print ($(NF-3))}' | xargs -i drush fr {} --force -y
+  drush fra -y --force
 
   echo 'Clearing caches...'
   drush cc all


### PR DESCRIPTION
After discussing with the team, it sounds like we'll always want to revert when our Features are in "Needs Review" state -- so let's simplify this by just force reverting all features, and see if this gets rid of our "Table already exists" issues.
