### PR TITLE
Mcc  form update

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -141,25 +141,6 @@ function paraneue_dosomething_preprocess_page(&$vars) {
 /**
  * Implements theme_preprocess_node().
  */
-function paraneue_dosomething_preprocess_block(&$vars) {
-
-  $vars['clean_output'] = false;
-
-  // Array containing names of blocks that need clean markup output.
-  $clean_output_blocks = array(
-    'block-dosomething-campaign-submit-campaign-idea',
-  );
-
-  if (in_array($vars['block_html_id'], $clean_output_blocks)) {
-    $vars['clean_output'] = true;
-  }
-
-}
-
-
-/**
- * Implements theme_preprocess_node().
- */
 function paraneue_dosomething_preprocess_node(&$vars) {
 
   switch($vars['node']->type) {

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -141,6 +141,25 @@ function paraneue_dosomething_preprocess_page(&$vars) {
 /**
  * Implements theme_preprocess_node().
  */
+function paraneue_dosomething_preprocess_block(&$vars) {
+
+  $vars['clean_output'] = false;
+
+  // Array containing names of blocks that need clean markup output.
+  $clean_output_blocks = array(
+    'block-dosomething-campaign-submit-campaign-idea',
+  );
+
+  if (in_array($vars['block_html_id'], $clean_output_blocks)) {
+    $vars['clean_output'] = true;
+  }
+
+}
+
+
+/**
+ * Implements theme_preprocess_node().
+ */
 function paraneue_dosomething_preprocess_node(&$vars) {
 
   switch($vars['node']->type) {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_hunt-mcc.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/campaign/_hunt-mcc.scss
@@ -75,16 +75,38 @@
   }
 
   .ss-q-other-container {
-    padding-left: 22px;
+
+    @include media($tablet) {
+      padding-left: 22px;
+    }
 
     input {
       max-width: 400px;
     }
   }
 
-  .ss-datetime-box select {
-    @include span-columns(2 of 8);
-    @include omega(3n);
+
+  // Birthday Dropdown
+  .ss-datetime-box {
+    overflow: hidden;
+
+    select {
+      float: left;
+      width: 30%;
+
+      @include media($tablet) {
+        @include span-columns(2 of 8);
+        @include omega(3n);
+      }
+    }
+
+    select + select {
+      margin-left: 3%;
+
+      @include media($tablet) {
+        margin-left: 0;
+      }
+    }
   }
 
   // Hide Google Datepicker control

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/submit-campaign-idea.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/submit-campaign-idea.tpl.php
@@ -2,7 +2,7 @@
 
   <form class="wrapper" action="https://docs.google.com/a/dosomething.org/forms/d/1YY2BTXz65IcqyjaTf6GT8FZx0Z2E1251LcSf5LIhc0s/formResponse" method="post" id="ss-form" target="_self" onsubmit="">
     <p class="required">
-      <strong><?php print t('All fields are required.'); ?></strong>
+      <strong>All fields are required.</strong>
     </p>
 
     <?php // First Name Field ?>
@@ -10,13 +10,11 @@
       <div dir="ltr" class="ss-item ss-item-required ss-text">
         <div class="ss-form-entry">
           <div class="ss-q-title">
-            <label class="ss-q-item-label" for="entry_212037837"><?php print t('First Name'); ?> <span class="ss-required-asterisk">*</span></label>
+            <label class="ss-q-item-label" for="entry_212037837">First Name <span class="ss-required-asterisk">*</span></label>
           </div>
-          <div class="ss-q-help ss-secondary-text" dir="ltr"></div><input type="text" name="entry.212037837" value="" class="ss-q-short" id="entry_212037837" dir="auto" aria-label="<?php print t('First Name'); ?>" aria-required="true" required="" title="">
+          <div class="ss-q-help ss-secondary-text" dir="ltr"></div><input type="text" name="entry.212037837" value="" class="ss-q-short" id="entry_212037837" dir="auto" aria-label="First Name" aria-required="true" required="" title="">
           <div class="error-message" id="1205439792_errorMessage"></div>
-          <div class="required-message">
-            <?php print t('This is a required question'); ?>
-          </div>
+          <div class="required-message">This is a required question.</div>
         </div>
       </div>
     </div>
@@ -26,13 +24,11 @@
       <div dir="ltr" class="ss-item ss-item-required ss-text">
         <div class="ss-form-entry">
           <div class="ss-q-title">
-            <label class="ss-q-item-label" for="entry_2068859039"><?php print t('Last Name'); ?> <span class="ss-required-asterisk">*</span></label>
+            <label class="ss-q-item-label" for="entry_2068859039">Last Name <span class="ss-required-asterisk">*</span></label>
           </div>
-          <div class="ss-q-help ss-secondary-text" dir="ltr"></div><input type="text" name="entry.2068859039" value="" class="ss-q-short" id="entry_2068859039" dir="auto" aria-label="<?php print t('Last Name'); ?>" aria-required="true" required="" title="">
+          <div class="ss-q-help ss-secondary-text" dir="ltr"></div><input type="text" name="entry.2068859039" value="" class="ss-q-short" id="entry_2068859039" dir="auto" aria-label="Last Name" aria-required="true" required="" title="">
           <div class="error-message" id="1427438197_errorMessage"></div>
-          <div class="required-message">
-            <?php print t('This is a required question'); ?>
-          </div>
+          <div class="required-message">This is a required question.</div>
         </div>
       </div>
     </div>
@@ -42,13 +38,11 @@
       <div dir="ltr" class="ss-item ss-item-required ss-text">
         <div class="ss-form-entry">
           <div class="ss-q-title">
-            <label class="ss-q-item-label" for="entry_1282358104"><?php print t('Email Address'); ?> <span class="ss-required-asterisk">*</span></label>
+            <label class="ss-q-item-label" for="entry_1282358104">Email Address <span class="ss-required-asterisk">*</span></label>
           </div>
-          <div class="ss-q-help ss-secondary-text" dir="ltr"></div><input type="text" name="entry.1282358104" value="" class="ss-q-short" id="entry_1282358104" dir="auto" aria-label="<?php print t('Email Address'); ?>" aria-required="true" required="" title="">
+          <div class="ss-q-help ss-secondary-text" dir="ltr"></div><input type="text" name="entry.1282358104" value="" class="ss-q-short" id="entry_1282358104" dir="auto" aria-label="Email Address" aria-required="true" required="" title="">
           <div class="error-message" id="970803978_errorMessage"></div>
-          <div class="required-message">
-            <?php print t('This is a required question'); ?>
-          </div>
+          <div class="required-message">This is a required question.</div>
         </div>
       </div>
     </div>
@@ -58,13 +52,11 @@
       <div dir="ltr" class="ss-item ss-item-required ss-text">
         <div class="ss-form-entry">
           <div class="ss-q-title">
-            <label class="ss-q-item-label" for="entry_35169248"><?php print t('Cell Number'); ?> <span class="ss-required-asterisk">*</span></label>
+            <label class="ss-q-item-label" for="entry_35169248">Cell Number <span class="ss-required-asterisk">*</span></label>
           </div>
-          <div class="ss-q-help ss-secondary-text" dir="ltr"></div><input type="text" name="entry.35169248" value="" class="ss-q-short" id="entry_35169248" dir="auto" aria-label="<?php print t('Cell Number'); ?>" aria-required="true" required="" title="">
+          <div class="ss-q-help ss-secondary-text" dir="ltr"></div><input type="text" name="entry.35169248" value="" class="ss-q-short" id="entry_35169248" dir="auto" aria-label="Cell Number" aria-required="true" required="" title="">
           <div class="error-message" id="437089912_errorMessage"></div>
-          <div class="required-message">
-            <?php print t('This is a required question'); ?>
-          </div>
+          <div class="required-message">This is a required question.</div>
         </div>
       </div>
     </div>
@@ -79,11 +71,78 @@
           <div class="ss-q-help ss-secondary-text" dir="ltr">
             <?php print t('You must be ages 13 to 25 (sorry 26-and-up-year-olds).'); ?>
           </div>
-          <?php // @TODO: Question if this should be a dropdown? ?>
-          <input type="date" name="entry.164235794" value="" class="ss-q-date" dir="auto" id="entry_164235794" aria-label="<?php print t('Birthday You must be ages 13 to 25 (sorry 26-and-up-year-olds).'); ?>" aria-required="true" required="">
-          <div class="required-message">
-            <?php print t('This is a required question'); ?>
+
+          <div class="ss-datetime-box">
+            <select name="entry.164235794_month" class="ss-month-dropdown" id="entry.164235794_month" aria-label="<?php print t('Month'); ?>" aria-required="true">
+              <option value=""><?php print t('Month'); ?></option>
+              <option value="1"><?php print t('January'); ?></option>
+              <option value="2"><?php print t('February'); ?></option>
+              <option value="3"><?php print t('March'); ?></option>
+              <option value="4"><?php print t('April'); ?></option>
+              <option value="5"><?php print t('May'); ?></option>
+              <option value="6"><?php print t('June'); ?></option>
+              <option value="7"><?php print t('July'); ?></option>
+              <option value="8"><?php print t('August'); ?></option>
+              <option value="9"><?php print t('September'); ?></option>
+              <option value="10"><?php print t('October'); ?></option>
+              <option value="11"><?php print t('November'); ?></option>
+              <option value="12"><?php print t('December'); ?></option>
+            </select>
+
+            <select name="entry.164235794_day" class="ss-day-dropdown" id="entry.164235794_day" aria-label="<?php print t('Day of month'); ?>" aria-required="true">
+              <option value=""><?php print t('Day'); ?></option>
+              <option value="1">1</option>
+              <option value="2">2</option>
+              <option value="3">3</option>
+              <option value="4">4</option>
+              <option value="5">5</option>
+              <option value="6">6</option>
+              <option value="7">7</option>
+              <option value="8">8</option>
+              <option value="9">9</option>
+              <option value="10">10</option>
+              <option value="11">11</option>
+              <option value="12">12</option>
+              <option value="13">13</option>
+              <option value="14">14</option>
+              <option value="15">15</option>
+              <option value="16">16</option>
+              <option value="17">17</option>
+              <option value="18">18</option>
+              <option value="19">19</option>
+              <option value="20">20</option>
+              <option value="21">21</option>
+              <option value="22">22</option>
+              <option value="23">23</option>
+              <option value="24">24</option>
+              <option value="25">25</option>
+              <option value="26">26</option>
+              <option value="27">27</option>
+              <option value="28">28</option>
+              <option value="29">29</option>
+              <option value="30">30</option>
+              <option value="31">31</option>
+            </select>
+
+            <select name="entry.164235794_year" id="entry.164235794_year" aria-label="Year" aria-required="true">
+              <option value="">Year</option>
+              <option value="1989">1989</option>
+              <option value="1990">1990</option>
+              <option value="1991">1991</option>
+              <option value="1992">1992</option>
+              <option value="1993">1993</option>
+              <option value="1994">1994</option>
+              <option value="1995">1995</option>
+              <option value="1996">1996</option>
+              <option value="1997">1997</option>
+              <option value="1998">1998</option>
+              <option value="1999">1999</option>
+              <option value="2000">2000</option>
+              <option value="2001">2001</option>
+            </select>
           </div>
+
+          <div class="required-message">This is a required question.</div>
         </div>
       </div>
     </div>
@@ -105,9 +164,7 @@
                     </li>
                 </ul>
                 <div class="error-message" id="1600151592_errorMessage"></div>
-                <div class="required-message">
-                    <?php print t('This is a required question'); ?>
-                </div>
+                <div class="required-message">This is a required question.</div>
             </div>
         </div>
     </div>
@@ -123,14 +180,12 @@
                     Please provide your (valid!) Zip Code.
                 </div><input type="text" name="entry.429981564" value="" class="ss-q-short" id="entry_429981564" dir="auto" aria-label="Where are you located? Please provide your (valid!) Zip Code." aria-required="true" required="" title="">
                 <div class="error-message" id="1112487280_errorMessage"></div>
-                <div class="required-message">
-                    <?php print t('This is a required question'); ?>
-                </div>
+                <div class="required-message">This is a required question.</div>
             </div>
         </div>
     </div>
 
-    <?php // ?>
+    <?php // Cause Area Radio Selection ?>
     <div class="ss-form-question errorbox-good">
         <div dir="ltr" class="ss-item ss-item-required ss-radio">
             <div class="ss-form-entry">
@@ -173,14 +228,12 @@
                     </li>
                 </ul>
                 <div class="error-message" id="1031662904_errorMessage"></div>
-                <div class="required-message">
-                    <?php print t('This is a required question'); ?>
-                </div>
+                <div class="required-message">This is a required question.</div>
             </div>
         </div>
     </div>
 
-    <?php // ?>
+    <?php // Type of Action Radio Selection ?>
     <div class="ss-form-question errorbox-good">
         <div dir="ltr" class="ss-item ss-item-required ss-radio">
             <div class="ss-form-entry">
@@ -217,14 +270,12 @@
                     </li>
                 </ul>
                 <div class="error-message" id="223902718_errorMessage"></div>
-                <div class="required-message">
-                    <?php print t('This is a required question'); ?>
-                </div>
+                <div class="required-message">This is a required question.</div>
             </div>
         </div>
     </div>
 
-    <?php // ?>
+    <?php // What Problem Addressed Text Area ?>
     <div class="ss-form-question errorbox-good">
         <div dir="ltr" class="ss-item ss-item-required ss-paragraph-text">
             <div class="ss-form-entry">
@@ -236,14 +287,12 @@
                 </div>
                 <textarea name="entry.1255883103" rows="8" cols="0" class="ss-q-long" id="entry_1255883103" dir="auto" aria-label="What problem are you addressing? You MUST include a fact/statistic that proves this problem. e.g. X% of animals end up in shelters after hurricanes. Limit 1-2 sentences." aria-required="true" required=""></textarea>
                 <div class="error-message" id="1184451617_errorMessage"></div>
-                <div class="required-message">
-                    <?php print t('This is a required question'); ?>
-                </div>
+                <div class="required-message">This is a required question.</div>
             </div>
         </div>
     </div>
 
-    <?php // ?>
+    <?php // Source Text Area ?>
     <div class="ss-form-question errorbox-good">
         <div dir="ltr" class="ss-item ss-item-required ss-paragraph-text">
             <div class="ss-form-entry">
@@ -255,14 +304,12 @@
                 </div>
                 <textarea name="entry.1631970968" rows="8" cols="0" class="ss-q-long" id="entry_1631970968" dir="auto" aria-label="Please cite the source(s) of the fact(s) you listed above. Get your research on. Be sure to include: (1) Title of specific study, article, website, or book OR (2) Organization or author that published it OR (3) Link to study or stat. Limit 1-2 sentences." aria-required="true" required=""></textarea>
                 <div class="error-message" id="2043198594_errorMessage"></div>
-                <div class="required-message">
-                    <?php print t('This is a required question'); ?>
-                </div>
+                <div class="required-message">This is a required question.</div>
             </div>
         </div>
     </div>
 
-    <?php // ?>
+    <?php // Action Description Text Area ?>
     <div class="ss-form-question errorbox-good">
         <div dir="ltr" class="ss-item ss-item-required ss-paragraph-text">
             <div class="ss-form-entry">
@@ -274,14 +321,12 @@
                 </div>
                 <textarea name="entry.334582054" rows="8" cols="0" class="ss-q-long" id="entry_334582054" dir="auto" aria-label="Describe the action you want people to take. This should be one clear single action anyone in the U.S. can do. E.g., “Collect gently used towels and deliver them to your local animal shelter.” Limit 1-2 sentences." aria-required="true" required=""></textarea>
                 <div class="error-message" id="711595546_errorMessage"></div>
-                <div class="required-message">
-                    <?php print t('This is a required question'); ?>
-                </div>
+                <div class="required-message">This is a required question.</div>
             </div>
         </div>
     </div>
 
-    <?php // ?>
+    <?php // Prove Idea Text Area ?>
     <div class="ss-form-question errorbox-good">
         <div dir="ltr" class="ss-item ss-item-required ss-paragraph-text">
             <div class="ss-form-entry">
@@ -293,9 +338,7 @@
                 </div>
                 <textarea name="entry.2116830440" rows="8" cols="0" class="ss-q-long" id="entry_2116830440" dir="auto" aria-label="How can you prove your idea is an effective solution to the problem? Do this by (1) Sharing results if you’ve done this before (e.g. “I ran this project last Christmas and fed 100 people”) OR (2) Linking to someone that’s successfully done this (e.g. “The Red Cross runs blood drives that save lives”) OR (3) Linking to research that proves your solution is valid (e.g. “The CDC says educating people about vaccines makes them more likely to get vaccinated”). Limit 1-2 sentences." aria-required="true" required=""></textarea>
                 <div class="error-message" id="1391945183_errorMessage"></div>
-                <div class="required-message">
-                    <?php print t('This is a required question'); ?>
-                </div>
+                <div class="required-message">This is a required question.</div>
             </div>
         </div>
     </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/submit-campaign-idea.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/submit-campaign-idea.tpl.php
@@ -1,646 +1,309 @@
-<section class="mcc--googleform">
-  
-    <div class="ss-form-container">
-
-      <script type="text/javascript">
-        var submitted=false;
-      </script>
-
-      <div class="ss-form">
-        <form action=
-        "https://docs.google.com/forms/d/1PjmkallseEPvmmrJuEyEIgOWTlGThg1ylzxgPZloXfU/formResponse"
-        method="post" id="ss-form" target="hidden_iframe" onsubmit="submitted=true;">
-
-        <iframe name="hidden_iframe" id="hidden_iframe" style="display:none;" onload="if(submitted) {window.location='/volunteer/hunt?submitted_mcc=true';}"></iframe>
-
-          <p class="required"><strong><?php print t('All fields are required!'); ?></strong></p>
-
-          <div role="list" class="ss-question-list">
-            <div class="ss-form-question errorbox-good -compact -alpha" role="listitem">
-              <div dir="ltr" class="ss-item ss-item-required ss-text">
-
-                <div class="ss-form-entry">
-                  <div class="ss-q-title">
-                    <label class="ss-q-item-label" for="entry_212037837"><?php print t('First Name'); ?><span class="ss-required-asterisk">*</span></label>
-                  </div>
-                  <div class="ss-q-help ss-secondary-text" dir="ltr"></div>
-                  <input type="text" name="entry.212037837" value="" class="ss-q-short" id="entry_212037837" dir="auto" aria-label="<?php print t('First Name'); ?>  " aria-required="true" required="" title="">
-                  <div class="error-message"></div>
-                  <div class="required-message"><?php print t('This is a required question'); ?></div>
-                </div>
-              </div>
-            </div>
-
-            <div class="ss-form-question errorbox-good -compact -beta" role="listitem">
-              <div dir="ltr" class="ss-item ss-item-required ss-text">
-                <div class="ss-form-entry">
-                  <div class="ss-q-title">
-                    <label class="ss-q-item-label" for="entry_2068859039"><?php print t('Last Name'); ?><span class="ss-required-asterisk">*</span></label>
-                  </div>
-                  <div class="ss-q-help ss-secondary-text" dir="ltr"></div>
-                  <input type="text" name="entry.2068859039" value="" class="ss-q-short" id="entry_2068859039" dir="auto" aria-label="<?php print t('Last Name'); ?>  " aria-required="true" required="" title="">
-                  <div class="error-message"></div>
-                  <div class="required-message"><?php print t('This is a required question'); ?></div>
-                </div>
-              </div>
-            </div>
-
-
-            <div class="ss-form-question errorbox-good -compact -alpha" role="listitem">
-              <div dir="ltr" class="ss-item ss-item-required ss-text">
-                <div class="ss-form-entry">
-                  <div class="ss-q-title">
-                    <label class="ss-q-item-label" for="entry_1282358104"><?php print t('Email Address'); ?>
-                    <span class="ss-required-asterisk">*</span></label>
-                  </div>
-
-                  <div class="ss-q-help ss-secondary-text" dir="ltr"></div><input type=
-                  "text" name="entry.1282358104" value="" class="ss-q-short" id=
-                  "entry_1282358104" dir="auto" aria-label="<?php print t('Email Address'); ?>" aria-required=
-                  "true" required="" title="" />
-
-                  <div class="error-message"></div>
-
-                  <div class="required-message"><?php print t('This is a required question'); ?></div>
-                </div>
-              </div>
-            </div>
-
-
-            <div class="ss-form-question errorbox-good -compact -beta" role="listitem">
-              <div dir="ltr" class="ss-item ss-item-required ss-text">
-                <div class="ss-form-entry">
-                  <div class="ss-q-title">
-                    <label class="ss-q-item-label" for="entry_35169248"><?php print t('Cell Number'); ?><span class="ss-required-asterisk">*</span></label>
-                  </div>
-
-                  <div class="ss-q-help ss-secondary-text" dir="ltr"></div><input type=
-                  "text" name="entry.35169248" value="" class="ss-q-short" id=
-                  "entry_35169248" dir="auto" aria-label="<?php print t('Phone Number'); ?>" aria-required=
-                  "true" required="" title="" />
-
-                  <div class="error-message"></div>
-
-                  <div class="required-message"><?php print t('This is a required question'); ?></div>
-                </div>
-              </div>
-            </div>
-
-
-            <div class="ss-form-question errorbox-good" role="listitem">
-              <div dir="ltr" class="ss-item ss-item-required ss-date">
-                <div class="ss-form-entry">
-                  <div class="ss-q-title">
-                    <label class="ss-q-item-label" for="entry_164235794"><?php print t('Birthday'); ?><span class="ss-required-asterisk">*</span></label>
-                  </div>
-
-                  <div class="ss-q-help ss-secondary-text" dir="ltr"><?php print t('You must be ages 13 to 25.'); ?></div>
-
-                  <div class="ss-q-date">
-                    <div class="ss-datetime-box goog-inline-block">
-                      <select name="entry.164235794_month" class="ss-month-dropdown" id=
-                      "entry.164235794_month" aria-label="<?php print t('Month'); ?>" aria-required="true">
-                        <option value=""><?php print t('Month'); ?></option>
-                        <option value="1"><?php print t('January'); ?></option>
-                        <option value="2"><?php print t('February'); ?></option>
-                        <option value="3"><?php print t('March'); ?></option>
-                        <option value="4"><?php print t('April'); ?></option>
-                        <option value="5"><?php print t('May'); ?></option>
-                        <option value="6"><?php print t('June'); ?></option>
-                        <option value="7"><?php print t('July'); ?></option>
-                        <option value="8"><?php print t('August'); ?></option>
-                        <option value="9"><?php print t('September'); ?></option>
-                        <option value="10"><?php print t('October'); ?></option>
-                        <option value="11"><?php print t('November'); ?></option>
-                        <option value="12"><?php print t('December'); ?></option>
-                      </select>
-                      <select name="entry.164235794_day" class="ss-day-dropdown" id="entry.164235794_day" aria-label="<?php print t('Day of month'); ?>" aria-required="true">
-                        <option value=""><?php print t('Day'); ?></option>
-                        <option value="1">1</option>
-                        <option value="2">2</option>
-                        <option value="3">3</option>
-                        <option value="4">4</option>
-                        <option value="5">5</option>
-                        <option value="6">6</option>
-                        <option value="7">7</option>
-                        <option value="8">8</option>
-                        <option value="9">9</option>
-                        <option value="10">10</option>
-                        <option value="11">11</option>
-                        <option value="12">12</option>
-                        <option value="13">13</option>
-                        <option value="14">14</option>
-                        <option value="15">15</option>
-                        <option value="16">16</option>
-                        <option value="17">17</option>
-                        <option value="18">18</option>
-                        <option value="19">19</option>
-                        <option value="20">20</option>
-                        <option value="21">21</option>
-                        <option value="22">22</option>
-                        <option value="23">23</option>
-                        <option value="24">24</option>
-                        <option value="25">25</option>
-                        <option value="26">26</option>
-                        <option value="27">27</option>
-                        <option value="28">28</option>
-                        <option value="29">29</option>
-                        <option value="30">30</option>
-                        <option value="31">31</option>
-                      </select>
-                      <select name="entry.164235794_year" id="entry.164235794_year" aria-label="<?php print t('Year'); ?>" aria-required="true">
-                        <option value=""><?php print t('Year'); ?></option>
-                        <option value="1989">1989</option>
-                        <option value="1990">1990</option>
-                        <option value="1991">1991</option>
-                        <option value="1992">1992</option>
-                        <option value="1993">1993</option>
-                        <option value="1994">1994</option>
-                        <option value="1995">1995</option>
-                        <option value="1996">1996</option>
-                        <option value="1997">1997</option>
-                        <option value="1998">1998</option>
-                        <option value="1999">1999</option>
-                        <option value="2000">2000</option>
-                        <option value="2001">2001</option>
-                      </select>
-
-                      <div class="ss-picker-button-container goog-inline-block"
-                      aria-hidden="true">
-                        <div id="entry.164235794_picker" class="ss-calendar-button"
-                        tabindex="0">
-                          <div class="docs-icon goog-inline-block">
-                            <div class=
-                            "docs-icon-img-container docs-icon-img docs-icon-calendar">
-                              &nbsp;
-                            </div>
-                          </div>
-                        </div>
-
-                        <div class="ss-picker-container" aria-hidden="true" style=
-                        "display: none;">
-                          <div class="goog-date-picker" tabindex="0">
-                            <table cellspacing="0" cellpadding="0">
-                              <thead>
-                                <tr class="goog-date-picker-head">
-                                  <td colspan="5"><button class=
-                                  "goog-date-picker-btn goog-date-picker-previousMonth">&#171;</button><button class="goog-date-picker-btn goog-date-picker-month">May</button><button class="goog-date-picker-btn goog-date-picker-nextMonth">&#187;</button></td>
-
-                                  <td colspan="3"><button class=
-                                  "goog-date-picker-btn goog-date-picker-previousYear">&#171;</button><button class="goog-date-picker-btn goog-date-picker-year">2014</button><button class="goog-date-picker-btn goog-date-picker-nextYear">&#187;</button></td>
-                                </tr>
-                              </thead>
-
-                              <tbody role="grid" tabindex="0" aria-activedescendant=":q">
-                                <tr>
-                                  <th></th>
-
-                                  <th class="goog-date-picker-wday" role="columnheader">
-                                  Sun</th>
-
-                                  <th class="goog-date-picker-wday" role="columnheader">
-                                  Mon</th>
-
-                                  <th class="goog-date-picker-wday" role="columnheader">
-                                  Tue</th>
-
-                                  <th class="goog-date-picker-wday" role="columnheader">
-                                  Wed</th>
-
-                                  <th class="goog-date-picker-wday" role="columnheader">
-                                  Thu</th>
-
-                                  <th class="goog-date-picker-wday" role="columnheader">
-                                  Fri</th>
-
-                                  <th class="goog-date-picker-wday" role="columnheader">
-                                  Sat</th>
-                                </tr>
-
-                                <tr>
-                                  <th class="" role="rowheader"></th>
-
-                                  <td id=":1" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-other-month goog-date-picker-wkend-end">
-                                  27</td>
-
-                                  <td id=":2" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-other-month">
-                                  28</td>
-
-                                  <td id=":3" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-other-month">
-                                  29</td>
-
-                                  <td id=":4" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-other-month">
-                                  30</td>
-
-                                  <td id=":5" role="gridcell" class=
-                                  "goog-date-picker-date">1</td>
-
-                                  <td id=":6" role="gridcell" class=
-                                  "goog-date-picker-date">2</td>
-
-                                  <td id=":7" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-wkend-start">
-                                  3</td>
-                                </tr>
-
-                                <tr>
-                                  <th class="" role="rowheader"></th>
-
-                                  <td id=":8" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-wkend-end">4</td>
-
-                                  <td id=":9" role="gridcell" class=
-                                  "goog-date-picker-date">5</td>
-
-                                  <td id=":a" role="gridcell" class=
-                                  "goog-date-picker-date">6</td>
-
-                                  <td id=":b" role="gridcell" class=
-                                  "goog-date-picker-date">7</td>
-
-                                  <td id=":c" role="gridcell" class=
-                                  "goog-date-picker-date">8</td>
-
-                                  <td id=":d" role="gridcell" class=
-                                  "goog-date-picker-date">9</td>
-
-                                  <td id=":e" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-wkend-start">
-                                  10</td>
-                                </tr>
-
-                                <tr>
-                                  <th class="" role="rowheader"></th>
-
-                                  <td id=":f" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-wkend-end">
-                                  11</td>
-
-                                  <td id=":g" role="gridcell" class=
-                                  "goog-date-picker-date">12</td>
-
-                                  <td id=":h" role="gridcell" class=
-                                  "goog-date-picker-date">13</td>
-
-                                  <td id=":i" role="gridcell" class=
-                                  "goog-date-picker-date">14</td>
-
-                                  <td id=":j" role="gridcell" class=
-                                  "goog-date-picker-date">15</td>
-
-                                  <td id=":k" role="gridcell" class=
-                                  "goog-date-picker-date">16</td>
-
-                                  <td id=":l" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-wkend-start">
-                                  17</td>
-                                </tr>
-
-                                <tr>
-                                  <th class="" role="rowheader"></th>
-
-                                  <td id=":m" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-wkend-end">
-                                  18</td>
-
-                                  <td id=":n" role="gridcell" class=
-                                  "goog-date-picker-date">19</td>
-
-                                  <td id=":o" role="gridcell" class=
-                                  "goog-date-picker-date">20</td>
-
-                                  <td id=":p" role="gridcell" class=
-                                  "goog-date-picker-date">21</td>
-
-                                  <td id=":q" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-today goog-date-picker-selected">
-                                  22</td>
-
-                                  <td id=":r" role="gridcell" class=
-                                  "goog-date-picker-date">23</td>
-
-                                  <td id=":s" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-wkend-start">
-                                  24</td>
-                                </tr>
-
-                                <tr>
-                                  <th class="" role="rowheader"></th>
-
-                                  <td id=":t" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-wkend-end">
-                                  25</td>
-
-                                  <td id=":u" role="gridcell" class=
-                                  "goog-date-picker-date">26</td>
-
-                                  <td id=":v" role="gridcell" class=
-                                  "goog-date-picker-date">27</td>
-
-                                  <td id=":w" role="gridcell" class=
-                                  "goog-date-picker-date">28</td>
-
-                                  <td id=":x" role="gridcell" class=
-                                  "goog-date-picker-date">29</td>
-
-                                  <td id=":y" role="gridcell" class=
-                                  "goog-date-picker-date">30</td>
-
-                                  <td id=":z" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-wkend-start">
-                                  31</td>
-                                </tr>
-
-                                <tr>
-                                  <th class="" role="rowheader"></th>
-
-                                  <td id=":10" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-other-month goog-date-picker-wkend-end">
-                                  1</td>
-
-                                  <td id=":11" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-other-month">
-                                  2</td>
-
-                                  <td id=":12" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-other-month">
-                                  3</td>
-
-                                  <td id=":13" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-other-month">
-                                  4</td>
-
-                                  <td id=":14" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-other-month">
-                                  5</td>
-
-                                  <td id=":15" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-other-month">
-                                  6</td>
-
-                                  <td id=":16" role="gridcell" class=
-                                  "goog-date-picker-date goog-date-picker-other-month goog-date-picker-wkend-start">
-                                  7</td>
-                                </tr>
-                              </tbody>
-
-                              <tfoot>
-                                <tr class="goog-date-picker-foot">
-                                  <td colspan="3" class="goog-date-picker-today-cont">
-                                  <button class=
-                                  "goog-date-picker-btn goog-date-picker-today-btn"><?php print t('Today'); ?></button></td>
-
-                                  <td colspan="3"></td>
-
-                                  <td colspan="2" class="goog-date-picker-none-cont">
-                                  <button class=
-                                  "goog-date-picker-btn goog-date-picker-none-btn"><?php print t('None'); ?></button></td>
-                                </tr>
-                              </tfoot>
-                            </table>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-
-            <div class="ss-form-question errorbox-good" role="listitem">
-              <div dir="ltr" class="ss-item ss-item-required ss-radio">
-                <div class="ss-form-entry">
-                  <div class="ss-q-title">
-                    <label class="ss-q-item-label" for="entry_1600151592"><?php print t('Can your idea be done by anyone in the United States?'); ?><span class="ss-required-asterisk">*</span></label>
-                  </div>
-                  <div class="ss-q-help ss-secondary-text" dir="ltr"></div>
-                  <ul class="ss-choices" role="radiogroup" aria-label="<?php print t('Can your idea be done by anyone in the United States?'); ?>  ">
-                    <li class="ss-choice-item">
-                      <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.1724618567" value="Yes" id="group_1724618567_1" role="radio" class="ss-q-radio" aria-label="<?php print t('Yes'); ?>" required="" aria-required="true"></span><span class="ss-choice-label"><?php print t('Yes'); ?></span></label>
-                    </li>
-                    <li class="ss-choice-item">
-                      <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.1724618567" value="No" id="group_1724618567_2" role="radio" class="ss-q-radio" aria-label="<?php print t('No'); ?>" required="" aria-required="true"></span><span class="ss-choice-label"><?php print t('No'); ?></span></label>
-                    </li>
-                  </ul>
-                  <div class="error-message"></div>
-                  <div class="required-message"><?php print t('This is a required question'); ?></div>
-                </div>
-              </div>
-            </div>
-
-
-            <div class="ss-form-question errorbox-good" role="listitem">
-              <div dir="ltr" class="ss-item ss-item-required ss-text">
-                <div class="ss-form-entry">
-                  <div class="ss-q-title">
-                    <label class="ss-q-item-label" for="entry_429981564"><?php print t('Where are you located?'); ?><span class="ss-required-asterisk">*</span></label>
-                  </div>
-                  <div class="ss-q-help ss-secondary-text" dir="ltr"><?php print t('Please provide your Zip Code.'); ?></div>
-                  <input type="text" name="entry.429981564" value="" class="ss-q-short" id="entry_429981564" dir="auto" aria-label="<?php print t('Where are you located? Please provide your Zip Code.'); ?> " aria-required="true" required="" title="">
-                  <div class="error-message"></div>
-                  <div class="required-message"><?php print t('This is a required question'); ?></div>
-                </div>
-              </div>
-            </div>
-
-
-            <div class="ss-form-question errorbox-good" role="listitem">
-              <div dir="ltr" class="ss-item ss-item-required ss-radio">
-                <div class="ss-form-entry">
-                  <div class="ss-q-title">
-                    <label class="ss-q-item-label" for="entry_885457401"><?php print t('Can your idea be completed in one day?'); ?><span class="ss-required-asterisk">*</span></label>
-                  </div>
-                  <div class="ss-q-help ss-secondary-text" dir="ltr"></div>
-                  <ul class="ss-choices" role="radiogroup" aria-label="<?php print t('Can your idea be completed in one day?'); ?>  ">
-                    <li class="ss-choice-item">
-                      <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.980282842" value="Yes" id="group_980282842_1" role="radio" class="ss-q-radio" aria-label="Yes" required="" aria-required="true"></span><span class="ss-choice-label"><?php print t('Yes'); ?></span></label>
-                    </li>
-                    <li class="ss-choice-item">
-                      <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.980282842" value="No" id="group_980282842_2" role="radio" class="ss-q-radio" aria-label="No" required="" aria-required="true"></span><span class="ss-choice-label"><?php print t('No'); ?></span></label>
-                    </li>
-                  </ul>
-                   <div class="error-message"></div>
-                   <div class="required-message"><?php print t('This is a required question'); ?></div>
-                 </div>
-              </div>
-            </div>
-
-
-            <div class="ss-form-question errorbox-good" role="listitem">
-              <div dir="ltr" class="ss-item ss-item-required ss-radio">
-                <div class="ss-form-entry">
-                  <div class="ss-q-title">
-                    <label class="ss-q-item-label" for="entry_1031662904"><?php print t('What cause area does your idea impact?'); ?> <span class="ss-required-asterisk">*</span></label>
-                  </div>
-
-                  <div class="ss-q-help ss-secondary-text" dir="ltr"><?php print t('If your idea addresses more than one cause, choose the one you think is most relevant.'); ?></div>
-
-                  <ul class="ss-choices" role="radiogroup" aria-label="<?php print t('What cause area does your idea impact? If your idea addresses more than one cause, choose the one you think is most relevant.'); ?> "><li class="ss-choice-item"><label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="<?php print t('Animals'); ?>" id="group_822732364_1" role="radio" class="ss-q-radio" aria-label="Animals" required="" aria-required="true"></span>
-<span class="ss-choice-label"><?php print t('Animals'); ?></span>
-</label></li> <li class="ss-choice-item"><label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="<?php print t('Bullying &amp; Discrimination'); ?>" id="group_822732364_2" role="radio" class="ss-q-radio" aria-label="<?php print t('Bullying &amp; Discrimination'); ?>" required="" aria-required="true"></span>
-<span class="ss-choice-label"><?php print t('Bullying &amp; Discrimination'); ?></span>
-</label></li> <li class="ss-choice-item"><label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="<?php print t('Education'); ?>" id="group_822732364_3" role="radio" class="ss-q-radio" aria-label="<?php print t('Education'); ?>" required="" aria-required="true"></span>
-<span class="ss-choice-label"><?php print t('Education'); ?></span>
-</label></li> <li class="ss-choice-item"><label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="<?php print t('Environment'); ?>" id="group_822732364_4" role="radio" class="ss-q-radio" aria-label="<?php print t('Environment'); ?>" required="" aria-required="true"></span>
-<span class="ss-choice-label"><?php print t('Environment'); ?></span>
-</label></li> <li class="ss-choice-item"><label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="<?php print t('Physical &amp; Mental Health'); ?>" id="group_822732364_5" role="radio" class="ss-q-radio" aria-label="<?php print t('Physical &amp; Mental Health'); ?>" required="" aria-required="true"></span>
-<span class="ss-choice-label"><?php print t('Physical &amp; Mental Health'); ?></span>
-</label></li> <li class="ss-choice-item"><label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="<?php print t('Poverty &amp; Homelessness'); ?>" id="group_822732364_6" role="radio" class="ss-q-radio" aria-label="<?php print t('Poverty &amp; Homelessness'); ?>" required="" aria-required="true"></span>
-<span class="ss-choice-label"><?php print t('Poverty &amp; Homelessness'); ?></span>
-</label></li> <li class="ss-choice-item"><label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="__other_option__" id="group_822732364_7" role="radio" class="ss-q-radio ss-q-other-toggle" required="" aria-required="true"></span>
-<span class="ss-choice-label"><?php print t('Other'); ?>:</span></label>
-<span class="ss-q-other-container goog-inline-block"><input type="text" name="entry.822732364.other_option_response" value="" class="ss-q-other" id="entry_822732364_other_option_response" dir="auto" aria-label="<?php print t('Other'); ?>"></span>
-</li></ul>
-
-                  <div class="error-message"></div>
-
-                  <div class="required-message"><?php print t('This is a required question'); ?></div>
-                </div>
-              </div>
-            </div>
-
-
-            <div class="ss-form-question errorbox-good" role="listitem">
-              <div dir="ltr" class="ss-item ss-item-required ss-radio">
-                <div class="ss-form-entry">
-                  <div class="ss-q-title">
-                    <label class="ss-q-item-label" for="entry_223902718"><?php print t('What type of action is your idea?'); ?> <span class="ss-required-asterisk">*</span></label>
-                  </div>
-
-                  <div class="ss-q-help ss-secondary-text" dir="ltr">
-                    <?php print t('If your idea is more than one type of action, choose the one that’s most relevant. Check out our <a target="_blank" href="https://docs.google.com/a/dosomething.org/file/d/0B5fENCbpVZv9R0VnMjh5VWJybFB1QTRyRS05clF3V19VdkFj/edit">descriptions on each type of action'); ?></a>.
-                  </div>
-
-                  <ul class="ss-choices" role="radiogroup" aria-label="What type of action is your idea? If your idea is more than one type of action, choose the one that’s most relevant. Check out our descriptions on each type of action. "><li class="ss-choice-item"><label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="<?php print t('Donate an item'); ?>" id="group_101412798_1" role="radio" class="ss-q-radio" aria-label="<?php print t('Donate an item'); ?>" required="" aria-required="true"></span>
-<span class="ss-choice-label"><?php print t('Donate an item'); ?></span>
-</label></li> <li class="ss-choice-item"><label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="<?php print t('Face to face interaction'); ?>" id="group_101412798_2" role="radio" class="ss-q-radio" aria-label="<?php print t('Face to face interaction'); ?>" required="" aria-required="true"></span>
-<span class="ss-choice-label"><?php print t('Face to face interaction'); ?></span>
-</label></li> <li class="ss-choice-item"><label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="<?php print t('Host an event'); ?>" id="group_101412798_3" role="radio" class="ss-q-radio" aria-label="<?php print t('Host an event'); ?>" required="" aria-required="true"></span>
-<span class="ss-choice-label"><?php print t('Host an event'); ?></span>
-</label></li> <li class="ss-choice-item"><label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="<?php print t('Improve/clean up a (physical) space'); ?>" id="group_101412798_4" role="radio" class="ss-q-radio" aria-label="<?php print t('Improve/clean up a (physical) space'); ?>" required="" aria-required="true"></span>
-<span class="ss-choice-label"><?php print t('Improve/clean up a (physical) space'); ?></span>
-</label></li> <li class="ss-choice-item"><label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="<?php print t('Make something'); ?>&nbsp;" id="group_101412798_5" role="radio" class="ss-q-radio" aria-label="<?php print t('Make something'); ?>&nbsp;" required="" aria-required="true"></span>
-<span class="ss-choice-label"><?php print t('Make something'); ?> </span>
-</label></li> <li class="ss-choice-item"><label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="<?php print t('Share something'); ?>&nbsp;" id="group_101412798_6" role="radio" class="ss-q-radio" aria-label="<?php print t('Share something'); ?>&nbsp;" required="" aria-required="true"></span>
-<span class="ss-choice-label"><?php print t('Share something'); ?> </span>
-</label></li> <li class="ss-choice-item"><label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="<?php print t('Start something (like a club)'); ?>" id="group_101412798_7" role="radio" class="ss-q-radio" aria-label="<?php print t('Start something (like a club)'); ?>" required="" aria-required="true"></span>
-<span class="ss-choice-label"><?php print t('Start something (like a club)'); ?></span>
-</label></li> <li class="ss-choice-item"><label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="Take a stand (protest-y stuff like petitions)" id="group_101412798_8" role="radio" class="ss-q-radio" aria-label="Take a stand (protest-y stuff like petitions)" required="" aria-required="true"></span>
-<span class="ss-choice-label"><?php print t('Take a stand (protest-y stuff like petitions)'); ?></span>
-</label></li></ul>
-
-                  <div class="error-message"></div>
-
-                  <div class="required-message"><?php print t('This is a required question'); ?></div>
-                </div>
-              </div>
-            </div>
-
-
-            <div class="ss-form-question errorbox-good" role="listitem">
-              <div dir="ltr" class="ss-item ss-item-required ss-paragraph-text">
-                <div class="ss-form-entry">
-                  <div class="ss-q-title">
-                    <label class="ss-q-item-label" for="entry_1255883103"><?php print t('What problem are you addressing?'); ?> <span class="ss-required-asterisk">*</span></label>
-                  </div>
-
-                  <div class="ss-q-help ss-secondary-text" dir="ltr"><?php print t('You MUST include a fact/statistic that proves this problem. E.g. X% of animals end up in shelters after hurricanes.'); ?></div>
-                  <textarea name="entry.1255883103" rows="8" cols="0" class="ss-q-long" id="entry_1255883103" dir="auto" aria-label="<?php print t('What problem are you addressing? You MUST include a fact/statistic that proves this problem. e.g. X% of animals end up in shelters after hurricanes. Must be fewer than 175 characters.'); ?>" aria-required="true" required=""></textarea>
-
-                  <div class="error-message"><?php print t('Must be fewer than 175 characters.'); ?></div>
-
-                  <div class="required-message"><?php print t('This is a required question'); ?></div>
-                </div>
-              </div>
-            </div>
-
-
-            <div class="ss-form-question errorbox-good" role="listitem">
-              <div dir="ltr" class="ss-item ss-item-required ss-paragraph-text">
-                <div class="ss-form-entry">
-                  <div class="ss-q-title">
-                    <label class="ss-q-item-label" for="entry_1631970968"><?php print t('Please cite the source(s) of the fact(s) you listed above.'); ?> <span class="ss-required-asterisk">*</span></label>
-                  </div>
-
-                  <div class="ss-q-help ss-secondary-text" dir="ltr"><?php print t('Your idea should be based on research.<br>
-                    Be sure to include:<br>
-                    • Title of specific study, article, website, or book OR; <br>
-                    • Organization or author that published it OR;<br>
-                    • Link to study or stat.
-                  '); ?></div>
-                  <textarea name="entry.1631970968" rows="8" cols="0" class="ss-q-long" id="entry_1631970968" dir="auto" aria-label="<?php print t('What is the source for this problem? Include: 1. Title of specific study, article, website, or book 2. Organization or author that published it 3. Publication date 4. Link to study or stat. NOTE: The citation should reference the author who created it. e.g. Don’t cite a Huffington Post’s article about a study or a stat, find the original study or stat and cite that instead.'); ?>" aria-required="true" required=""></textarea>
-
-                  <div class="error-message"></div>
-
-                  <div class="required-message"><?php print t('This is a required question'); ?></div>
-                </div>
-              </div>
-            </div>
-
-
-            <div class="ss-form-question errorbox-good" role="listitem">
-              <div dir="ltr" class="ss-item ss-item-required ss-paragraph-text">
-                <div class="ss-form-entry">
-                  <div class="ss-q-title">
-                    <label class="ss-q-item-label" for="entry_334582054"><?php print t('Describe the action you want people to take.'); ?> <span class="ss-required-asterisk">*</span></label>
-                  </div>
-
-                  <div class="ss-q-help ss-secondary-text" dir="ltr"><?php print t('This should be one clear action someone could complete in one day. E.g., “Collect gently used towels and deliver them to your local animal shelter.”
-                  '); ?></div>
-                  <textarea name="entry.334582054" rows="8" cols="0" class="ss-q-long" id="entry_334582054" dir="auto" aria-label="<?php print t('What exactly do you want people to do? This should be one clear action where the benefit can been seen after one day. e.g. collect gently used towels in your neighborhood and deliver them to your local animal shelter for shelter dogs. Must be fewer than 175 characters.'); ?>" aria-required="true" required=""></textarea>
-                  <div class="error-message"><?php print t('Must be fewer than 175 characters.'); ?></div>
-
-                  <div class="required-message"><?php print t('This is a required question'); ?></div>
-                </div>
-              </div>
-            </div>
-
-
-            <div class="ss-form-question errorbox-good" role="listitem">
-              <div dir="ltr" class="ss-item ss-item-required ss-paragraph-text">
-                <div class="ss-form-entry">
-                  <div class="ss-q-title">
-                    <label class="ss-q-item-label" for="entry_2116830440"><?php print t('How can you prove your idea is an effective solution to the problem?'); ?> <span class="ss-required-asterisk">*</span></label>
-                  </div>
-
-                  <div class="ss-q-help ss-secondary-text" dir="ltr"><?php print t('Do this by:<br>
-                    • Sharing results if you’ve done this before E.g. “I ran this project last Christmas and fed 100 people” OR;<br>
-                    • Linking to an org that’s successfully done this E.g. “The Red Cross runs blood drives that save lives” OR;<br>
-                    • Linking to research that proves your solution is valid. E.g. “The CDC says educating people about vaccines makes them more likely to get vaccinated.”
-                  '); ?></div>
-                  <textarea name="entry.2116830440" rows="8" cols="0" class="ss-q-long" id="entry_2116830440" dir="auto" aria-label="<?php print t('Link to the solution of this problem. You MUST be able to prove that this solution will help solve the problem above. You can do this by telling us about your project (if you&#8217;ve done this before) OR by linking to a research study that proves that your solution is valid. e.g. &#8220;I run this campaign in my town every Christmas and last year we fed 100 people.&#8221; OR e.g. &quot;The CDC says that educating people about vaccines makes them more likely to get them.&quot; Must be fewer than 175 characters.'); ?>" aria-required="true" required=""></textarea>
-
-                  <div class="error-message"><?php print t('Must be fewer than 175 characters.'); ?></div>
-
-                  <div class="required-message"><?php print t('This is a required question'); ?></div>
-                </div>
-              </div>
-            </div>
-
-
-            <input type="hidden" name="draftResponse" value="[,,&quot;-2491597392743010610&quot;] " /> <input type="hidden" name="pageHistory" value="0" /> <input type="hidden" name="fbzx" value="-2491597392743010610" />
-
-            <div class="ss-item ss-navigate">
-              <table id="navigation-table">
-                <tbody>
-                  <tr>
-                    <td class="ss-form-entry goog-inline-block" id="navigation-buttons"
-                    dir="ltr">
-                      <input type="submit" name="submit" value="<?php print t('Submit'); ?>" id="ss-submit" class="btn" />
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-
+<section class="container mcc--googleform">
+
+  <form class="wrapper" action="https://docs.google.com/a/dosomething.org/forms/d/1YY2BTXz65IcqyjaTf6GT8FZx0Z2E1251LcSf5LIhc0s/formResponse" method="post" id="ss-form" target="_self" onsubmit="">
+    <p class="required">
+      <strong><?php print t('All fields are required.'); ?></strong>
+    </p>
+
+    <?php // First Name Field ?>
+    <div class="ss-form-question errorbox-good -compact -alpha">
+      <div dir="ltr" class="ss-item ss-item-required ss-text">
+        <div class="ss-form-entry">
+          <div class="ss-q-title">
+            <label class="ss-q-item-label" for="entry_212037837"><?php print t('First Name'); ?> <span class="ss-required-asterisk">*</span></label>
           </div>
-        </form>
+          <div class="ss-q-help ss-secondary-text" dir="ltr"></div><input type="text" name="entry.212037837" value="" class="ss-q-short" id="entry_212037837" dir="auto" aria-label="<?php print t('First Name'); ?>" aria-required="true" required="" title="">
+          <div class="error-message" id="1205439792_errorMessage"></div>
+          <div class="required-message">
+            <?php print t('This is a required question'); ?>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
+
+    <?php // Last Name Field ?>
+    <div class="ss-form-question errorbox-good -compact -beta">
+      <div dir="ltr" class="ss-item ss-item-required ss-text">
+        <div class="ss-form-entry">
+          <div class="ss-q-title">
+            <label class="ss-q-item-label" for="entry_2068859039"><?php print t('Last Name'); ?> <span class="ss-required-asterisk">*</span></label>
+          </div>
+          <div class="ss-q-help ss-secondary-text" dir="ltr"></div><input type="text" name="entry.2068859039" value="" class="ss-q-short" id="entry_2068859039" dir="auto" aria-label="<?php print t('Last Name'); ?>" aria-required="true" required="" title="">
+          <div class="error-message" id="1427438197_errorMessage"></div>
+          <div class="required-message">
+            <?php print t('This is a required question'); ?>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <?php // Email Address Field ?>
+    <div class="ss-form-question errorbox-good -compact -alpha">
+      <div dir="ltr" class="ss-item ss-item-required ss-text">
+        <div class="ss-form-entry">
+          <div class="ss-q-title">
+            <label class="ss-q-item-label" for="entry_1282358104"><?php print t('Email Address'); ?> <span class="ss-required-asterisk">*</span></label>
+          </div>
+          <div class="ss-q-help ss-secondary-text" dir="ltr"></div><input type="text" name="entry.1282358104" value="" class="ss-q-short" id="entry_1282358104" dir="auto" aria-label="<?php print t('Email Address'); ?>" aria-required="true" required="" title="">
+          <div class="error-message" id="970803978_errorMessage"></div>
+          <div class="required-message">
+            <?php print t('This is a required question'); ?>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <?php // Cell Number Field ?>
+    <div class="ss-form-question errorbox-good -compact -beta">
+      <div dir="ltr" class="ss-item ss-item-required ss-text">
+        <div class="ss-form-entry">
+          <div class="ss-q-title">
+            <label class="ss-q-item-label" for="entry_35169248"><?php print t('Cell Number'); ?> <span class="ss-required-asterisk">*</span></label>
+          </div>
+          <div class="ss-q-help ss-secondary-text" dir="ltr"></div><input type="text" name="entry.35169248" value="" class="ss-q-short" id="entry_35169248" dir="auto" aria-label="<?php print t('Cell Number'); ?>" aria-required="true" required="" title="">
+          <div class="error-message" id="437089912_errorMessage"></div>
+          <div class="required-message">
+            <?php print t('This is a required question'); ?>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <?php // Birthday Field ?>
+    <div class="ss-form-question errorbox-good">
+      <div dir="ltr" class="ss-item ss-item-required ss-date">
+        <div class="ss-form-entry">
+          <div class="ss-q-title">
+            <label class="ss-q-item-label" for="entry_164235794"><?php print t('Birthday'); ?> <span class="ss-required-asterisk">*</span></label>
+          </div>
+          <div class="ss-q-help ss-secondary-text" dir="ltr">
+            <?php print t('You must be ages 13 to 25 (sorry 26-and-up-year-olds).'); ?>
+          </div>
+          <?php // @TODO: Question if this should be a dropdown? ?>
+          <input type="date" name="entry.164235794" value="" class="ss-q-date" dir="auto" id="entry_164235794" aria-label="<?php print t('Birthday You must be ages 13 to 25 (sorry 26-and-up-year-olds).'); ?>" aria-required="true" required="">
+          <div class="required-message">
+            <?php print t('This is a required question'); ?>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <?php // Idea in USA Radio Selection ?>
+    <div class="ss-form-question errorbox-good">
+        <div dir="ltr" class="ss-item ss-item-required ss-radio">
+            <div class="ss-form-entry">
+                <div class="ss-q-title">
+                    <label class="ss-q-item-label" for="entry_1600151592">Can your idea be done by anyone in the United States? <span class="ss-required-asterisk">*</span></label>
+                </div>
+                <div class="ss-q-help ss-secondary-text" dir="ltr"></div>
+                <ul class="ss-choices" role="radiogroup" aria-label="Can your idea be done by anyone in the United States?">
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.1724618567" value="Yes" id="group_1724618567_1" role="radio" class="ss-q-radio" aria-label="Yes" required="" aria-required="true"></span> <span class="ss-choice-label">Yes</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.1724618567" value="No" id="group_1724618567_2" role="radio" class="ss-q-radio" aria-label="No" required="" aria-required="true"></span> <span class="ss-choice-label">No</span></label>
+                    </li>
+                </ul>
+                <div class="error-message" id="1600151592_errorMessage"></div>
+                <div class="required-message">
+                    <?php print t('This is a required question'); ?>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <?php // Location Field ?>
+    <div class="ss-form-question errorbox-good">
+        <div dir="ltr" class="ss-item ss-item-required ss-text">
+            <div class="ss-form-entry">
+                <div class="ss-q-title">
+                    <label class="ss-q-item-label" for="entry_429981564">Where are you located? <span class="ss-required-asterisk">*</span></label>
+                </div>
+                <div class="ss-q-help ss-secondary-text" dir="ltr">
+                    Please provide your (valid!) Zip Code.
+                </div><input type="text" name="entry.429981564" value="" class="ss-q-short" id="entry_429981564" dir="auto" aria-label="Where are you located? Please provide your (valid!) Zip Code." aria-required="true" required="" title="">
+                <div class="error-message" id="1112487280_errorMessage"></div>
+                <div class="required-message">
+                    <?php print t('This is a required question'); ?>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <?php // ?>
+    <div class="ss-form-question errorbox-good">
+        <div dir="ltr" class="ss-item ss-item-required ss-radio">
+            <div class="ss-form-entry">
+                <div class="ss-q-title">
+                    <label class="ss-q-item-label" for="entry_1031662904">What cause area does your idea impact? <span class="ss-required-asterisk">*</span></label>
+                </div>
+                <div class="ss-q-help ss-secondary-text" dir="ltr">
+                    If your idea addresses more than one cause, choose the one you think is most relevant.
+                </div>
+                <ul class="ss-choices" role="radiogroup" aria-label="What cause area does your idea impact? If your idea addresses more than one cause, choose the one you think is most relevant.">
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="Animals" id="group_822732364_1" role="radio" class="ss-q-radio" aria-label="Animals" required="" aria-required="true"></span> <span class="ss-choice-label">Animals</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="Bullying &amp; Violence" id="group_822732364_2" role="radio" class="ss-q-radio" aria-label="Bullying &amp; Violence" required="" aria-required="true"></span> <span class="ss-choice-label">Bullying &amp; Violence</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="Disasters" id="group_822732364_3" role="radio" class="ss-q-radio" aria-label="Disasters" required="" aria-required="true"></span> <span class="ss-choice-label">Disasters</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="Discrimination" id="group_822732364_4" role="radio" class="ss-q-radio" aria-label="Discrimination" required="" aria-required="true"></span> <span class="ss-choice-label">Discrimination</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="Education" id="group_822732364_5" role="radio" class="ss-q-radio" aria-label="Education" required="" aria-required="true"></span> <span class="ss-choice-label">Education</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="Environment" id="group_822732364_6" role="radio" class="ss-q-radio" aria-label="Environment" required="" aria-required="true"></span> <span class="ss-choice-label">Environment</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="Homelessness &amp; Poverty" id="group_822732364_7" role="radio" class="ss-q-radio" aria-label="Homelessness &amp; Poverty" required="" aria-required="true"></span> <span class="ss-choice-label">Homelessness &amp; Poverty</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="Physical &amp; Mental Health" id="group_822732364_8" role="radio" class="ss-q-radio" aria-label="Physical &amp; Mental Health" required="" aria-required="true"></span> <span class="ss-choice-label">Physical &amp; Mental Health</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="Sex &amp; Relationships" id="group_822732364_9" role="radio" class="ss-q-radio" aria-label="Sex &amp; Relationships" required="" aria-required="true"></span> <span class="ss-choice-label">Sex &amp; Relationships</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.822732364" value="__other_option__" id="group_822732364_10" role="radio" class="ss-q-radio ss-q-other-toggle" required="" aria-required="true"></span> <span class="ss-choice-label">Other:</span></label> <span class="ss-q-other-container goog-inline-block"><input type="text" name="entry.822732364.other_option_response" value="" class="ss-q-other" id="entry_822732364_other_option_response" dir="auto" aria-label="Other"></span>
+                    </li>
+                </ul>
+                <div class="error-message" id="1031662904_errorMessage"></div>
+                <div class="required-message">
+                    <?php print t('This is a required question'); ?>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <?php // ?>
+    <div class="ss-form-question errorbox-good">
+        <div dir="ltr" class="ss-item ss-item-required ss-radio">
+            <div class="ss-form-entry">
+                <div class="ss-q-title">
+                    <label class="ss-q-item-label" for="entry_223902718">What type of action is your idea? <span class="ss-required-asterisk">*</span></label>
+                </div>
+                <div class="ss-q-help ss-secondary-text" dir="ltr">
+                    If your idea is more than one type of action, choose the one that’s most relevant. Check out our descriptions on each type of action.
+                </div>
+                <ul class="ss-choices" role="radiogroup" aria-label="What type of action is your idea? If your idea is more than one type of action, choose the one that’s most relevant. Check out our descriptions on each type of action.">
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="Donate an item" id="group_101412798_1" role="radio" class="ss-q-radio" aria-label="Donate an item" required="" aria-required="true"></span> <span class="ss-choice-label">Donate an item</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="Face-to-face interaction" id="group_101412798_2" role="radio" class="ss-q-radio" aria-label="Face-to-face interaction" required="" aria-required="true"></span> <span class="ss-choice-label">Face-to-face interaction</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="Host an event" id="group_101412798_3" role="radio" class="ss-q-radio" aria-label="Host an event" required="" aria-required="true"></span> <span class="ss-choice-label">Host an event</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="Improve/clean up a (physical) space" id="group_101412798_4" role="radio" class="ss-q-radio" aria-label="Improve/clean up a (physical) space" required="" aria-required="true"></span> <span class="ss-choice-label">Improve/clean up a (physical) space</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="Make something&nbsp;" id="group_101412798_5" role="radio" class="ss-q-radio" aria-label="Make something&nbsp;" required="" aria-required="true"></span> <span class="ss-choice-label">Make something&nbsp;</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="Share something&nbsp;" id="group_101412798_6" role="radio" class="ss-q-radio" aria-label="Share something&nbsp;" required="" aria-required="true"></span> <span class="ss-choice-label">Share something&nbsp;</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="Start something (like a club)" id="group_101412798_7" role="radio" class="ss-q-radio" aria-label="Start something (like a club)" required="" aria-required="true"></span> <span class="ss-choice-label">Start something (like a club)</span></label>
+                    </li>
+                    <li class="ss-choice-item">
+                        <label><span class="ss-choice-item-control goog-inline-block"><input type="radio" name="entry.101412798" value="Take a stand (think protest-y stuff)" id="group_101412798_8" role="radio" class="ss-q-radio" aria-label="Take a stand (think protest-y stuff)" required="" aria-required="true"></span> <span class="ss-choice-label">Take a stand (think protest-y stuff)</span></label>
+                    </li>
+                </ul>
+                <div class="error-message" id="223902718_errorMessage"></div>
+                <div class="required-message">
+                    <?php print t('This is a required question'); ?>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <?php // ?>
+    <div class="ss-form-question errorbox-good">
+        <div dir="ltr" class="ss-item ss-item-required ss-paragraph-text">
+            <div class="ss-form-entry">
+                <div class="ss-q-title">
+                    <label class="ss-q-item-label" for="entry_1255883103">What problem are you addressing? <span class="ss-required-asterisk">*</span></label>
+                </div>
+                <div class="ss-q-help ss-secondary-text" dir="ltr">
+                    You MUST include a fact/statistic that proves this problem. e.g. X% of animals end up in shelters after hurricanes. Limit 1-2 sentences.
+                </div>
+                <textarea name="entry.1255883103" rows="8" cols="0" class="ss-q-long" id="entry_1255883103" dir="auto" aria-label="What problem are you addressing? You MUST include a fact/statistic that proves this problem. e.g. X% of animals end up in shelters after hurricanes. Limit 1-2 sentences." aria-required="true" required=""></textarea>
+                <div class="error-message" id="1184451617_errorMessage"></div>
+                <div class="required-message">
+                    <?php print t('This is a required question'); ?>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <?php // ?>
+    <div class="ss-form-question errorbox-good">
+        <div dir="ltr" class="ss-item ss-item-required ss-paragraph-text">
+            <div class="ss-form-entry">
+                <div class="ss-q-title">
+                    <label class="ss-q-item-label" for="entry_1631970968">Please cite the source(s) of the fact(s) you listed above. <span class="ss-required-asterisk">*</span></label>
+                </div>
+                <div class="ss-q-help ss-secondary-text" dir="ltr">
+                    Get your research on. Be sure to include: (1) Title of specific study, article, website, or book OR (2) Organization or author that published it OR (3) Link to study or stat. Limit 1-2 sentences.
+                </div>
+                <textarea name="entry.1631970968" rows="8" cols="0" class="ss-q-long" id="entry_1631970968" dir="auto" aria-label="Please cite the source(s) of the fact(s) you listed above. Get your research on. Be sure to include: (1) Title of specific study, article, website, or book OR (2) Organization or author that published it OR (3) Link to study or stat. Limit 1-2 sentences." aria-required="true" required=""></textarea>
+                <div class="error-message" id="2043198594_errorMessage"></div>
+                <div class="required-message">
+                    <?php print t('This is a required question'); ?>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <?php // ?>
+    <div class="ss-form-question errorbox-good">
+        <div dir="ltr" class="ss-item ss-item-required ss-paragraph-text">
+            <div class="ss-form-entry">
+                <div class="ss-q-title">
+                    <label class="ss-q-item-label" for="entry_334582054">Describe the action you want people to take. <span class="ss-required-asterisk">*</span></label>
+                </div>
+                <div class="ss-q-help ss-secondary-text" dir="ltr">
+                    This should be one clear single action anyone in the U.S. can do. E.g., “Collect gently used towels and deliver them to your local animal shelter.” Limit 1-2 sentences.
+                </div>
+                <textarea name="entry.334582054" rows="8" cols="0" class="ss-q-long" id="entry_334582054" dir="auto" aria-label="Describe the action you want people to take. This should be one clear single action anyone in the U.S. can do. E.g., “Collect gently used towels and deliver them to your local animal shelter.” Limit 1-2 sentences." aria-required="true" required=""></textarea>
+                <div class="error-message" id="711595546_errorMessage"></div>
+                <div class="required-message">
+                    <?php print t('This is a required question'); ?>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <?php // ?>
+    <div class="ss-form-question errorbox-good">
+        <div dir="ltr" class="ss-item ss-item-required ss-paragraph-text">
+            <div class="ss-form-entry">
+                <div class="ss-q-title">
+                    <label class="ss-q-item-label" for="entry_2116830440">How can you prove your idea is an effective solution to the problem? <span class="ss-required-asterisk">*</span></label>
+                </div>
+                <div class="ss-q-help ss-secondary-text" dir="ltr">
+                    Do this by (1) Sharing results if you’ve done this before (e.g. “I ran this project last Christmas and fed 100 people”) OR (2) Linking to someone that’s successfully done this (e.g. “The Red Cross runs blood drives that save lives”) OR (3) Linking to research that proves your solution is valid (e.g. “The CDC says educating people about vaccines makes them more likely to get vaccinated”). Limit 1-2 sentences.
+                </div>
+                <textarea name="entry.2116830440" rows="8" cols="0" class="ss-q-long" id="entry_2116830440" dir="auto" aria-label="How can you prove your idea is an effective solution to the problem? Do this by (1) Sharing results if you’ve done this before (e.g. “I ran this project last Christmas and fed 100 people”) OR (2) Linking to someone that’s successfully done this (e.g. “The Red Cross runs blood drives that save lives”) OR (3) Linking to research that proves your solution is valid (e.g. “The CDC says educating people about vaccines makes them more likely to get vaccinated”). Limit 1-2 sentences." aria-required="true" required=""></textarea>
+                <div class="error-message" id="1391945183_errorMessage"></div>
+                <div class="required-message">
+                    <?php print t('This is a required question'); ?>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <input type="hidden" name="draftResponse" value="[,,&quot;-2455914862412393102&quot;] "> <input type="hidden" name="pageHistory" value="0"> <input type="hidden" name="fbzx" value="-2455914862412393102">
+
+    <input type="submit" name="submit" value="<?php print t('Submit'); ?>" id="ss-submit" class="btn">
+  </form>
+
 </section>
+

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/block.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/block.tpl.php
@@ -5,15 +5,23 @@
  */
 ?>
 
-<div id="<?php print $block_html_id; ?>" class="<?php print $classes; ?>"<?php print $attributes; ?>>
+<?php if ($clean_output): ?>
 
-  <?php print render($title_prefix); ?>
-<?php if ($block->subject): ?>
-  <h2<?php print $title_attributes; ?>><?php print $block->subject ?></h2>
-<?php endif;?>
-  <?php print render($title_suffix); ?>
+  <?php print $content ?>
 
-  <div class="content"<?php print $content_attributes; ?>>
-    <?php print $content ?>
+<?php else: ?>
+
+  <div id="<?php print $block_html_id; ?>" class="<?php print $classes; ?>"<?php print $attributes; ?>>
+
+    <?php print render($title_prefix); ?>
+  <?php if ($block->subject): ?>
+    <h2<?php print $title_attributes; ?>><?php print $block->subject ?></h2>
+  <?php endif;?>
+    <?php print render($title_suffix); ?>
+
+    <div class="content"<?php print $content_attributes; ?>>
+      <?php print $content ?>
+    </div>
   </div>
-</div>
+
+<?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/block.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/block.tpl.php
@@ -2,31 +2,7 @@
 /**
  * Returns the HTML for a block.
  * @see https://drupal.org/node/1728246
- *
- * @see
- * paraneue_dosomething_preprocess_block() in includes/preprocess.inc
- * If the $clean_output variable is set to TRUE, then the content for
- * the block will be output, without any of the extra markup around it.
  */
 ?>
 
-<?php if ($clean_output): ?>
-
-  <?php print $content ?>
-
-<?php else: ?>
-
-  <div id="<?php print $block_html_id; ?>" class="<?php print $classes; ?>"<?php print $attributes; ?>>
-
-    <?php print render($title_prefix); ?>
-  <?php if ($block->subject): ?>
-    <h2<?php print $title_attributes; ?>><?php print $block->subject ?></h2>
-  <?php endif;?>
-    <?php print render($title_suffix); ?>
-
-    <div class="content"<?php print $content_attributes; ?>>
-      <?php print $content ?>
-    </div>
-  </div>
-
-<?php endif; ?>
+<?php print $content ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/block.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/block.tpl.php
@@ -2,6 +2,11 @@
 /**
  * Returns the HTML for a block.
  * @see https://drupal.org/node/1728246
+ *
+ * @see
+ * paraneue_dosomething_preprocess_block() in includes/preprocess.inc
+ * If the $clean_output variable is set to TRUE, then the content for
+ * the block will be output, without any of the extra markup around it.
  */
 ?>
 


### PR DESCRIPTION
@DFurnes @aaronschachter @barryclark 

Here's the update for the MCC Form. I've include some logic for blocks, because I needed the output for the form as a block without any of the block wrapper markup. With the approach I took it would allow for indicating other block ids that we want to output with clean markup. 

@DFurnes suggested maybe nuking the wrapper markup for all block output at a later date anyhoo, but we'd ideally test the site thoroughly before that happens. The `$clean_ouput` provides an intermediary approach to eventually get to that point :tropical_drink: 

**EDIT**: It was decided that the markup around blocks wasn't really necessary, so we nuked it now instead of later! :bomb:
