### PR TITLE
Reportback form: Number of participants

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -142,9 +142,17 @@ function dosomething_campaign_admin_custom_settings_page($node) {
     $signup_data_config_form = drupal_get_form('dosomething_signup_node_signup_data_form', $node);
     $output .= render($signup_data_config_form);
   }
-  if (module_exists('dosomething_reportback')) {
-    $reportback_field_form = drupal_get_form('dosomething_reportback_node_reportback_field_form', $node);
+  if (module_exists('dosomething_helpers')) {
+    $form_id = 'dosomething_campaign_reportback_config_form';
+    $reportback_field_form = drupal_get_form($form_id, $node);
     $output .= render($reportback_field_form);
+    if (user_access('administer modules')) {
+      // Only admin's can use this Reportback Field form.
+      // This form will soon be deprecated but Thumb Wars uses it.
+      $form_id = 'dosomething_reportback_node_reportback_field_form';
+      $reportback_field_form = drupal_get_form($form_id, $node);
+      $output .= render($reportback_field_form);
+    }
   }
   return $output;
 }
@@ -229,4 +237,48 @@ function dosomething_campaign_admin_status_call_to_action_query($char_count = 65
   $query->addExpression('CHAR_LENGTH(cta.field_call_to_action_value)', 'length');
   $query->where('CHAR_LENGTH(cta.field_call_to_action_value) > ' . $char_count);
   return $query->execute();
+}
+
+/**
+ * Sets helpers variables related to Reportback functionality.
+ */
+function dosomething_campaign_reportback_config_form($form, &$form_state, $node) {
+  // Load the node's helpers variables.
+  $vars = dosomething_helpers_get_variables($node->nid);
+  $form['nid'] = array(
+    '#type' => 'hidden',
+    '#value' => $node->nid,
+  );
+  $form['rb'] = array(
+    '#type' => 'fieldset',
+    '#title' => t("Reportbacks"),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['rb']['collect_num_participants'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Collect number of participants'),
+    '#description' => t('If set, the Reportback form will include an additional question asking for number of participants.'),
+    '#default_value' => $vars['collect_num_participants'],
+    '#size' => 20,
+  );
+  $form['rb']['actions'] = array(
+    '#type' => 'actions',
+    'submit' => array(
+      '#type' => 'submit',
+      '#value' => 'Save',
+    ),
+  );
+  return $form;
+}
+
+/**
+ * Submit callback for dosomething_campaign_reportback_config_form().
+ */
+function dosomething_campaign_reportback_config_form_submit(&$form, &$form_state) {
+  $var_name = 'collect_num_participants';
+  $values = $form_state['values'];
+  $node = node_load($values['nid']);
+  dosomething_helpers_set_variable($node, $var_name, $values[$var_name]);
+  drupal_set_message("Updated.");
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -82,6 +82,7 @@ function dosomething_helpers_get_variable_names() {
     'alt_bg_fid',
     'alt_color',
     'alt_image_campaign_cover_nid',
+    'collect_num_participants',
     'mobilecommons_opt_in_path',
     'mobilecommons_friends_opt_in_path',
     'signup_form_submit_label',

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -64,6 +64,25 @@ function dosomething_reportback_form($form, &$form_state, $entity) {
     ),
     '#default_value' => $entity->quantity,
   );
+
+  // Load helpers variables for the nid this reportback is for.
+  $config = dosomething_helpers_get_variables($entity->nid);
+  if ($config['collect_num_participants']) {
+    $form['num_participants'] = array(
+      '#type' => 'textfield',
+      '#required' => TRUE,
+      '#attributes' => array(
+        'placeholder' => t("Enter # here"),
+        'class' => array('js-validate'),
+        'data-validate' => 'reportbackNumber',
+        'data-validate-required' => '',
+      ),
+      '#element_validate' => array('element_validate_integer_positive'),
+      '#title' => t("Total # of people participated"),
+      '#default_value' => $entity->num_participants,
+    );
+  }
+
   // If a custom reportback field exists and is set to active:
   if (isset($entity->field) && $entity->field['status'] == 1) {
     $field_name = $entity->field['name'];

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -397,7 +397,13 @@ function dosomething_reportback_save($values) {
  */
 function dosomething_reportback_set_properties(&$entity, $values) {
   // List all possible entity properties to write.
-  $properties = array('uid', 'nid', 'quantity', 'why_participated');
+  $properties = array(
+    'uid',
+    'nid',
+    'quantity',
+    'why_participated',
+    'num_participants',
+  );
   // For each of them:
   foreach ($properties as $property) {
     // If we have a value set for this property.

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -311,6 +311,13 @@ class ReportbackEntityController extends EntityAPIController {
       '#markup' => 'Quantity: <strong>' . check_plain($entity->quantity) . '</strong> ' . $quantity_label,
       '#suffix' => '</p>',
     );
+    if ($entity->num_participants) {
+       $build['num_participants'] = array(
+        '#prefix' => '<p>',
+        '#markup' => '# of Participants: <strong>' . $entity->num_participants . '</strong> ',
+        '#suffix' => '</p>',
+      );
+    }
       // If entity has an active reportback field:
     if (isset($entity->field) && $entity->field['status']==1) {
       $reportback_field_label = $entity->field['label'];


### PR DESCRIPTION
Creates a new admin form on the `node/*/custom-settings` which allows editors to check whether or not to collect Number of Participants on the reportback form.

If checked, the form adds the additional field and saves to the reportback.
![screen shot 2014-07-31 at 1 50 16 pm](https://cloud.githubusercontent.com/assets/1236811/3768808/34744a1a-18db-11e4-90f2-99d5f551fc20.png)

![screen shot 2014-07-31 at 1 49 57 pm](https://cloud.githubusercontent.com/assets/1236811/3768806/2fe54062-18db-11e4-8ef9-e9f59756e9f7.png)
