### PR TITLE
Sponsor logos template

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -100,6 +100,9 @@ function dosomething_campaign_load($node, $public = FALSE) {
     $campaign->scholarship = (int) $campaign->scholarship;
   }
 
+  // Set partners.
+  $campaign->partners = dosomething_taxonomy_get_partners_data($node);
+
   // Plain text properties.
   $plain_text = dosomething_campaign_get_property_names_plain_text();
   foreach ($plain_text as $property) {

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -7,7 +7,72 @@
 include_once 'dosomething_taxonomy.features.inc';
 
 /**
- * Returns array of values of sponsor data.
+ * Returns data from field_partners field collection for a given $node.
+ *
+ * @param object $node
+ *   A loaded Node object.
+ *
+ * @return mixed
+ *   Multi-dimensional array of partners/sponsors, or NULL if empty.
+ *
+ */
+function dosomething_taxonomy_get_partners_data($node) {
+  $wrapper = entity_metadata_wrapper('node', $node);
+  // Intialize return array.
+  $partners = array();
+
+  if (!isset($wrapper->field_partners)) {
+    return NULL;
+  }
+
+  // Default style to render the logo.
+  $logo_style = 'wmax-423px';
+
+  // Loop through field collection items.
+  foreach ($wrapper->field_partners->value() as $delta => $item) {
+
+    $fc_item = entity_metadata_wrapper('field_collection_item', $item);
+
+    // Gather partner term data.
+    $term = taxonomy_term_load($fc_item->field_partner->value()->tid);
+    $term_wrapper = entity_metadata_wrapper('taxonomy_term', $term);
+    $partners[$delta]['tid'] = $term_wrapper->getIdentifier();
+    $partners[$delta]['name'] = $term_wrapper->label();
+
+    $partners[$delta]['is_sponsor'] = $fc_item->field_is_sponsor->value();
+
+    if ($url = $fc_item->field_partner_url->value()) {
+      $partners[$delta]['url'] = $url['url'];
+    }
+
+    // If a logo has been uploaded:
+    if ($logo = $term_wrapper->field_partner_logo->value()) {
+      $partners[$delta]['logo']['fid'] = $logo['fid'];
+      // Get url of themed file in the default $logo_style.
+      $logo_url = image_style_url($logo_style, $logo['uri']);
+      $partners[$delta]['logo']['url']['default'] = $logo_url;
+    }
+
+    $partners[$delta]['info'] = NULL;
+    // If copy exists, add it and relevant image/video into info.
+    if ($copy = $fc_item->field_partner_copy->value()) {
+      $partners[$delta]['info'] = array(
+        'copy' => $copy['safe_value'],
+        'image' => $fc_item->field_image_partner->value(),
+        'video' => $fc_item->field_video->value(),
+      );
+    }
+  }
+
+  if (!empty($partners)) {
+    return $partners;
+  }
+  return NULL;
+}
+
+/**
+ * Returns array of values of partners / sponsor data.
+ * This function will be replaced by dosomething_taxonomy_get_partners_data().
  *
  * @param object $sponsor_field_wrapper
  *   An entity_metadata_wrapper object.

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -149,6 +149,7 @@ function paraneue_dosomething_preprocess_node(&$vars) {
     $partials = array(
       'campaign_creator',
       'campaign_headings',
+      'sponsor_logos',
     );
     // Initialize to NULL.
     foreach ($partials as $partial) {
@@ -157,16 +158,38 @@ function paraneue_dosomething_preprocess_node(&$vars) {
     // Check for campaign class:
     // @see dosomething_campaign_preprocess_node().
     if (isset($vars['campaign'])) {
+
+      $campaign = $vars['campaign'];
+
       // Add $campaign_scholarship variable.
       paraneue_dosomething_preprocess_node_campaign_scholarship($vars);
+
       // Set campaign headings.
       $vars['campaign_headings'] = theme('campaign_headings', $vars);
       // If creator property has been set:
-      if ($creator = $vars['campaign']->creator) {
+      if ($creator = $campaign->creator) {
         // Pass $campaign->creator array to the campaign_creator theme function.
         $vars['campaign_creator'] = theme('campaign_creator', $creator);
       }
+
+      // Check for sponsors.
+      if ($partners = $campaign->partners) {
+        $sponsors = array();
+        foreach ($partners as $delta => $partner) {
+          if ($partner['is_sponsor']) {
+            $sponsors[$delta]['name'] = $partner['name'];
+            $sponsors[$delta]['logo_url'] = $partner['logo']['url']['default'];
+          }
+        }
+        if (!empty($sponsors)) {
+          $vars['sponsor_logos'] = theme('sponsor_logos', array(
+            'sponsors' => $sponsors,
+          ));
+        }
+      }
+
     }
+
     // If the campaign requires a signup modal to display:
     if (isset($vars['node']->required_signup_data_form)) {
       // Add JS to open the signup data form modal.

--- a/lib/themes/dosomething/paraneue_dosomething/includes/theme.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/theme.inc
@@ -79,6 +79,14 @@ function paraneue_dosomething_theme() {
       'path' => PARANEUE_DS_PATH . '/templates/system/partials',
     ),
 
+    'sponsor_logos' => array(
+      'template' => 'sponsor-logos',
+      'path' => PARANEUE_DS_PATH . '/templates/system/partials',
+      'variables' => array(
+        'sponsors' => NULL,
+      ),
+    ),
+
     'thumbnail' => array(
       'template' => 'thumbnail',
       'path' => PARANEUE_DS_PATH . '/templates/home/partials',

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
@@ -36,14 +36,7 @@
         </div>
       <?php endif; ?>
 
-      <?php if (isset($sponsors[0]['display'])): ?>
-      <div class="sponsor">
-        <p class="__copy">Powered by</p>
-        <?php foreach ($sponsors as $key => $sponsor) :?>
-          <?php if (isset($sponsor['display'])): print $sponsor['display']; endif; ?>
-        <?php endforeach; ?>
-      </div>
-      <?php endif; ?>
+      <?php print $sponsor_logos; ?>
 
     </div>
   </header>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -22,14 +22,7 @@
         </div>
       <?php endif; ?>
 
-      <?php if (isset($sponsors[0]['display'])): ?>
-      <div class="sponsor">
-        <p class="__copy">Powered by</p>
-        <?php foreach ($sponsors as $key => $sponsor) :?>
-          <?php if (isset($sponsor['display'])): print $sponsor['display']; endif; ?>
-        <?php endforeach; ?>
-      </div>
-      <?php endif; ?>
+      <?php print $sponsor_logos; ?>
     </div>
   </header>
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -15,14 +15,7 @@
     <div class="wrapper">
       <?php print $campaign_headings; ?>
 
-      <?php if (isset($sponsors[0]['display'])): ?>
-      <div class="sponsor">
-        <p class="__copy">Powered by</p>
-        <?php foreach ($sponsors as $key => $sponsor) :?>
-          <?php if (isset($sponsor['display'])): print $sponsor['display']; endif; ?>
-        <?php endforeach; ?>
-      </div>
-      <?php endif; ?>
+      <?php print $sponsor_logos; ?>
     </div>
   </header>
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -16,14 +16,7 @@
     <div class="wrapper">
       <?php print $campaign_headings; ?>
 
-      <?php if (isset($sponsors[0]['display'])): ?>
-      <div class="sponsor">
-        <p class="__copy">Powered by</p>
-        <?php foreach ($sponsors as $key => $sponsor) :?>
-          <?php if (isset($sponsor['display'])): print $sponsor['display']; endif; ?>
-        <?php endforeach; ?>
-      </div>
-      <?php endif; ?>
+      <?php print $sponsor_logos; ?>
 
       <?php print $campaign_scholarship; ?>
     </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/sponsor-logos.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/sponsor-logos.tpl.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Expected variables:
+ *  - $sponsors: (array) Expected data:
+ *    - logo_url: (string) URL of the logo file to render.
+ *    - name: (string) Sponsor name
+ */
+?>
+<div class="sponsor">
+  <p class="__copy">Powered by</p>
+  <?php foreach ($sponsors as $sponsor) :?>
+    <img src="<?php print $sponsor['logo_url']; ?>" alt="<?php print $sponsor['name']; ?>" />
+  <?php endforeach; ?>
+</div>


### PR DESCRIPTION
Closes #2375 -- creates a `sponsor-logos.tpl.php`

Refs #2826 -- Adds a `$campaign->partners` property to make the data accessible to API.

TODO: Refactor Static Content and Grouped Campaign preprocess / template to use this new tpl.
