### PR TITLE
DoSomething js i18n: wrap hardcoded strings into Drupal.t().

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/.jshintrc
+++ b/lib/themes/dosomething/paraneue_dosomething/.jshintrc
@@ -21,6 +21,7 @@
       "DEBUG": false,
       "jQuery": false,
       "$": false,
+      "Drupal": false,
       "_gaq": false
     },
     "strict": true,

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
@@ -14,7 +14,7 @@ define(function(require) {
 
       $container.wrap("<div style='clear: both'></div>");
 
-      var $uploadBtn = $("<a href='#' class='btn secondary small'>Upload A Pic</a>");
+      var $uploadBtn = $("<a href='#' class='btn secondary small'>" + Drupal.t("Upload A Pic") + "</a>");
       $uploadBtn.insertAfter( $(el) );
 
       var $imgPreview = $("<img class='preview' src=''>");
@@ -30,7 +30,7 @@ define(function(require) {
         $imgPreview.hide();
 
         // Change button state
-        $uploadBtn.text("Change Pic");
+        $uploadBtn.text(Drupal.t("Change Pic"));
 
         var files = !!this.files ? this.files : [];
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/Campaign.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/Campaign.js
@@ -12,8 +12,8 @@ define(function(require) {
   var Campaign = function (data) {
     // Default values for a newly created campaign
     var defaults = {
-      title: "New Campaign",
-      description: "Take your dad to get his blood pressure checked",
+      title: Drupal.t("New Campaign"),
+      description: Drupal.t("Take your dad to get his blood pressure checked"),
       url: "#",
       staffPick: false,
       featured: false

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/FormView.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/FormView.js
@@ -115,7 +115,7 @@ define(function(require) {
     checkInit: function () {
       if (FormView.$div === null) {
         // Nope. I'm gonna vomit...
-        throw "Error: FormView is not initialized.";
+        throw Drupal.t("Error: FormView is not initialized.");
       }
 
       // Yup.

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
@@ -40,7 +40,12 @@ define(function(require) {
       ResultsView.$container.hide();
 
 
-      ResultsView.$paginationLink = $("<div class='pagination-link'><a href='#' class='secondary js-finder-show-more'>Show More</a></div>");
+      ResultsView.$paginationLink = $(
+        "<div class='pagination-link'><a href='#' class='secondary js-finder-show-more'>" +
+          + Drupal.t("Show More") +
+        "</a></div>"
+      );
+
       $("body").on("click", ".js-finder-show-more", function(event) {
         event.preventDefault();
         paginateAction(ResultsView.start);
@@ -155,7 +160,7 @@ define(function(require) {
     checkInit: function () {
       if (ResultsView.$container === null) {
         // Nope. I'm gonna vomit...
-        throw "Error: ResultsView is not initialized.";
+        throw Drupal.t("Error: ResultsView is not initialized.");
       }
 
       // Yup.

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
@@ -42,7 +42,7 @@ define(function(require) {
 
       ResultsView.$paginationLink = $(
         "<div class='pagination-link'><a href='#' class='secondary js-finder-show-more'>" +
-          + Drupal.t("Show More") +
+          Drupal.t("Show More") +
         "</a></div>"
       );
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/templates/campaign.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/templates/campaign.tpl.html
@@ -1,7 +1,7 @@
 <li>
 <article class="tile tile--campaign campaign-result<% if(featured) { %> big<% } %>">
   <a class="wrapper" href="<%= url %>">
-    <% if(staffPick) {  %><div class="__flag -staff-pick">Staff Pick</div><% } %>
+    <% if(staffPick) {  %><div class="__flag -staff-pick"><%= Drupal.t("Staff Pick") %></div><% } %>
     <div class="tile--meta">
       <h1 class="__title"><%= title %></h1>
       <p class="__tagline"><%= description %></p>

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/templates/error.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/templates/error.tpl.html
@@ -1,1 +1,3 @@
-<div class="messages error">Ooof! We're not sure what's up? Maybe it's us, or it could be your internet connection. Want to try again in a few minutes?</div>
+<div class="messages error">
+  <%= Drupal.t("Ooof! We're not sure what's up? Maybe it's us, or it could be your internet connection. Want to try again in a few minutes?") %>
+</div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/templates/no-results.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/templates/no-results.tpl.html
@@ -1,6 +1,10 @@
 <div class="no-result">
   <div class="wrapper">
-    <p class="message ">Oh snap! We'll work on that.</p>
-    <p><a id="reset-filters" href="/">Want to try another combo?</a></p>
+    <p class="message"><%= Drupal.t("Oh snap! We'll work on that.") %></p>
+    <p>
+      <a id="reset-filters" href="/">
+        <%= Drupal.t("Want to try another combo?") %>
+      </a>
+    </p>
   </div>
 </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/address.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/address.js
@@ -24,44 +24,44 @@ define(function(require) {
    */
   Validation.registerValidationFunction("fname", function(string, done) {
     return requiredValidator(string, done, {
-      success: "Oh hey, " + string + "!",
-      failure: "We need your name. We’re on a first-name basis, right?"
+      success: Drupal.t("Oh hey, @fname!", {"@fname": string}),
+      failure: Drupal.t("We need your name. We’re on a first-name basis, right?")
     });
   });
 
   Validation.registerValidationFunction("lname", function(string, done) {
     return requiredValidator(string, done, {
-      success: "The " + string + "-inator! People call you that, right?",
-      failure: "We need your last name."
+      success: Drupal.t("The @lname-inator! People call you that, right?", {"@lname": string}),
+      failure: Drupal.t("We need your last name.")
 
     });
   });
 
   Validation.registerValidationFunction("address1", function(string, done) {
     return requiredValidator(string, done, {
-      success: "Got it!",
-      failure: "We need your street name and number."
+      success: Drupal.t("Got it!"),
+      failure: Drupal.t("We need your street name and number.")
     });
   });
 
   Validation.registerValidationFunction("address2", function(string, done) {
     return requiredValidator(string, done, {
-      success: "Got that too!",
+      success: Drupal.t("Got that too!"),
       failure: ""
     });
   });
 
   Validation.registerValidationFunction("city", function(string, done) {
     return requiredValidator(string, done, {
-      success: "Sweet, thanks!",
-      failure: "We need your city."
+      success: Drupal.t("Sweet, thanks!"),
+      failure: Drupal.t("We need your city.")
     });
   });
 
   Validation.registerValidationFunction("state", function(string, done) {
     return requiredValidator(string, done, {
-      success: "I \u2764 " + string,
-      failure: "We need your state."
+      success: Drupal.t("I \u2764 @state", {"@state": string}),
+      failure: Drupal.t("We need your state.")
     });
   });
 
@@ -69,20 +69,20 @@ define(function(require) {
     if( string.match(/^\d{5}(?:[-\s]\d{4})?$/) ) {
       return done({
         success: true,
-        message: "Almost done!"
+        message: Drupal.t("Almost done!")
       });
     } else {
       return done({
         success: false,
-        message: "We need your zip code."
+        message: Drupal.t("We need your zip code.")
       });
     }
   });
 
   Validation.registerValidationFunction("why_signedup", function(string, done) {
     return requiredValidator(string, done, {
-      success: "Thanks for caring!",
-      failure: "Oops! Can't leave this one blank."
+      success: Drupal.t("Thanks for caring!"),
+      failure: Drupal.t("Oops! Can't leave this one blank.")
     });
   });
 
@@ -91,8 +91,19 @@ define(function(require) {
    * Custom validation for UPS address fieldset.
    */
   Validation.registerValidationFunction("ups_address", function($el, done) {
-    var $sorryError = $("<div class='messages error'><strong>We couldn't find that address.</strong> Double check for typos and try submitting again.</div>");
-    var $networkError= $("<div class='messages error'>We're having trouble submitting the form, are you sure your internet connection is working? Email us if you continue having problems.</div>");
+    var $sorryError = $(
+      "<div class='messages error'>" +
+        "<strong>" + Drupal.t("We couldn't find that address.") + "</strong>" +
+        Drupal.t("Double check for typos and try submitting again.") +
+      "</div>"
+    );
+
+    var $networkError= $(
+      "<div class='messages error'>" +
+        Drupal.t("We're having trouble submitting the form, are you sure your internet connection is working? Email us if you continue having problems.") +
+      "</div>"
+    );
+
     var addressFieldData = $el.find("select, input").serializeArray();
 
     // Remove previous messages.

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
@@ -34,12 +34,12 @@ define(function(require) {
     if( string !== "" ) {
       return done({
         success: true,
-        message: "Hey, " + string + "!"
+        message: Drupal.t("Hey, @name!", {"@name": string})
       });
     } else {
       return done({
         success: false,
-        message: "We need your first name."
+        message: Drupal.t("We need your first name.")
       });
     }
   });
@@ -59,7 +59,7 @@ define(function(require) {
     } else {
       return done({
         success: false,
-        message: "Enter your birthday MM/DD/YYYY!"
+        message: Drupal.t("Enter your birthday MM/DD/YYYY!")
       });
     }
 
@@ -67,7 +67,7 @@ define(function(require) {
     if (birthMonth > 12) {
       return done({
         success: false,
-        message: "That doesn't seem right."
+        message: Drupal.t("That doesn't seem right.")
       });
     }
 
@@ -76,7 +76,7 @@ define(function(require) {
     if (birthDay > 31) {
       return done({
         success: false,
-        message: "That doesn't seem right."
+        message: Drupal.t("That doesn't seem right.")
       });
     }
 
@@ -93,41 +93,41 @@ define(function(require) {
     if (age < 0)  {
       return done({
         success: false,
-        message: "Are you a time traveller?"
+        message: Drupal.t("Are you a time traveller?")
       });
     } else if( age > 0 && age <= 25  ) {
 
       if (birthDate.getMonth() === now.getMonth() && now.getDate() === birthDate.getDate() ) {
         return done({
           success: true,
-          message: "Wow, happy birthday!"
+          message: Drupal.t("Wow, happy birthday!")
         });
       } else if ( age < 10) {
         return done({
           success: true,
-          message: "Wow, you're " + age + "!"
+          message: Drupal.t("Wow, you're @age!", {"@age": age})
         });
       } else {
         return done({
           success: true,
-          message: "Cool, " + age + "!"
+          message: Drupal.t("Cool, @age!", {"@age": age})
         });
       }
 
     } else if (age > 25 && age < 130) {
       return done({
         success: true,
-        message: "Yikes, you're old!"
+        message: Drupal.t("Yikes, you're old!")
       });
     } else if (string === "") {
       return done({
         success: false,
-        message: "We need your birthday."
+        message: Drupal.t("We need your birthday.")
       });
     } else {
       return done({
         success: false,
-        message: "That doesn't seem right."
+        message: Drupal.t("That doesn't seem right.")
       });
     }
   });
@@ -154,14 +154,14 @@ define(function(require) {
         empty: function() {
           return done({
             success: true,
-            message: "Great, thanks!"
+            message: Drupal.t("Great, thanks!")
           });
         }
       });
     } else {
       return done({
         success: false,
-        message: "We need a valid email."
+        message: Drupal.t("We need a valid email.")
       });
     }
   });
@@ -173,12 +173,12 @@ define(function(require) {
     if(string.length >= 6) {
       return done({
         success: true,
-        message: "Keep it secret, keep it safe!"
+        message: Drupal.t("Keep it secret, keep it safe!")
       });
     } else {
       return done({
         success: false,
-        message: "Must be 6+ characters."
+        message: Drupal.t("Must be 6+ characters.")
       });
     }
   });
@@ -196,12 +196,12 @@ define(function(require) {
     if(isValidFormat && !allRepeatingDigits && !hasRepeatingFives) {
       return done({
         success: true,
-        message: "Thanks!"
+        message: Drupal.t("Thanks!")
       });
     } else {
       return done({
         success: false,
-        message: "Enter a valid telephone number."
+        message: Drupal.t("Enter a valid telephone number.")
       });
     }
   });

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
@@ -117,7 +117,7 @@ define(function(require) {
     } else if (age > 25 && age < 130) {
       return done({
         success: true,
-        message: Drupal.t("Yikes, you're old!")
+        message: Drupal.t("Got it!")
       });
     } else if (string === "") {
       return done({

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/reportback.js
@@ -8,12 +8,12 @@ define(function (require) {
     if( string !== "" && /^[,0-9]+$/.test(string) ) {
       return done({
         success: true,
-        message: "That's great!"
+        message: Drupal.t("That's great!")
       });
     } else {
       return done({
         success: false,
-        message: "Enter a number!"
+        message: Drupal.t("Enter a number!")
       });
     }
   });
@@ -23,12 +23,12 @@ define(function (require) {
     if( string !== "" ) {
       return done({
         success: true,
-        message: "Thanks for caring!"
+        message: Drupal.t("Thanks for caring!")
       });
     } else {
       return done({
         success: false,
-        message: "Tell us why you cared!"
+        message: Drupal.t("Tell us why you cared!")
       });
     }
   });


### PR DESCRIPTION
#### What's this PR do?
- Wraps all Paraneue DoSomething hardcoded strings found in javascripts files into [`Drupal.t()`](https://www.drupal.org/node/323109) function
#### How should this be manually tested?
- Build javascript: `bin/ds grunt`
- Open [http://localhost:8888/](http://localhost:8888/)
- Run `drush cc css-js`
- Refresh [http://localhost:8888/](http://localhost:8888/)
- Check for one of srings (see diff) in the [translation interface](http://localhost:8888/admin/config/regional/translate/translate)

You can gain access to it by running `drush upwd admin --password 1` and then log in as `admin@example.com` with password `1`. 
#### What are the relevant tickets?

Step 1: #2878: wrap PHP templates text into t().
Jira: [#DOS-91](https://jira.dosomething.org/browse/DOS-91)
#### Known bugs:
1. <del>`bin/ds grunt --watch` multiple errors: `Drupal is not defined`</del>
2. `bin/ds grunt --watch` fails tests: `ReferenceError: Can't find variable: Drupal`

@DFurnes, it should be fixed when we include drupal.js to grunt, right?
@weerd Could you please review code?
CC: @mshmsh5000 @aaronschachter 
