### PR TITLE
Added cache for dosomething_reportback table.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.drush.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.drush.inc
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * Implements hook_drush_cache_clear().
+ */
+function dosomething_reportback_drush_cache_clear(&$types) {
+  $types['dosomething reportback'] = 'dosomething_reportback_cache_clear_all';
+}

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -237,6 +237,8 @@ function dosomething_reportback_schema() {
       'rbid' => array('rbid'),
     ),
   );
+  // Add a custom cache table.
+  $schema['cache_dosomething_reportback'] = drupal_get_schema_unprocessed('system', 'cache');
   return $schema;
 }
 
@@ -378,4 +380,12 @@ function dosomething_reportback_update_7009() {
    if (!db_index_exists($table, $column)) {
     db_add_index($table, $column, array($column));
   }
+ }
+
+/**
+ * Creates dosomething reportback cache table.
+ */
+ function dosomething_reportback_update_7011() {
+   $schema = drupal_get_schema_unprocessed('system', 'cache');
+   db_create_table('cache_dosomething_reportback', $schema);
  }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -386,6 +386,8 @@ function dosomething_reportback_update_7009() {
  * Creates dosomething reportback cache table.
  */
  function dosomething_reportback_update_7011() {
-   $schema = drupal_get_schema_unprocessed('system', 'cache');
-   db_create_table('cache_dosomething_reportback', $schema);
+   if (!db_table_exists('cache_dosomething_reportback')) {
+     $schema = drupal_get_schema_unprocessed('system', 'cache');
+     db_create_table('cache_dosomething_reportback', $schema);
+   }
  }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -669,29 +669,36 @@ function dosomething_reportback_get_gallery_item_ids($nid, $num_items = NULL) {
  * @return array
  */
 function dosomething_reportback_get_gallery_vars($nid, $style = '300x300', $num_items = NULL) {
-  $vars = array();
-  $result = dosomething_reportback_get_gallery_item_ids($nid, $num_items);
-  foreach ($result as $delta => $record) {
-    // Set reportback rbid that file belongs to.
-    $vars[$delta]['rbid'] = $record->rbid;
-    // Set variables for the file:
-    $fid = $record->fid;
-    $vars[$delta]['fid'] = $fid;
-    $vars[$delta]['image'] = dosomething_image_get_themed_image_by_fid($fid, $style);
-    // Set the file author name.
-    $account = user_load($record->uid);
-    $vars[$delta]['first_name'] = dosomething_user_get_field('field_first_name', $account);
-    // Set variables stored on the flagging object:
-    $flagging_id = $record->flagging_id;
-    $flagging = flagging_load($flagging_id);
-    $vars[$delta]['flagging_id'] = $flagging_id;
-    $vars[$delta]['weight'] = $flagging->field_weight[LANGUAGE_NONE][0]['value'];
-    $caption = $flagging->field_image_description;
-    if ($caption_value = $caption[LANGUAGE_NONE][0]) {
-      $vars[$delta]['caption'] = $caption_value;
-    }
+  $cache = cache_get('ds_reportback_gallery_' . $nid . '_' . $style, 'cache_dosomething_reportback');
+  if (is_object($cache)) {
+    return $cache->data;
   }
-  return $vars;
+  else {
+    $vars = array();
+    $result = dosomething_reportback_get_gallery_item_ids($nid, $num_items);
+    foreach ($result as $delta => $record) {
+      // Set reportback rbid that file belongs to.
+      $vars[$delta]['rbid'] = $record->rbid;
+      // Set variables for the file:
+      $fid = $record->fid;
+      $vars[$delta]['fid'] = $fid;
+      $vars[$delta]['image'] = dosomething_image_get_themed_image_by_fid($fid, $style);
+      // Set the file author name.
+      $account = user_load($record->uid);
+      $vars[$delta]['first_name'] = dosomething_user_get_field('field_first_name', $account);
+      // Set variables stored on the flagging object:
+      $flagging_id = $record->flagging_id;
+      $flagging = flagging_load($flagging_id);
+      $vars[$delta]['flagging_id'] = $flagging_id;
+      $vars[$delta]['weight'] = $flagging->field_weight[LANGUAGE_NONE][0]['value'];
+      $caption = $flagging->field_image_description;
+      if ($caption_value = $caption[LANGUAGE_NONE][0]) {
+        $vars[$delta]['caption'] = $caption_value;
+      }
+    }
+    cache_set('ds_reportback_gallery_' . $nid . '_' . $style, $vars, 'cache_dosomething_reportback');
+    return $vars;
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -880,6 +880,15 @@ function dosomething_reportback_services_resources() {
   return $resources;
 }
 
+/**
+ * Implements hook_flag_flag().
+ */
+function dosomething_reportback_flag_flag($flag, $entity_id, $account, $flagging) {
+    if ($flag->name == 'promoted') {
+      dosomething_reportback_cache_clear_all();
+    }
+
+}
 
 /**
  * Clear cache on dosomething_reportback table.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -879,3 +879,11 @@ function dosomething_reportback_services_resources() {
   );
   return $resources;
 }
+
+
+/**
+ * Clear cache on dosomething_reportback table.
+ */
+function dosomething_reportback_cache_clear_all() {
+  cache_clear_all('*', 'cache_dosomething_reportback', TRUE);
+}


### PR DESCRIPTION
Caches the reportback galleries.
The `dosomething_reportback_get_gallery_item_ids` query was showing up in the slow query new relic log.

@aaronschachter can you pull this down and make sure it creates/stores things properly in the table?

still todo: clear the cache on flagging. 
