### PR TITLE
Create shipment on Signup Data Form submit

### DIFF
--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
@@ -27,37 +27,8 @@ function dosomething_reward_redeem_form($form, &$form_state, $reward) {
   // Add Address form fields.
   dosomething_user_address_form_element($form, $form_state);
 
-  $form['item_header'] = array(
-    '#markup' => t("Your Shirt"),
-  );
-  $form['item'] = array(
-    '#type' => 'radios',
-    '#required' => TRUE,
-    '#title' => t("Your Shirt style"),
-    '#options' => $shirt_options,
-  );
-  $form['item_option'] = array(
-    '#type' => 'select',
-    '#required' => TRUE,
-    '#title' => t("Your Shirt Size"),
-    '#options' => $size_options,
-  );
-
-  $form['item_additional_header'] = array(
-    '#markup' => t("Your Friend's Shirt"),
-  );
-  $form['item_additional'] = array(
-    '#type' => 'radios',
-    '#required' => TRUE,
-    '#title' => t("Your Friend's Shirt style"),
-    '#options' => $shirt_options,
-  );
-  $form['item_additional_option'] = array(
-    '#type' => 'select',
-    '#required' => TRUE,
-    '#title' => t("Your Friend's Shirt Size"),
-    '#options' => $size_options,
-  );
+  // Add Shirt form fields.
+  dosomething_shipment_shirt_form_element($form, $form_state, $friend = TRUE);
 
   $form['actions'] = array(
     '#type' => 'actions',

--- a/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
+++ b/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
@@ -253,6 +253,49 @@ function dosomething_shipment_get_item_options() {
   );
 }
 
+
+/**
+ * Adds Shirt style and size form element to a given Form API $form.
+ *
+ * @param array $form
+ *   A Form API array.
+ * @param array $form_state
+ *   A Form State Form API array.
+ */
+function dosomething_shipment_shirt_form_element(&$form, &$form_state, $additional = FALSE) {
+  $form['item_header'] = array(
+    '#markup' => t("Your Shirt"),
+  );
+  $form['item'] = array(
+    '#type' => 'radios',
+    '#required' => TRUE,
+    '#title' => t("Your Shirt"),
+    '#options' => dosomething_shipment_get_shirt_options(),
+  );
+  $form['item_option'] = array(
+    '#type' => 'select',
+    '#required' => TRUE,
+    '#title' => t("Your Shirt Size"),
+    '#options' => dosomething_shipment_get_shirt_size_options(),
+  );
+  if ($additional) {
+    $form['item_additional_header'] = array(
+      '#markup' => t("Your Friend's Shirt"),
+    );
+    $form['item_additional'] = array(
+      '#type' => 'radios',
+      '#required' => TRUE,
+      '#title' => t("Your Friend's Shirt"),
+      '#options' => dosomething_shipment_get_shirt_options(),
+    );
+    $form['item_additional_option'] = array(
+      '#type' => 'select',
+      '#required' => TRUE,
+      '#title' => t("Your Friend's Shirt Size"),
+      '#options' => dosomething_shipment_get_shirt_size_options(),
+    );
+  }
+}
 /**
  * Returns array of available shirts.
  */

--- a/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
+++ b/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
@@ -243,6 +243,17 @@ function dosomething_shipment_get_shipment_id_by_entity($type, $id) {
 }
 
 /**
+ * Returns array of valid values for a Shipment's item / additional_item.
+ */
+function dosomething_shipment_get_item_options() {
+  return array(
+    'banner' => t('Banner'),
+    'shirt' => t('Shirt'),
+    'thumb_socks' => t('Thumb Socks'),
+  );
+}
+
+/**
  * Returns array of available shirts.
  */
 function dosomething_shipment_get_shirt_options($images = TRUE, $ratio = 'square', $size = '100x100') {

--- a/lib/modules/dosomething/dosomething_shipment/includes/dosomething_shipment.inc
+++ b/lib/modules/dosomething/dosomething_shipment/includes/dosomething_shipment.inc
@@ -32,6 +32,9 @@ class ShipmentEntityController extends EntityAPIController {
     $op = NULL;
     if (isset($entity->is_new)) {
       $op = 'insert';
+      if (!isset($entity->created)) {
+        $entity->created = REQUEST_TIME;
+      }
     }
     parent::save($entity, $transaction);
     if (DOSOMETHING_SHIPMENT_LOG) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -129,14 +129,14 @@ function dosomething_signup_node_signup_data_form($form, &$form_state, $node) {
     '#default_value' => $values['collect_user_address'],
     '#description' => t('If checked, collect the user address and save to profile.'),
   );
+  $shipment_item_options = array();
+  if (module_exists('dosomething_shipment')) {
+    $shipment_item_options = dosomething_shipment_get_item_options();
+  }
   $form[$fieldset]['config']['elements'] [$prefix . 'shipment_item'] = array(
     '#type' => 'select',
     '#title' => t('Select Shipment Item'),
-    '#options' => array(
-      'banner' => t('Banner'),
-      'shirt' => t('T-Shirt'),
-      'thumb_socks' => t('Thumb Socks'),
-    ),
+    '#options' => $shipment_item_options,
     '#default_value' => $values['shipment_item'],
     '#description' => t('When the User submits the form, a User Shipment will be created for this Item.'),
     // Why_signedup label should only be visible if collect_user_address is checked.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -289,6 +289,12 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       );
       // If shipping shirts:
       if ($config['shipment_item'] == 'shirt') {
+        // Prompt for shirt style.
+        $form['item'] = array(
+          '#type' => 'radios',
+          '#required' => TRUE,
+          '#options' => dosomething_shipment_get_shirt_options(),
+        );
         // Prompt for shirt size.
         $form['item_option'] = array(
           '#type' => 'select',

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -280,6 +280,24 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
   );
   if ($config['collect_user_address']) {
     dosomething_user_address_form_element($form, $form_state);
+    if (isset($config['shipment_item'])) {
+      // Store the shipment item to create.
+      $form['item'] = array(
+        '#type' => 'hidden',
+        '#value' => $config['shipment_item'],
+        '#access' => FALSE,
+      );
+      // If shipping shirts:
+      if ($config['shipment_item'] == 'shirt') {
+        // Prompt for shirt size.
+        $form['item_option'] = array(
+          '#type' => 'select',
+          '#required' => TRUE,
+          '#title' => t("Your Shirt Size"),
+          '#options' => dosomething_shipment_get_shirt_size_options(),
+        );
+      }
+    }
   }
   // If we are collecting why_signedup:
   if ($config['collect_why_signedup']) {
@@ -318,12 +336,25 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
  * Form submit handler for dosomething_signup_user_signup_data_form().
  */
 function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
+  global $user;
   $values = $form_state['values'];
   // Load signup_data_form record to gather relevant config and confirm_msg.
   $config = dosomething_signup_get_signup_data_form_info($values['nid']);
   if ($config['collect_user_address']) {
     // Update user address.
     dosomething_user_save_address_values($values);
+    if (isset($values['item'])) {
+      // Create a shipment entity for this signup.
+      $shipment = entity_create('shipment', array(
+        'uid' => $user->uid,
+        'entity_type' => 'signup',
+        'entity_id' => $values['sid'],
+        'item' => $values['item'],
+        'item_option' => $values['item_option'],
+      ));
+      // Save the shipment entity.
+      $shipment->save();
+    }
   }
   // Update signup record.
   dosomething_signup_update_signup_data($values);

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -289,19 +289,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       );
       // If shipping shirts:
       if ($config['shipment_item'] == 'shirt') {
-        // Prompt for shirt style.
-        $form['item'] = array(
-          '#type' => 'radios',
-          '#required' => TRUE,
-          '#options' => dosomething_shipment_get_shirt_options(),
-        );
-        // Prompt for shirt size.
-        $form['item_option'] = array(
-          '#type' => 'select',
-          '#required' => TRUE,
-          '#title' => t("Your Shirt Size"),
-          '#options' => dosomething_shipment_get_shirt_size_options(),
-        );
+        dosomething_shipment_shirt_form_element($form, $form_state);
       }
     }
   }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
@@ -9,8 +9,10 @@
 /**
  * Adds an address form element to a given Form API $form.
  *
- * @param object $node
- *   The loaded node to save the signup data form configuration for.
+ * @param array $form
+ *   A Form API array.
+ * @param array $form_state
+ *   A Form State Form API array.
  */
 function dosomething_user_address_form_element(&$form, &$form_state) {
   global $user;

--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -8,29 +8,53 @@
 function paraneue_dosomething_form_alter_base(&$form, &$form_state, $form_id) {
   // Add `.btn` to all form submit buttons.
   $form['actions']['submit']['#attributes']['class'][] = 'btn';
+  // Check if this form needs Shirt Styles applied.
+  paraneue_dosomething_form_alter_shirt_options($form, $form_state, $form_id);
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
+ * Checks if given $form needs Shirt Styles applied based on its $form_id.
  */
-function paraneue_dosomething_form_dosomething_reward_redeem_form_alter(&$form, &$form_state, $form_id) {
-  $class_name = 'js-media-options';
-  $form['item']['#attributes']['class'][] = $class_name;
-  $form['item']['#prefix'] = '<div data-validate="shirt_style" data-validate-required>';
-  $form['item']['#suffix'] = '</div>';
-  $form['item']['#title'] = '<div class="label">' . t("Your Shirt Style") . '</div>';
-  $form['item_additional']['#attributes']['class'][] = $class_name;
-  $form['item_additional']['#prefix'] = '<div data-validate="shirt_style" data-validate-required>';
-  $form['item_additional']['#suffix'] = '</div>';
-  $form['item_additional']['#title'] = '<div class="label">' . t("Your Friend's Shirt Style") . '</div>';
+function paraneue_dosomething_form_alter_shirt_options(&$form, &$form_state, $form_id) {
+  // Form IDs which need Shirt styles.
+  $form_ids = array(
+    'dosomething_reward_redeem_form',
+    'dosomething_signup_user_signup_data_form'
+  );
+  // If this form is not one of the Shirt Style forms.
+  if (!in_array($form_id, $form_ids)) {
+    // Exit out.
+    return;
+  }
+  // If this is the User Signup Data Form:
+  if ($form_id == 'dosomething_signup_user_signup_data_form') {
+    // If we aren't collecting an item:
+    if (!isset($form['item'])) {
+      // Exit out.
+      return;
+    }
+  }
   $form['item_header']['#markup'] = '<h3>' . t('Your Shirt') . '</h3>';
-  $form['item_additional_header']['#markup'] = '<h3>' . t("Your Friend's Shirt") . '</h3>';
-  $form['item_option']['#attributes'] = array(
+  // Class to be applied to the Shirt Style options.
+  $shirt_style_class = 'js-media-options';
+  // Attributes to be applied to the Shirt Size options.
+  $shirt_size_attributes = array(
     'data-validate' => 'shirt_size',
     'data-validate-required' => '',
   );
-  $form['item_additional_option']['#attributes'] = array(
-    'data-validate' => 'shirt_size',
-    'data-validate-required' => '',
-  );
+  $form['item']['#attributes']['class'][] = $shirt_style_class;
+  $shirt_style_prefix = '<div data-validate="shirt_style" data-validate-required>';
+  $shirt_style_suffix = '</div>';
+  $form['item']['#prefix'] = $shirt_style_prefix;
+  $form['item']['#suffix'] = $shirt_style_suffix;
+  $form['item']['#title'] = '<div class="label">' . t("Your Shirt Style") . '</div>';
+  $form['item_option']['#attributes'] = $size_attributes;
+  if (isset($form['item_additional'])) {
+    $form['item_additional_header']['#markup'] = '<h3>' . t("Your Friend's Shirt") . '</h3>';
+    $form['item_additional']['#attributes']['class'][] = $shirt_style_class;
+    $form['item_additional']['#prefix'] = $style_prefix;
+    $form['item_additional']['#suffix'] = $style_suffix;
+    $form['item_additional']['#title'] = '<div class="label">' . t("Your Friend's Shirt Style") . '</div>'; 
+    $form['item_additional_option']['#attributes'] = $size_attributes;
+  }
 }


### PR DESCRIPTION
If the Signup Data Form is configured to ship something, creates a Shipment entity for the Signup upon a User submitting the Campaign Signup Data Form.

Closes https://jira.dosomething.org/browse/DS-261
