### PR TITLE
Campaign fixtures taxonomy

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -364,7 +364,6 @@ function dosomething_campaign_create_node_from_json($string) {
 
   // Set issue
   if(isset($data->issue)) {
-    $cause = dosomething_taxonomy_create_vocabulary_once("Cause", "cause");
     $term = dosomething_taxonomy_create_term_once($data->issue, $cause->machine_name);
     $node->field_issue[LANGUAGE_NONE][0]['tid'] = $term->tid;
   }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -318,8 +318,10 @@ function dosomething_campaign_load_stats(&$campaign) {
 function dosomething_campaign_create_node_from_json($string) {
   $data = json_decode($string);
   $node = new stdClass();
+
   $node->type = $data->type;
   $node->title = $data->title;
+
   // Set all plain text properties:
   $plain_text = dosomething_campaign_get_property_names_plain_text();
   foreach ($plain_text as $text_field) {
@@ -345,6 +347,18 @@ function dosomething_campaign_create_node_from_json($string) {
       $field_name = 'field_' . $fact_field;
       $fact_node = dosomething_fact_create_node_from_json(json_encode($data->{$fact_field}));
       $node->{$field_name}[LANGUAGE_NONE][0]['target_id'] = $fact_node->nid;
+    }
+  }
+
+  // Set all fact array properties:
+  $fact_array = dosomething_campaign_get_property_names_fact_array();
+  foreach($fact_array as $fact_field) {
+    if (isset($data->{$fact_field})) {
+      $field_name = 'field_' . $fact_field;
+      foreach($data->{$fact_field} as $data_fact) {
+        $fact_node = dosomething_fact_create_node_from_json(json_encode($data_fact));
+        $node->{$field_name}[LANGUAGE_NONE][]['target_id'] = $fact_node->nid;
+      }
     }
   }
 
@@ -396,6 +410,15 @@ function dosomething_campaign_get_property_names_fact() {
   return array(
     'fact_problem',
     'fact_solution',
+  );
+}
+
+/**
+ * Returns array of campaign property names which contain an array of fact nodes.
+ */
+function dosomething_campaign_get_property_names_fact_array() {
+  return array(
+    'facts',
   );
 }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -364,7 +364,7 @@ function dosomething_campaign_create_node_from_json($string) {
 
   // Set issue
   if(isset($data->issue)) {
-    $term = dosomething_taxonomy_create_term_once($data->issue, $cause->machine_name);
+    $term = dosomething_taxonomy_create_term($data->issue, "cause");
     $node->field_issue[LANGUAGE_NONE][0]['tid'] = $term->tid;
   }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -362,6 +362,13 @@ function dosomething_campaign_create_node_from_json($string) {
     }
   }
 
+  // Set issue
+  if(isset($data->issue)) {
+    $cause = dosomething_taxonomy_create_vocabulary_once("Cause", "cause");
+    $term = dosomething_taxonomy_create_term_once($data->issue, $cause->machine_name);
+    $node->field_issue[LANGUAGE_NONE][0]['tid'] = $term->tid;
+  }
+
   node_save($node);
   return $node;
 }

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.helpers.inc
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.helpers.inc
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @file
+ * Helper functions for dosomething_taxonomy functionality.
+ */
+
+
+/**
+ * Creates a taxonomy term with the given name if it doesn't already exist.
+ * @return term object
+ */
+function dosomething_taxonomy_create_term_once($name, $vocabulary_machine_name) {
+  if ($vocabulary = taxonomy_vocabulary_machine_name_load($vocabulary_machine_name)) {
+    $vid = $vocabulary->vid;
+    $existing_term = dosomething_taxonomy_get_term_from_name($name, $vid);
+
+    $term = new stdClass();
+
+    $term->name = $name;
+    $term->vid = $vid;
+
+    if($existing_term) {
+      $term->tid = $existing_term;
+    }
+
+    taxonomy_term_save($term);
+    return $term;
+  }
+}
+
+/**
+ * Helper function to dynamically get the tid from the term_name
+ * Source: https://api.drupal.org/comment/18909#comment-18909
+ *
+ * @param $term_name Term name
+ * @param $vid ID of the vocabulary to search the term in
+ *
+ * @return Term ID of the found term or else FALSE
+ */
+function dosomething_taxonomy_get_term_from_name($term_name, $vid) {
+  $tree = taxonomy_get_tree($vid);
+  foreach ($tree as $term) {
+    if ($term->name == $term_name) {
+      return $term;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+ * Creates a vocabulary with the given machine name if it doesn't already exist.
+ * Otherwise, update the existing vocabulary with the new name.
+ * @return vocabulary object
+ */
+function dosomething_taxonomy_create_vocabulary_once($name, $machine_name) {
+  $vocabulary = new stdClass();
+  $vocabulary->name = $name;
+  $vocabulary->machine_name = $machine_name;
+
+  if($existing_vocabulary = taxonomy_vocabulary_machine_name_load($machine_name)) {
+    $vocabulary->vid = $existing_vocabulary->vid;
+  }
+
+  taxonomy_vocabulary_save($vocabulary);
+  return $vocabulary;
+}

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.helpers.inc
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.helpers.inc
@@ -9,7 +9,7 @@
  * Creates a taxonomy term with the given name if it doesn't already exist.
  * @return term object
  */
-function dosomething_taxonomy_create_term_once($name, $vocabulary_machine_name) {
+function dosomething_taxonomy_create_term($name, $vocabulary_machine_name) {
   if ($vocabulary = taxonomy_vocabulary_machine_name_load($vocabulary_machine_name)) {
     $vid = $vocabulary->vid;
     $existing_tid = dosomething_taxonomy_get_tid_from_name($name, $vid);

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.helpers.inc
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.helpers.inc
@@ -12,7 +12,7 @@
 function dosomething_taxonomy_create_term_once($name, $vocabulary_machine_name) {
   if ($vocabulary = taxonomy_vocabulary_machine_name_load($vocabulary_machine_name)) {
     $vid = $vocabulary->vid;
-    $existing_term = dosomething_taxonomy_get_term_from_name($name, $vid);
+    $existing_tid = dosomething_taxonomy_get_tid_from_name($name, $vid);
 
     $term = new stdClass();
 
@@ -20,7 +20,7 @@ function dosomething_taxonomy_create_term_once($name, $vocabulary_machine_name) 
     $term->vid = $vid;
 
     if($existing_term) {
-      $term->tid = $existing_term;
+      $term->tid = $existing_tid;
     }
 
     taxonomy_term_save($term);
@@ -37,7 +37,7 @@ function dosomething_taxonomy_create_term_once($name, $vocabulary_machine_name) 
  *
  * @return Term ID of the found term or else FALSE
  */
-function dosomething_taxonomy_get_term_from_name($term_name, $vid) {
+function dosomething_taxonomy_get_tid_from_name($term_name, $vid) {
   $tree = taxonomy_get_tree($vid);
   foreach ($tree as $term) {
     if ($term->name == $term_name) {

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.helpers.inc
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.helpers.inc
@@ -47,21 +47,3 @@ function dosomething_taxonomy_get_term_from_name($term_name, $vid) {
 
   return FALSE;
 }
-
-/**
- * Creates a vocabulary with the given machine name if it doesn't already exist.
- * Otherwise, update the existing vocabulary with the new name.
- * @return vocabulary object
- */
-function dosomething_taxonomy_create_vocabulary_once($name, $machine_name) {
-  $vocabulary = new stdClass();
-  $vocabulary->name = $name;
-  $vocabulary->machine_name = $machine_name;
-
-  if($existing_vocabulary = taxonomy_vocabulary_machine_name_load($machine_name)) {
-    $vocabulary->vid = $existing_vocabulary->vid;
-  }
-
-  taxonomy_vocabulary_save($vocabulary);
-  return $vocabulary;
-}

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -5,6 +5,7 @@
  */
 
 include_once 'dosomething_taxonomy.features.inc';
+include_once 'dosomething_taxonomy.helpers.inc';
 
 /**
  * Returns data from field_partners field collection for a given $node.

--- a/tests/fixtures/campaign.json
+++ b/tests/fixtures/campaign.json
@@ -2,6 +2,7 @@
     "title": "Test Campaign",
     "type": "campaign",
 
+    "issue": "Testing",
     "status": "active",
     "active_hours": "2",
 
@@ -21,6 +22,26 @@
         "Lorch, Julie. \"Coffee Sure Is Great\", Royal Academy of Coffee, 2010."
       ]
     },
+    "facts": [ 
+      {
+        "title": "1 in 3 teenagers have slept through math or English class in the past week.",
+        "sources": [
+          "Holford, Matt. \"Students Need Coffee\", National Coffee Review, 2010."
+        ]
+      },
+      {
+        "title": "Legend has it a 9th-century Ethiopian goat herder discovered coffee by accident when he noticed how crazy the beans were making his goats.",
+        "sources": [
+          "Broderick, Ryan. \"22 Facts About Coffee: The World’s Most Important Beverage\", Buzzfeed, 2012."
+        ]
+      },
+      {
+        "title": "Coffee grows on trees.",
+        "sources": [
+          "Inman, Matthew. \"15 Things Worth Knowing About Coffee\", The Oatmeal, 2013."
+        ]
+      }
+    ],
 
     "items_needed": "* Fresh coffee beans\n* Aeropress or Chemex\n* Hot water",
     "vips": "Celestial at Birch Coffee knows what's up.",

--- a/tests/fixtures/campaign.json
+++ b/tests/fixtures/campaign.json
@@ -2,7 +2,7 @@
     "title": "Test Campaign",
     "type": "campaign",
 
-    "issue": "Testing",
+    "issue": "Test Issue",
     "status": "active",
     "active_hours": "2",
 


### PR DESCRIPTION
## Changes
- Creates an array of fact nodes for the More Facts modal.
- Creates a "Test Issue" issue in the Causes taxonomy if it doesn't already exist.

For review: @aaronschachter @angaither 
## Usage

To create test campaign: `drush campaign-create ../tests/fixtures/campaign.json`
## Screenshot

![test-campaign-taxonomy](https://cloud.githubusercontent.com/assets/583202/3726369/99000870-1692-11e4-968f-bbbb86b0394a.png)
