### PR TITLE
Exports campaigns resource

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -35,7 +35,7 @@ function dosomething_api_services_resources() {
   $resources['campaigns'] = array(
     'operations' => array(
       'index' => array(
-        'help' => 'List all campaigns',
+        'help' => 'List all active campaigns.',
         'file' => array('type' => 'inc', 'module' => 'dosomething_api', 'name' => 'resources/campaign_resource'),
         'callback' => '_campaign_resource_index',
         'access callback' => '_campaign_resource_access',

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -39,21 +39,6 @@ function dosomething_api_default_services_endpoint() {
     ),
   );
   $endpoint->resources = array(
-    'node' => array(
-      'alias' => 'content',
-      'operations' => array(
-        'retrieve' => array(
-          'enabled' => '1',
-        ),
-      ),
-    ),
-    'system' => array(
-      'actions' => array(
-        'connect' => array(
-          'enabled' => '1',
-        ),
-      ),
-    ),
     'user' => array(
       'alias' => 'auth',
       'actions' => array(
@@ -74,6 +59,28 @@ function dosomething_api_default_services_endpoint() {
           ),
         ),
         'token' => array(
+          'enabled' => '1',
+        ),
+      ),
+    ),
+    'campaigns' => array(
+      'operations' => array(
+        'index' => array(
+          'enabled' => '1',
+        ),
+      ),
+    ),
+    'node' => array(
+      'alias' => 'content',
+      'operations' => array(
+        'retrieve' => array(
+          'enabled' => '1',
+        ),
+      ),
+    ),
+    'system' => array(
+      'actions' => array(
+        'connect' => array(
           'enabled' => '1',
         ),
       ),


### PR DESCRIPTION
Exports the `/campaigns` resource into `dosomething_api`.  Missed this in #2974
