### PR TITLE
User Profile variables

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.info
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.info
@@ -109,6 +109,7 @@ features[variable][] = user_mail_register_no_approval_required_notify
 features[variable][] = user_mail_status_activated_notify
 features[variable][] = user_mail_status_blocked_notify
 features[variable][] = user_mail_status_canceled_notify
+features[variable][] = user_picture_dimensions
 features[variable][] = user_picture_path
 features[variable][] = user_picture_style
 features[variable][] = user_pictures

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.strongarm.inc
@@ -90,6 +90,13 @@ function dosomething_user_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'user_picture_dimensions';
+  $strongarm->value = '600x600';
+  $export['user_picture_dimensions'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'user_picture_path';
   $strongarm->value = 'user';
   $export['user_picture_path'] = $strongarm;
@@ -98,7 +105,7 @@ function dosomething_user_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'user_picture_style';
-  $strongarm->value = '310x310';
+  $strongarm->value = '300x300';
   $export['user_picture_style'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
Without explicitly setting the `user_picture_dimensions` variable, profile pictures save to 85x85.  This fixes.
