### PR TITLE
Adds CDN contrib module to installation profile

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -27,6 +27,10 @@ projects[apachesolr_views][subdir] = "contrib"
 projects[blockreference][version] = "1.16"
 projects[blockreference][subdir] = "contrib"
 
+; CDN
+projects[cdn][version] = "2.6"
+projects[cdn][subdir] = "contrib"
+
 ; Ctools
 projects[ctools][version] = "1.4"
 projects[ctools][subdir] = "contrib"


### PR DESCRIPTION
But does not enable.

This module will only be used on production, not in staging or in local development (since we pull from staging).

Refs https://jira.dosomething.org/browse/DS-109
