### PR TITLE
Joining bubble query with AND

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
@@ -176,7 +176,7 @@ define(function(require) {
       var pos = query.push("q=") - 1;
 
       // Add a function query to bubble staff picks, sponsored, and high season to the top.
-      var bubble = "_query_:\"{!func}scale(is_bubble_factor,0,100)\"";
+      var bubble = "_query_:\"{!func}scale(is_bubble_factor,0,100)\" AND ";
 
       if (q.length > 0) {
         // If there is a query, join that sucker together


### PR DESCRIPTION
The bubble query has to be joined to the other query with AND so that filtering works properly and the correct number of documents are returned.

@DFurnes @weerd 
