### PR TITLE
Shipment item and additional_item properties

### DIFF
--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
@@ -36,7 +36,7 @@ function dosomething_reward_redeem_form($form, &$form_state, $reward) {
     '#title' => t("Your Shirt style"),
     '#options' => $shirt_options,
   );
-  $form['item_size'] = array(
+  $form['item_option'] = array(
     '#type' => 'select',
     '#required' => TRUE,
     '#title' => t("Your Shirt Size"),
@@ -52,7 +52,7 @@ function dosomething_reward_redeem_form($form, &$form_state, $reward) {
     '#title' => t("Your Friend's Shirt style"),
     '#options' => $shirt_options,
   );
-  $form['item_additional_size'] = array(
+  $form['item_additional_option'] = array(
     '#type' => 'select',
     '#required' => TRUE,
     '#title' => t("Your Friend's Shirt Size"),

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
@@ -14,6 +14,7 @@
  */
 function dosomething_reward_redeem_form($form, &$form_state, $reward) {
   $submit_label = variable_get('dosomething_reward_redeem_form_button_text');
+  $shirt_options = dosomething_shipment_get_shirt_options();
   $size_options = dosomething_shipment_get_shirt_size_options();
 
   $form['id'] = array(
@@ -26,18 +27,38 @@ function dosomething_reward_redeem_form($form, &$form_state, $reward) {
   // Add Address form fields.
   dosomething_user_address_form_element($form, $form_state);
 
-  $form['shirt_size'] = array(
+  $form['item_header'] = array(
+    '#markup' => t("Your Shirt"),
+  );
+  $form['item'] = array(
     '#type' => 'radios',
     '#required' => TRUE,
-    '#title' => t("Your T-Shirt size"),
+    '#title' => t("Your Shirt style"),
+    '#options' => $shirt_options,
+  );
+  $form['item_size'] = array(
+    '#type' => 'select',
+    '#required' => TRUE,
+    '#title' => t("Your Shirt Size"),
     '#options' => $size_options,
   );
-  $form['shirt_size_additional'] = array(
+
+  $form['item_additional_header'] = array(
+    '#markup' => t("Your Friend's Shirt"),
+  );
+  $form['item_additional'] = array(
     '#type' => 'radios',
     '#required' => TRUE,
-    '#title' => t("Your friend's T-Shirt size"),
+    '#title' => t("Your Friend's Shirt style"),
+    '#options' => $shirt_options,
+  );
+  $form['item_additional_size'] = array(
+    '#type' => 'select',
+    '#required' => TRUE,
+    '#title' => t("Your Friend's Shirt Size"),
     '#options' => $size_options,
   );
+
   $form['actions'] = array(
     '#type' => 'actions',
     'submit' => array(

--- a/lib/modules/dosomething/dosomething_reward/includes/dosomething_reward.inc
+++ b/lib/modules/dosomething/dosomething_reward/includes/dosomething_reward.inc
@@ -37,9 +37,10 @@ class RewardEntity extends Entity {
         'created' => $time,
         'entity_type' => 'reward',
         'entity_id' => $this->id,
-        'shipment_type' => 'shirts',
-        'shirt_size' => $values['shirt_size'],
-        'shirt_size_additional' => $values['shirt_size_additional'],
+        'item' => $values['item'],
+        'item_option' => $values['item_option'],
+        'item_additional' => $values['item_additional'],
+        'item_additional_option' => $values['item_additional_option'],
       ));
       if (DOSOMETHING_REWARD_LOG) {
         watchdog('dosomething_reward', 'Shipment entity_create: @entity', array(

--- a/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.install
+++ b/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.install
@@ -24,13 +24,6 @@ function dosomething_shipment_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
-      'shipment_type' => array(
-        'description' => 'The type of Shipment.',
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => TRUE,
-        'default' => '',
-      ),
       'entity_type' => array(
         'description' => 'The type of the Entity associated with the Shipment.',
         'type' => 'varchar',
@@ -46,13 +39,23 @@ function dosomething_shipment_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
-      'shirt_size' => array(
-        'description' => 'The size of shirt, if applicable.',
+      'item' => array(
+        'description' => 'The shipment item.',
         'type' => 'varchar',
         'length' => 255,
       ),
-      'shirt_size_additional' => array(
-        'description' => 'The size of additional shirt, if applicable.',
+      'item_option' => array(
+        'description' => 'The shipment item option, if applicable.',
+        'type' => 'varchar',
+        'length' => 255,
+      ),
+      'item_additional' => array(
+        'description' => 'The additional shipment item, if applicable.',
+        'type' => 'varchar',
+        'length' => 255,
+      ),
+      'item_additional_option' => array(
+        'description' => 'The additional shipment item option, if applicable.',
         'type' => 'varchar',
         'length' => 255,
       ),

--- a/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
+++ b/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
@@ -82,23 +82,6 @@ function dosomething_shipment_views_data() {
       'label' => t('Shipment User'),
     ),
   );
-  $data['dosomething_shipment']['shipment_type'] = array(
-    'title' => t('Shipment type'),
-    'help' => t('Shipment type.'),
-    'field' => array(
-      'handler' => 'views_handler_field',
-      'click sortable' => TRUE,
-    ),
-    'sort' => array(
-      'handler' => 'views_handler_sort',
-    ),
-    'filter' => array(
-      'handler' => 'views_handler_filter_string',
-    ),
-    'argument' => array(
-      'handler' => 'views_handler_argument_string',
-    ),
-  );
   $data['dosomething_shipment']['entity_type'] = array(
     'title' => t('Shipment Entity type'),
     'help' => t('The type of the Entity associated with the Shipment.'),
@@ -144,9 +127,9 @@ function dosomething_shipment_views_data() {
       'handler' => 'views_handler_filter_date',
     ),
   );
-  $data['dosomething_shipment']['shirt_size'] = array(
-    'title' => t('Shipment shirt size'),
-    'help' => t('Shipment shirt size, if applicable'),
+  $data['dosomething_shipment']['item'] = array(
+    'title' => t('Shipment item'),
+    'help' => t('Shipment item'),
     'field' => array(
       'handler' => 'views_handler_field',
       'click sortable' => TRUE,
@@ -161,9 +144,43 @@ function dosomething_shipment_views_data() {
       'handler' => 'views_handler_argument_string',
     ),
   );
-  $data['dosomething_shipment']['shirt_size_additional'] = array(
-    'title' => t('Shipment additional shirt size'),
-    'help' => t('Shipment additional shirt size, if applicable'),
+  $data['dosomething_shipment']['item_option'] = array(
+    'title' => t('Shipment item option'),
+    'help' => t('Shipment item option, if applicable.'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_string',
+    ),
+  );
+  $data['dosomething_shipment']['item_additional'] = array(
+    'title' => t('Shipment additional item'),
+    'help' => t('Shipment additional item, if applicable.'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_string',
+    ),
+  );
+  $data['dosomething_shipment']['item_additional_option'] = array(
+    'title' => t('Shipment item option'),
+    'help' => t('Shipment additional item size, if applicable.'),
     'field' => array(
       'handler' => 'views_handler_field',
       'click sortable' => TRUE,

--- a/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
+++ b/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
@@ -224,6 +224,17 @@ function dosomething_shipment_get_shipment_id_by_entity($type, $id) {
 }
 
 /**
+ * Returns array of available shirts.
+ */
+function dosomething_shipment_get_shirt_options() {
+  //@todo: Return images as the description.
+  return array(
+    'shirt_dope' => t('Dope shirt'),
+    'shirt_social_action' => t('Social action speaks louder'),
+  );
+}
+
+/**
  * Returns array of available shirt sizes.
  */
 function dosomething_shipment_get_shirt_size_options() {

--- a/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.views_default.inc
+++ b/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.views_default.inc
@@ -140,11 +140,6 @@ function dosomething_shipment_views_default_views() {
   $handler->display->display_options['fields']['mail']['field'] = 'mail';
   $handler->display->display_options['fields']['mail']['relationship'] = 'uid';
   $handler->display->display_options['fields']['mail']['label'] = 'Email';
-  /* Field: Shipments: Shipment type */
-  $handler->display->display_options['fields']['shipment_type']['id'] = 'shipment_type';
-  $handler->display->display_options['fields']['shipment_type']['table'] = 'dosomething_shipment';
-  $handler->display->display_options['fields']['shipment_type']['field'] = 'shipment_type';
-  $handler->display->display_options['fields']['shipment_type']['label'] = 'Type';
   /* Field: Shipments: Shipment Entity type */
   $handler->display->display_options['fields']['entity_type']['id'] = 'entity_type';
   $handler->display->display_options['fields']['entity_type']['table'] = 'dosomething_shipment';
@@ -159,16 +154,26 @@ function dosomething_shipment_views_default_views() {
   $handler->display->display_options['fields']['entity_id']['alter']['alter_text'] = TRUE;
   $handler->display->display_options['fields']['entity_id']['alter']['text'] = '[entity_type]/[entity_id] ';
   $handler->display->display_options['fields']['entity_id']['separator'] = '';
-  /* Field: Shipments: Shipment shirt size */
-  $handler->display->display_options['fields']['shirt_size']['id'] = 'shirt_size';
-  $handler->display->display_options['fields']['shirt_size']['table'] = 'dosomething_shipment';
-  $handler->display->display_options['fields']['shirt_size']['field'] = 'shirt_size';
-  $handler->display->display_options['fields']['shirt_size']['label'] = 'Shirt Size';
-  /* Field: Shipments: Shipment additional shirt size */
-  $handler->display->display_options['fields']['shirt_size_additional']['id'] = 'shirt_size_additional';
-  $handler->display->display_options['fields']['shirt_size_additional']['table'] = 'dosomething_shipment';
-  $handler->display->display_options['fields']['shirt_size_additional']['field'] = 'shirt_size_additional';
-  $handler->display->display_options['fields']['shirt_size_additional']['label'] = 'Additional Shirt Size';
+  /* Field: Shipments: Shipment item */
+  $handler->display->display_options['fields']['item']['id'] = 'item';
+  $handler->display->display_options['fields']['item']['table'] = 'dosomething_shipment';
+  $handler->display->display_options['fields']['item']['field'] = 'item';
+  $handler->display->display_options['fields']['item']['label'] = 'Item';
+  /* Field: Shipments: Shipment item option */
+  $handler->display->display_options['fields']['item_option']['id'] = 'item_option';
+  $handler->display->display_options['fields']['item_option']['table'] = 'dosomething_shipment';
+  $handler->display->display_options['fields']['item_option']['field'] = 'item_option';
+  $handler->display->display_options['fields']['item_option']['label'] = 'Item option';
+  /* Field: Shipments: Shipment additional item */
+  $handler->display->display_options['fields']['item_additional']['id'] = 'item_additional';
+  $handler->display->display_options['fields']['item_additional']['table'] = 'dosomething_shipment';
+  $handler->display->display_options['fields']['item_additional']['field'] = 'item_additional';
+  $handler->display->display_options['fields']['item_additional']['label'] = 'Additional item';
+  /* Field: Shipments: Shipment item option */
+  $handler->display->display_options['fields']['item_additional_option']['id'] = 'item_additional_option';
+  $handler->display->display_options['fields']['item_additional_option']['table'] = 'dosomething_shipment';
+  $handler->display->display_options['fields']['item_additional_option']['field'] = 'item_additional_option';
+  $handler->display->display_options['fields']['item_additional_option']['label'] = 'Additional item option';
   /* Filter criterion: Shipments: Uid */
   $handler->display->display_options['filters']['uid']['id'] = 'uid';
   $handler->display->display_options['filters']['uid']['table'] = 'dosomething_shipment';
@@ -245,12 +250,13 @@ function dosomething_shipment_views_default_views() {
     t('Date created'),
     t('Uid'),
     t('Email'),
-    t('Type'),
     t('Entity type'),
     t('Entity'),
     t('[entity_type]/[entity_id] '),
-    t('Shirt Size'),
-    t('Additional Shirt Size'),
+    t('Item'),
+    t('Item option'),
+    t('Additional item'),
+    t('Additional item option'),
     t('Page'),
   );
   $export['user_shipments'] = $view;


### PR DESCRIPTION
Closes https://jira.dosomething.org/browse/DS-232

Removes `shirt_size` and `shirt_size_additional` columns and adds the following columns:
- item
- item_option
- item_additional
- item_additional_option

Also removes the `shipment_type`, as the `item` column will be used to store what item is being shipped.

These changes are done in the `dosomething_shipment.install` file because it hasn't been enabled on stage yet.
- Updates the `user_shipments` view with new columns
- Updated Reward Redeem Form to prompt for all new columns and create the Shipment record with submitted values
