### PR TITLE
Fix errors on Reportback Delete form.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -243,6 +243,7 @@ function dosomething_reportback_delete_form_submit($form, &$form_state) {
     // Redirect back to the node that the reportback was for.
     $form_state['redirect'] = 'node/' . $form_state['values']['nid'];
     drupal_set_message(t("Reportback deleted."));
+    return;
   }
   // Else, there was some rat fuckery.
   drupal_set_message(t("There was an error processing your request."));

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -423,7 +423,7 @@ class ReportbackEntityController extends EntityAPIController {
   public function delete($ids, DatabaseTransaction $transaction = NULL) {
     // Log deletions.
     foreach ($ids as $id) {
-      $rb = reportback_load($ids);
+      $rb = reportback_load($id);
       $rb->insertLog('delete');
     }
     parent::delete($ids, $transaction);


### PR DESCRIPTION
Fixes an oldie but a goodie, #1537.  

Only staff can delete reportbacks, so this was never user facing.  Keeps the existing logic though in case one day users ever can delete their own reportbacks.
