### PR TITLE
Campaign finder  bug

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
@@ -81,7 +81,6 @@ define(function(require) {
      * @param  {Object} data The raw data from the query
      */
     parseResults: function (data) {
-      console.log(data);
       // Remove the old results
       ResultsView.clear();
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
@@ -81,6 +81,7 @@ define(function(require) {
      * @param  {Object} data The raw data from the query
      */
     parseResults: function (data) {
+      console.log(data);
       // Remove the old results
       ResultsView.clear();
 
@@ -167,6 +168,7 @@ define(function(require) {
     clear: function () {
       ResultsView.checkInit();
       ResultsView.$container.empty();
+      ResultsView.$gallery.empty();
 
       ResultsView.$container.show();
       ResultsView.$blankSlateDiv.hide();


### PR DESCRIPTION
@DFurnes This resolves the duplicating results issue that started occurring after the Campaign Finder refactoring. While this solves the issue, I'm not sure why the $container wasn't being emptied properly before? Please take a gander and let me know what you think!

cc @blisteringherb 
