### PR TITLE
Fix @self alias.

### DIFF
--- a/provision/salt/roots/salt/drush/ds.aliases.drushrc.php
+++ b/provision/salt/roots/salt/drush/ds.aliases.drushrc.php
@@ -1,5 +1,34 @@
 <?php
 
+$aliases["default"] = array (
+  'root' => '/var/www/vagrant/html',
+  'uri' => true,
+  'path-aliases' =>
+  array (
+    '%drush' => '/opt/drush',
+    '%site' => 'sites/1/',
+  ),
+  '%dump-dir' => '/tmp',
+  'databases' =>
+  array (
+    'default' =>
+    array (
+      'default' =>
+      array (
+        'database' => 'dosomething',
+        'username' => 'root',
+        'password' => '',
+        'host' => 'localhost',
+        'port' => '',
+        'driver' => 'mysql',
+        'prefix' => '',
+      ),
+    ),
+  ),
+  '#file' => '/home/vagrant/.drush/ds.aliases.drushrc.php',
+  '#name' => 'default',
+);
+
 $aliases['staging'] = array(
  'uri' => 'staging.beta.dosomething.org',
  'root' => '/var/www/beta.dosomething.org/current/html',


### PR DESCRIPTION
After refactoring #2809 `drush` site alias `@self` got broken.
For unknown reason it points to Botswana:

```
vagrant@dev:/var/www/vagrant/html/sites/default$ drush @self status
 Drupal version                  :  7.31
 Site URI                        :  http://dev.botswana.dosomething.org
 Database driver                 :  mysql
 Database username               :  root
 Database name                   :  dosomething
 Database                        :  Connected
 Drupal bootstrap                :  Successful
 Drupal user                     :  Anonymous
 Default theme                   :  paraneue_dosomething
 Administration theme            :  seven
 PHP executable                  :  /usr/bin/php
 PHP configuration               :  /etc/php5/cli/php.ini
 PHP OS                          :  Linux
 Drush version                   :  6.3.0
 Drush configuration             :
 Drush alias files               :  /home/vagrant/.drush/ds.aliases.drushrc.php
 Drupal root                     :  /var/www/vagrant/html
 Site path                       :  sites/default
 File directory path             :  sites/default/files
 Temporary file directory path   :  /tmp
```

It causes multiple issues with `bin/ds` script. The most important — it fails `bin/ds pull stage`:

```
vagrant@dev:/var/www/vagrant$ bin/ds pull stage
Pulling down db from staging
WARNING:  Using temporary files to store and transfer sql-dump.  It is recommended that you specify --source-dump and --target-dump options on the command line, or set '%dump' or '%dump-dir' in the path-aliases section of your site alias records. This facilitates fast file transfer via rsync.

You will destroy data in dosomething_botswana and replace with data from staging.beta.dosomething.org/dosomething.

You might want to make a backup first, using the sql-dump command.

Do you really want to continue? (y/n): y
ERROR 1049 (42000): Unknown database 'dosomething_botswana'
Enabling Stage File Proxy...
stage_file_proxy is already enabled.                                                                                                                                                             [ok]
There were no extensions that could be enabled.                                                                                                                                                  [ok]
Setting Stage File Proxy to staging URL...
stage_file_proxy_origin was set to "http://staging.beta.dosomething.org".                                                                                                                        [success]
Pulling down files from stage. Any affiliate sites will be destroyed
You will destroy data from /var/www/vagrant/html/ and replace with data from dosomething@staging.beta.dosomething.org:/var/www/beta.dosomething.org/current/html//
Do you really want to continue? (y/n): y
```

I generated explicit `@self` declaration manually and added it to salt-managed `ds.aliases.drushrc.php`.

```
vagrant@dev:/var/www/vagrant/html$ drush --uri http://default sa --with-db --show-passwords --with-optional @self
$aliases["default"] = array (
  'root' => '/var/www/vagrant/html',
  'uri' => true,
  'path-aliases' =>
  array (
    '%drush' => '/opt/drush',
    '%site' => 'sites/1/',
  ),
  '%dump-dir' => '/tmp',
  'databases' =>
  array (
    'default' =>
    array (
      'default' =>
      array (
        'database' => 'dosomething',
        'username' => 'root',
        'password' => '',
        'host' => 'localhost',
        'port' => '3306',
        'driver' => 'mysql',
        'prefix' => '',
      ),
    ),
  ),
  '#file' => '/home/vagrant/.drush/ds.aliases.drushrc.php',
  '#name' => 'default',
);
```

I'm not sure if this is the right way to fix `@self` alias and why it suddenly broke.
Before that there was no explicit declaration of `@self`.
#### Existing vagrants

You need to copy this file to `.drush` to make it work:  
`cp -v /srv/salt/drush/ds.aliases.drushrc.php ~/.drush/ds.aliases.drushrc.php`

As an alternative, you can override aliases without fetching this PR:

```
curl https://raw.githubusercontent.com/sergii-tkachenko/dosomething/30343ffb37806e32f523ea3bf513935775b271b5/provision/salt/roots/salt/drush/ds.aliases.drushrc.php?token=672669__eyJzY29wZSI6IlJhd0Jsb2I6c2VyZ2lpLXRrYWNoZW5rby9kb3NvbWV0aGluZy8zMDM0M2ZmYjM3ODA2ZTMyZjUyM2VhM2JmNTEzOTM1Nzc1YjI3MWI1L3Byb3Zpc2lvbi9zYWx0L3Jvb3RzL3NhbHQvZHJ1c2gvZHMuYWxpYXNlcy5kcnVzaHJjLnBocCIsImV4cGlyZXMiOjE0MTAzMzc4NDZ9--02a2eeabcb6bb0134f4aa30e1aedabe9fbac9ca1 > ~/.drush/ds.aliases.drushrc.php
```

> **In both cases you may also need to clean the cache: `drush cc all`**

CC: @blisteringherb @aaronschachter @mshmsh5000 

EDIT:
- Sep 3, 2014: Direct link in curl updated, the old one doesn't work anymore.
