### PR TITLE
New SMS Game variables

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -86,6 +86,8 @@ function dosomething_helpers_get_variable_names() {
     'mobilecommons_opt_in_path',
     'mobilecommons_friends_opt_in_path',
     'signup_form_submit_label',
+    'sms_game_mp_story_id',
+    'sms_game_mp_story_type',
   );
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -8,7 +8,7 @@
 /**
  * Form constructor for Signup opt-in configuration.
  */
-function dosomething_signup_optin_config_form($form, &$form_state) {
+function dosomething_signup_opt_in_config_form($form, &$form_state) {
 
   // General Drupal variables.
   $name = 'dosomething_mobilecommons_opt_in_path_user_register';
@@ -33,8 +33,8 @@ function dosomething_signup_optin_config_form($form, &$form_state) {
   );
 
   // Node helpers variables.
-  $optin_helpers = dosomething_signup_get_optin_config_form_helpers_vars();
-  foreach ($optin_helpers as $key => $vars) {
+  $opt_in_helpers = dosomething_signup_get_opt_in_config_form_helpers_vars();
+  foreach ($opt_in_helpers as $key => $vars) {
     // Output group header:
     $form[$key] = array(
       '#markup' => '<h3>' . $vars['title'] . '</h3>',
@@ -46,7 +46,7 @@ function dosomething_signup_optin_config_form($form, &$form_state) {
       // Loop through each node:
       foreach ($vars['node_vars'] as $node_vars) {
         // Add a form element for the node's helpers variables.
-        dosomething_signup_optin_config_form_add_elements($form, $node_vars, $helpers_vars);
+        dosomething_signup_opt_in_config_form_add_elements($form, $node_vars, $helpers_vars);
       }
     }
   }
@@ -59,9 +59,9 @@ function dosomething_signup_optin_config_form($form, &$form_state) {
 }
 
 /**
- * Submit handler for dosomething_signup_optin_config_form().
+ * Submit handler for dosomething_signup_opt_in_config_form().
  */
-function dosomething_signup_optin_config_form_submit($form, &$form_state) {
+function dosomething_signup_opt_in_config_form_submit($form, &$form_state) {
   $values = $form_state['values'];
 
   // Save general Drupal variables.
@@ -74,10 +74,12 @@ function dosomething_signup_optin_config_form_submit($form, &$form_state) {
   }
 
   // Save node helpers variables.
-  $optin_helpers = dosomething_signup_get_optin_config_form_helpers_vars();
-  foreach ($optin_helpers as $vars) {
+  $opt_in_helpers = dosomething_signup_get_opt_in_config_form_helpers_vars();
+  foreach ($opt_in_helpers as $vars) {
     // If no nodes exist, go to next group.
-    if (empty($vars['node_vars'])) { continue; }
+    if (empty($vars['node_vars'])) {
+      continue;
+    }
 
     // Loop through each node:
     foreach ($vars['node_vars'] as $node_vars) {
@@ -108,9 +110,9 @@ function dosomething_signup_optin_config_form_submit($form, &$form_state) {
  * @param array $helpers_vars
  *   The helpers variable names to get/set for this node.
  */
-function dosomething_signup_optin_config_form_add_elements(&$form, $node_vars, $helpers_vars) {
+function dosomething_signup_opt_in_config_form_add_elements(&$form, $node_vars, $helpers_vars) {
   $nid = $node_vars['nid'];
-  $title = isset($node_vars['title']) ? $node_vars['title'] : NULL;
+  $title = !empty($node_vars['title']) ? $node_vars['title'] : t("Undefined");
   // Create a fieldset for each campaign.
   $form[$nid] = array(
     '#type' => 'fieldset',
@@ -157,7 +159,7 @@ function dosomething_signup_get_signup_helpers_var_names() {
  *
  * @return array
  */
-function dosomething_signup_get_optin_config_form_helpers_vars() {
+function dosomething_signup_get_opt_in_config_form_helpers_vars() {
   $vars = array();
   $helpers_var_names = dosomething_signup_get_signup_helpers_var_names();
   $vars['staff_pick'] = array(

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -62,6 +62,7 @@ function dosomething_signup_optin_config_form($form, &$form_state) {
 function dosomething_signup_optin_config_form_submit($form, &$form_state) {
   $values = $form_state['values'];
 
+  // Save general Drupal variables.
   $config_variables = array(
     'dosomething_mobilecommons_opt_in_path_user_register',
     'dosomething_mobilecommons_opt_in_path_general_campaign_signup',
@@ -70,47 +71,25 @@ function dosomething_signup_optin_config_form_submit($form, &$form_state) {
     variable_set($var_name, $values[$var_name]);
   }
 
-  // Store list of variables that each Campaign can implement.
-  $variables = dosomething_signup_get_admin_config_campaign_variables();
+  // Save node helpers variables.
+  foreach (dosomething_signup_get_optin_config_form_helpers_vars() as $vars) {
+    // If no nodes exist, go to next group.
+    if (empty($vars['node_vars'])) continue;
 
-  // Save staff pick helpers variables.
-  $staff_picks = dosomething_campaign_get_staff_picks();
-  if ($staff_picks) {
-    foreach ($staff_picks as $vars) {
-      $nid = $vars['nid'];
+    // Loop through each node:
+    foreach ($vars['node_vars'] as $node_vars) {
+      $nid = $node_vars['nid'];
       $node = node_load($nid);
-      foreach ($variables as $name => $description) {
+      // Loop through the relevant helpers_vars for this node.
+      foreach ($vars['helpers_vars'] as $name => $description) {
+        // Get the form input value for this node helpers variable.
         $value = $values[$nid . '_' . $name];
+        // Save it as a helpers variable.
         dosomething_helpers_set_variable($node, $name, $value);
       }
     }
   }
 
-  // Save Campaign Group helpers variables.
-  if ($campaign_groups = dosomething_helpers_get_node_vars('campaign_group')) {
-    foreach ($campaign_groups as $vars) {
-      $nid = $vars['nid'];
-      $node = node_load($nid);
-      foreach ($variables as $name => $description) {
-        $value = $values[$nid . '_' . $name];
-        dosomething_helpers_set_variable($node, $name, $value);
-      }
-    }
-  }
-
-  // Save SMS Games helpers variables.
-  $sms_games = dosomething_campaign_get_sms_games();
-  if ($sms_games) {
-    $variables = dosomething_signup_get_admin_config_sms_game_variables();
-    foreach ($sms_games as $vars) {
-      $nid = $vars['nid'];
-      $node = node_load($nid);
-      foreach ($variables as $name => $description) {
-        $value = $values[$nid . '_' . $name];
-        dosomething_helpers_set_variable($node, $name, $value);
-      }
-    }
-  }
   drupal_set_message(t("Configuration saved."));
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -34,17 +34,19 @@ function dosomething_signup_optin_config_form($form, &$form_state) {
 
   // Node helpers variables.
   foreach (dosomething_signup_get_optin_config_form_helpers_vars() as $key => $vars) {
-    // Output section header:
+    // Output group header:
     $form[$key] =array(
       '#markup' => '<h3>' . $vars['title'] . '</h3>',
     );
-    // If nodes exist for this section:
+    // If nodes exist for this group:
     if (!empty($vars['node_vars'])) {
+      // Get the helpers_vars names for this group.
+      $helpers_vars = $vars['helpers_vars'];
       // Loop through each node:
       foreach ($vars['node_vars'] as $node_vars) {
         $type = $vars['form_element_type'];
         // Add a form element for the node's helpers variables.
-        dosomething_signup_optin_config_form_add_elements($form, $node_vars, $type);
+        dosomething_signup_optin_config_form_add_elements($form, $node_vars, $helpers_vars);
       }
     }
   }
@@ -94,27 +96,29 @@ function dosomething_signup_optin_config_form_submit($form, &$form_state) {
 }
 
 /**
- * Adds form elements to store third party values for given set of $vars.
+ * Adds form elements to store third party values for given set of $node_vars.
+ *
+ * @param array $form
+ *   The Form API form to add the elements to.
+ * @param array $node_vars
+ *   The relevant node variables for these form elements. Expected values:
+ *   - nid: The node nid (int).
+ *   - title: The node title (string).
+ * @param array $helpers_vars
+ *   The helpers variable names to get/set for this node.
  */
-function dosomething_signup_optin_config_form_add_elements(&$form, $vars, $type = NULL) {
-  $nid = $vars['nid'];
-
-  // Get the helper variables to create form elements based on the $type.
-  $variables = dosomething_signup_get_admin_config_campaign_variables();
-  if ($type == 'sms_game') {
-    $variables = dosomething_signup_get_admin_config_sms_game_variables();
-  }
- 
+function dosomething_signup_optin_config_form_add_elements(&$form, $node_vars, $helpers_vars) {
+  $nid = $node_vars['nid']; 
   // Create a fieldset for each campaign.
   $form[$nid] = array(
     '#type' => 'fieldset',
-    '#title' => $vars['title'] . ' | NID ' . $nid,
+    '#title' => $node_vars['title'] . ' | NID ' . $nid,
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  // Loop through each variable it can contain:
-  foreach ($variables as $name => $description) {
-    // Create a form element for it.
+  // Loop through each helpers variable name for this node:
+  foreach ($helpers_vars as $name => $description) {
+    // Create a form element for setting the node helpers variable.
     $form[$nid][$nid . '_' . $name] = array(
       '#type' => 'textfield',
       '#title' => $name,
@@ -125,31 +129,24 @@ function dosomething_signup_optin_config_form_add_elements(&$form, $vars, $type 
 }
 
 /**
- * Returns list of helper variables that a standard Campaign can implement.
+ * Returns multi-dimensional array of relevant Signup helpers variable names.
  *
  * @return array
- *   Associative array keyed by variable name.
+ *   Returns multi-dimensional array, keyed by the Campaign type.
  */
-function dosomething_signup_get_admin_config_campaign_variables() {
+function dosomething_signup_get_signup_helpers_var_names() {
   return array(
-    'mailchimp_grouping_id' => t('The numeric Grouping ID for the Group Name.'),
-    'mailchimp_group_name' => t('The alphanumeric Interest Group Name.'),
-    'mobilecommons_opt_in_path' => t('The numeric Mobilecommons opt-in path.'),
-  );
-}
-
-/**
- * Returns list of helper variables that a SMS Game Campaign can implement.
- *
- * @return array
- *   Associative array keyed by variable name.
- */
-function dosomething_signup_get_admin_config_sms_game_variables() {
-  return array(
-    'mobilecommons_opt_in_path' => t('Single-player: Mobile Commons Alpha Opt-In Path'),
-    'mobilecommons_friends_opt_in_path' => t('Single-player: Mobile Commons Beta Opt-In Path'),
-    'sms_game_mp_story_id' => t('Multi-player: Story Id'),
-    'sms_game_mp_story_type' => t('Multi-player: Story Type'),
+    'campaign' => array(
+      'mailchimp_grouping_id' => t('The numeric Grouping ID for the Group Name.'),
+      'mailchimp_group_name' => t('The alphanumeric Interest Group Name.'),
+      'mobilecommons_opt_in_path' => t('The numeric Mobilecommons opt-in path.'),
+    ),
+    'sms_game' => array(
+      'mobilecommons_opt_in_path' => t('Single-player: Mobile Commons Alpha Opt-In Path'),
+      'mobilecommons_friends_opt_in_path' => t('Single-player: Mobile Commons Beta Opt-In Path'),
+      'sms_game_mp_story_id' => t('Multi-player: Story Id'),
+      'sms_game_mp_story_type' => t('Multi-player: Story Type'),
+    ),
   );
 }
 
@@ -160,22 +157,24 @@ function dosomething_signup_get_admin_config_sms_game_variables() {
  */
 function dosomething_signup_get_optin_config_form_helpers_vars() {
   $vars = array();
+  $helpers_var_names = dosomething_signup_get_signup_helpers_var_names();
   $vars['staff_pick'] = array(
     'title' => t("Staff Picks"),
     'node_vars' => dosomething_campaign_get_staff_picks(),
-    'helpers_vars' => dosomething_signup_get_admin_config_campaign_variables(),
+    'helpers_vars' => $helpers_var_names['campaign'],
     'form_element_type' => NULL,
   );
   $vars['campaign_group'] = array(
     'title' => t("Grouped Campaigns"),
     'node_vars' => dosomething_helpers_get_node_vars('campaign_group'),
-    'helpers_vars' => dosomething_signup_get_admin_config_campaign_variables(),
+    // A Campaign Group uses the same helpers variables as a standard Campaign.
+    'helpers_vars' => $helpers_var_names['campaign'],
     'form_element_type' => NULL,
   );
   $vars['sms_game'] = array(
     'title' => t("SMS Games"),
     'node_vars' => dosomething_campaign_get_sms_games(),
-    'helpers_vars' => dosomething_signup_get_admin_config_sms_game_variables(),
+    'helpers_vars' => $helpers_var_names['sms_game'],
     'form_element_type' => 'sms_game',
   );
   return $vars;
@@ -194,7 +193,7 @@ function dosomething_signup_admin_config_form($form, &$form_state) {
     '#type' => 'textfield',
     '#required' => TRUE,
     '#title' => t('SMS Multi-player Game Endpoint'),
-    '#description' => t("URL to post a multi-player SMS Game request, e.g. <em>http://ds-heroku/sms-multiplayer-game/create</em>"),
+    '#description' => t("URL to post a multi-player SMS Game request, e.g. <em>http://ds-heroku.biz/sms-multiplayer-game/create</em>"),
     '#default_value' => variable_get($var_name),
   );
   $form['log'] = array(

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -33,15 +33,16 @@ function dosomething_signup_optin_config_form($form, &$form_state) {
   );
 
   // Node helpers variables.
-  foreach (dosomething_signup_get_optin_config_form_helpers_vars() as $key => $vars) {
+  $optin_helpers = dosomething_signup_get_optin_config_form_helpers_vars();
+  foreach ($optin_helpers as $key => $vars) {
     // Output group header:
-    $form[$key] =array(
+    $form[$key] = array(
       '#markup' => '<h3>' . $vars['title'] . '</h3>',
     );
     // If nodes exist for this group:
     if (!empty($vars['node_vars'])) {
       // Get the helpers_vars names for this group.
-      $helpers_vars = $vars['helpers_vars'];
+      $helpers_vars = &$vars['helpers_vars'];
       // Loop through each node:
       foreach ($vars['node_vars'] as $node_vars) {
         // Add a form element for the node's helpers variables.
@@ -73,9 +74,10 @@ function dosomething_signup_optin_config_form_submit($form, &$form_state) {
   }
 
   // Save node helpers variables.
-  foreach (dosomething_signup_get_optin_config_form_helpers_vars() as $vars) {
+  $optin_helpers = dosomething_signup_get_optin_config_form_helpers_vars();
+  foreach ($optin_helpers as $vars) {
     // If no nodes exist, go to next group.
-    if (empty($vars['node_vars'])) continue;
+    if (empty($vars['node_vars'])) { continue; }
 
     // Loop through each node:
     foreach ($vars['node_vars'] as $node_vars) {
@@ -107,11 +109,12 @@ function dosomething_signup_optin_config_form_submit($form, &$form_state) {
  *   The helpers variable names to get/set for this node.
  */
 function dosomething_signup_optin_config_form_add_elements(&$form, $node_vars, $helpers_vars) {
-  $nid = $node_vars['nid']; 
+  $nid = $node_vars['nid'];
+  $title = isset($node_vars['title']) ? $node_vars['title'] : NULL;
   // Create a fieldset for each campaign.
   $form[$nid] = array(
     '#type' => 'fieldset',
-    '#title' => $node_vars['title'] . ' | NID ' . $nid,
+    '#title' => $title . ' | NID ' . $nid,
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
@@ -131,7 +134,7 @@ function dosomething_signup_optin_config_form_add_elements(&$form, $node_vars, $
  * Returns multi-dimensional array of relevant Signup helpers variable names.
  *
  * @return array
- *   Returns multi-dimensional array, keyed by the Campaign type.
+ *   Returns multi-dimensional array, indexed by the Campaign type.
  */
 function dosomething_signup_get_signup_helpers_var_names() {
   return array(

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -52,24 +52,7 @@ function dosomething_signup_optin_config_form($form, &$form_state) {
   $sms_games = dosomething_campaign_get_sms_games();
   if ($sms_games) {
     foreach ($sms_games as $vars) {
-      $nid = $vars['nid'];
-      // Create a fieldset for each SMS Game.
-      $form[$nid] = array(
-        '#type' => 'fieldset',
-        '#title' => $vars['title'] . ' | NID ' . $nid,
-        '#collapsible' => TRUE,
-        '#collapsed' => TRUE,
-      );
-      $form[$nid][$nid . '_alpha'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Mobile Commons Alpha Opt-In Path'),
-        '#default_value' => dosomething_helpers_get_variable($nid, 'mobilecommons_opt_in_path'),
-      );
-      $form[$nid][$nid . '_beta'] = array(
-        '#type' => 'textfield',
-        '#title' => t('Mobile Commons Beta Opt-In Path'),
-        '#default_value' => dosomething_helpers_get_variable($nid, 'mobilecommons_friends_opt_in_path'),
-      );
+      dosomething_signup_optin_config_form_sms_game_element($form, $vars);
     }
   }
   $form['actions']['submit'] = array(
@@ -163,6 +146,27 @@ function dosomething_signup_optin_config_form_add_elements(&$form, $vars) {
       '#description' => $description,
     );
   }
+}
+
+function dosomething_signup_optin_config_form_sms_game_element(&$form, $vars) {
+  $nid = $vars['nid'];
+  // Create a fieldset for each SMS Game.
+  $form[$nid] = array(
+    '#type' => 'fieldset',
+    '#title' => $vars['title'] . ' | NID ' . $nid,
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form[$nid][$nid . '_alpha'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Mobile Commons Alpha Opt-In Path'),
+    '#default_value' => dosomething_helpers_get_variable($nid, 'mobilecommons_opt_in_path'),
+  );
+  $form[$nid][$nid . '_beta'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Mobile Commons Beta Opt-In Path'),
+    '#default_value' => dosomething_helpers_get_variable($nid, 'mobilecommons_friends_opt_in_path'),
+  );
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -9,6 +9,8 @@
  * Form constructor for Signup opt-in configuration.
  */
 function dosomething_signup_optin_config_form($form, &$form_state) {
+
+  // General Drupal variables.
   $name = 'dosomething_mobilecommons_opt_in_path_user_register';
   $desc = t("Numeric Mobilecommons opt-in path when user registers for site.");
   $form[$name] = array(
@@ -29,32 +31,24 @@ function dosomething_signup_optin_config_form($form, &$form_state) {
     '#size' => 10,
     '#description' => $desc,
   );
-  $form['staff_picks'] = array(
-    '#markup' => '<h3>Staff Picks</h3>',
-  );
-  $staff_picks = dosomething_campaign_get_staff_picks();
-  if ($staff_picks) {
-    foreach ($staff_picks as $vars) {
-      dosomething_signup_optin_config_form_add_elements($form, $vars);
+
+  // Node helpers variables.
+  foreach (dosomething_signup_get_optin_config_form_helpers_vars() as $key => $vars) {
+    // Output section header:
+    $form[$key] =array(
+      '#markup' => '<h3>' . $vars['title'] . '</h3>',
+    );
+    // If nodes exist for this section:
+    if (!empty($vars['node_vars'])) {
+      // Loop through each node:
+      foreach ($vars['node_vars'] as $node_vars) {
+        $type = $vars['form_element_type'];
+        // Add a form element for the node's helpers variables.
+        dosomething_signup_optin_config_form_add_elements($form, $node_vars, $type);
+      }
     }
   }
-  $form['campaign_groups'] = array(
-    '#markup' => '<h3>Grouped Campaigns</h3>',
-  );
-  if ($campaign_groups = dosomething_helpers_get_node_vars('campaign_group')) {
-    foreach ($campaign_groups as $vars) {
-      dosomething_signup_optin_config_form_add_elements($form, $vars);
-    }
-  }
-  $form['header'] = array(
-    '#markup' => '<h3>SMS Games</h3>',
-  );
-  $sms_games = dosomething_campaign_get_sms_games();
-  if ($sms_games) {
-    foreach ($sms_games as $vars) {
-      dosomething_signup_optin_config_form_add_elements($form, $vars, 'sms_game');
-    }
-  }
+
   $form['actions']['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Save'),
@@ -178,6 +172,34 @@ function dosomething_signup_get_admin_config_sms_game_variables() {
     'sms_game_mp_story_id' => t('Multi-player: Story Id'),
     'sms_game_mp_story_type' => t('Multi-player: Story Type'),
   );
+}
+
+/**
+ * Returns list of variables to construct the Op-tin Config form.
+ *
+ * @return array
+ */
+function dosomething_signup_get_optin_config_form_helpers_vars() {
+  $vars = array();
+  $vars['staff_pick'] = array(
+    'title' => t("Staff Picks"),
+    'node_vars' => dosomething_campaign_get_staff_picks(),
+    'helpers_vars' => dosomething_signup_get_admin_config_campaign_variables(),
+    'form_element_type' => NULL,
+  );
+  $vars['campaign_group'] = array(
+    'title' => t("Grouped Campaigns"),
+    'node_vars' => dosomething_helpers_get_node_vars('campaign_group'),
+    'helpers_vars' => dosomething_signup_get_admin_config_campaign_variables(),
+    'form_element_type' => NULL,
+  );
+  $vars['sms_game'] = array(
+    'title' => t("SMS Games"),
+    'node_vars' => dosomething_campaign_get_sms_games(),
+    'helpers_vars' => dosomething_signup_get_admin_config_sms_game_variables(),
+    'form_element_type' => 'sms_game',
+  );
+  return $vars;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -183,6 +183,18 @@ function dosomething_signup_get_admin_config_campaign_variables() {
  * System settings form for DoSomething Signup specific variables.
  */
 function dosomething_signup_admin_config_form($form, &$form_state) {
+  $form['sms_game'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('SMS Game'),
+  );
+  $var_name = 'dosomething_signup_sms_game_multiplayer_endpoint';
+  $form['sms_game'][$var_name] = array(
+    '#type' => 'textfield',
+    '#required' => TRUE,
+    '#title' => t('SMS Multi-player Game Endpoint'),
+    '#description' => t("URL to post a multi-player SMS Game request, e.g. <em>http://ds-heroku/sms-multiplayer-game/create</em>"),
+    '#default_value' => variable_get($var_name),
+  );
   $form['log'] = array(
     '#type' => 'fieldset',
     '#title' => t('Logging'),

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -52,7 +52,7 @@ function dosomething_signup_optin_config_form($form, &$form_state) {
   $sms_games = dosomething_campaign_get_sms_games();
   if ($sms_games) {
     foreach ($sms_games as $vars) {
-      dosomething_signup_optin_config_form_sms_game_element($form, $vars);
+      dosomething_signup_optin_config_form_add_elements($form, $vars, 'sms_game');
     }
   }
   $form['actions']['submit'] = array(
@@ -107,15 +107,14 @@ function dosomething_signup_optin_config_form_submit($form, &$form_state) {
   // Save SMS Games helpers variables.
   $sms_games = dosomething_campaign_get_sms_games();
   if ($sms_games) {
+    $variables = dosomething_signup_get_admin_config_sms_game_variables();
     foreach ($sms_games as $vars) {
       $nid = $vars['nid'];
       $node = node_load($nid);
-      $alpha_name = 'mobilecommons_opt_in_path';
-      $alpha_value = $values[$nid . '_alpha'];
-      $beta_name = 'mobilecommons_friends_opt_in_path';
-      $beta_value = $values[$nid . '_beta'];
-      dosomething_helpers_set_variable($node, $alpha_name, $alpha_value);
-      dosomething_helpers_set_variable($node, $beta_name, $beta_value);
+      foreach ($variables as $name => $description) {
+        $value = $values[$nid . '_' . $name];
+        dosomething_helpers_set_variable($node, $name, $value);
+      }
     }
   }
   drupal_set_message(t("Configuration saved."));
@@ -124,15 +123,19 @@ function dosomething_signup_optin_config_form_submit($form, &$form_state) {
 /**
  * Adds form elements to store third party values for given set of $vars.
  */
-function dosomething_signup_optin_config_form_add_elements(&$form, $vars) {
+function dosomething_signup_optin_config_form_add_elements(&$form, $vars, $type = NULL) {
   $nid = $vars['nid'];
-  $title = $vars['title'];
-  $variables = dosomething_signup_get_admin_config_campaign_variables();
 
+  // Get the helper variables to create form elements based on the $type.
+  $variables = dosomething_signup_get_admin_config_campaign_variables();
+  if ($type == 'sms_game') {
+    $variables = dosomething_signup_get_admin_config_sms_game_variables();
+  }
+ 
   // Create a fieldset for each campaign.
   $form[$nid] = array(
     '#type' => 'fieldset',
-    '#title' => $title . ' | NID ' . $nid,
+    '#title' => $vars['title'] . ' | NID ' . $nid,
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
@@ -148,27 +151,6 @@ function dosomething_signup_optin_config_form_add_elements(&$form, $vars) {
   }
 }
 
-function dosomething_signup_optin_config_form_sms_game_element(&$form, $vars) {
-  $nid = $vars['nid'];
-  // Create a fieldset for each SMS Game.
-  $form[$nid] = array(
-    '#type' => 'fieldset',
-    '#title' => $vars['title'] . ' | NID ' . $nid,
-    '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
-  );
-  $form[$nid][$nid . '_alpha'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Mobile Commons Alpha Opt-In Path'),
-    '#default_value' => dosomething_helpers_get_variable($nid, 'mobilecommons_opt_in_path'),
-  );
-  $form[$nid][$nid . '_beta'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Mobile Commons Beta Opt-In Path'),
-    '#default_value' => dosomething_helpers_get_variable($nid, 'mobilecommons_friends_opt_in_path'),
-  );
-}
-
 /**
  * Returns list of helper variables that a standard Campaign can implement.
  *
@@ -180,6 +162,21 @@ function dosomething_signup_get_admin_config_campaign_variables() {
     'mailchimp_grouping_id' => t('The numeric Grouping ID for the Group Name.'),
     'mailchimp_group_name' => t('The alphanumeric Interest Group Name.'),
     'mobilecommons_opt_in_path' => t('The numeric Mobilecommons opt-in path.'),
+  );
+}
+
+/**
+ * Returns list of helper variables that a SMS Game Campaign can implement.
+ *
+ * @return array
+ *   Associative array keyed by variable name.
+ */
+function dosomething_signup_get_admin_config_sms_game_variables() {
+  return array(
+    'mobilecommons_opt_in_path' => t('Single-player: Mobile Commons Alpha Opt-In Path'),
+    'mobilecommons_friends_opt_in_path' => t('Single-player: Mobile Commons Beta Opt-In Path'),
+    'sms_game_mp_story_id' => t('Multi-player: Story Id'),
+    'sms_game_mp_story_type' => t('Multi-player: Story Type'),
   );
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -44,7 +44,6 @@ function dosomething_signup_optin_config_form($form, &$form_state) {
       $helpers_vars = $vars['helpers_vars'];
       // Loop through each node:
       foreach ($vars['node_vars'] as $node_vars) {
-        $type = $vars['form_element_type'];
         // Add a form element for the node's helpers variables.
         dosomething_signup_optin_config_form_add_elements($form, $node_vars, $helpers_vars);
       }
@@ -162,20 +161,17 @@ function dosomething_signup_get_optin_config_form_helpers_vars() {
     'title' => t("Staff Picks"),
     'node_vars' => dosomething_campaign_get_staff_picks(),
     'helpers_vars' => $helpers_var_names['campaign'],
-    'form_element_type' => NULL,
   );
   $vars['campaign_group'] = array(
     'title' => t("Grouped Campaigns"),
     'node_vars' => dosomething_helpers_get_node_vars('campaign_group'),
     // A Campaign Group uses the same helpers variables as a standard Campaign.
     'helpers_vars' => $helpers_var_names['campaign'],
-    'form_element_type' => NULL,
   );
   $vars['sms_game'] = array(
     'title' => t("SMS Games"),
     'node_vars' => dosomething_campaign_get_sms_games(),
     'helpers_vars' => $helpers_var_names['sms_game'],
-    'form_element_type' => 'sms_game',
   );
   return $vars;
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -17,11 +17,11 @@ include_once 'includes/dosomething_signup.variable.inc';
 function dosomething_signup_menu() {
   $items = array();
 
-  $items['admin/config/dosomething/optins'] = array(
+  $items['admin/config/dosomething/opt_in'] = array(
     'title' => t('Third Party Opt-Ins'),
     'description' => 'Admin form to manage custom opt-ins',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('dosomething_signup_optin_config_form'),
+    'page arguments' => array('dosomething_signup_opt_in_config_form'),
     'access callback' => 'user_access',
     'access arguments' => array('administer third party communication'),
     'file' => 'dosomething_signup.admin.inc'


### PR DESCRIPTION
Work done for subtasks in https://jira.dosomething.org/browse/DS-206
- Adds a `dosomething_signup_sms_game_multiplayer_endpoint` variable to store the URL to post multi-player SMS Games to.
- Adds two new helper variables, `sms_game_mp_story_id` and `sms_game_mp_story_type` for Multi-Player SMS Game campaign nodes.  
- Refactors the SMS Game helper variable set/get opt-in form to use an array of SMS Game variables as (similar to the array of standard Campaign helper variables, to make it easier to add new variables
