### PR TITLE
Fixes bug in Signup Data Form Shirt collector

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -282,7 +282,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     dosomething_user_address_form_element($form, $form_state);
     if (isset($config['shipment_item'])) {
       // Store the shipment item to create.
-      $form['item'] = array(
+      $form['shipment_item'] = array(
         '#type' => 'hidden',
         '#value' => $config['shipment_item'],
         '#access' => FALSE,

--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -30,7 +30,7 @@ function paraneue_dosomething_form_alter_shirt_options(&$form, &$form_state, $fo
   if ($form_id == 'dosomething_signup_user_signup_data_form') {
     // If we aren't collecting a shirt, item_header won't be set.
     // @see dosomething_signup_user_signup_data_form().
-    if (!isset($form['item_header'])) {
+    if (isset($form['shipment_item']) && ($form['shipment_item']['#value'] != 'shirt')) {
       // Exit out.
       return;
     }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -28,8 +28,9 @@ function paraneue_dosomething_form_alter_shirt_options(&$form, &$form_state, $fo
   }
   // If this is the User Signup Data Form:
   if ($form_id == 'dosomething_signup_user_signup_data_form') {
-    // If we aren't collecting an item:
-    if (!isset($form['item'])) {
+    // If we aren't collecting a shirt, item_header won't be set.
+    // @see dosomething_signup_user_signup_data_form().
+    if (!isset($form['item_header'])) {
       // Exit out.
       return;
     }
@@ -48,13 +49,13 @@ function paraneue_dosomething_form_alter_shirt_options(&$form, &$form_state, $fo
   $form['item']['#prefix'] = $shirt_style_prefix;
   $form['item']['#suffix'] = $shirt_style_suffix;
   $form['item']['#title'] = '<div class="label">' . t("Your Shirt Style") . '</div>';
-  $form['item_option']['#attributes'] = $size_attributes;
+  $form['item_option']['#attributes'] = $shirt_size_attributes;
   if (isset($form['item_additional'])) {
     $form['item_additional_header']['#markup'] = '<h3>' . t("Your Friend's Shirt") . '</h3>';
     $form['item_additional']['#attributes']['class'][] = $shirt_style_class;
     $form['item_additional']['#prefix'] = $style_prefix;
     $form['item_additional']['#suffix'] = $style_suffix;
     $form['item_additional']['#title'] = '<div class="label">' . t("Your Friend's Shirt Style") . '</div>'; 
-    $form['item_additional_option']['#attributes'] = $size_attributes;
+    $form['item_additional_option']['#attributes'] = $shirt_size_attributes;
   }
 }


### PR DESCRIPTION
Fixes https://jira.dosomething.org/browse/DS-274

Instead of trying to overwrite `$form['item']` from a hidden element to a radio, it adds the hidden element as `$form['shipment_item']`.  Also fixes variable name bug.
