### PR TITLE
Reward page / form template

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
@@ -43,8 +43,12 @@ function dosomething_campaign_reportback_confirmation_page($node) {
       ))
     );
     if (module_exists('dosomething_reward')) {
+      // @todo: Modify this check to return TRUE only when Reward is redeemable.
       if ($reward = dosomething_reward_exists('reportback_count')) {
-        $vars['redeem_form'] = dosomething_reward_get_redeem_form_vars($reward);
+        // Get the Reward Redeem vars for this Reward.
+        $vars = dosomething_reward_get_redeem_form_vars($reward);
+        // Return the themed Reward Redeem page.
+        return theme('reward_redeem_reportback_count', $vars);
       }
     }
   }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
@@ -43,12 +43,15 @@ function dosomething_campaign_reportback_confirmation_page($node) {
       ))
     );
     if (module_exists('dosomething_reward')) {
-      // @todo: Modify this check to return TRUE only when Reward is redeemable.
+      // If a reportback count reward exists:
       if ($reward = dosomething_reward_exists('reportback_count')) {
-        // Get the Reward Redeem vars for this Reward.
-        $vars = dosomething_reward_get_redeem_form_vars($reward);
-        // Return the themed Reward Redeem page.
-        return theme('reward_redeem_reportback_count', $vars);
+        // If Reward has not been redeemed:
+        if (!$reward->redeemed) {
+          // Get the Reward Redeem vars for this Reward.
+          $vars = dosomething_reward_get_redeem_form_vars($reward);
+          // Return the themed Reward Redeem page.
+          return theme('reward_redeem_reportback_count', $vars);
+        }
       }
     }
   }

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.admin.inc
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.admin.inc
@@ -89,6 +89,26 @@ function dosomething_reward_admin_config_form($form, &$form_state) {
     '#default_value' => variable_get($var_name),
   );
 
+  $var_name = 'dosomething_reward_image_shirt_dope';
+  $form['copy']['form'][$var_name] = array(
+    '#type' => 'entity_autocomplete',
+    '#title' => t('Dope Shirt Image'),
+    '#entity_type' => 'node',
+    '#bundles' => array('image'),
+    '#required' => TRUE,
+    '#default_value' => variable_get($var_name),
+  );
+
+  $var_name = 'dosomething_reward_image_shirt_social_action';
+  $form['copy']['form'][$var_name] = array(
+    '#type' => 'entity_autocomplete',
+    '#title' => t('Social Action Shirt Image'),
+    '#entity_type' => 'node',
+    '#bundles' => array('image'),
+    '#required' => TRUE,
+    '#default_value' => variable_get($var_name),
+  );
+
   $var_name = 'dosomething_reward_redeem_form_button_text';
   $form['copy']['form'][$var_name] = array(
     '#type' => 'textfield',

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.admin.inc
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.admin.inc
@@ -8,13 +8,61 @@
  * System settings form for DoSomething Signup specific variables.
  */
 function dosomething_reward_admin_config_form($form, &$form_state) {
+
+  $var_name = 'dosomething_reward_enable_reportback_count';
+  $form[$var_name] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable Reportback Count Rewards'),
+    '#default_value' => variable_get($var_name, FALSE),
+    '#description' => t("When checked, users can earn a Reportback Count Reward."),
+  );
+
   $form['copy'] = array(
     '#type' => 'fieldset',
     '#title' => t('Copy'),
+    '#collapsible' => TRUE,
+  );
+  $form['copy']['page'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Redeem Page'),
+    '#collapsible' => TRUE,
+  );
+  $form['copy']['form'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Redeem Form'),
+    '#collapsible' => TRUE,
+  );
+  $var_name = 'dosomething_reward_redeem_page_header';
+  $form['copy']['page'][$var_name] = array(
+    '#type' => 'textfield',
+    '#title' => t('Redeem Page Header'),
+    '#description' => t("Redeem Page content header."),
+    '#required' => TRUE,
+    '#default_value' => variable_get($var_name),
+  );
+
+  $var_name = 'dosomething_reward_redeem_page_copy';
+  $form['copy']['page'][$var_name] = array(
+    '#type' => 'textarea',
+    '#title' => t('Redeem Page Copy'),
+    '#description' => t("Redeem Page content copy."),
+    '#required' => TRUE,
+    '#default_value' => variable_get($var_name),
+  );
+
+  $var_name = 'dosomething_reward_redeem_page_image';
+  $form['copy']['page'][$var_name] = array(
+    '#type' => 'entity_autocomplete',
+    '#title' => t('Redeem Page Image'),
+    '#description' => t("Redeem Page content image."),
+    '#entity_type' => 'node',
+    '#bundles' => array('image'),
+    '#required' => TRUE,
+    '#default_value' => variable_get($var_name),
   );
 
   $var_name = 'dosomething_reward_redeem_form_link';
-  $form['copy'][$var_name] = array(
+  $form['copy']['page'][$var_name] = array(
     '#type' => 'textfield',
     '#title' => t('Redeem Form Link Text'),
     '#description' => t("Link text that opens the Redeem Form modal."),
@@ -23,7 +71,7 @@ function dosomething_reward_admin_config_form($form, &$form_state) {
   );
 
   $var_name = 'dosomething_reward_redeem_form_header';
-  $form['copy'][$var_name] = array(
+  $form['copy']['form'][$var_name] = array(
     '#type' => 'textfield',
     '#title' => t('Redeem Form Header'),
     '#description' => t("Header text of the Redeem Form modal."),
@@ -32,7 +80,7 @@ function dosomething_reward_admin_config_form($form, &$form_state) {
   );
 
   $var_name = 'dosomething_reward_redeem_form_copy';
-  $form['copy'][$var_name] = array(
+  $form['copy']['form'][$var_name] = array(
     '#type' => 'textarea',
     '#rows' => 4,
     '#title' => t('Redeem Form Copy'),
@@ -42,7 +90,7 @@ function dosomething_reward_admin_config_form($form, &$form_state) {
   );
 
   $var_name = 'dosomething_reward_redeem_form_button_text';
-  $form['copy'][$var_name] = array(
+  $form['copy']['form'][$var_name] = array(
     '#type' => 'textfield',
     '#title' => t('Redeem Form Button Label'),
     '#description' => t("Label displayed on the Redeem Form submit button."),
@@ -51,7 +99,7 @@ function dosomething_reward_admin_config_form($form, &$form_state) {
   );
 
   $var_name = 'dosomething_reward_redeem_form_confirm_msg';
-  $form['copy'][$var_name] = array(
+  $form['copy']['form'][$var_name] = array(
     '#type' => 'textarea',
     '#rows' => 2,
     '#title' => t('Redeem Form Confirmation Message'),
@@ -64,7 +112,6 @@ function dosomething_reward_admin_config_form($form, &$form_state) {
     '#type' => 'fieldset',
     '#title' => t('Logging'),
   );
-
   $var_name = 'dosomething_reward_log';
   $form['log'][$var_name] = array(
     '#type' => 'checkbox',
@@ -72,5 +119,6 @@ function dosomething_reward_admin_config_form($form, &$form_state) {
     '#default_value' => variable_get($var_name, FALSE),
     '#description' => t("Logs Reward activity. This should be disabled on production."),
   );
+
   return system_settings_form($form);
 }

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.admin.inc
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.admin.inc
@@ -9,32 +9,32 @@
  */
 function dosomething_reward_admin_config_form($form, &$form_state) {
 
-  $form['copy'] = array(
+  $form['rb_count'] = array(
     '#type' => 'fieldset',
     '#title' => t('Reportback Count'),
     '#collapsible' => TRUE,
   );
   $var_name = 'dosomething_reward_enable_reportback_count';
-  $form['copy'][$var_name] = array(
+  $form['rb_count'][$var_name] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable Reportback Count Rewards'),
     '#default_value' => variable_get($var_name, FALSE),
     '#description' => t("When checked, users can earn a Reportback Count Reward."),
   );
-  $form['copy']['page'] = array(
+  $form['rb_count']['page'] = array(
     '#type' => 'fieldset',
     '#title' => t('Redeem Page'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $form['copy']['form'] = array(
+  $form['rb_count']['form'] = array(
     '#type' => 'fieldset',
     '#title' => t('Redeem Form'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
   $var_name = 'dosomething_reward_redeem_page_header';
-  $form['copy']['page'][$var_name] = array(
+  $form['rb_count']['page'][$var_name] = array(
     '#type' => 'textfield',
     '#title' => t('Redeem Page Header'),
     '#description' => t("Redeem Page content header."),
@@ -43,7 +43,7 @@ function dosomething_reward_admin_config_form($form, &$form_state) {
   );
 
   $var_name = 'dosomething_reward_redeem_page_copy';
-  $form['copy']['page'][$var_name] = array(
+  $form['rb_count']['page'][$var_name] = array(
     '#type' => 'textarea',
     '#title' => t('Redeem Page Copy'),
     '#description' => t("Redeem Page content copy."),
@@ -52,7 +52,7 @@ function dosomething_reward_admin_config_form($form, &$form_state) {
   );
 
   $var_name = 'dosomething_reward_redeem_page_image';
-  $form['copy']['page'][$var_name] = array(
+  $form['rb_count']['page'][$var_name] = array(
     '#type' => 'entity_autocomplete',
     '#title' => t('Redeem Page Image'),
     '#description' => t("Redeem Page content image."),
@@ -63,7 +63,7 @@ function dosomething_reward_admin_config_form($form, &$form_state) {
   );
 
   $var_name = 'dosomething_reward_redeem_form_link';
-  $form['copy']['page'][$var_name] = array(
+  $form['rb_count']['page'][$var_name] = array(
     '#type' => 'textfield',
     '#title' => t('Redeem Form Link Text'),
     '#description' => t("Link text that opens the Redeem Form modal."),
@@ -72,7 +72,7 @@ function dosomething_reward_admin_config_form($form, &$form_state) {
   );
 
   $var_name = 'dosomething_reward_redeem_form_header';
-  $form['copy']['form'][$var_name] = array(
+  $form['rb_count']['form'][$var_name] = array(
     '#type' => 'textfield',
     '#title' => t('Redeem Form Header'),
     '#description' => t("Header text of the Redeem Form modal."),
@@ -81,7 +81,7 @@ function dosomething_reward_admin_config_form($form, &$form_state) {
   );
 
   $var_name = 'dosomething_reward_redeem_form_copy';
-  $form['copy']['form'][$var_name] = array(
+  $form['rb_count']['form'][$var_name] = array(
     '#type' => 'textarea',
     '#rows' => 4,
     '#title' => t('Redeem Form Copy'),
@@ -91,7 +91,7 @@ function dosomething_reward_admin_config_form($form, &$form_state) {
   );
 
   $var_name = 'dosomething_reward_redeem_form_button_text';
-  $form['copy']['form'][$var_name] = array(
+  $form['rb_count']['form'][$var_name] = array(
     '#type' => 'textfield',
     '#title' => t('Redeem Form Button Label'),
     '#description' => t("Label displayed on the Redeem Form submit button."),
@@ -100,7 +100,7 @@ function dosomething_reward_admin_config_form($form, &$form_state) {
   );
 
   $var_name = 'dosomething_reward_redeem_form_confirm_msg';
-  $form['copy']['form'][$var_name] = array(
+  $form['rb_count']['form'][$var_name] = array(
     '#type' => 'textarea',
     '#rows' => 2,
     '#title' => t('Redeem Form Confirmation Message'),

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.admin.inc
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.admin.inc
@@ -9,28 +9,29 @@
  */
 function dosomething_reward_admin_config_form($form, &$form_state) {
 
+  $form['copy'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Reportback Count'),
+    '#collapsible' => TRUE,
+  );
   $var_name = 'dosomething_reward_enable_reportback_count';
-  $form[$var_name] = array(
+  $form['copy'][$var_name] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable Reportback Count Rewards'),
     '#default_value' => variable_get($var_name, FALSE),
     '#description' => t("When checked, users can earn a Reportback Count Reward."),
   );
-
-  $form['copy'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Copy'),
-    '#collapsible' => TRUE,
-  );
   $form['copy']['page'] = array(
     '#type' => 'fieldset',
     '#title' => t('Redeem Page'),
     '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
   );
   $form['copy']['form'] = array(
     '#type' => 'fieldset',
     '#title' => t('Redeem Form'),
     '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
   );
   $var_name = 'dosomething_reward_redeem_page_header';
   $form['copy']['page'][$var_name] = array(
@@ -85,26 +86,6 @@ function dosomething_reward_admin_config_form($form, &$form_state) {
     '#rows' => 4,
     '#title' => t('Redeem Form Copy'),
     '#description' => t("Copy displayed in the Redeem Form modal."),
-    '#required' => TRUE,
-    '#default_value' => variable_get($var_name),
-  );
-
-  $var_name = 'dosomething_reward_image_shirt_dope';
-  $form['copy']['form'][$var_name] = array(
-    '#type' => 'entity_autocomplete',
-    '#title' => t('Dope Shirt Image'),
-    '#entity_type' => 'node',
-    '#bundles' => array('image'),
-    '#required' => TRUE,
-    '#default_value' => variable_get($var_name),
-  );
-
-  $var_name = 'dosomething_reward_image_shirt_social_action';
-  $form['copy']['form'][$var_name] = array(
-    '#type' => 'entity_autocomplete',
-    '#title' => t('Social Action Shirt Image'),
-    '#entity_type' => 'node',
-    '#bundles' => array('image'),
     '#required' => TRUE,
     '#default_value' => variable_get($var_name),
   );

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.install
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.install
@@ -94,6 +94,8 @@ function dosomething_reward_uninstall() {
   $vars = array(
     'dosomething_reward_log',
     'dosomething_reward_enable_reportback_count',
+    'dosomething_reward_image_shirt_dope',
+    'dosomething_reward_image_shirt_social_action',
     'dosomething_reward_redeem_form_button_text',
     'dosomething_reward_redeem_form_confirm_msg',
     'dosomething_reward_redeem_form_copy',

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.install
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.install
@@ -64,13 +64,19 @@ function dosomething_reward_schema() {
  */
 function dosomething_reward_install() {
 
+  $value = "Free Stuff!  You've earned some swag.";
+  variable_set('dosomething_reward_redeem_page_header', $value);
+
+  $value = "You're a kickass DoSomething.org member. For completing 2 campaigns within a year, we want to thank you by offering you two free DoSomething.org t-shirts - one for you and one for a friend.";
+  variable_set('dosomething_reward_redeem_page_copy', $value);
+
   $value = "Hey, do you want a T-Shirt?";
   variable_set('dosomething_reward_redeem_form_link', $value);
 
   $value = "Free T-shirts";
   variable_set('dosomething_reward_redeem_form_header', $value);
 
-  $value = "You're a kickass DoSomething.org member. For completing 2 campaigns within a year, we want to thank you by offering you two free DoSomething.org t-shirts - one for you and one for a friend. Fill out the form below to get both shirts mailed to you.";
+  $value = "Fill out the form below to get both shirts mailed to you.";
   variable_set('dosomething_reward_redeem_form_copy', $value);
 
   $value = "Submit";
@@ -87,11 +93,15 @@ function dosomething_reward_install() {
 function dosomething_reward_uninstall() {
   $vars = array(
     'dosomething_reward_log',
+    'dosomething_reward_enable_reportback_count',
     'dosomething_reward_redeem_form_button_text',
     'dosomething_reward_redeem_form_confirm_msg',
     'dosomething_reward_redeem_form_copy',
     'dosomething_reward_redeem_form_header',
     'dosomething_reward_redeem_form_link',
+    'dosomething_reward_redeem_page_copy',
+    'dosomething_reward_redeem_page_header',
+    'dosomething_reward_redeem_page_image',
   );
   foreach ($vars as $var) {
     variable_del($var);

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.install
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.install
@@ -70,7 +70,7 @@ function dosomething_reward_install() {
   $value = "You're a kickass DoSomething.org member. For completing 2 campaigns within a year, we want to thank you by offering you two free DoSomething.org t-shirts - one for you and one for a friend.";
   variable_set('dosomething_reward_redeem_page_copy', $value);
 
-  $value = "Hey, do you want a T-Shirt?";
+  $value = "Get your shirts";
   variable_set('dosomething_reward_redeem_form_link', $value);
 
   $value = "Free T-shirts";

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
@@ -226,6 +226,10 @@ function dosomething_reward_exists($reward_type, $uid = NULL) {
  *   The Reward object, or FALSE.
  */
 function dosomething_reward_reportback_count($reportback) {
+  // If Reportback Count is not enabled:
+  if (!variable_get('dosomething_reward_enable_reportback_count', FALSE)) {
+    return FALSE;
+  }
   $reward_type = 'reportback_count';
   $uid = $reportback->uid;
   $account = user_load($uid);

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
@@ -329,6 +329,17 @@ function dosomething_reward_get_redeem_form_vars($reward) {
     $var_name = 'dosomething_reward_redeem_' . $key;
     $vars[$key] = variable_get($var_name);
   }
+  // Store the image HTML.
+  if ($img_nid = $vars['page_image']) {
+    $img_ratio = 'landscape';
+    $img_size = '300x300';
+    $vars['page_image'] = dosomething_image_get_themed_image($img_nid, $img_ratio, $img_size);
+  }
+
+  // Placeholders until finalized.
+  $vars['page_title'] = t("You did it!");
+  $vars['page_subtitle'] = t("You got a T-Shirt!");
+
   // Initialize delete form.
   $vars['delete_form'] = NULL;
   // Allow staff to delete the Reward to test functionality.

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
@@ -48,6 +48,18 @@ function dosomething_reward_entity_info() {
 }
 
 /**
+ * Implements hook_theme().
+ */
+function dosomething_reward_theme($existing, $type, $theme, $path) {
+  return array(
+    'reward_redeem_reportback_count' => array(
+      'template' => 'reward-redeem-reportback-count',
+      'path' => drupal_get_path('module', 'dosomething_reward') . '/theme',
+    ),
+  );
+}
+
+/**
  * Implements hook_views_data().
  */
 function dosomething_reward_views_data() {
@@ -306,12 +318,15 @@ function dosomething_reward_get_redeem_form_vars($reward) {
   $vars['form'] = drupal_get_form('dosomething_reward_redeem_form', $reward);
   // Set copy variables.
   $copy_vars = array(
-    'copy',
-    'header',
-    'link',
+    'form_copy',
+    'form_header',
+    'form_link',
+    'page_copy',
+    'page_header',
+    'page_image',
   );
   foreach ($copy_vars as $key) {
-    $var_name = 'dosomething_reward_redeem_form_' . $key;
+    $var_name = 'dosomething_reward_redeem_' . $key;
     $vars[$key] = variable_get($var_name);
   }
   // Initialize delete form.

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
@@ -342,8 +342,8 @@ function dosomething_reward_get_redeem_form_vars($reward) {
 
   // Initialize delete form.
   $vars['delete_form'] = NULL;
-  // Allow staff to delete the Reward to test functionality.
-  if (dosomething_user_is_staff()) {
+  // Allow staff to delete the Reward to test by using with secret query string.
+  if (dosomething_user_is_staff() && isset($_GET['delete-reward'])) {
     $form_id = 'dosomething_reward_delete_form';
     $vars['delete_form'] = drupal_get_form($form_id, $reward);
   }

--- a/lib/modules/dosomething/dosomething_reward/theme/reward-redeem-reportback-count.tpl.php
+++ b/lib/modules/dosomething/dosomething_reward/theme/reward-redeem-reportback-count.tpl.php
@@ -1,0 +1,9 @@
+<div>
+  <h1><?php print $page_header; ?></h1>
+  <p><?php print $page_copy; ?></p>
+  <div>
+    <h2><?php print $form_header; ?>
+    <p><?php print $form_copy; ?>
+    <?php print render($form); ?>
+  </div>
+</div>

--- a/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.admin.inc
+++ b/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.admin.inc
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @file
+ * Admin config form settings.
+ */
+
+/**
+ * System settings form for DoSomething Shipment specific variables.
+ */
+function dosomething_shipment_admin_config_form($form, &$form_state) {
+  $var_name = 'dosomething_shipment_image_shirt_dope';
+  $form[$var_name] = array(
+    '#type' => 'entity_autocomplete',
+    '#title' => t('Dope Shirt Image'),
+    '#entity_type' => 'node',
+    '#bundles' => array('image'),
+    '#required' => TRUE,
+    '#default_value' => variable_get($var_name),
+  );
+
+  $var_name = 'dosomething_shipment_image_shirt_social_action';
+  $form[$var_name] = array(
+    '#type' => 'entity_autocomplete',
+    '#title' => t('Social Action Shirt Image'),
+    '#entity_type' => 'node',
+    '#bundles' => array('image'),
+    '#required' => TRUE,
+    '#default_value' => variable_get($var_name),
+  );
+
+  $form['log'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Logging'),
+  );
+  $var_name = 'dosomething_shipment_log';
+  $form['log'][$var_name] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Log Shipments.'),
+    '#default_value' => variable_get($var_name, FALSE),
+    '#description' => t("Logs Shipment activity. This should be disabled on production."),
+  );
+
+  return system_settings_form($form);
+}
+

--- a/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.install
+++ b/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.install
@@ -67,3 +67,17 @@ function dosomething_shipment_schema() {
   );
   return $schema;
 }
+
+/**
+ * Implements hook_uninstall().
+ */
+function dosomething_shipment_uninstall() {
+  $vars = array(
+    'dosomething_shipment_image_shirt_dope',
+    'dosomething_shipment_image_shirt_social_action',
+    'dosomething_shipment_log',
+  );
+  foreach ($vars as $var) {
+    variable_del($var);
+  }
+}

--- a/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
+++ b/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
@@ -226,11 +226,18 @@ function dosomething_shipment_get_shipment_id_by_entity($type, $id) {
 /**
  * Returns array of available shirts.
  */
-function dosomething_shipment_get_shirt_options() {
-  //@todo: Return images as the description.
+function dosomething_shipment_get_shirt_options($ratio = 'square', $size = '100x100') {
+  $img_dope = t("Dope shirt");
+  if ($nid_dope = variable_get('dosomething_reward_image_shirt_dope')) {
+    $img_dope = dosomething_image_get_themed_image($nid_dope, $ratio, $size);
+  }
+  $img_social = t("Social action shirt");
+  if ($nid_social = variable_get('dosomething_reward_image_shirt_social_action')) {
+    $img_social = dosomething_image_get_themed_image($nid_social, $ratio, $size);
+  }
   return array(
-    'shirt_dope' => t('Dope shirt'),
-    'shirt_social_action' => t('Social action speaks louder'),
+    'shirt_dope' => $img_dope,
+    'shirt_social_action' => $img_social,
   );
 }
 

--- a/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
+++ b/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
@@ -6,6 +6,8 @@
 
 include_once 'dosomething_shipment.features.inc';
 
+DEFINE('DOSOMETHING_SHIPMENT_LOG', variable_get('dosomething_shipment_log') ? TRUE : FALSE);
+
 /**
  * Implements hook_entity_info().
  */
@@ -24,6 +26,23 @@ function dosomething_shipment_entity_info() {
     'module' => 'dosomething_shipment',
   );
   return $info;
+}
+
+/**
+ * Implements hook_menu().
+ */
+function dosomething_shipment_menu() {
+  $items = array();
+  $items['admin/config/dosomething/dosomething_shipment'] = array(
+    'title' => 'DoSomething Shipment',
+    'description' => 'Admin configuration form for DoSomething Shipment.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_shipment_admin_config_form'),
+    'access callback' => 'user_access',
+    'access arguments' => array('administer modules'),
+    'file' => 'dosomething_shipment.admin.inc',
+  );
+  return $items;
 }
 
 /**
@@ -226,18 +245,24 @@ function dosomething_shipment_get_shipment_id_by_entity($type, $id) {
 /**
  * Returns array of available shirts.
  */
-function dosomething_shipment_get_shirt_options($ratio = 'square', $size = '100x100') {
-  $img_dope = t("Dope shirt");
-  if ($nid_dope = variable_get('dosomething_reward_image_shirt_dope')) {
-    $img_dope = dosomething_image_get_themed_image($nid_dope, $ratio, $size);
+function dosomething_shipment_get_shirt_options($images = TRUE, $ratio = 'square', $size = '100x100') {
+  // Default as text.
+  $opt_dope = t("Dope shirt");
+  $var_dope = 'dosomething_shipment_image_shirt_dope';
+  // If displaying as images, and we have an Image set for this shirt:
+  if ($images && $nid_dope = variable_get($var_dope)) {
+    // Render the image with the ratio and size.
+    $opt_dope = dosomething_image_get_themed_image($nid_dope, $ratio, $size);
   }
-  $img_social = t("Social action shirt");
-  if ($nid_social = variable_get('dosomething_reward_image_shirt_social_action')) {
-    $img_social = dosomething_image_get_themed_image($nid_social, $ratio, $size);
+  // Repeat for Social action shirt.
+  $opt_social = t("Social action shirt");
+  $var_social = 'dosomething_shipment_image_shirt_social_action';
+  if ($images && $nid_social = variable_get($var_social)) {
+    $opt_social = dosomething_image_get_themed_image($nid_social, $ratio, $size);
   }
   return array(
-    'shirt_dope' => $img_dope,
-    'shirt_social_action' => $img_social,
+    'shirt_dope' => $opt_dope,
+    'shirt_social_action' => $opt_social,
   );
 }
 

--- a/lib/modules/dosomething/dosomething_shipment/includes/dosomething_shipment.inc
+++ b/lib/modules/dosomething/dosomething_shipment/includes/dosomething_shipment.inc
@@ -34,6 +34,11 @@ class ShipmentEntityController extends EntityAPIController {
       $op = 'insert';
     }
     parent::save($entity, $transaction);
+    if (DOSOMETHING_SHIPMENT_LOG) {
+      watchdog('dosomething_shipment', 'Save: @entity', array(
+        '@entity' => json_encode($entity),
+      ));
+    }
     if ($op == 'insert') {
       // @todo: Send MBP request with shipment details.
     }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
@@ -72,16 +72,4 @@
     </div>
   <?php endif; ?>
 
-  <?php if ($redeem_form): ?>
-    <a href="#" data-modal-href="#modal-redeem-form"><?php print $redeem_form['link']; ?></a>
-    <div data-modal id="modal-redeem-form" role="dialog">
-      <h2 class="banner"><?php print ($redeem_form['header']); ?></h2>
-      <?php print $redeem_form['copy']; ?>
-      <?php print render($redeem_form['form']); ?>
-    </div>
-    <?php if ($redeem_form['delete_form']): ?>
-      <?php print render($redeem_form['delete_form']); ?>
-    <?php endif; ?>
-  <?php endif; ?>
-
 </section>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reward-redeem-reportback-count.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reward-redeem-reportback-count.tpl.php
@@ -5,8 +5,14 @@
  * Available Variables
  * - $page_title: The page title (string).
  * - $page_subtitle: (string).
+ * - $page_header: (string).
  * - $page_copy: (string).
- * - $redeem_form: Array containing variables for Reward Reedem Form, if exists.
+ * - $page_image: Rendered image (string).
+ * - $form_link: (string).
+ * - $form_header: (string).
+ * - $form_copy: (string).
+ * - $form: Array containing Reward Reedem Form.
+ * - $delete_form: Array containing Reward Delete Form, if exists.
  */
 ?>
 
@@ -33,9 +39,9 @@
     <?php print $form_copy; ?>
     <?php print render($form); ?>
   </div>
-  <?php if ($redeem_form['delete_form']): ?>
-    <?php print render($redeem_form['delete_form']); ?>
-  <?php endif; ?>
 
+  <?php if ($delete_form): ?>
+    <?php print render($delete_form); ?>
+  <?php endif; ?>
 
 </section>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reward-redeem-reportback-count.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reward-redeem-reportback-count.tpl.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Returns the HTML for the Campaign Reportback Confirmation.
+ *
+ * Available Variables
+ * - $page_title: The page title (string).
+ * - $page_subtitle: (string).
+ * - $page_copy: (string).
+ * - $redeem_form: Array containing variables for Reward Reedem Form, if exists.
+ */
+?>
+
+<section class="confirmation-wrapper">
+
+  <header role="banner" class="-basic">
+    <div class="wrapper">
+      <h1 class="__title"><?php print $page_title; ?></h1>
+      <h2 class="__subtitle"><?php print $page_subtitle; ?></h2>
+    </div>
+  </header>
+
+  <div>
+    <h2><?php print $page_header; ?></h2>
+    <p><?php print $page_copy; ?></h2>
+    <?php if (isset($page_image)): ?>
+    <?php print $page_image; ?>
+    <?php endif; ?>
+  </div>
+
+  <a href="#" data-modal-href="#modal-redeem-form" class="btn medium"><?php print $form_link; ?></a>
+  <div data-modal id="modal-redeem-form" role="dialog">
+    <h2 class="banner"><?php print ($form_header); ?></h2>
+    <?php print $form_copy; ?>
+    <?php print render($form); ?>
+  </div>
+  <?php if ($redeem_form['delete_form']): ?>
+    <?php print render($redeem_form['delete_form']); ?>
+  <?php endif; ?>
+
+
+</section>


### PR DESCRIPTION
@sergii-tkachenko Can you please review?

This PR will unblock fenders from theming the Reward Redeem page / form. 
- Adds tpl file for the Redeem Reward page / modal, moving it out of the Confirmation page tpl.
- Only displays the page/form if the Reward has not been redeemed
- Adds lots of variables for the Reward page/modal, including Shirt image nodes.
- Only creates Reportback Count Rewards if the `dosomething_reward_enable_reportback_count` variable is set, to allow enabling/disabling without any code changes.
