### PR TITLE
Clears QA IP address from flood table before running tests.

### DIFF
--- a/tests/scripts/before_tests.sh
+++ b/tests/scripts/before_tests.sh
@@ -12,6 +12,7 @@ cd $WEB_PATH
 # Clear out localhost from flood table (prevents "more than 5 failed login attempts" error)
 echo "Clearing localhost from flood table..."
 drush sql-query "DELETE FROM flood WHERE identifier LIKE '%127.0.0.1';"
+drush sql-query "DELETE FROM flood WHERE identifier LIKE '%192.168.1.161';"
 
 # Create fresh test accounts
 drush_get_uid_from_email() {


### PR DESCRIPTION
## Changes

Tests were failing (after a few consecutive runs) on QA because of the flood table. This stops it from doing that by clearing the QA IP address before running tests.
