### PR TITLE
Increase visual test failure threshold to 2% difference.

### DIFF
--- a/tests/scripts/common.js
+++ b/tests/scripts/common.js
@@ -21,7 +21,7 @@ phantomcss.init({
   screenshotRoot: ROOT + '/tests/visual',
   failedComparisonsRoot: ROOT + '/tests/visual/failures',
   addLabelToFailedImage: false,
-  mismatchTolerance: 0.02,
+  mismatchTolerance: 2.00,
   onPass: function(test) {
     casper.test.pass('No changes found for visual regression test "' + formattedFilename(test) + '".');
   },


### PR DESCRIPTION
Increasing visual test failure threshold to 2% difference because of rendering issues on QA. As discussed with @mshmsh5000, the long term fix is probably sorting out those environment issues but this is a quick solution for now. :ambulance: 
