### PR TITLE
Reward Redeem Form

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -349,13 +349,6 @@ function dosomething_campaign_theme($existing, $type, $theme, $path) {
     'reportback_confirmation' => array(
       'template' => 'reportback-confirmation',
       'path' => drupal_get_path('module', 'dosomething_campaign') . '/theme',
-      'variables' => array(
-        'page_title' => NULL,
-        'copy' => NULL,
-        'more_campaigns_link' => NULL,
-        'back_to_campaign_link' => NULL,
-        'recommended' => NULL,
-      ),
     ),
     'campaign_block' => array(
       'template' => 'campaign-block',

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
@@ -15,27 +15,45 @@
  */
 function dosomething_campaign_reportback_confirmation_page($node) {
   $wrapper = entity_metadata_wrapper('node', $node);
+  // Initialize $vars to pass to the reportback_confirmation theme function.
+  $vars = array(
+    'back_to_campaign_link' => NULL,
+    'call_to_action' => NULL,
+    'copy' => $node->field_reportback_confirm_msg[LANGUAGE_NONE][0]['value'],
+    'more_campaigns_link' => NULL,
+    'page_title' => NULL,
+    'recommended' => NULL,
+    'reward_form' => NULL,
+  );
 
+  // Set variables for anonymous user:
   if (!user_is_logged_in()) {
     $button_text = variable_get('dosomething_campaign_confirmation_page_anon_button_text');
-    $call_to_action = variable_get('dosomething_campaign_confirmation_page_anon_cta_text');
+    $vars['call_to_action'] = variable_get('dosomething_campaign_confirmation_page_anon_cta_text');
     // The button should open the login/register form.
-    $more_campaigns_link = dosomething_user_get_login_modal_link_markup($button_text, 'large');
+    $vars['more_campaigns_link'] = dosomething_user_get_login_modal_link_markup($button_text, 'large');
   }
+  // Else set variables for authenticated user:
   else {
     $button_text = variable_get('dosomething_campaign_confirmation_page_button_text');
-    $call_to_action = NULL;
     // Set button to link to /campaigns.
-    $more_campaigns_link = l(t($button_text), 'campaigns', array(
+    $vars['more_campaigns_link'] = l(t($button_text), 'campaigns', array(
       'attributes' => array('class' =>
         array('btn')
       ))
     );
+    if (module_exists('dosomething_reward')) {
+      if ($reward = dosomething_reward_exists('reportback_count')) {
+        $form_id = 'dosomething_reward_redeem_form';
+        $vars['reward_form'] = drupal_get_form($form_id, $reward);
+      }
+    }
   }
 
   // Link back to current node.
   $campaign_link_title = t('Back to @title', array('@title' => $node->title));
-  $back_to_campaign_link = l($campaign_link_title, 'node/' . $node->nid, array('html' => TRUE));
+  $vars['back_to_campaign_link'] = l($campaign_link_title, 'node/' . $node->nid, array('html' => TRUE));
+
   // Store current node's primary cause tid.
   $tid = $wrapper->field_primary_cause->getIdentifier();
   // Get 4 recommended campaign nids for term $tid and current user.
@@ -52,20 +70,12 @@ function dosomething_campaign_reportback_confirmation_page($node) {
     }
   }
   // We only want to display 3 campaigns blocks - we might have 4.
-  $rec_vars = array_slice($rec_vars, 0, 3);
+  $vars['recommended'] = array_slice($rec_vars, 0, 3);
 
   // Page title is set already based on campaign type.
   // @see dosomething_campaign_menu().
-  $page_title = drupal_get_title();
+  $vars['page_title'] = drupal_get_title();
 
   // Returned themed reportback confirmation page.
-  return theme('reportback_confirmation', array(
-    'page_title' => $page_title,
-    'copy' => $wrapper->field_reportback_confirm_msg->value(),
-    'more_campaigns_link' => $more_campaigns_link,
-    'back_to_campaign_link' => $back_to_campaign_link,
-    'recommended' => $rec_vars,
-    'call_to_action' => $call_to_action,
-    )
-  );
+  return theme('reportback_confirmation', $vars);
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
@@ -23,7 +23,7 @@ function dosomething_campaign_reportback_confirmation_page($node) {
     'more_campaigns_link' => NULL,
     'page_title' => NULL,
     'recommended' => NULL,
-    'reward_form' => NULL,
+    'redeem_form' => NULL,
   );
 
   // Set variables for anonymous user:
@@ -44,8 +44,7 @@ function dosomething_campaign_reportback_confirmation_page($node) {
     );
     if (module_exists('dosomething_reward')) {
       if ($reward = dosomething_reward_exists('reportback_count')) {
-        $form_id = 'dosomething_reward_redeem_form';
-        $vars['reward_form'] = drupal_get_form($form_id, $reward);
+        $vars['redeem_form'] = dosomething_reward_get_redeem_form_vars($reward);
       }
     }
   }

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.admin.inc
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.admin.inc
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @file
+ * Admin config form settings.
+ */
+
+/**
+ * System settings form for DoSomething Signup specific variables.
+ */
+function dosomething_reward_admin_config_form($form, &$form_state) {
+  $form['copy'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Copy'),
+  );
+
+  $var_name = 'dosomething_reward_redeem_form_link';
+  $form['copy'][$var_name] = array(
+    '#type' => 'textfield',
+    '#title' => t('Redeem Form Link Text'),
+    '#description' => t("Link text that opens the Redeem Form modal."),
+    '#required' => TRUE,
+    '#default_value' => variable_get($var_name),
+  );
+
+  $var_name = 'dosomething_reward_redeem_form_header';
+  $form['copy'][$var_name] = array(
+    '#type' => 'textfield',
+    '#title' => t('Redeem Form Header'),
+    '#description' => t("Header text of the Redeem Form modal."),
+    '#required' => TRUE,
+    '#default_value' => variable_get($var_name),
+  );
+
+  $var_name = 'dosomething_reward_redeem_form_copy';
+  $form['copy'][$var_name] = array(
+    '#type' => 'textarea',
+    '#rows' => 4,
+    '#title' => t('Redeem Form Copy'),
+    '#description' => t("Copy displayed in the Redeem Form modal."),
+    '#required' => TRUE,
+    '#default_value' => variable_get($var_name),
+  );
+
+  $var_name = 'dosomething_reward_redeem_form_button_text';
+  $form['copy'][$var_name] = array(
+    '#type' => 'textfield',
+    '#title' => t('Redeem Form Button Label'),
+    '#description' => t("Label displayed on the Redeem Form submit button."),
+    '#required' => TRUE,
+    '#default_value' => variable_get($var_name),
+  );
+
+  $var_name = 'dosomething_reward_redeem_form_confirm_msg';
+  $form['copy'][$var_name] = array(
+    '#type' => 'textarea',
+    '#rows' => 2,
+    '#title' => t('Redeem Form Confirmation Message'),
+    '#description' => t("Message displayed after submitting the Redeem Form."),
+    '#required' => TRUE,
+    '#default_value' => variable_get($var_name),
+  );
+
+  $form['log'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Logging'),
+  );
+
+  $var_name = 'dosomething_reward_log';
+  $form['log'][$var_name] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Log Rewards.'),
+    '#default_value' => variable_get($var_name, FALSE),
+    '#description' => t("Logs Reward activity. This should be disabled on production."),
+  );
+  return system_settings_form($form);
+}

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @file
+ * Provides form constructors for the DoSomething Reward module.
+ */
+
+/**
+ * Form constructor for a Reward Redeem form.
+ *
+ * @param object $reward
+ *   The Reward entity to redeem.
+ *
+ * @ingroup forms
+ */
+function dosomething_reward_redeem_form($form, &$form_state, $reward) {
+  $submit_label = t("Redeem");
+  $size_options = array(
+    'S' => t('S'), 
+    'M' => t('M'),
+    'L' => t('L'),
+  );
+  $form['id'] = array(
+    '#type' => 'hidden',
+    '#default_value' => $entity->id,
+    // Prevent this element from rendering in the browser.
+    '#access' => FALSE,
+  );
+  $form['size'] = array(
+    '#type' => 'radios',
+    '#title' => t('T-Shirt size'),
+    '#options' => $size_options,
+  );
+  $form['actions'] = array(
+    '#type' => 'actions',
+    'submit' => array(
+      '#type' => 'submit',
+      '#value' => $submit_label,
+    ),
+  );
+  return $form;
+}
+
+/**
+ * Validation callback for dosomething_reportback_form().
+ */
+function dosomething_reward_redeem_form_submit($form, &$form_state) {
+  // If user session no longer exists:
+  if (!user_is_logged_in()) {
+    // Tell them that.
+    drupal_set_message(t("You are no longer logged in. Please log in."), 'error');
+  }
+  $reward = entity_load_single('reward', $form_state['values']['id']);
+  $reward->redeem();
+  drupal_set_message(t("Reward redeemed!"));
+}

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
@@ -13,7 +13,7 @@
  * @ingroup forms
  */
 function dosomething_reward_redeem_form($form, &$form_state, $reward) {
-  $submit_label = t("Redeem");
+  $submit_label = variable_get('dosomething_reward_redeem_form_button_text');
   $size_options = array(
     'S' => t('S'), 
     'M' => t('M'),

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
@@ -21,7 +21,7 @@ function dosomething_reward_redeem_form($form, &$form_state, $reward) {
   );
   $form['id'] = array(
     '#type' => 'hidden',
-    '#default_value' => $entity->id,
+    '#default_value' => $reward->id,
     // Prevent this element from rendering in the browser.
     '#access' => FALSE,
   );

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
@@ -51,5 +51,6 @@ function dosomething_reward_redeem_form_submit($form, &$form_state) {
   }
   $reward = entity_load_single('reward', $form_state['values']['id']);
   $reward->redeem();
-  drupal_set_message(t("Reward redeemed!"));
+  $msg = variable_get('dosomething_reward_redeem_form_confirm_msg');
+  drupal_set_message($msg);
 }

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.install
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.install
@@ -58,3 +58,42 @@ function dosomething_reward_schema() {
   );
   return $schema;
 }
+
+/**
+ * Implements hook_install().
+ */
+function dosomething_reward_install() {
+
+  $value = "Hey, do you want a T-Shirt?";
+  variable_set('dosomething_reward_redeem_form_link', $value);
+
+  $value = "Free T-shirts";
+  variable_set('dosomething_reward_redeem_form_header', $value);
+
+  $value = "You're a kickass DoSomething.org member. For completing 2 campaigns within a year, we want to thank you by offering you two free DoSomething.org t-shirts - one for you and one for a friend. Fill out the form below to get both shirts mailed to you.";
+  variable_set('dosomething_reward_redeem_form_copy', $value);
+
+  $value = "Submit";
+  variable_set('dosomething_reward_redeem_form_button_text', $value);
+
+  $value = "Sweet thanks! You'll receive your t-shirts within 2-3 weeks. We'll email you when they've been shipped so you can track the package. Keep up the awesome work.";
+  variable_set('dosomething_reward_redeem_form_confirm_msg', $value);
+
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function dosomething_reward_uninstall() {
+  $vars = array(
+    'dosomething_reward_log',
+    'dosomething_reward_redeem_form_button_text',
+    'dosomething_reward_redeem_form_confirm_msg',
+    'dosomething_reward_redeem_form_copy',
+    'dosomething_reward_redeem_form_header',
+    'dosomething_reward_redeem_form_link',
+  );
+  foreach ($vars as $var) {
+    variable_del($var);
+  }
+}

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
@@ -9,6 +9,23 @@ include_once 'dosomething_reward.forms.inc';
 DEFINE('DOSOMETHING_REWARD_NUM_REPORTBACK_COUNT', 2);
 
 /**
+ * Implements hook_menu().
+ */
+function dosomething_reward_menu() {
+  $items = array();
+  $items['admin/config/dosomething/dosomething_reward'] = array(
+    'title' => 'DoSomething Reward',
+    'description' => 'Admin configuration form for DoSomething Reward.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_reward_admin_config_form'),
+    'access callback' => 'user_access',
+    'access arguments' => array('administer modules'),
+    'file' => 'dosomething_reward.admin.inc',
+  );
+  return $items;
+}
+
+/**
  * Implements hook_entity_info().
  */
 function dosomething_reward_entity_info() {

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
@@ -260,9 +260,7 @@ function dosomething_reward_get_redeem_form_vars($reward) {
   // Initialize return array.
   $vars = array();
   // Get the Redeem Form for this $reward.
-  $form = drupal_get_form('dosomething_reward_redeem_form', $reward);
-  // Set the rendered Redeem Form markup.
-  $vars['form'] = render($form);
+  $vars['form'] = drupal_get_form('dosomething_reward_redeem_form', $reward);
   // Set copy variables.
   $copy_vars = array(
     'copy',

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
@@ -5,11 +5,9 @@
  */
 
 include_once 'dosomething_reward.features.inc';
-/**
- * @file
- * Code for the DoSomething Reward module.
- */
+include_once 'dosomething_reward.forms.inc';
 DEFINE('DOSOMETHING_REWARD_NUM_REPORTBACK_COUNT', 2);
+
 /**
  * Implements hook_entity_info().
  */
@@ -29,7 +27,6 @@ function dosomething_reward_entity_info() {
   );
   return $info;
 }
-
 
 /**
  * Implements hook_views_data().

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
@@ -252,3 +252,26 @@ function dosomething_reward_reportback_count($reportback) {
   }
   return FALSE;
 }
+
+/**
+ * For a given $reward, return an array of relevant Redeem Form variables.
+ */
+function dosomething_reward_get_redeem_form_vars($reward) {
+  // Initialize return array.
+  $vars = array();
+  // Get the Redeem Form for this $reward.
+  $form = drupal_get_form('dosomething_reward_redeem_form', $reward);
+  // Set the rendered Redeem Form markup.
+  $vars['form'] = render($form);
+  // Set copy variables.
+  $copy_vars = array(
+    'copy',
+    'header',
+    'link',
+  );
+  foreach ($copy_vars as $key) {
+    $var_name = 'dosomething_reward_redeem_form_' . $key;
+    $vars[$key] = variable_get($var_name);
+  }
+  return $vars;
+}

--- a/lib/modules/dosomething/dosomething_reward/includes/dosomething_reward.inc
+++ b/lib/modules/dosomething/dosomething_reward/includes/dosomething_reward.inc
@@ -16,6 +16,17 @@ class RewardEntity extends Entity {
   protected function defaultUri() {
     return array('path' => 'reward/' . $this->identifier());
   }
+
+  /**
+   * Sets the Reward's redeemed property to current time.
+   */
+  public function redeem() {
+    $this->redeemed = REQUEST_TIME;
+    $this->save();
+    if (module_exists('dosomething_mbp')) {
+      //@todo: Send confirmation Message Broker request.
+    }
+  }
 }
 
 /**
@@ -34,4 +45,5 @@ class RewardEntityController extends EntityAPIController {
     }
     parent::save($entity, $transaction);
   }
+
 }

--- a/lib/modules/dosomething/dosomething_reward/includes/dosomething_reward.inc
+++ b/lib/modules/dosomething/dosomething_reward/includes/dosomething_reward.inc
@@ -18,10 +18,10 @@ class RewardEntity extends Entity {
   }
 
   /**
-   * Sets the Reward's redeemed property to current time.
+   * Sets the Reward's redeemed property to given $timestamp or current time.
    */
-  public function redeem() {
-    $this->redeemed = REQUEST_TIME;
+  public function redeem($timestamp = REQUEST_TIME) {
+    $this->redeemed = $timestamp;
     $this->save();
     if (module_exists('dosomething_mbp')) {
       //@todo: Send confirmation Message Broker request.

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
@@ -15,7 +15,11 @@
  *   - [path]: URL path for campaign node (string).
  *   - [pretty_path]: Pretty URL path for campaign node (string).
  *   - [staff_pick]: Indicate if this campaign a staff pick (boolean).
- * - $redeem_form: Array containing relevant markup:Form array, to be rendered.
+ * - $redeem_form: Array containing variables for Reward Reedem Form, if exists:
+ *   - [copy]: Copy displayed in the Redeem Form modal (string).
+ *   - [form]: Reward Reedem Form to be rendered (array).
+ *   - [header]: Header text of the Redeem Form modal (string).
+ *   - [link]: Label of link to open the Redeem form modal (string).
  */
 ?>
 
@@ -68,7 +72,12 @@
   <?php endif; ?>
 
   <?php if ($redeem_form): ?>
-  <?php print $redeem_form['form']; ?>
+    <a href="#" data-modal-href="#modal-redeem-form"><?php print $redeem_form['link']; ?></a>
+    <div data-modal id="modal-redeem-form" role="dialog">
+      <h2 class="banner"><?php print ($redeem_form['header']); ?></h2>
+      <?php print $redeem_form['copy']; ?>
+      <?php print render($redeem_form['form']); ?>
+    </div>
   <?php endif; ?>
 
 </section>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
@@ -15,7 +15,7 @@
  *   - [path]: URL path for campaign node (string).
  *   - [pretty_path]: Pretty URL path for campaign node (string).
  *   - [staff_pick]: Indicate if this campaign a staff pick (boolean).
- * - $reward_form: Form array, to be rendered.
+ * - $redeem_form: Array containing relevant markup:Form array, to be rendered.
  */
 ?>
 
@@ -66,7 +66,9 @@
       </div>
     </div>
   <?php endif; ?>
-  <?php if ($reward_form): ?>
-  <?php print render($reward_form); ?>
+
+  <?php if ($redeem_form): ?>
+  <?php print $redeem_form['form']; ?>
   <?php endif; ?>
+
 </section>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
@@ -15,7 +15,7 @@
  *   - [path]: URL path for campaign node (string).
  *   - [pretty_path]: Pretty URL path for campaign node (string).
  *   - [staff_pick]: Indicate if this campaign a staff pick (boolean).
- * - $classes: Additional classes passed for output (string).
+ * - $reward_form: Form array, to be rendered.
  */
 ?>
 
@@ -65,5 +65,8 @@
         <div class="cta-back-to-campaign"><?php if (isset($back_to_campaign_link)): ?><?php print $back_to_campaign_link; ?><?php endif; ?></div>
       </div>
     </div>
+  <?php endif; ?>
+  <?php if ($reward_form): ?>
+  <?php print render($reward_form); ?>
   <?php endif; ?>
 </section>


### PR DESCRIPTION
Chipping away at https://jira.dosomething.org/browse/DS-127 subtasks.
- Creates the `dosomething_reward_redeem_form` constructor and submit function, which sets the Reward redeemed timestamp when submitted
- Renders the Redeem Form on the Reportback Confirmation page if `dosomething_reward` module is enabled (should still remain disabled while under development)
- Creates admin settings form to set copy for Redeem Form links and modal
- Cleans up Reportback Confirmation theme function -- send an array of variables instead of specifying specific parameters
