### PR TITLE
Multi-player SMS Game signup

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -379,7 +379,7 @@ function dosomething_campaign_node_view($node, $view_mode, $langcode) {
 
     // Check if SMS Game:
     if (dosomething_campaign_get_campaign_type($node) == 'sms_game') {
-      $node->content['signup_form'] = drupal_get_form('dosomething_signup_friends_form', $node);
+      $node->content['signup_form'] = drupal_get_form('dosomething_signup_sms_game_form', $node);
       return;
     }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -86,14 +86,14 @@ function dosomething_signup_presignup_form_submit($form, &$form_state) {
 }
 
 /**
- * Form constructor for a Friends signup form.
+ * Form constructor for a SMS Game signup form.
  *
  * @param int $nid
  *   Loaded $node that the form is being rendered on.
  * @param int $num_friends
  *   Number of inputs to provide for friends' numbers.
  */
-function dosomething_signup_friends_form($form, &$form_state, $node, $num_friends = 3) {
+function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_friends = 3) {
   $nid = $node->nid;
   $vars = dosomething_helpers_get_variables($node->nid);
   $opt_in_path = $vars['mobilecommons_opt_in_path'];
@@ -207,11 +207,11 @@ function dosomething_signup_friends_form($form, &$form_state, $node, $num_friend
 }
 
 /**
- * Form validation handler for dosomething_signup_friends_form().
+ * Form validation handler for dosomething_signup_sms_game_form().
  *
  * Provides server-side checks for valid and duplicate numbers, cleans input format.
  */
-function dosomething_signup_friends_form_validate($form, &$form_state) {
+function dosomething_signup_sms_game_form_validate($form, &$form_state) {
   $values = $form_state['values'];
   // Text to display for invalid number format.
   $invalid_format_msg = t("Please provide a valid telephone number.");
@@ -257,11 +257,11 @@ function dosomething_signup_friends_form_validate($form, &$form_state) {
 }
 
 /**
- * Form submission handler for dosomething_signup_friends_form().
+ * Form submission handler for dosomething_signup_sms_game_form().
  *
  * Redirects user to the reportback confirmation page for given node.
  */
-function dosomething_signup_friends_form_submit($form, &$form_state) {
+function dosomething_signup_sms_game_form_submit($form, &$form_state) {
   $values = $form_state['values'];
   $nid = $values['nid'];
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -95,10 +95,9 @@ function dosomething_signup_presignup_form_submit($form, &$form_state) {
  */
 function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_friends = 3) {
   $nid = $node->nid;
-  $vars = dosomething_helpers_get_variables($node->nid);
-  $opt_in_path = $vars['mobilecommons_opt_in_path'];
-  $friends_opt_in_path = $vars['mobilecommons_friends_opt_in_path'];
- 
+  // Add relevant configuration form elements.
+  dosomething_signup_sms_game_form_config($form, $nid);
+
   $form['nid'] = array(
     '#type' => 'hidden',
     '#default_value' => $nid,
@@ -109,24 +108,6 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
     '#default_value' => $node->title,
     '#access' => FALSE,
   );
-  // If we have opt-in paths set:
-  if ($opt_in_path && $friends_opt_in_path) {
-    // Add as hidden form elements.
-    $form['opt_in_path'] = array(
-      '#type' => 'hidden',
-      '#default_value' => $opt_in_path,
-      '#access' => FALSE,
-    );
-    $form['friends_opt_in_path'] = array(
-      '#type' => 'hidden',
-      '#default_value' => $friends_opt_in_path,
-      '#access' => FALSE,
-    );
-  }
-  else {
-    // Else set a warning message to inform staff to not expect any texts.
-    drupal_set_message(t("The opt-in paths for this SMS Game have not been configured."), "error");
-  }
   $form['num_betas'] = array(
     '#type' => 'hidden',
     '#default_value' => $num_friends,
@@ -204,6 +185,57 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
     ),
   );
   return $form;
+}
+
+/**
+ * Add hidden form elements for SMS Game $nid, or set message if not configured.
+ *
+ * @param array $form
+ *   A Form API form to add the elements to.
+ * @param int $nid
+ *   The node $nid to check configuration values for.
+ */
+function dosomething_signup_sms_game_form_config(&$form, $nid) {
+  $vars = dosomething_helpers_get_variables($nid);
+
+  // Single-player variables:
+  $opt_in_path = $vars['mobilecommons_opt_in_path'];
+  $friends_opt_in_path = $vars['mobilecommons_friends_opt_in_path'];
+
+  // Multi-player variables:
+  $mp_story_id = $vars['sms_game_mp_story_id'];
+  $mp_story_type = $vars['sms_game_mp_story_type'];
+
+  // Check for single-player variables:
+  if ($opt_in_path && $friends_opt_in_path) {
+    $form['opt_in_path'] = array(
+      '#type' => 'hidden',
+      '#default_value' => $opt_in_path,
+      '#access' => FALSE,
+    );
+    $form['friends_opt_in_path'] = array(
+      '#type' => 'hidden',
+      '#default_value' => $friends_opt_in_path,
+      '#access' => FALSE,
+    );
+  }
+  // Else check for multi-player variables:
+  elseif ($mp_story_id && $mp_story_type) {
+    $form['story_id'] = array(
+      '#type' => 'hidden',
+      '#default_value' => $mp_story_id,
+      '#access' => FALSE,
+    );
+    $form['story_type'] = array(
+      '#type' => 'hidden',
+      '#default_value' => $mp_story_type,
+      '#access' => FALSE,
+    );
+  }
+  else {
+    // Else set a warning message to inform staff to not expect any texts.
+    drupal_set_message(t("This SMS Game is not properly configured."), "error");
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -198,6 +198,8 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
 function dosomething_signup_sms_game_form_config(&$form, $nid) {
   $vars = dosomething_helpers_get_variables($nid);
 
+  $sms_game_type = NULL;
+
   // Single-player variables:
   $opt_in_path = $vars['mobilecommons_opt_in_path'];
   $friends_opt_in_path = $vars['mobilecommons_friends_opt_in_path'];
@@ -208,6 +210,7 @@ function dosomething_signup_sms_game_form_config(&$form, $nid) {
 
   // Check for single-player variables:
   if ($opt_in_path && $friends_opt_in_path) {
+    $sms_game_type = 'single_player';
     $form['opt_in_path'] = array(
       '#type' => 'hidden',
       '#default_value' => $opt_in_path,
@@ -221,6 +224,7 @@ function dosomething_signup_sms_game_form_config(&$form, $nid) {
   }
   // Else check for multi-player variables:
   elseif ($mp_story_id && $mp_story_type) {
+    $sms_game_type = 'multi_player';
     $form['story_id'] = array(
       '#type' => 'hidden',
       '#default_value' => $mp_story_id,
@@ -235,6 +239,14 @@ function dosomething_signup_sms_game_form_config(&$form, $nid) {
   else {
     // Else set a warning message to inform staff to not expect any texts.
     drupal_set_message(t("This SMS Game is not properly configured."), "error");
+  }
+
+  if ($sms_game_type) {
+    $form['sms_game_type'] = array(
+      '#type' => 'hidden',
+      '#default_value' => $sms_game_type,
+      '#access' => FALSE,
+    );
   }
 }
 
@@ -311,12 +323,10 @@ function dosomething_signup_sms_game_form_submit($form, &$form_state) {
     // If $account happens to be the logged in user, it's okay.
     // dosomething_signup_create will check if a signup exists before creating.
     dosomething_signup_create($nid, $account->uid);
-
   }
 
-  
-  // Send opt_in request to Mobilecommons API.
-  dosomething_signup_mobilecommons_opt_in_friends($values);
+  // Send request to relevant SMS Game endpoints.
+  dosomething_signup_sms_game_signup_request($values['sms_game_type'], $values);
 
   // Redirect to the reportback confirmation page.
   $confirmation_path = 'node/' . $values['nid'] . '/confirmation';

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -682,3 +682,58 @@ function dosomething_signup_get_signup_total_by_nid($nid) {
     ->execute();
   return $result->rowCount();
 }
+
+/**
+ * Handles a SMS Game Signup Form signup.
+ *
+ * @param string $sms_game_type
+ *   Expected values: 'single_player' | 'multi_player'.
+ * @param array $values
+ *   Values to use for the signup request.
+ *   @see dosomething_signup_sms_game_form()
+ */
+function dosomething_signup_sms_game_signup_request($sms_game_type, $values) {
+  if ($sms_game_type == 'single_player') {
+    // Send opt_in request to Mobilecommons API.
+    return dosomething_signup_mobilecommons_opt_in_friends($values);
+  }
+  // Default to multi-player signup:
+  dosomething_signup_sms_game_multi_player_signup_request($values);
+}
+
+/**
+ * Posts to to the Multi-player SMS Game URL with relevant $values.
+ *
+ * @param array @values
+ */
+function dosomething_signup_sms_game_multi_player_signup_request($values) {
+  // Initialize post data.
+  $data = array();
+  $data_vars = array(
+    'alpha_first_name',
+    'alpha_mobile',
+    'beta_mobile_0',
+    'beta_mobile_1',
+    'beta_mobile_2',
+    'story_id',
+    'story_type',
+  );
+  foreach ($data_vars as $var) {
+    $data[$var] = $values[$var];
+  }
+  $options = array(
+    'method' => 'POST',
+    'data' => drupal_http_build_query($data),
+    'timeout' => 60,
+    'headers' => array('Content-Type' => 'application/x-www-form-urlencoded'),
+  );
+
+  $url = variable_get('dosomething_signup_sms_game_multiplayer_endpoint');
+  $response = drupal_http_request($url, $options);
+
+  if (DOSOMETHING_SIGNUP_LOG_SIGNUPS) {
+    $log = json_encode($response);
+    watchdog('dosomething_signup_sms_game_multi_player_signup_request', $log);
+  }
+  return $response;
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -11,6 +11,9 @@ include_once 'dosomething_signup.theme.inc';
 include_once 'includes/dosomething_signup.mobilecommons.inc';
 include_once 'includes/dosomething_signup.variable.inc';
 
+DEFINE('DOSOMETHING_SIGNUP_LOG_MOBILECOMMONS', variable_get('dosomething_signup_log_mobilecommons') ? TRUE : FALSE);
+DEFINE('DOSOMETHING_SIGNUP_LOG_SIGNUPS', variable_get('dosomething_signup_log_signups') ? TRUE : FALSE);
+
 /**
  * Implements hook_menu().
  */

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.inc
@@ -80,7 +80,7 @@ class SignupEntityController extends EntityAPIController {
       }
     }
     parent::save($entity, $transaction);
-    if (variable_get('dosomething_signup_log_signups')) {
+    if (DOSOMETHING_SIGNUP_LOG_SIGNUPS) {
       watchdog('dosomething_signup', json_encode($entity));
     }
   }

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
@@ -26,8 +26,8 @@ function dosomething_signup_mobilecommons_opt_in($account, $lid, $title = NULL) 
   try {
     // If valid args for given $user:
     if ($args = dosomething_signup_get_mobilecommons_vars($account, $lid, $title)) {
-      if (variable_get('dosomething_signup_log_mobilecommons')) {
-        watchdog('dosomething_signup', json_encode($args));
+      if (DOSOMETHING_SIGNUP_LOG_MOBILECOMMONS) {
+        watchdog('dosomething_signup_mobilecommons_opt_in', json_encode($args));
       }
       // Submit Mobilecommons request.
       return mobilecommons_request('opt_in', $args);
@@ -131,6 +131,9 @@ function dosomething_signup_get_mobilecommons_friends_vars($values) {
  */
 function dosomething_signup_mobilecommons_opt_in_friends($values) {
   $vars = dosomething_signup_get_mobilecommons_friends_vars($values);
+  if (DOSOMETHING_SIGNUP_LOG_MOBILECOMMONS) {
+    watchdog('dosomething_signup_mobilecommons_opt_in_friends', json_encode($vars));
+  }
   try {
     return mobilecommons_request('opt_in_with_friends', $vars);
   }


### PR DESCRIPTION
- Renames `dosomething_signup_friends_form` to `dosomething_signup_sms_game_form`
- Sets hidden form values for a Multi-player SMS Game if the relevant opt-in variables are set.
- Sets hidden form value for the type of SMS Game (`single_player` or `multi_player`)
- Creates `dosomething_signup_sms_game_multi_player_signup_request` function to post a request to the `dosomething_signup_sms_game_multiplayer_endpoint` endpoint.
- Adds constants for Signup logging.
