### PR TITLE
Remove non-features-exported hook_ctools_plugin_api

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -10,15 +10,6 @@ include_once('dosomething_helpers.strongarm.inc');
 include_once('dosomething_helpers.variable.inc');
 
 /**
- * Implements hook_ctools_plugin_api().
- */
-function dosomething_helpers_ctools_plugin_api($module = NULL, $api = NULL) {
-  if ($module == "strongarm" && $api == "strongarm") {
-    return array("version" => "1");
-  }
-}
-
-/**
  * Implements hook_menu().
  */
 function dosomething_helpers_menu() {


### PR DESCRIPTION
Used features export to export the Entity Autocomplete permissions, which added `dosomething_helpers_ctools_plugin_api` into a new features.inc #2919

Removing the one in the module file, not sure that this was ever working.
