### PR TITLE
Include app.js using Drupal API so it supports Drupal.t().

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -4,6 +4,40 @@
  * Implements theme_preprocess_page().
  */
 function paraneue_dosomething_preprocess_page(&$vars) {
+
+  // Build app.js URL:
+  // 1. Build path:
+  //    a) DS_ASSET_PATH is local. Path must be built with drupal_get_path()
+  //       function (already assigned to PARANEUE_DS_PATH).
+  //       Using DS_ASSET_PATH in this case is wrong: it starts
+  //       with '/' so Drupal can't open js file for parsing.
+  //       @see drupal_add_js().
+  //    b) DS_ASSET_PATH is not local. It is already a valid URL to CDN.
+  $app_js = DS_ASSET_PATH == LOCAL_ASSET_PATH ? PARANEUE_DS_PATH . '/dist'
+                                              : DS_ASSET_PATH;
+
+  // 2. Build name. Determine whether suffix '.min' should be inserted.
+  $minified = theme_get_setting('use_minified_assets');
+  $app_js .= '/app' . (!$minified ?: '.min') . '.js';
+
+  // Add app.js using Drupal API:
+  // - Please note that group must be JS_LIBRARY, weight must be < -100,
+  //   every_page must be set to TRUE. This way app.js will be added
+  //   above drupal.js (weight -100, same options).
+  //   @see drupal_add_js(), 'weight' option.
+  // - The reason why app.js must be above drupal.js is that app.js contains
+  //   bundled libraries (e.g. jQuery) which drupal.js depends.on.
+  //   @see paraneue_dosomething_js_alter().
+  // - Preprocess is turned off to avoid double minification
+  //   of local (non-cdn) app.min.js.
+  //   @see drupal_add_js(), 'preprocess' option.
+  drupal_add_js($app_js, array(
+    'group'      => JS_LIBRARY,
+    'weight'     => -200,
+    'every_page' => TRUE,
+    'preprocess' => FALSE,
+  ));
+
   // Add theme suggestion for page template based on node.
   if (isset($vars['node']->type)) {
     // If the content type's machine name is "my_machine_name" the file

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -13,8 +13,8 @@ function paraneue_dosomething_preprocess_page(&$vars) {
   //       with '/' so Drupal can't open js file for parsing.
   //       @see drupal_add_js().
   //    b) DS_ASSET_PATH is not local. It is already a valid URL to CDN.
-  $app_js = DS_ASSET_PATH == LOCAL_ASSET_PATH ? PARANEUE_DS_PATH . '/dist'
-                                              : DS_ASSET_PATH;
+  $is_local_asset = DS_ASSET_PATH == LOCAL_ASSET_PATH;
+  $app_js = $is_local_asset ? (PARANEUE_DS_PATH . '/dist') : DS_ASSET_PATH;
 
   // 2. Build name. Determine whether suffix '.min' should be inserted.
   $minified = theme_get_setting('use_minified_assets');

--- a/lib/themes/dosomething/paraneue_dosomething/template.php
+++ b/lib/themes/dosomething/paraneue_dosomething/template.php
@@ -13,13 +13,11 @@ if(theme_get_setting('asset_path')) {
   define('DS_ASSET_PATH', LOCAL_ASSET_PATH);
 }
 
-// Determine whether to use minified script or not
+// Determine whether to use minified stylesheets or not.
 if(theme_get_setting('use_minified_assets')) {
   define('DS_STYLE_PATH', DS_ASSET_PATH . '/app.min.css');
-  define('DS_JAVASCRIPT_PATH', DS_ASSET_PATH . '/app.min.js');
 } else {
   define('DS_STYLE_PATH', DS_ASSET_PATH . '/app.css');
-  define('DS_JAVASCRIPT_PATH', DS_ASSET_PATH . '/app.js');
 }
 
 // Define asset directory paths

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -51,7 +51,6 @@
     <?php print $page; ?>
   </div>
 
-  <script type="text/javascript" src="<?php print DS_JAVASCRIPT_PATH; ?>"></script>
   <?php print $scripts; ?>
   <?php print $page_bottom; ?>
 </body>


### PR DESCRIPTION
#### What's this PR do?
1. Changes the way `app.js` is included:
   - `<script …>` tag is replaced with proper `drupal_add_js()`
2. Changes the way path to `app.js` is generated:
   - `DS_JAVASCRIPT_PATH` constant is removed. Using DS_ASSET_PATH in this case is wrong: it starts with '/' so Drupal can't open js file for parsing
   - `app.js` path is generated with `drupal_get_path()` so it's compatible with `drupal_add_js()`
#### How should this be manually tested?

This is very difficult process.

I altered `Finder.js` init function to test if `Drupal.t()` works.
Basically I added `alert(Drupal.t("Hello world #1,2..")` and checked if it's appeared in the [translation interface](http://localhost:8888/admin/config/regional/translate/translate).

You can gain access to it by running `drush upwd admin --password 1` and then log in as `admin@example.com` with password `1`. 

You should use `ds grunt --watch` to rebuild app.js.
You should also reset "Asset Path" on Paraneue DoSomething [theme settings](http://localhost:8888/admin/appearance/settings/paraneue_dosomething)

Normal flow of adding translation from js:
- Add `Drupal.t("something something")` to js file
- Build file with `ds grunt`
- Open http://localhost:8888 in browser
- Run `drush cc css-js`
- Refresh http://localhost:8888
- Search for "something something" in the translation interface

Apart from that, I tested the same with "Asset Path" set to VM host (nginx on my laptop), since normal cdn doesn't have `Drupal.t` calls yet.
To achieve that I had to alter hosts file on VM and manually sync assets after each `ds grunt` rebuild. I used rsync for that:
- `mkdir -p /vagrant/lib/themes/dosomething/paraneue_dosomething/dist`
- `rsync -rtv /var/www/vagrant/lib/themes/dosomething/paraneue_dosomething/dist/`
  On laptop:
- `mkdir -p /Users/sergii/Sites/home.sergii.org/sites/default/files/assets`
- `ln -nvfs /Users/sergii/Development/dosomething/lib/themes/dosomething/paraneue_dosomething/dist /Users/sergii/Sites/home.sergii.org/sites/default/files/assets/v0.2.169`
#### What are the relevant tickets?

Ref: [#DOS-91](https://jira.dosomething.org/browse/DOS-91)

CC: @aaronschachter @DFurnes @mshmsh5000 
