### PR TITLE
Removing git commit symlink from build.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -224,8 +224,6 @@ function symlinks {
   rm -rf "$WEB_PATH/profiles/dosomething/themes/dosomething/paraneue_dosomething"
   ln -s "$LIB_PATH/themes/dosomething/paraneue_dosomething" "$WEB_PATH/profiles/dosomething/themes/dosomething/paraneue_dosomething"
 
-  echo 'Add git pre-commit hook'
-  ln -s "../../hooks/pre-commit" ".git/hooks/pre-commit"
 }
 
 #=== FUNCTION ==================================================================


### PR DESCRIPTION
this is only needed on first build, doesn't need to happen every time.

I've added this step into the [wiki](https://github.com/DoSomething/dosomething/wiki/Building-your-local-environment) as it only needs to be done once on the first build of your local environment. 
