### PR TITLE
File proxy update

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -350,10 +350,13 @@ function grunt {
 function pull_db {
   if [[ $1 == "stage" ]]
   then
-    echo "Pulling down db from staging"
+    echo "Pulling down db from staging..."
     cd $WEB_PATH
     drush sql-sync @ds.staging @self -y
+    echo "Enabling Stage File Proxy..."
     drush en -y stage_file_proxy
+    echo "Setting Stage File Proxy to staging URL..."
+    drush vset stage_file_proxy_origin "http://staging.beta.dosomething.org"
   fi
 }
 

--- a/config/default.settings.local.php
+++ b/config/default.settings.local.php
@@ -64,6 +64,3 @@ $conf['dosomething_search_finder_url'] = (getenv('DS_FINDER_URL') ?: 'http://sol
 $conf['dosomething_search_finder_collection'] = $solr_path;
 
 #$conf['apachesolr_read_only'] = 1;
-
-$conf['stage_file_proxy_origin'] = "http://staging.beta.dosomething.org";
-

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -208,7 +208,7 @@ projects[coder][version] = "2.2"
 projects[coder][subdir] = "contrib"
 
 ; Stage File Proxy
-projects[stage_file_proxy][version] = "1.5"
+projects[stage_file_proxy][version] = "1.6"
 projects[stage_file_proxy][subdir] = "contrib"
 
 


### PR DESCRIPTION
Updates Stage File Proxy module to 1.6, which provides an admin config form at `admin/config/system/stage_file_proxy`

Sets the origin variable within `ds pull stage --db` to fix bug described in https://github.com/DoSomething/dosomething/pull/2760#issuecomment-51093919 
