### PR TITLE
Adding a new bubble factor field and improving Finder results

### DIFF
--- a/config/default.settings.local.php
+++ b/config/default.settings.local.php
@@ -58,5 +58,10 @@ $conf_path = explode('/', conf_path());
 $solr_path = $conf_path[1] == 'default' ? 'collection1' : $conf_path[1];
 $conf['apachesolr_path'] = "solr/{$solr_path}";
 
-$conf['apachesolr_read_only'] = 1;
+// This is different from the apachesolr host because it's on the client side
+$conf['dosomething_search_finder_url'] = (getenv('DS_FINDER_URL') ?: 'http://solr.dev.dosomething.org') . ":{$conf['apachesolr_port']}/solr/";
+
+$conf['dosomething_search_finder_collection'] = $solr_path;
+
+#$conf['apachesolr_read_only'] = 1;
 

--- a/config/settings.php
+++ b/config/settings.php
@@ -136,3 +136,8 @@ $conf['apachesolr_port'] = getenv('DS_APACHESOLR_PORT') ?: '8080';
 $conf_path = explode('/', conf_path());
 $solr_path = $conf_path[1] == 'default' ? 'collection1' : $conf_path[1];
 $conf['apachesolr_path'] = "solr/{$solr_path}";
+
+// This is different from the apachesolr host because it's on the client side
+$conf['dosomething_search_finder_url'] = (getenv('DS_FINDER_URL') ?: 'http://search.dosomething.org') . "/solr/";
+
+$conf['dosomething_search_finder_collection'] = $solr_path;

--- a/lib/modules/dosomething/dosomething_search/dosomething_search.module
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.module
@@ -7,6 +7,17 @@
 include_once 'dosomething_search.features.inc';
 
 function dosomething_search_preprocess_page(&$vars) {
+  $solrURL = variable_get('dosomething_search_finder_url', 'https://search.dosomething.org');
+  $collection = variable_get('dosomething_search_finder_collection', 'collection1');
+  drupal_add_js(
+    array('dosomething_search' =>
+      array(
+        'solrURL' => $solrURL,
+        'collection' => $collection
+      )
+    ),
+    'setting'
+  );
   $form = drupal_get_form('search_block_form');
   $vars['search_box'] = drupal_render($form);
 }

--- a/lib/modules/dosomething/dosomething_search/dosomething_search.module
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.module
@@ -120,6 +120,7 @@ function dosomething_search_apachesolr_index_document_build_node(ApacheSolrDocum
       }
     }
 
+    $bubble_factor = 0;
     $node = entity_metadata_wrapper('node', $entity);
     foreach (array('high_season', 'low_season') as $season) {
       if (isset($node->{"field_" . $season})) {
@@ -128,6 +129,9 @@ function dosomething_search_apachesolr_index_document_build_node(ApacheSolrDocum
           $now = time();
           if ($now >= $node->{"field_" . $season}->value->value() && $now <= $node->{"field_" . $season}->value2->value()) {
             $document->setField("bs_{$season}", 'true');
+            if ($node->field_high_season->value() && $season == 'high_season') {
+              $bubble_factor += 5;
+            }
           }
         }
       }
@@ -135,9 +139,17 @@ function dosomething_search_apachesolr_index_document_build_node(ApacheSolrDocum
     $sponsored = $node->field_partners->value();
     if (isset($sponsored)) {
       $document->setField("bs_sponsored", 'true');
+      $bubble_factor += 10;
     }
+
+    if (isset($node->field_staff_pick) && $node->field_staff_pick->value()) {
+      $bubble_factor += 20;
+    }
+
+    $document->setField('is_bubble_factor', $bubble_factor);
   }
 }
+
 
 /**
  * Preprocess a single search result.

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
@@ -26,8 +26,8 @@ define(function(require) {
      * Configure this too. What's the base URL of the Solr server that you want
      * the browser pinging? And what collection?
      **/
-    baseURL: "https://search.dosomething.org/solr/",
-    collection: "collection1",
+    baseURL: Drupal.settings.dosomething_search.solrURL,
+    collection: Drupal.settings.dosomething_search.collection,
 
     // The current throttle timeout identifier
     throttle: null,
@@ -43,7 +43,6 @@ define(function(require) {
       "facet.field=fs_field_active_hours",
       "facet.field=im_field_cause",
       "facet.field=im_field_action_type",
-      "sort=bs_field_staff_pick+desc",
       "rows=8",
       "fl=label,tid,im_vid_1,sm_vid_Action_Type,tm_vid_1_names,im_field_cause,im_vid_2,sm_vid_Cause,tm_vid_2_names,im_field_tags,im_vid_5,sm_vid_Tags,tm_vid_5_names,fs_field_active_hours,sm_field_call_to_action,bs_field_staff_pick,ss_field_search_image_400x400,ss_field_search_image_720x720,url"
     ],

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
@@ -34,6 +34,7 @@ define(function(require) {
 
     // This would be awesome with an object key:value, but Solr allows multiple of the same key
     defaultQuery: [
+      "q=_query_:\"{!func}scale(is_bubble_factor,0,100)\"",
       "fq=-sm_field_campaign_status:(closed) bundle:[campaign TO campaign_group]",
       //"fq=ss_field_search_image:[* TO *]",
       "wt=json",

--- a/provision/salt/roots/salt/lamp-drupal.sls
+++ b/provision/salt/roots/salt/lamp-drupal.sls
@@ -164,4 +164,10 @@ solr_port:
      - value: 8080
      - update_minion: True
 
+finder_url:
+  environ.set:
+     - name: DS_FINDER_URL
+     - value: http://solr.dev.dosomething.org
+
+
 {% endif %}


### PR DESCRIPTION
- The new bubble_factor field can now be used to significantly bump
  staff pick, high season and sponsored campaigns to the top of
  Finder, /campaigns, and search results with a function query
- Adding a function query to the Finder to boost selected documents
  to the top of Finder results.
- Updating finder js to use an environment specific url for finder results

Fixes: https://jira.dosomething.org/browse/DOS-117

@aaronschachter @DFurnes 
