### PR TITLE
Clean Slate form

### DIFF
--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
@@ -90,39 +90,3 @@ function dosomething_reward_redeem_form_submit($form, &$form_state) {
   $msg = variable_get('dosomething_reward_redeem_form_confirm_msg');
   drupal_set_message($msg);
 }
-
-/**
- * Form constructor for a Delete Reward form.
- *
- * @param object $reward
- *   The Reward entity to delete.
- *
- * @ingroup forms
- */
-function dosomething_reward_delete_form($form, &$form_state, $reward) {
-  $form['id'] = array(
-    '#type' => 'hidden',
-    '#default_value' => $reward->id,
-    '#access' => FALSE,
-  );
-  $help = "As staff, you may delete your Reward (id: @id) for testing.  The corresponding Shipment record will also be deleted if the Reward has been redeemed.";
-  $form['help'] = array(
-    '#markup' => t($help, array('@id' => $reward->id)),
-  );
-  $form['actions'] = array(
-    '#type' => 'actions',
-    'submit' => array(
-      '#type' => 'submit',
-      '#value' => t("Delete Reward"),
-    ),
-  );
-  return $form;
-}
-
-/**
- * Submit callback for dosomething_reward_delete_form().
- */
-function dosomething_reward_delete_form_submit($form, &$form_state) {
-  entity_delete('reward', $form_state['values']['id']);
-  drupal_set_message(t("Reward deleted."));
-}

--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.module
@@ -339,13 +339,5 @@ function dosomething_reward_get_redeem_form_vars($reward) {
   // Placeholders until finalized.
   $vars['page_title'] = t("You did it!");
   $vars['page_subtitle'] = t("You got a T-Shirt!");
-
-  // Initialize delete form.
-  $vars['delete_form'] = NULL;
-  // Allow staff to delete the Reward to test by using with secret query string.
-  if (dosomething_user_is_staff() && isset($_GET['delete-reward'])) {
-    $form_id = 'dosomething_reward_delete_form';
-    $vars['delete_form'] = drupal_get_form($form_id, $reward);
-  }
   return $vars;
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @file
+ * Admin config form settings.
+ */
+
+/**
+ * System settings form for DoSomething Shipment specific variables.
+ */
+function dosomething_user_admin_config_form($form, &$form_state) {
+  $var_name = 'dosomething_user_enable_clean_slate';
+  $form['log'][$var_name] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable Clean Slate Form.'),
+    '#default_value' => variable_get($var_name, FALSE),
+    '#description' => t("Allows staff user access to delete all activity for their account. This should be disabled on production."),
+  );
+  return system_settings_form($form);
+}
+
+/**
+ * Form constructor for a Clean Slate form.
+ *
+ * Deletes all of the logged in user's campaign activity.
+ *
+ * @ingroup forms
+ */
+function dosomething_user_clean_slate_form($form, &$form_state) {
+  if (variable_get('dosomething_user_enable_clean_slate', FALSE) == FALSE) {
+    $form['disabled'] = array(
+      '#markup' => t("Clean Slate has been disabled."),
+    );
+    return $form;
+  }
+  $help = "As staff, you may delete all of your Campaign Signups, Reportbacks, Rewards, and Shipments.<h1>WARNING THIS CANNOT BE UNDONE</h1><h1>ARE YOU REALLY SURE ABOUT THIS</h1><h2>YOU ARE BRINGING THIS UPON YOURSELF</h2>";
+  $form['help'] = array(
+    '#markup' => $help,
+  );
+  $form['actions'] = array(
+    '#type' => 'actions',
+    'submit' => array(
+      '#type' => 'submit',
+      '#value' => t("Clean Slate Me"),
+    ),
+  );
+  return $form;
+}
+
+/**
+ * Submit callback for dosomething_user_clean_slate_form().
+ */
+function dosomething_user_clean_slate_form_submit($form, &$form_state) {
+  global $user;
+  $msg = t("Clean Slate form submitted for User %uid", array(
+    '%uid' => $user->uid,
+  ));
+  watchdog('dosomething_user_clean_slate', $msg);
+  // Go git em.
+  dosomething_user_clean_slate($user->uid);
+}

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -59,6 +59,14 @@ function dosomething_user_menu() {
     'access arguments' => array('edit user info'),
     'type' => MENU_LOCAL_TASK,
   );
+  $items['admin/users/clean-slate'] = array(
+    'title' => 'Clean Slate',
+    'access callback' => 'user_access',
+    'access arguments' => array('access administration menu'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_user_clean_slate_form'),
+    'weight' => 500,
+  );
   return $items;
 }
 
@@ -929,4 +937,106 @@ function dosomething_user_info_form_submit($form, &$form_state) {
     file_usage_add($file, 'user', 'user', $account->uid);
   }
   drupal_set_message("User information saved.");
+}
+
+/**
+ * Form constructor for a Clean Slate form.
+ *
+ * Deletes all of the logged in user's campaign activity.
+ *
+ * @ingroup forms
+ */
+function dosomething_user_clean_slate_form($form, &$form_state) {
+  $help = "As staff, you may delete all of your Campaign Signups, Reportbacks, Rewards, and Shipments.<h1>WARNING THIS CANNOT BE UNDONE</h1><h1>ARE YOU REALLY SURE ABOUT THIS</h1><h2>YOU ARE BRINGING THIS UPON YOURSELF</h2>";
+  $form['help'] = array(
+    '#markup' => $help,
+  );
+  $form['actions'] = array(
+    '#type' => 'actions',
+    'submit' => array(
+      '#type' => 'submit',
+      '#value' => t("Clean Slate Me"),
+    ),
+  );
+  return $form;
+}
+
+/**
+ * Submit callback for dosomething_user_clean_slate_form().
+ */
+function dosomething_user_clean_slate_form_submit($form, &$form_state) {
+  global $user;
+  $msg = t("Clean Slate form submitted for User %uid", array(
+    '%uid' => $user->uid,
+  ));
+  watchdog('dosomething_user_clean_slate', $msg);
+  // Go git em.
+  dosomething_user_clean_slate($user->uid);
+}
+
+/**
+ * Returns all records from table $tbl_name for a given user uid.
+ *
+ * @param string $tbl_name
+ *   The name of the table to query.
+ * @param int $uid
+ *    The user $uid to filter by.
+ *
+ * @return
+ *   Array of record objects.
+ */
+function dosomething_user_get_records($tbl_name, $uid) {
+  if (db_table_exists($tbl_name)) {
+   return db_select($tbl_name, 't')
+    ->fields('t')
+    ->condition('uid', $uid, '=')
+    ->execute()
+    ->fetchAll();   
+  }
+  else {
+    watchdog('dosomething_user', 'Table %tbl_name', array('%tbl_name' => $tbl_name), WATCHDOG_WARNING);
+  }
+}
+
+/**
+ * Deletes all entities for a given user $uid a clean slate.
+ *
+ * To be used with great responsibility.
+ *
+ * @param int $uid
+ *   The user $uid to delete records for.
+ */
+function dosomething_user_clean_slate($uid, $display_messages = TRUE) {
+  // List of all entities users can create, and their identifiers.
+  $entity_list = array(
+    'signup' => 'sid',
+    'reportback' => 'rbid',
+    'reward' => 'id',
+    'shipment' => 'id',
+  );
+  foreach ($entity_list as $entity_type => $identifier) {
+    $tbl = 'dosomething_' . $entity_type;
+    // Get all records from the entity table for this user.
+    $results = dosomething_user_get_records($tbl, $uid);
+    if (empty($results)) {
+      continue;
+    }
+    // Loop through each result:
+    foreach ($results as $result) {
+      // Load the entity.
+      $entity = entity_load_single($entity_type, $result->{$identifier});
+      // Store entity identifier.
+      $id = $entity->{$identifier};
+      $entity->delete();
+      $msg = t("@type @identifier @id deleted.", array(
+        '@type' => ucfirst($entity_type),
+        '@identifier' => $identifier,
+        '@id' => $id,
+      ));
+      if ($display_messages) {
+        drupal_set_message($msg);
+      }
+      watchdog('dosomething_user_clean_slate', $msg);
+    }
+  }
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -42,6 +42,15 @@ function dosomething_user_menu() {
     'page callback' => 'dosomething_user_validate_user_address',
     'file' => 'dosomething_user_valid_address.inc'
   );
+  $items['admin/config/dosomething/dosomething_user'] = array(
+    'title' => 'DoSomething User',
+    'description' => 'Admin configuration form for DoSomething User.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_user_admin_config_form'),
+    'file' => 'dosomething_user.admin.inc',
+    'access callback' => 'user_access',
+    'access arguments' => array('administer modules'),
+  );
   $items['admin/config/dosomething/ups-api-settings'] = array(
     'title' => t('UPS API Configuration'),
     'description' => t('UPS integration that provices address validation'),
@@ -65,6 +74,7 @@ function dosomething_user_menu() {
     'access arguments' => array('access administration menu'),
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_user_clean_slate_form'),
+    'file' => 'dosomething_user.admin.inc',
     'weight' => 500,
   );
   return $items;
@@ -937,41 +947,6 @@ function dosomething_user_info_form_submit($form, &$form_state) {
     file_usage_add($file, 'user', 'user', $account->uid);
   }
   drupal_set_message("User information saved.");
-}
-
-/**
- * Form constructor for a Clean Slate form.
- *
- * Deletes all of the logged in user's campaign activity.
- *
- * @ingroup forms
- */
-function dosomething_user_clean_slate_form($form, &$form_state) {
-  $help = "As staff, you may delete all of your Campaign Signups, Reportbacks, Rewards, and Shipments.<h1>WARNING THIS CANNOT BE UNDONE</h1><h1>ARE YOU REALLY SURE ABOUT THIS</h1><h2>YOU ARE BRINGING THIS UPON YOURSELF</h2>";
-  $form['help'] = array(
-    '#markup' => $help,
-  );
-  $form['actions'] = array(
-    '#type' => 'actions',
-    'submit' => array(
-      '#type' => 'submit',
-      '#value' => t("Clean Slate Me"),
-    ),
-  );
-  return $form;
-}
-
-/**
- * Submit callback for dosomething_user_clean_slate_form().
- */
-function dosomething_user_clean_slate_form_submit($form, &$form_state) {
-  global $user;
-  $msg = t("Clean Slate form submitted for User %uid", array(
-    '%uid' => $user->uid,
-  ));
-  watchdog('dosomething_user_clean_slate', $msg);
-  // Go git em.
-  dosomething_user_clean_slate($user->uid);
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reward-redeem-reportback-count.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reward-redeem-reportback-count.tpl.php
@@ -12,7 +12,6 @@
  * - $form_header: (string).
  * - $form_copy: (string).
  * - $form: Array containing Reward Reedem Form.
- * - $delete_form: Array containing Reward Delete Form, if exists.
  */
 ?>
 
@@ -39,9 +38,5 @@
     <?php print $form_copy; ?>
     <?php print render($form); ?>
   </div>
-
-  <?php if ($delete_form): ?>
-    <?php print render($delete_form); ?>
-  <?php endif; ?>
 
 </section>


### PR DESCRIPTION
@sergii-tkachenko Can you review if you have a chance?
## Overview

Closes https://jira.dosomething.org/browse/DS-215

Removes the "Delete Reward" form in favor of a Clean Slate form, which deletes all the logged in user's Signups, Reportbacks, Rewards, and Shipments.  Only available to staff, and if the `dosomething_user_enable_clean_slate` variable is set to TRUE.
## Screenshot

![clean-slate](https://cloud.githubusercontent.com/assets/1236811/3973742/2eeea2ba-27eb-11e4-8535-02a0d8b386cf.png)
