### PR TITLE
Static Content Gallery -- Use Thumbnail field when Gallery Style != default

### DIFF
--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
@@ -82,41 +82,51 @@ function dosomething_static_content_preprocess_node(&$vars) {
  * @see dosomething_static_content_preprocess_node().
  */
 function dosomething_static_content_preprocess_gallery_vars(&$vars) {
+  // Set Gallery style default variables:
+  $style = 'default';
+  // Defaults to use the Image node square field.
+  $image_ratio = 'square';
+  $image_style = '300x300';
+
   $content = $vars['content'];
   $gallery_count = count($content['field_gallery']['#items']);
 
   $vars['galleries'] = array();
+
   // Loop through the galleries.
   for ($i = 0; $i < $gallery_count; $i++) {
+
     $vars['galleries'][$i] = array();
     $collection_item = reset($content['field_gallery'][$i]['entity']['field_collection_item']);
     $vars['galleries'][$i]['title'] = $collection_item['field_gallery_title'][0]['#markup'];
+
     // Check for a Gallery Style field value:
     if (isset($collection_item['field_gallery_style'][0])) {
       // Store the Gallery Style key.
       $style = $collection_item['field_gallery_style']['#items'][0]['value'];
+      // If a key exists and it's not the default:
+      if ($style && $style != 'default') {
+        // Set to use the thumbnail field on the Image node instead.
+        $image_ratio = 'thumb';
+        $image_style = '100x100';
+      }
     }
-    else {
-      $style = "-triad";
-    }
-    $vars['galleries'][$i]['style'] = paraneue_dosomething_get_gallery_style($style);
-    $collection_item = $collection_item['field_gallery_item'];
+    // Set Style variable for theme layer.
+    $vars['galleries'][$i]['style'] = $style;
 
+    $collection_item = $collection_item['field_gallery_item'];
     $gallery_item_count = count($collection_item['#items']);
 
+    // Loop through the gallery items.
     for ($a = 0; $a < $gallery_item_count; $a++) {
       $gallery_item = reset($collection_item[$a]['entity']['field_collection_item']);
-      $vars['galleries'][$i]['items'][$a]['image'] = dosomething_image_get_themed_image($gallery_item['field_gallery_image']['#items'][0]['target_id'], 'square', '300x300');
+      $vars['galleries'][$i]['items'][$a]['image'] = dosomething_image_get_themed_image($gallery_item['field_gallery_image']['#items'][0]['target_id'], $image_ratio, $image_style);
 
       $link_field = $gallery_item['field_image_title'][0]['#element'];
       
       $vars['galleries'][$i]['items'][$a]['image_title'] = $link_field['url'] ? l(t($link_field['title']), $link_field['url'], array('target' => '_blank')) : $link_field['title'];
       $vars['galleries'][$i]['items'][$a]['image_url'] = $link_field['url'];
       $vars['galleries'][$i]['items'][$a]['image_description'] = $gallery_item['field_image_description'][0]['#markup'];
-
-      if (function_exists('paraneue_dosomething_get_gallery_item_order_class')) {
-        $vars['galleries'][$i]['items'][$a]['order_class'] = paraneue_dosomething_get_gallery_item_order_class($a);
-      }
     }
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -143,31 +143,41 @@ function paraneue_dosomething_preprocess_page(&$vars) {
  */
 function paraneue_dosomething_preprocess_node(&$vars) {
 
-  $type = isset($vars['node']->type) ? $vars['node']->type : null;
-  if ($type == "campaign") {
-    paraneue_dosomething_preprocess_node_campaign($vars);
+  switch($vars['node']->type) {
+
+    case "campaign":
+      paraneue_dosomething_preprocess_node_campaign($vars);
+      break;
+
+    case "fact_page":
+      // Return facts as a chunked array.
+      // Allow cta's to be properly embedded in between.
+      $vars['facts_chunked'] = array_chunk($vars['facts'], 5);
+      break;
+
+    case "home":
+      // Set these here to remove db calls from tpl files:
+      $vars['show_campaign_finder'] = theme_get_setting('show_campaign_finder');
+      $vars['show_sponsors'] = theme_get_setting('show_sponsors');
+      break;
+
+    case "static_content":
+      // Preprocess field_gallery.
+      paraneue_dosomething_preprocess_node_field_gallery($vars);
+      break;
+
   }
 
-  elseif ($type == "home") {
-    // Set these here to remove db calls from tpl files
-    $vars['show_campaign_finder'] = theme_get_setting('show_campaign_finder');
-    $vars['show_sponsors'] = theme_get_setting('show_sponsors');
-  }
+  // Add $info_bar for all nodes.
+  paraneue_dosomething_add_info_bar($vars);
+}
 
-  elseif ($type == 'fact_page') {
-    // Return facts as a chunked array to allow cta's to be properly embedded in between
-    $vars['facts_chunked'] = array_chunk($vars['facts'], 5);
-  }
-
-  elseif ($type == 'static_content') {
-    // Preprocess field_gallery.
-    paraneue_dosomething_preprocess_node_field_gallery($vars);
-  }
-
-  /**
-   * Info Bar
-   */
-
+/**
+ * Preprocesses an info_bar based on given $vars.
+ *
+ * @see paraneue_dosomething_preprocess_node().
+ */
+function paraneue_dosomething_add_info_bar(&$vars) {
   // Initialize info_bar_vars with variable that will always be set:
   $zendesk_form_header = t(variable_get('dosomething_zendesk_form_header'));
   $info_bar_vars = array(
@@ -188,6 +198,7 @@ function paraneue_dosomething_preprocess_node(&$vars) {
       $info_bar_vars[$variable] = $vars[$variable];
     }
   }
+
   $vars['info_bar'] = theme('info_bar', $info_bar_vars);
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -145,58 +145,7 @@ function paraneue_dosomething_preprocess_node(&$vars) {
 
   $type = isset($vars['node']->type) ? $vars['node']->type : null;
   if ($type == "campaign") {
-    // List of theme functions to display.
-    $partials = array(
-      'campaign_creator',
-      'campaign_headings',
-      'sponsor_logos',
-    );
-    // Initialize to NULL.
-    foreach ($partials as $partial) {
-      $vars[$partial] = NULL;
-    }
-    // Check for campaign class:
-    // @see dosomething_campaign_preprocess_node().
-    if (isset($vars['campaign'])) {
-
-      $campaign = $vars['campaign'];
-
-      // Add $campaign_scholarship variable.
-      paraneue_dosomething_preprocess_node_campaign_scholarship($vars);
-
-      // Set campaign headings.
-      $vars['campaign_headings'] = theme('campaign_headings', $vars);
-      // If creator property has been set:
-      if ($creator = $campaign->creator) {
-        // Pass $campaign->creator array to the campaign_creator theme function.
-        $vars['campaign_creator'] = theme('campaign_creator', $creator);
-      }
-
-      // Check for sponsors.
-      if ($partners = $campaign->partners) {
-        $sponsors = array();
-        foreach ($partners as $delta => $partner) {
-          if ($partner['is_sponsor']) {
-            $sponsors[$delta]['name'] = $partner['name'];
-            $sponsors[$delta]['logo_url'] = $partner['logo']['url']['default'];
-          }
-        }
-        if (!empty($sponsors)) {
-          $vars['sponsor_logos'] = theme('sponsor_logos', array(
-            'sponsors' => $sponsors,
-          ));
-        }
-      }
-
-    }
-
-    // If the campaign requires a signup modal to display:
-    if (isset($vars['node']->required_signup_data_form)) {
-      // Add JS to open the signup data form modal.
-      $id = 'modal-signup-data-form';
-      $js = 'require(["neue/modal"], function(Modal) { Modal.open( jQuery("#' . $id . '"), {animated: false, closeButton: "skip", skipForm: "#dosomething-signup-user-skip-signup-data-form"}); });';
-      drupal_add_js($js, 'inline');
-    }
+    paraneue_dosomething_preprocess_node_campaign($vars);
   }
 
   elseif ($type == "home") {
@@ -210,6 +159,10 @@ function paraneue_dosomething_preprocess_node(&$vars) {
     $vars['facts_chunked'] = array_chunk($vars['facts'], 5);
   }
 
+  elseif ($type == 'static_content') {
+    // Preprocess field_gallery.
+    paraneue_dosomething_preprocess_node_field_gallery($vars);
+  }
 
   /**
    * Info Bar
@@ -236,6 +189,67 @@ function paraneue_dosomething_preprocess_node(&$vars) {
     }
   }
   $vars['info_bar'] = theme('info_bar', $info_bar_vars);
+}
+
+/**
+ * Preprocesses a campaign node's $vars.
+ *
+ * @see paraneue_dosomething_preprocess_node().
+ */
+function paraneue_dosomething_preprocess_node_campaign(&$vars) {
+
+  // List of partials to add as $vars.
+  $partials = array(
+    'campaign_creator',
+    'campaign_headings',
+    'sponsor_logos',
+  );
+  // Initialize to NULL.
+  foreach ($partials as $partial) {
+    $vars[$partial] = NULL;
+  }
+
+  // Check for campaign class:
+  // @see dosomething_campaign_preprocess_node().
+  if (isset($vars['campaign'])) {
+
+    $campaign = $vars['campaign'];
+
+    // Add $campaign_scholarship variable.
+    paraneue_dosomething_preprocess_node_campaign_scholarship($vars);
+
+    // Set campaign headings.
+    $vars['campaign_headings'] = theme('campaign_headings', $vars);
+    // If creator property has been set:
+    if ($creator = $campaign->creator) {
+      // Pass $campaign->creator array to the campaign_creator theme function.
+      $vars['campaign_creator'] = theme('campaign_creator', $creator);
+    }
+
+    // Check for sponsors.
+    if ($partners = $campaign->partners) {
+      $sponsors = array();
+      foreach ($partners as $delta => $partner) {
+        if ($partner['is_sponsor']) {
+          $sponsors[$delta]['name'] = $partner['name'];
+          $sponsors[$delta]['logo_url'] = $partner['logo']['url']['default'];
+        }
+      }
+      if (!empty($sponsors)) {
+        $vars['sponsor_logos'] = theme('sponsor_logos', array(
+          'sponsors' => $sponsors,
+        ));
+      }
+    }
+  }
+
+  // If the campaign requires a signup modal to display:
+  if (isset($vars['node']->required_signup_data_form)) {
+    // Add JS to open the signup data form modal.
+    $id = 'modal-signup-data-form';
+    $js = 'require(["neue/modal"], function(Modal) { Modal.open( jQuery("#' . $id . '"), {animated: false, closeButton: "skip", skipForm: "#dosomething-signup-user-skip-signup-data-form"}); });';
+    drupal_add_js($js, 'inline');
+  }
 }
 
 /**
@@ -270,4 +284,33 @@ function paraneue_dosomething_preprocess_node_campaign_scholarship(&$vars) {
       'classes' => $classes,
     ));
   }
+}
+
+/**
+ * Preprocesses the $vars['galleries'] if exists.
+ *
+ * @see dosomething_static_content_preprocess_gallery_vars().
+ *
+ * @param array $vars
+ *   Vars passed from a hook_preprocess_node().
+ */
+function paraneue_dosomething_preprocess_node_field_gallery(&$vars) {
+
+  if (!isset($vars['galleries'])) return;
+
+  // Loop through each gallery:
+  foreach ($vars['galleries'] as $delta => &$gallery) {
+    // Get the class to apply based on gallery style.
+    $gallery_class = paraneue_dosomething_get_gallery_style($gallery['style']);
+    // Sets $vars['galleries'][$delta]['class'] to $gallery_class.
+    $gallery['class'] = $gallery_class;
+    $items_count = count($gallery['items']);
+    // Preprocess the $gallery['items'] array.
+    for ($i = 0; $i <= $items_count; $i++) {
+      // Get class based on the gallery item's sequence.
+      $order_class = paraneue_dosomething_get_gallery_item_order_class($i);
+      $gallery['items'][$i]['order_class'] = $order_class;
+    }
+  }
+
 }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/static_content/node--static_content.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/static_content/node--static_content.tpl.php
@@ -68,7 +68,7 @@
           <h2 class="container__title inline--alt-color"><?php print $gallery['title']; ?></h2>
         <?php endif; ?>
 
-        <ul class="gallery -triad">
+        <ul class="gallery <?php print $gallery['class']; ?>">
           <?php foreach ($gallery['items'] as $gallery_item): ?>
             <li class="<?php print $gallery_item['order_class']; ?>">
               <div class="tile tile--figure">


### PR DESCRIPTION
@tjrosario Can you pls review? cc @angaither 

per #2749 the gallery needs to display the Thumbnail field on the Image node instead of the Square field if the Gallery Style is anything than default.

This PR changes `dosomething_static_content_preprocess_gallery` to use the correct Image field based on the the Gallery Style, but there are CSS issues when the `-duo` class is used.

It also adds a `paraneue_dosomething_preprocess_node_field_gallery` function to keep Neue specific preprocessing in the theme layer, and breaks out Campaign node specific preprocessing into `paraneue_dosomething_preprocess_node_campaign`.
