### PR TITLE
Fix PHP notice for Undefined num_participants property 

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -403,6 +403,7 @@ function dosomething_campaign_node_view($node, $view_mode, $langcode) {
           'nid' => $node->nid,
           'quantity' => NULL,
           'why_participated' => NULL,
+          'num_participants' => NULL,
         ));
       }
       // Set Reportback Form variable in node content for rendering in theme layer.


### PR DESCRIPTION
Occurs when a Campaign is set to collect `num_participants` in the Reportback Form.  The property needs to be initialized when we create the blank Reportback entity to save.

Fixes https://jira.dosomething.org/browse/DS-203
