### PR TITLE
Fixes DOS-147: Latest version of Predis library missing 'lib' directory

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -225,6 +225,8 @@ libraries[mobilecommons-php][download][url] = "https://github.com/DoSomething/mo
 ; Predis
 libraries[predis][download][type] = "git"
 libraries[predis][download][url] = "https://github.com/nrk/predis.git"
+; Pin to 0.8 release, which still has the lib directory.
+libraries[predis][download][revision] = "4123fcd85d61354c6c9900db76c9597dbd129bf6"
 
 ; Zendesk PHP
 libraries[zendesk][download][type] = "git"


### PR DESCRIPTION
This PR pins the drupal-org.make reference to the [v0.8 release](https://github.com/nrk/predis/tree/v0.8) of Predis, or commit 4123fcd85d61354c6c9900db76c9597dbd129bf6.

This is the last tagged release with the 'lib' directory.
