### PR TITLE
Confirmation Page path change

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -79,7 +79,7 @@ function dosomething_campaign_menu() {
     'weight' => 40,
   );
   // User reportback confirmation page.
-  $items['node/%node/confirmation'] = array(
+  $items['campaigns/%node/confirmation'] = array(
     'title callback' => 'dosomething_campaign_reportback_confirmation_page_title',
     'title arguments' => array(1),
     'page callback' => 'dosomething_campaign_reportback_confirmation_page',
@@ -159,7 +159,16 @@ function dosomething_campaign_scholarship_block_content() {
 }
 
 /**
- * Returns all published campaigns with a schalorship.
+ * Returns a given campaign $nid confirmation path.
+ *
+ * @see dosomething_campaign_menu().
+ */
+function dosomething_campaign_get_confirmation_path($nid) {
+  return 'campaigns/' . $nid . '/confirmation';
+}
+
+/**
+ * Returns all published campaigns with a scholarship.
  */
 function dosomething_campaign_get_scholarships() {
   // Find active campaigns with a scholarship.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -133,9 +133,6 @@ function dosomething_reportback_form_validate($form, &$form_state) {
 function dosomething_reportback_form_submit($form, &$form_state) {
   global $user;
   $values = $form_state['values'];
-
-  // Set confirmation_path for redirect.
-  $confirmation_path = 'node/' . $values['nid'] . '/confirmation';
   $values['uid'] = $user->uid;
 
   // Save uploaded file.
@@ -147,7 +144,8 @@ function dosomething_reportback_form_submit($form, &$form_state) {
   dosomething_reportback_save($values);
 
   // Redirect to confirmation.
-  $form_state['redirect'] = $confirmation_path;
+  $redirect = dosomething_campaign_get_confirmation_path($values['nid']);
+  $form_state['redirect'] = $redirect;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -329,8 +329,8 @@ function dosomething_signup_sms_game_form_submit($form, &$form_state) {
   dosomething_signup_sms_game_signup_request($values['sms_game_type'], $values);
 
   // Redirect to the reportback confirmation page.
-  $confirmation_path = 'node/' . $values['nid'] . '/confirmation';
-  $form_state['redirect'] = $confirmation_path;
+  $redirect = dosomething_campaign_get_confirmation_path($values['nid']);
+  $form_state['redirect'] = $redirect;
 }
 
 /**


### PR DESCRIPTION
Uses `campaigns/*/confirmation` instead of `node/*/confirmation` as a quick win for tracking Google Analytics on the Confirmation page, closing https://jira.dosomething.org/browse/DS-234

By using `campaigns`, we don't have to worry about Varnish, and also if a user navigates to `campaigns/[nid]` they'll be redirected to just regular `/campaigns`. 
