### PR TITLE
Hotfix for DOS-103

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -9,9 +9,9 @@
  * Implements hook_preprocess_node().
  */
 function dosomething_campaign_preprocess_node(&$vars) {
-  if ($vars['type'] != 'campaign') { return; }
+  if ($vars['type'] != 'campaign' || $vars['view_mode'] != 'full') return;
 
-  $node = menu_get_object();
+  $node = $vars['node'];
   $vars['campaign'] = dosomething_campaign_load($node);
   $wrapper = entity_metadata_wrapper('node', $node);
 


### PR DESCRIPTION
Refs: https://jira.dosomething.org/browse/DOS-103

@sergii-tkachenko Can you review?

I think what's going on here is that when Apache SOLR runs cron, the `$node = menu_get_object()` is not reliable.

This PR alters the preprocessing to only occur when we are viewing a full view mode, when a `$vars['node']` will be available.
