### PR TITLE
Fix ds pull stage: force "yes" on files override dialog.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -369,7 +369,7 @@ function pull_files {
   then
     echo "Pulling down files from staging"
     cd $WEB_PATH
-    drush rsync @ds.staging @self -y
+    drush -y rsync @ds.staging @self
     symlinks
   fi
 }


### PR DESCRIPTION
Drush only accepts `-y` argument before the command.

With this fix `ds pull stage` will not ask
`You will destroy data from /var/www/vagrant/html/ and replace with data from
dosomething@staging.beta.dosomething.org:/var/www/beta.dosomething.org/current/html//`
`Do you really want to continue? (y/n):`
anymore.
