### PR TITLE
Indexed fields

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
@@ -428,9 +428,9 @@ function dosomething_campaign_field_default_field_instances() {
         'weight' => 65,
       ),
       'search_index' => array(
-        'label' => 'above',
+        'label' => 'hidden',
         'settings' => array(),
-        'type' => 'hidden',
+        'type' => 'list_default',
         'weight' => 65,
       ),
       'teaser' => array(
@@ -2402,9 +2402,9 @@ function dosomething_campaign_field_default_field_instances() {
         'weight' => 20,
       ),
       'search_index' => array(
-        'label' => 'above',
+        'label' => 'hidden',
         'settings' => array(),
-        'type' => 'hidden',
+        'type' => 'list_default',
         'weight' => 20,
       ),
       'teaser' => array(

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
@@ -1206,9 +1206,9 @@ function dosomething_campaign_group_field_default_field_instances() {
         'weight' => 28,
       ),
       'search_index' => array(
-        'label' => 'above',
+        'label' => 'hidden',
         'settings' => array(),
-        'type' => 'hidden',
+        'type' => 'list_default',
         'weight' => 28,
       ),
       'teaser' => array(


### PR DESCRIPTION
Readding the Staff Pick field for the Campaign and Campaign Group content type and the Campaign Status field for campaigns to fields indexed by Solr.  The staff pick field is necessary for appropriately boosting the results, and the campaign status field is necessary for correctly excluding closed campaigns from the finder and /campaigns.

Addresses: https://jira.dosomething.org/browse/DOS-117
@aaronschachter 
