### PR TITLE
Content API: Campaign stats + hi res Cover Image

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -70,6 +70,8 @@
  *       - copy (string) HTML.
  *   - starter_statement (string). HTML.
  *   - starter_statement_header (string). Plain text.
+ *   - stats (array)
+ *     - signups (int)
  *   - time_and_place (string). HTML.
  *   - variables (array). Used to control various presentation settings.
  *   - vips (string). HTML.
@@ -212,6 +214,9 @@ function dosomething_campaign_load($node, $public = FALSE) {
   // Load Creator property.
   dosomething_campaign_load_creator($campaign, $wrapper);
 
+  // Add stats property.
+  dosomething_campaign_load_stats($campaign);
+
   // If this is accessed via API:
   if ($public) {
     // Unset properties which shouldn't be public.
@@ -269,6 +274,16 @@ function dosomething_campaign_load_end_date(&$campaign, $wrapper) {
     $campaign->end_date = $wrapper->field_high_season->value2->value();
   }
 }
+
+/**
+ * Adds stats property to given $campaign.
+ */
+function dosomething_campaign_load_stats(&$campaign) {
+  $campaign->stats = array(
+    'signups' => dosomething_signup_get_signup_total_by_nid($campaign->nid),
+  );
+}
+
 
 /**
  * Creates and returns a campaign node from given JSON string.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -52,6 +52,9 @@
  *     - nid (int)
  *     - is_dark_image (bool)
  *     - src (string)
+ *     - url (array)
+ *       - square (array)
+ *         - raw (string). URL to the raw file uploaded.
  *   - is_staff_pick (bool)
  *   - items_needed (string). HTML.
  *   - low_season_end (string). Date string.
@@ -187,7 +190,10 @@ function dosomething_campaign_load($node, $public = FALSE) {
       $campaign->image_cover['is_dark_image'] = (bool) $image_cover->field_dark_image[LANGUAGE_NONE][0]['value'];
     }
     // Set the src property.
+    // @todo: Deprecate when Message Broker uses url array instead.
     $campaign->image_cover['src'] = dosomething_image_get_themed_image_url($campaign->image_cover['nid'], $image_src_ratio, $image_src_style);
+    // Set the url array.
+    dosomething_campaign_load_image_url($campaign->image_cover['url'], $image_cover);
   }
 
   // Set image_header property.
@@ -272,6 +278,25 @@ function dosomething_campaign_load_end_date(&$campaign, $wrapper) {
   // Check if there is a value in the High Season date field.
   if ($display_date == 1 && $wrapper->field_high_season->value()) {
     $campaign->end_date = $wrapper->field_high_season->value2->value();
+  }
+}
+
+function dosomething_campaign_load_image_url(&$campaign_property, $image_node) {
+  $fields = array(
+    'landscape',
+    'square',
+    'portrait',
+    'thumbnail',
+  );
+  foreach ($fields as $name) {
+    $campaign_property[$name] = NULL;
+    $field_name = 'field_image_' . $name;
+    if (isset($image_node->{$field_name}[LANGUAGE_NONE][0])) {
+      $file = $image_node->{$field_name}[LANGUAGE_NONE][0];
+      $campaign_property[$name] = array(
+        'raw' => file_create_url($file['uri']),
+      );
+    }
   }
 }
 


### PR DESCRIPTION
Adds new properties for dashboard crew:
Closes #2863

```
$num_signups = $campaign->stats->signups;
$hi_res_src = $campaign->image_cover['url']['square']['raw'];
```

@angaither Can you review?
