### PR TITLE
Updating solr settings to use default hostname and standard port

### DIFF
--- a/config/default.settings.local.php
+++ b/config/default.settings.local.php
@@ -45,14 +45,14 @@ $conf['cache_class_cache_page'] = 'VarnishCache';
 
 // This is managed from salt://varnishd/secret
 $conf['varnish_control_key'] = '00c9203c65874ca5b4c359e19f00bf56';
-    
+
 // Drupal 7 does not cache pages when we invoke hooks during bootstrap.
 // This needs to be disabled.
 $conf['page_cache_invoke_hooks'] = FALSE;
 
 // These settings point to the solr instance on staging.
-$conf['apachesolr_host'] = '192.168.1.169';
-$conf['apachesolr_port'] = '8008';
+$conf['apachesolr_host'] = 'solr';
+$conf['apachesolr_port'] = '8080';
 $conf['apachesolr_path'] = '/solr/collection1';
 $conf['apachesolr_read_only'] = 1;
 

--- a/config/default.settings.local.php
+++ b/config/default.settings.local.php
@@ -53,6 +53,10 @@ $conf['page_cache_invoke_hooks'] = FALSE;
 // These settings point to the solr instance on staging.
 $conf['apachesolr_host'] = 'solr';
 $conf['apachesolr_port'] = '8080';
-$conf['apachesolr_path'] = '/solr/collection1';
+
+$conf_path = explode('/', conf_path());
+$solr_path = $conf_path[1] == 'default' ? 'collection1' : $conf_path[1];
+$conf['apachesolr_path'] = "solr/{$solr_path}";
+
 $conf['apachesolr_read_only'] = 1;
 

--- a/config/settings.php
+++ b/config/settings.php
@@ -132,4 +132,7 @@ $conf['dosomething_is_affiliate'] = FALSE;
 // The 'solr' hostname must be defined in /etc/hosts.
 $conf['apachesolr_host'] = getenv('DS_APACHESOLR_HOST') ?: 'solr';
 $conf['apachesolr_port'] = getenv('DS_APACHESOLR_PORT') ?: '8080';
-$conf['apachesolr_path'] = 'solr/' . ($hostname == 'default' ? 'collection1' : $hostname);
+
+$conf_path = explode('/', conf_path());
+$solr_path = $conf_path[1] == 'default' ? 'collection1' : $conf_path[1];
+$conf['apachesolr_path'] = "solr/{$solr_path}";

--- a/config/settings.php
+++ b/config/settings.php
@@ -128,3 +128,8 @@ $conf['optimizely_id'] = '747623297';
 // e.g. in_array($hostname, $affiliates);
 // @see https://github.com/DoSomething/dosomething/pull/2809
 $conf['dosomething_is_affiliate'] = FALSE;
+
+// The 'solr' hostname must be defined in /etc/hosts.
+$conf['apachesolr_host'] = getenv('DS_APACHESOLR_HOST') ?: 'solr';
+$conf['apachesolr_port'] = getenv('DS_APACHESOLR_PORT') ?: '8080';
+$conf['apachesolr_path'] = 'solr/' . ($hostname == 'default' ? 'collection1' : $hostname);

--- a/lib/modules/dosomething/dosomething_search/dosomething_search.apachesolr_environments.inc
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.apachesolr_environments.inc
@@ -9,10 +9,13 @@
  */
 function dosomething_search_apachesolr_environments() {
   $export = array();
-  
-  $host = variable_get('apachesolr_host', '192.168.1.169');
+
+  $host = variable_get('apachesolr_host', 'solr');
   $port = variable_get('apachesolr_port', '8080');
-  $path = variable_get('apachesolr_path', 'solr/collection1');
+
+  $conf_path = explode('/', conf_path());
+  $solr_path = $conf_path[1] == 'default' ? 'collection1' : $conf_path[1];
+  $path = variable_get('apachesolr_path', "solr/{$solr_path}");
 
   $environment = new stdClass();
   $environment->api_version = 1;

--- a/provision/salt/roots/salt/lamp-drupal.sls
+++ b/provision/salt/roots/salt/lamp-drupal.sls
@@ -154,4 +154,14 @@ apt-update:
   cmd.run:
     - name: sudo apt-get update
 
+solr:
+  host.present:
+    - ip: 192.168.1.169
+
+solr_port:
+   environ.set:
+     - name: DS_APACHESOLR_PORT
+     - value: 8080
+     - update_minion: True
+
 {% endif %}


### PR DESCRIPTION
- Vagrantfile now adds standard 8080 and QA solr hostname for dev
  boxes
- settings.php files will use the hostname 'solr' which is set up
  in QA, staging, and production environments
- Apachesolr environment vars in features will default to standard
  hostname, port, and use the folder name to determine the solr
  path

Wikis have been updated to reflect these changes:  
The dosomething wiki - https://github.com/DoSomething/dosomething/wiki/Solr,-Finder,--campaigns,-Search-Development-and-Troubleshooting#solrapachesolr-search-development-tips

New solr IPs and admin interface guide on the tech wiki. - https://sites.google.com/a/dosomething.org/tech/developer-orientation/solr-ips-and-admin-interface

@aaronschachter 
