### PR TITLE
Updated image style for 3col galleries.

### DIFF
--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
@@ -106,9 +106,14 @@ function dosomething_static_content_preprocess_gallery_vars(&$vars) {
       $style = $collection_item['field_gallery_style']['#items'][0]['value'];
       // If a key exists and it's not the default:
       if ($style && $style != 'default') {
-        // Set to use the thumbnail field on the Image node instead.
         $image_ratio = 'thumb';
-        $image_style = '100x100';
+        if ($style == '3col_short') {
+          $image_style = 'wmax-300-hmax-75';
+        }
+        else {
+          // Set to use the thumbnail field on the Image node instead.
+          $image_style = '100x100';
+        }
       }
     }
     // Set Style variable for theme layer.


### PR DESCRIPTION
Pull smaller images when there are more images.

Refs DS-252
cc: @tjrosario the css is stretching these to 100% width and making them pixely
![](http://cl.ly/image/3f0O0w1c0F3v/Screen%20Shot%202014-08-18%20at%2010.24.41%20AM.png)
![](http://cl.ly/image/0d0v2t2C1d2D/Screen%20Shot%202014-08-18%20at%2010.31.10%20AM.png)
