### PR TITLE
Parent opt in

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
@@ -145,6 +145,7 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
 function dosomething_campaign_group_get_parent_nid($nid) {
   $result = db_select('field_data_field_campaigns', 'c')
     ->condition('field_campaigns_target_id', $nid)
+    ->condition('bundle', 'campaign_group')
     ->condition('deleted', 0)
     ->fields('c', array('entity_id'))
     ->execute();

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.admin.inc
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.admin.inc
@@ -17,9 +17,13 @@ function dosomething_mbp_config_form($form, &$form_state) {
   $form['campaign_api']['dosomething_mbp_send_campaign_api'] = array(
     '#type' => 'checkbox',
     '#title' => t('Send campaign details to Message Broker Campaign API'),
-    '#required' => TRUE,
     '#default_value' => variable_get('dosomething_mbp_send_campaign_api', FALSE),
   );
-  
+  $form['dosomething_mbp_log'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Log Message Broker Producer requests.'),
+    '#default_value' => variable_get('dosomething_mbp_log', FALSE),
+    '#description' => t("This should be disabled on production."),
+  );
   return system_settings_form($form);
 }

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -53,7 +53,9 @@ function dosomething_mbp_request($origin, $params = NULL) {
       break;
 
   }
-
+  if (variable_get('dosomething_mbp_log')) {
+    watchdog('dosomething_mbp', json_encode($payload));
+  }
   try {
     return message_broker_producer_request($production_type, $payload);
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -8,7 +8,7 @@
 /**
  * Form constructor for Signup opt-in configuration.
  */
-function dosomething_signup_admin_opt_in_form($form, &$form_state) {
+function dosomething_signup_optin_config_form($form, &$form_state) {
   $name = 'dosomething_mobilecommons_opt_in_path_user_register';
   $desc = t("Numeric Mobilecommons opt-in path when user registers for site.");
   $form[$name] = array(
@@ -80,9 +80,9 @@ function dosomething_signup_admin_opt_in_form($form, &$form_state) {
 }
 
 /**
- * Submit handler for dosomething_signup_admin_config_form().
+ * Submit handler for dosomething_signup_optin_config_form().
  */
-function dosomething_signup_admin_config_form_submit($form, &$form_state) {
+function dosomething_signup_optin_config_form_submit($form, &$form_state) {
   $values = $form_state['values'];
 
   $config_variables = array(

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -8,7 +8,7 @@
 /**
  * Form constructor for Signup opt-in configuration.
  */
-function dosomething_signup_admin_config_form($form, &$form_state) {
+function dosomething_signup_admin_opt_in_form($form, &$form_state) {
   $name = 'dosomething_mobilecommons_opt_in_path_user_register';
   $desc = t("Numeric Mobilecommons opt-in path when user registers for site.");
   $form[$name] = array(
@@ -178,3 +178,27 @@ function dosomething_signup_get_admin_config_campaign_variables() {
     'mobilecommons_opt_in_path' => t('The numeric Mobilecommons opt-in path.'),
   );
 }
+
+/**
+ * System settings form for DoSomething Signup specific variables.
+ */
+function dosomething_signup_admin_config_form($form, &$form_state) {
+  $form['log'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Logging'),
+  );
+  $form['log']['dosomething_signup_log_signups'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Log Signups.'),
+    '#default_value' => variable_get('dosomething_signup_log_signups', FALSE),
+    '#description' => t("Logs Signup entity activity. This should be disabled on production."),
+  );
+  $form['log']['dosomething_signup_log_mobilecommons'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Log Mobile Commons requests.'),
+    '#default_value' => variable_get('dosomething_signup_log_mobilecommons', FALSE),
+    '#description' => t("This should be disabled on production."),
+  );
+  return system_settings_form($form);
+}
+

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -341,6 +341,12 @@ function dosomething_signup_entity_insert($entity, $type) {
  * Sends third-party subscription requests for given $account and $node.
  */
 function dosomething_signup_third_party_subscribe($account, $node) {
+  // If this $node belongs to a Campaign Group:
+  if ($parent_nid = dosomething_campaign_group_get_parent_nid($node->nid)) {
+    // Exit out of function.
+    // The third_party_subscribe will be called by the parent signup.
+    return;
+  }
   $var_name  = 'mobilecommons_opt_in_path';
   // Is there an override set on this campaign?
   $opt_in = dosomething_helpers_get_variable($node->nid, $var_name);

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -21,9 +21,18 @@ function dosomething_signup_menu() {
     'title' => t('Third Party Opt-Ins'),
     'description' => 'Admin form to manage custom opt-ins',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('dosomething_signup_admin_config_form'),
+    'page arguments' => array('dosomething_signup_admin_opt_in_form'),
     'access callback' => 'user_access',
     'access arguments' => array('administer third party communication'),
+    'file' => 'dosomething_signup.admin.inc'
+  );
+  $items['admin/config/dosomething/dosomething_signup'] = array(
+    'title' => t('DoSomething Signup'),
+    'description' => t('Admin configuration form for DoSomething Signup.'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_signup_admin_config_form'),
+    'access callback' => 'user_access',
+    'access arguments' => array('administer modules'),
     'file' => 'dosomething_signup.admin.inc'
   );
   $items['node/%node/unsignup'] = array(

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -21,7 +21,7 @@ function dosomething_signup_menu() {
     'title' => t('Third Party Opt-Ins'),
     'description' => 'Admin form to manage custom opt-ins',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('dosomething_signup_admin_opt_in_form'),
+    'page arguments' => array('dosomething_signup_optin_config_form'),
     'access callback' => 'user_access',
     'access arguments' => array('administer third party communication'),
     'file' => 'dosomething_signup.admin.inc'

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.inc
@@ -80,5 +80,8 @@ class SignupEntityController extends EntityAPIController {
       }
     }
     parent::save($entity, $transaction);
+    if (variable_get('dosomething_signup_log_signups')) {
+      watchdog('dosomething_signup', json_encode($entity));
+    }
   }
 }

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
@@ -26,6 +26,9 @@ function dosomething_signup_mobilecommons_opt_in($account, $lid, $title = NULL) 
   try {
     // If valid args for given $user:
     if ($args = dosomething_signup_get_mobilecommons_vars($account, $lid, $title)) {
+      if (variable_get('dosomething_signup_log_mobilecommons')) {
+        watchdog('dosomething_signup', json_encode($args));
+      }
       // Submit Mobilecommons request.
       return mobilecommons_request('opt_in', $args);
     }


### PR DESCRIPTION
Resolves https://jira.dosomething.org/browse/DOS-129 by not sending third-party opt-ins for a Campaign which is a child of a Campaign Group.

Also adds logging variables, allowing us to log Message Broker payloads, MobileCommons requests, and Signup Entity insert/updates, which I used to test.
