### PR TITLE
Only load campaign stats for API requests

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -236,11 +236,10 @@ function dosomething_campaign_load($node, $public = FALSE) {
   // Load Creator property.
   dosomething_campaign_load_creator($campaign, $wrapper);
 
-  // Add stats property.
-  dosomething_campaign_load_stats($campaign);
-
   // If this is accessed via API:
   if ($public) {
+    // Add stats property.
+    dosomething_campaign_load_stats($campaign);
     // Unset properties which shouldn't be public.
     unset($campaign->variables);
   }


### PR DESCRIPTION
Only queries for signups when we load the campaign via API, which is the only place this is used right now.  Should significantly cut down on number of queries in general.

Closes https://jira.dosomething.org/browse/DS-166
