### PR TITLE
Signup Data Form - Shipment Item

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -168,6 +168,11 @@ function dosomething_signup_schema() {
         'length' => 255,
         'not null' => TRUE,
       ),
+      'shipment_item' => array(
+        'description' => 'Item to ship if address is collected.',
+        'type' => 'varchar',
+        'length' => 255,
+      ),
     ),
     'primary key' => array('nid'),
   );
@@ -422,5 +427,21 @@ function dosomething_signup_update_7012() {
   $column = 'nid';
   if (!db_index_exists($table, $column)) {
       db_add_index($table, $column, array($column));
+  }
+}
+
+/**
+ * Adds shipment_item column to the dosomething_signup_data_form table.
+ */
+function dosomething_signup_update_7013() {
+  $tbl_name = 'dosomething_signup_data_form';
+  // Load schema to get table definition.
+  $schema = dosomething_signup_schema();
+  // New field to add.
+  $field_name = 'shipment_item';
+  // If the field doesn't exist already:
+  if (!db_field_exists($tbl_name, $field_name)) {
+    // Add it per the schema field definition.
+    db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
   }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -129,6 +129,23 @@ function dosomething_signup_node_signup_data_form($form, &$form_state, $node) {
     '#default_value' => $values['collect_user_address'],
     '#description' => t('If checked, collect the user address and save to profile.'),
   );
+  $form[$fieldset]['config']['elements'] [$prefix . 'shipment_item'] = array(
+    '#type' => 'select',
+    '#title' => t('Select Shipment Item'),
+    '#options' => array(
+      'banner' => t('Banner'),
+      'shirt' => t('T-Shirt'),
+      'thumb_socks' => t('Thumb Socks'),
+    ),
+    '#default_value' => $values['shipment_item'],
+    '#description' => t('When the User submits the form, a User Shipment will be created for this Item.'),
+    // Why_signedup label should only be visible if collect_user_address is checked.
+    '#states' => array(
+      'visible' => array(
+        ':input[name="' . $prefix . 'collect_user_address"]' => array('checked' => TRUE),
+      ),
+    ),
+  );
   $form[$fieldset]['config']['elements'] [$prefix . 'collect_why_signedup'] = array(
     '#type' => 'checkbox',
     '#title' => t('Collect signup reason'),
@@ -214,6 +231,7 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
         'why_signedup_label' => $values[$prefix . 'why_signedup_label'],
         'prevent_old_people_submit' => $values[$prefix . 'prevent_old_people_submit'],
         'old_people_copy' => $values[$prefix . 'old_people_copy'],
+        'shipment_item' => $values[$prefix . 'shipment_item'],
     ))
     ->execute();
 }


### PR DESCRIPTION
Adds a `shipment_item` field to the Signup Data Form table, and makes it editable from the Signup Data Form configuration form.

Closes https://jira.dosomething.org/browse/DS-259
