### PR TITLE
Test cleanup

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -332,6 +332,9 @@ function dosomething_campaign_create_node_from_json($string) {
   $data = json_decode($string);
   $node = new stdClass();
 
+  // We'll use this as a flag to find test nodes.
+  $node->created = '-1'; 
+  
   $node->type = $data->type;
   $node->title = $data->title;
 

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.helpers.inc
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.helpers.inc
@@ -10,6 +10,10 @@
 function dosomething_fact_create_node_from_json($string) {
   $data = json_decode($string);
   $node = new stdClass();
+
+  // We'll use this as a flag to find test nodes.
+  $node->created = '-1'; 
+
   $node->type = 'fact';
   $node->title = $data->title;
   

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.drush.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.drush.inc
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Implementation of hook_drush_command().
+ */
+function dosomething_helpers_drush_command() {
+  $items = array();
+  // Name of the drush command.
+  $items['test-node-delete'] = array(
+    'description' => 'Delete any nodes created by test fixtures.',
+    'callback' => 'dosomething_helpers_drush_test_node_delete',
+    'examples' => array(
+      'drush test-node-delete' => 'Deletes any nodes created by test fixtures (for example, `drush campaign-create` or `drush fact-create`).',
+    ),
+  );
+  return $items;
+}
+
+/**
+ * Callback for campaign-create command.
+ */
+function dosomething_helpers_drush_test_node_delete() {
+  $deleted_nids = dosomething_helpers_delete_test_nodes();
+
+  $message = "Deleted " . count($deleted_nids) . " test nodes.";
+  return $message;
+}

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -5,6 +5,7 @@ include_once 'dosomething_helpers.features.inc';
  * Code for the Dosomething helpers feature.
  */
 
+include_once('dosomething_helpers.drush.inc');
 include_once('dosomething_helpers.theme.inc');
 include_once('dosomething_helpers.strongarm.inc');
 include_once('dosomething_helpers.variable.inc');
@@ -22,6 +23,26 @@ function dosomething_helpers_menu() {
     'file path' => drupal_get_path('module', 'system'),
   );
   return $items;
+}
+
+/**
+ * Utility function to delete automated test data.
+ */
+function dosomething_helpers_delete_test_nodes() {
+  $query = new EntityFieldQuery();
+
+  $query->entityCondition('entity_type', 'node');
+  $query->propertyCondition('created', -1);
+
+  $result = $query->execute();
+  if (isset($result['node'])) {
+    $test_nids = array_keys($result['node']);
+    node_delete_multiple($test_nids);
+
+    return $test_nids;
+  } else {
+    return null;
+  }
 }
 
 

--- a/lib/modules/dosomething/dosomething_image/dosomething_image.helpers.inc
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.helpers.inc
@@ -11,6 +11,9 @@ function dosomething_image_create_node_from_json($string) {
   $data = json_decode($string);
   $image = new stdClass();
 
+  // We'll use this as a flag to find test nodes.
+  $node->created = '-1'; 
+
   $node->type = 'image';
   $node->title = $data->title;
   $node->active = 1;

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.helpers.inc
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.helpers.inc
@@ -16,6 +16,9 @@ function dosomething_taxonomy_create_term($name, $vocabulary_machine_name) {
 
     $term = new stdClass();
 
+    // We'll use this as a flag to find test nodes.
+    $term->created = '-1'; 
+
     $term->name = $name;
     $term->vid = $vid;
 


### PR DESCRIPTION
Re-thinking how best to clean up test nodes based on discussion in #2934.
## Changes
- Flags all nodes created from JSON with a `created` value of `-1` so we can find them later.
- Creates a `drush test-node-delete` task to remove all nodes with `created == -1`.
