### PR TITLE
SMS Worfklow debugging

### DIFF
--- a/lib/modules/dosomething/dosomething_sms/dosomething_sms.admin.inc
+++ b/lib/modules/dosomething/dosomething_sms/dosomething_sms.admin.inc
@@ -46,6 +46,10 @@ function dosomething_sms_workflow_overview_page() {
     'header' => $header,
     'rows' => $rows,
   ));
+  $output .= '<h2>Development</h2>';
+  $output .= '<p>These should be turned off in production.</p>';
+  $config_form = drupal_get_form('dosomething_sms_workflow_config_form');
+  $output .= render($config_form);
   return $output;
 }
 
@@ -128,4 +132,23 @@ function dosomething_sms_workflow_form_submit($form, &$form_state) {
   $entity->save();
   $form_state['redirect'] = DOSOMETHING_SMS_WORKFLOW_ADMIN_PATH;
   drupal_set_message("SMS Workflow saved.");
+}
+
+/**
+ * Form constructor for SMS Workflow config form.
+ */
+function dosomething_sms_workflow_config_form($form, &$form_state) {
+  $form['dosomething_sms_workflow_log'] =  array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable logging'),
+    '#description' => t("Logs requests to any SMS Workflow endpoint."),
+    '#default_value' => variable_get('dosomething_sms_workflow_log'),
+  );
+  $form['dosomething_sms_workflow_access_bypass'] =  array(
+    '#type' => 'checkbox',
+    '#title' => t('Bypass IP checks'),
+    '#description' => t("Disables check for incoming MobileCommons IP."),
+    '#default_value' => variable_get('dosomething_sms_workflow_access_bypass'),
+  );
+  return system_settings_form($form);
 }

--- a/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
+++ b/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
@@ -201,6 +201,9 @@ function dosomething_sms_incoming_callback($path) {
     'carrier' => $carrier,
     'sender' => $sender,
   );
+  if (variable_get('dosomething_sms_workflow_log')) {
+    watchdog('dosomething_sms', '$context: ' . json_encode($context));
+  }
 
   // Pass message on to Conductor to handle and generate a response
   $output = '';
@@ -208,6 +211,9 @@ function dosomething_sms_incoming_callback($path) {
 
   // Reply with output back to Mobile Commons. If empty, Mobile Commons will ignore it.
   print $output;
+  if (variable_get('dosomething_sms_workflow_log')) {
+    watchdog('dosomething_sms', '$output: ' . json_encode($output));
+  }
 
   return NULL;
 }
@@ -216,6 +222,9 @@ function dosomething_sms_incoming_callback($path) {
  * Filter to ensure incoming texts are coming from Mobile Commons' IP.
  */
 function dosomething_sms_incoming_check() {
+  if (variable_get('dosomething_sms_workflow_access_bypass')) {
+    return TRUE;
+  }
   // Valid IP range as specified by Mobile Commons is: 64.22.127.0/24.
   // This translates to any IP 64.22.127.0 - 64.22.127.255
   $ips = array();


### PR DESCRIPTION
Adds settings and functionality for:
- Bypass IP access checks for Mobile Commons IP's.  Useful for testing from a browser REST console.
- Log `$context` input and `$output` if logging variable is set.
