### PR TITLE
DS User Address Form element

### DIFF
--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
@@ -15,12 +15,17 @@
 function dosomething_reward_redeem_form($form, &$form_state, $reward) {
   $submit_label = variable_get('dosomething_reward_redeem_form_button_text');
   $size_options = dosomething_shipment_get_shirt_size_options();
+
   $form['id'] = array(
     '#type' => 'hidden',
     '#default_value' => $reward->id,
     // Prevent this element from rendering in the browser.
     '#access' => FALSE,
   );
+
+  // Add Address form fields.
+  dosomething_user_address_form_element($form, $form_state);
+
   $form['shirt_size'] = array(
     '#type' => 'radios',
     '#required' => TRUE,
@@ -52,7 +57,13 @@ function dosomething_reward_redeem_form_submit($form, &$form_state) {
     // Tell them that.
     drupal_set_message(t("You are no longer logged in. Please log in."), 'error');
   }
+
   $values = $form_state['values'];
+
+  // Save User address.
+  dosomething_user_save_address_values($values);
+
+  // Redeem the reward.
   $reward = entity_load_single('reward', $values['id']);
   $reward->redeem($values);
   $msg = variable_get('dosomething_reward_redeem_form_confirm_msg');

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -261,43 +261,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     '#suffix' => '</p>',
   );
   if ($config['collect_user_address']) {
-    global $user;
-    // Load user to get relevant field values as form default_values.
-    $account = user_load($user->uid);
-    $form['user_first_name'] = array(
-      '#type' => 'textfield',
-      '#required' => TRUE,
-      '#title' => t('First Name'),
-      '#default_value' => isset($account->field_first_name[LANGUAGE_NONE][0]['value']) ? $account->field_first_name[LANGUAGE_NONE][0]['value'] : '',
-      '#attributes' => array(
-        'data-validate' => 'fname',
-        'data-validate-required' => '',
-      ),
-    );
-    $form['user_last_name'] = array(
-      '#type' => 'textfield',
-      '#required' => TRUE,
-      '#title' => t('Last Name'),
-      '#default_value' => isset($account->field_last_name[LANGUAGE_NONE][0]['value']) ? $account->field_last_name[LANGUAGE_NONE][0]['value'] : '',
-      '#attributes' => array(
-        'data-validate' => 'lname',
-        'data-validate-required' => '',
-      ),
-    );
-    $form['user_address'] = array(
-      '#prefix' => '<div data-validate="ups_address" data-validate-required>',
-      '#suffix' => '</div>',
-      '#type' => 'addressfield',
-      '#handlers' => array(
-        'address' => 'address',
-        'address-hide-country' => 'address-hide-country',
-      ),
-      '#required' => TRUE,
-      '#context' => array('countries' => array('US')),
-      '#default_value' => isset($account->field_address[LANGUAGE_NONE][0]) ? $account->field_address[LANGUAGE_NONE][0] : '',
-    );
-    // If we are collecting an address, run address validation.
-    $form['#validate'][] = 'dosomething_signup_data_validate_address';
+    dosomething_user_address_form_element($form, $form_state);
   }
   // If we are collecting why_signedup:
   if ($config['collect_why_signedup']) {
@@ -329,59 +293,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     ),
   );
 
-  $form['#after_build'][] = 'dosomething_user_remove_extra_values_from_address_field';
-  $form['#after_build'][] = 'dosomething_user_add_validation_attributes_to_address_fields';
-
   return $form;
-}
-
-/**
- * Validation callback for address field in dosomething_signup_user_signup_data_form().
- */
-function dosomething_signup_data_validate_address($form, &$form_state) {
-  // Validate address against UPS api.
-  $address = $form_state['input']['user_address'];
-  $first_name = $form_state['input']['user_first_name'];
-  $last_name = $form_state['input']['user_last_name'];
-
-  $formatted_address = dosomething_user_validate_any_address($first_name, $last_name, $address);
-
-  // Did we not get any results?
-  if (in_array('sorry', $formatted_address)) {
-    form_set_error('dosomething_user_validate_address', t('Hmmm, we couldn’t find that address. Please try again.'));
-  }
-  // Did it come back from the api as ambiguous? -- Check with the user.
-  elseif (in_array('ambiguous', $formatted_address)) {
-    dosomething_signup_data_set_address_values($form, $form_state, $formatted_address);
-    form_set_error('dosomething_user_ambiguous_address', t('Hmmm, we couldn’t find that address. Did you mean:'));
-  }
-  // We have a full address, save it!
-  else {
-    dosomething_signup_data_set_address_values($form, $form_state, $formatted_address);
-  }
-}
-
-/**
- * Set the formatted address values in a form.
- *
- * @param array $form
- *  A drupal form.
- * @param array $form_state
- *  A drupal form_state.
- * @param array $address
- *  A validated drupal addressfield array.
- */
-function dosomething_signup_data_set_address_values($form, &$form_state, $address) {
-  form_set_value($form['user_address']['address']['street_block']['thoroughfare'],
-      array('value' => $address['thoroughfare']), $form_state);
-  form_set_value($form['user_address']['address']['street_block']['premise'],
-      array('value' => $address['premise']), $form_state);
-  form_set_value($form['user_address']['address']['locality_block']['locality'],
-      array('value' => $address['locality']), $form_state);
-  form_set_value($form['user_address']['address']['locality_block']['administrative_area'],
-      array('value' => $address['administrative_area']), $form_state);
-  form_set_value($form['user_address']['address']['locality_block']['postal_code'],
-      array('value' => $address['postal_code']), $form_state);
 }
 
 /**
@@ -392,8 +304,8 @@ function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
   // Load signup_data_form record to gather relevant config and confirm_msg.
   $config = dosomething_signup_get_signup_data_form_info($values['nid']);
   if ($config['collect_user_address']) {
-    // Update user data.
-    dosomething_signup_update_user_data($values);
+    // Update user address.
+    dosomething_user_save_address_values($values);
   }
   // Update signup record.
   dosomething_signup_update_signup_data($values);
@@ -433,44 +345,6 @@ function dosomething_signup_user_skip_signup_data_form($form, &$form_state, $sig
 function dosomething_signup_user_skip_signup_data_form_submit($form, &$form_state) {
   // Update signup record with response = 0.
   dosomething_signup_update_signup_data($form_state['values'], 0);
-}
-
-/**
- * Saves signup_form_data to fields on the user.
- *
- * @param array $values
- *   The values passed from a user signup_data_form submission.
- */
-function dosomething_signup_update_user_data($values) {
-  global $user;
-  $account = $user;
-  $edit = array();
-  if (isset($values['user_address'])) {
-    $edit['field_address'] = array(
-      LANGUAGE_NONE => array(
-        0 => $values['user_address']
-      ),
-    );
-  }
-  if (isset($values['user_first_name'])) {
-    $edit['field_first_name'] = array(
-      LANGUAGE_NONE => array(
-        0 => array(
-          'value' => $values['user_first_name'],
-        ),
-      ),
-    );
-  }
-  if (isset($values['user_last_name'])) {
-    $edit['field_last_name'] = array(
-      LANGUAGE_NONE => array(
-        0 => array(
-          'value' => $values['user_last_name'],
-        ),
-      ),
-    );
-  }
-  user_save($account, $edit);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
@@ -1,0 +1,142 @@
+<?php
+/**
+ * @file
+ * Code for DoSomething User Address functionality.
+ *
+ * Provides functions to add and validate a Address form element via Form API.
+ */
+
+/**
+ * Adds an address form element to a given Form API $form.
+ *
+ * @param object $node
+ *   The loaded node to save the signup data form configuration for.
+ */
+function dosomething_user_address_form_element(&$form, &$form_state) {
+  global $user;
+  // Load user to get relevant field values as form default_values.
+  $account = user_load($user->uid);
+  $form['user_first_name'] = array(
+    '#type' => 'textfield',
+    '#required' => TRUE,
+    '#title' => t('First Name'),
+    '#default_value' => isset($account->field_first_name[LANGUAGE_NONE][0]['value']) ? $account->field_first_name[LANGUAGE_NONE][0]['value'] : '',
+    '#attributes' => array(
+      'data-validate' => 'fname',
+      'data-validate-required' => '',
+    ),
+  );
+  $form['user_last_name'] = array(
+    '#type' => 'textfield',
+    '#required' => TRUE,
+    '#title' => t('Last Name'),
+    '#default_value' => isset($account->field_last_name[LANGUAGE_NONE][0]['value']) ? $account->field_last_name[LANGUAGE_NONE][0]['value'] : '',
+    '#attributes' => array(
+      'data-validate' => 'lname',
+      'data-validate-required' => '',
+    ),
+  );
+  $form['user_address'] = array(
+    '#prefix' => '<div data-validate="ups_address" data-validate-required>',
+    '#suffix' => '</div>',
+    '#type' => 'addressfield',
+    '#handlers' => array(
+      'address' => 'address',
+      'address-hide-country' => 'address-hide-country',
+    ),
+    '#required' => TRUE,
+    '#context' => array('countries' => array('US')),
+    '#default_value' => isset($account->field_address[LANGUAGE_NONE][0]) ? $account->field_address[LANGUAGE_NONE][0] : '',
+  );
+  // If we are collecting an address, run address validation.
+  $form['#validate'][] = 'dosomething_user_address_form_element_validate';
+  $form['#after_build'][] = 'dosomething_user_remove_extra_values_from_address_field';
+  $form['#after_build'][] = 'dosomething_user_add_validation_attributes_to_address_fields';
+}
+
+/**
+ * Validation callback called by dosomething_user_address_form_element().
+ */
+function dosomething_user_address_form_element_validate($form, &$form_state) {
+  // Validate address against UPS api.
+  $address = $form_state['input']['user_address'];
+  $first_name = $form_state['input']['user_first_name'];
+  $last_name = $form_state['input']['user_last_name'];
+
+  $formatted_address = dosomething_user_validate_any_address($first_name, $last_name, $address);
+
+  // Did we not get any results?
+  if (in_array('sorry', $formatted_address)) {
+    form_set_error('dosomething_user_validate_address', t('Hmmm, we couldn’t find that address. Please try again.'));
+  }
+  // Did it come back from the api as ambiguous? -- Check with the user.
+  elseif (in_array('ambiguous', $formatted_address)) {
+    dosomething_signup_data_set_address_values($form, $form_state, $formatted_address);
+    form_set_error('dosomething_user_ambiguous_address', t('Hmmm, we couldn’t find that address. Did you mean:'));
+  }
+  // We have a full address, save it!
+  else {
+    dosomething_user_address_form_element_set_values($form, $form_state, $formatted_address);
+  }
+}
+
+/**
+ * Set the formatted address values in a form.
+ *
+ * @param array $form
+ *  A drupal form.
+ * @param array $form_state
+ *  A drupal form_state.
+ * @param array $address
+ *  A validated drupal addressfield array.
+ */
+function dosomething_user_address_form_element_set_values($form, &$form_state, $address) {
+  form_set_value($form['user_address']['address']['street_block']['thoroughfare'],
+      array('value' => $address['thoroughfare']), $form_state);
+  form_set_value($form['user_address']['address']['street_block']['premise'],
+      array('value' => $address['premise']), $form_state);
+  form_set_value($form['user_address']['address']['locality_block']['locality'],
+      array('value' => $address['locality']), $form_state);
+  form_set_value($form['user_address']['address']['locality_block']['administrative_area'],
+      array('value' => $address['administrative_area']), $form_state);
+  form_set_value($form['user_address']['address']['locality_block']['postal_code'],
+      array('value' => $address['postal_code']), $form_state);
+}
+
+/**
+ * Saves signup_form_data to fields on the user.
+ *
+ * @param array $values
+ *   The values passed from a user signup_data_form submission.
+ */
+function dosomething_user_save_address_values($values) {
+  global $user;
+  $account = $user;
+  $edit = array();
+  if (isset($values['user_address'])) {
+    $edit['field_address'] = array(
+      LANGUAGE_NONE => array(
+        0 => $values['user_address']
+      ),
+    );
+  }
+  if (isset($values['user_first_name'])) {
+    $edit['field_first_name'] = array(
+      LANGUAGE_NONE => array(
+        0 => array(
+          'value' => $values['user_first_name'],
+        ),
+      ),
+    );
+  }
+  if (isset($values['user_last_name'])) {
+    $edit['field_last_name'] = array(
+      LANGUAGE_NONE => array(
+        0 => array(
+          'value' => $values['user_last_name'],
+        ),
+      ),
+    );
+  }
+  user_save($account, $edit);
+}

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -4,6 +4,7 @@
  * Code for the DoSomething User feature.
  */
 
+include_once 'dosomething_user.address.inc';
 include_once 'dosomething_user.features.inc';
 include_once 'dosomething_user_profile.inc';
 include_once 'dosomething_user_valid_address.inc';


### PR DESCRIPTION
@angaither Can you please review when you have a chance?

This PR moves the Address Form API elements out of the `dosomething_signup_user_signup_data_form` and into a new function called `dosomething_user_address_form_element` so it can be re-used in the Reward Redeem Form to close out https://jira.dosomething.org/browse/DS-134

I've tested on Thumb Wars to make sure the Address Collection works there, and it's working fine.  JS Validation seems to working on the Reward Redeem Form as well, but the "Fix it" error messages are not displaying.. any clues to why? cc @DFurnes 

Refs https://jira.dosomething.org/browse/DS-141
