### PR TITLE
API updates (Signup and Reportback)

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -39,6 +39,7 @@ function dosomething_api_services_resources() {
         'file' => array('type' => 'inc', 'module' => 'dosomething_api', 'name' => 'resources/campaign_resource'),
         'callback' => '_campaign_resource_index',
         'access callback' => '_campaign_resource_access',
+        'access arguments' => array('index'),
         'args' => array(
           array(
             'name' => 'parameters',

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -57,8 +57,8 @@ function dosomething_api_services_resources() {
         'file' => array('type' => 'inc', 'module' => 'dosomething_api', 'name' => 'resources/campaign_resource'),
         'callback' => '_campaign_resource_signup',
         'access callback' => '_campaign_resource_access',
-        //'access arguments' => array('signup'),
-        //'access arguments append' => TRUE,
+        'access arguments' => array('signup'),
+        'access arguments append' => TRUE,
         'args' => array(
           array(
             'name' => 'nid',

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -77,6 +77,28 @@ function dosomething_api_services_resources() {
           // ),
         ),
       ),
+      'reportback' => array(
+        'help' => 'Post a user reportback for a campaign: campaigns/123/reportback',
+        'file' => array('type' => 'inc', 'module' => 'dosomething_api', 'name' => 'resources/campaign_resource'),
+        'callback' => '_campaign_resource_reportback',
+        'access callback' => '_campaign_resource_access',
+        'args' => array(
+          array(
+            'name' => 'nid',
+            'optional' => FALSE,
+            'source' => array('path' => 0),
+            'type' => 'int',
+            'description' => 'The nid of the Campaign node to post a reportback.',
+          ),
+          array(
+            'name' => 'values',
+            'optional' => FALSE,
+            'source' => 'data',
+            'description' => 'The Reportback data',
+            'type' => 'array',
+          ),
+        ),
+      ),
     ),
   );
   return $resources;

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -51,6 +51,33 @@ function dosomething_api_services_resources() {
         ),
       ),
     ),
+    'targeted_actions' => array(
+      'signup' => array(
+        'help' => 'Signup a user for a campaign. POST to campaigns/123/signup',
+        'file' => array('type' => 'inc', 'module' => 'dosomething_api', 'name' => 'resources/campaign_resource'),
+        'callback' => '_campaign_resource_signup',
+        'access callback' => '_campaign_resource_access',
+        //'access arguments' => array('signup'),
+        //'access arguments append' => TRUE,
+        'args' => array(
+          array(
+            'name' => 'nid',
+            'optional' => FALSE,
+            'source' => array('path' => 0),
+            'type' => 'int',
+            'description' => 'The nid of the Campaign node to signup for.',
+          ),
+          // @todo: We'll want this for SMS campaigns where uid doesn't exist?
+          // array(
+          //   'name' => 'uid',
+          //   'optional' => TRUE,
+          //   'source' => array('data' => 'uid'),
+          //   'description' => 'The User uid to signup',
+          //   'type' => 'int',
+          // ),
+        ),
+      ),
+    ),
   );
   return $resources;
 }

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -12,6 +12,10 @@
  * @see node_access()
  */
 function _campaign_resource_access($op = 'view', $args = array()) {
+  if ($op == 'index') {
+    return TRUE;
+  }
+
   $node = node_load($args[0]);
 
   if ($op == 'view') {

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -42,3 +42,12 @@ function _campaign_resource_index($parameters) {
   return $index;
 }
 
+/**
+ * Callback for Campaigns signup targeted action.
+ */
+function _campaign_resource_signup($nid) {
+  // @todo: Pass parameter into signup_create whether or not to send SMS.
+  // Since SMS campaign signups would hit this endpoint, would not want 
+  // to send an additional "You've signed up text".
+  return dosomething_signup_create($nid);
+}

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -43,11 +43,50 @@ function _campaign_resource_index($parameters) {
 }
 
 /**
- * Callback for Campaigns signup targeted action.
+ * Callback for Campaigns Signup targeted action.
  */
 function _campaign_resource_signup($nid) {
   // @todo: Pass parameter into signup_create whether or not to send SMS.
   // Since SMS campaign signups would hit this endpoint, would not want 
   // to send an additional "You've signed up text".
   return dosomething_signup_create($nid);
+}
+
+/**
+ * Callback for Campaigns Reportback targeted action.
+ *
+ * @param int $nid
+ *   The Node nid to post the reportback to.
+ * @param array $values
+ *   The reportback data to post. Expected keys:
+ *   - uid: The user uid (int).  Optional, uses global $user if not set.
+ *   - file_url: The URL of the reportback file.
+ *   - quantity (int).
+ *   - why_participated (string).
+ *   - num_participants (int).
+ */
+function _campaign_resource_reportback($nid, $values) {
+  // @todo: Return error if signup doesn't exist.
+  $values['nid'] = $nid;
+  if (!isset($values['uid'])) {
+    global $user;
+    $values['uid'] = $user->uid;
+  }
+  $uid = $values['uid'];
+
+  // Create a file from the $file_url.
+  $file = dosomething_reportback_save_file_from_url($nid, $uid, $values['file_url']);
+  if (!$file) {
+    return FALSE;
+  }
+  $values['fid'] = $file->fid;
+
+  // @todo: Move this logic into dosomething_reportback_save().
+  $rbid = dosomething_reportback_exists($nid, $uid);
+  if (!$rbid) {
+    $rbid = 0;
+  }
+  $values['rbid'] = $rbid;
+
+  return dosomething_reportback_save($values);
 }

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -1,10 +1,29 @@
 <?php
 
 /**
- * Access callback for Campaign resources.
+ * Determine whether the current user can access a node resource.
+ *
+ * @param string $op
+ *   Possible values of view, signup, reportback.
+ * @param array $args
+ *   Resource arguments passed through from the original request.
+ * @return bool
+ *
+ * @see node_access()
  */
-function _campaign_resource_access() {
-  return TRUE;
+function _campaign_resource_access($op = 'view', $args = array()) {
+  $node = node_load($args[0]);
+
+  if ($op == 'view') {
+    return node_access($op, $node);
+  }
+
+  if (dosomething_campaign_is_active($node)) {
+    return TRUE;
+    //@todo: If op==reportback and SMS Game, return 403 error.
+  }
+
+  return services_error(t('Campaign node @nid is not active.', array('@nid' => $node->nid)), 403);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -522,6 +522,19 @@ function dosomething_campaign_is_closed($node) {
 }
 
 /**
+ * For given campaign $node, determines if it is active.
+ *
+ * @param obj $node
+ *   A loaded node.
+ *
+ * @return bool
+ */
+function dosomething_campaign_is_active($node) {
+  // Node must be published, and campaign status != closed.
+  return $node->status == 1 && !dosomething_campaign_is_closed($node);
+}
+
+/**
  * Returns array of nid's of recommended campaigns for $uid.
  *
  * First finds published staff pick campaigns that user has not signed up for.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -827,55 +827,6 @@ function dosomething_reportback_services_resources() {
         'access callback' => '_dosomething_reportback_resource_access',
       ),
     ),
-    'actions' => array(
-      'save' => array(
-        'help'   => 'Creates or updates a reportback for given uid and nid.',
-        'file' => array(
-          'type' => 'inc',
-          'module' => 'dosomething_reportback',
-          'name' => 'resources/dosomething_reportback.resource',
-        ),
-        'callback' => '_dosomething_reportback_resource_save',
-        'access callback' => '_dosomething_reportback_resource_access',
-        'args' => array(
-          array(
-            'name' => 'uid',
-            'optional' => FALSE,
-            'source' => array('data' => 'uid'),
-            'description' => t('The uid of the user reporting back.'),
-            'type' => 'int',
-          ),
-          array(
-            'name' => 'nid',
-            'optional' => FALSE,
-            'source' => array('data' => 'nid'),
-            'description' => t('The nid of node the user is reporting back for.'),
-            'type' => 'int',
-          ),
-          array(
-            'name' => 'quantity',
-            'optional' => FALSE,
-            'source' => array('data' => 'quantity'),
-            'description' => t('The reportback quantity.'),
-            'type' => 'int',
-          ),
-          array(
-            'name' => 'why_participated',
-            'optional' => FALSE,
-            'source' => array('data' => 'why_participated'),
-            'description' => t('The reportback reason.'),
-            'type' => 'int',
-          ),
-          array(
-            'name' => 'file_url',
-            'optional' => FALSE,
-            'source' => array('data' => 'file_url'),
-            'description' => t('The URL of the reportback image.'),
-            'type' => 'string',
-          ),
-        ),
-      ),
-    ),
   );
   return $resources;
 }

--- a/lib/modules/dosomething/dosomething_reportback/resources/dosomething_reportback.resource.inc
+++ b/lib/modules/dosomething/dosomething_reportback/resources/dosomething_reportback.resource.inc
@@ -26,29 +26,3 @@ function _dosomething_reportback_resource_retrieve($rbid) {
     return FALSE;
   }
 }
-
-/**
- * Callback for Reportback resource save.
- */
-function _dosomething_reportback_resource_save($uid, $nid, $quantity, $why_participated, $file_url) {
-  // Create a file from the $file_url.
-  $file = dosomething_reportback_save_file_from_url($nid, $uid, $file_url);
-  if (!$file) {
-    return FALSE;
-  }
-  // @todo: Move this logic into dosomething_reportback_save().
-  $rbid = dosomething_reportback_exists($nid, $uid);
-  if (!$rbid) {
-    $rbid = 0;
-  }
-  // Prepare values for save.
-  $values = array(
-    'rbid' => $rbid,
-    'uid' => $uid,
-    'nid' => $nid,
-    'quantity' => $quantity,
-    'why_participated' => $why_participated,
-    'fid' => $file->fid,
-  );
-  return dosomething_reportback_save($values);
-}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -135,8 +135,15 @@ function dosomething_signup_admin_paths() {
  *   The sid of the newly inserted signup, or FALSE if error.
  */
 function dosomething_signup_create($nid, $uid = NULL, $data = NULL, $timestamp = NULL) {
+  if ($uid == NULL) {
+    global $user;
+    $uid = $user->uid;
+  }
   // If a signup already exists, exit.
   if (dosomething_signup_exists($nid, $uid)) { return FALSE; }
+
+  // @todo: If the campaign is closed, return error.
+  // @todo: If campaign is unpublished and non-staff $uid, return error.
 
   $values = array(
     'nid' => $nid,


### PR DESCRIPTION
Provides `campaigns/[nid]/signup` and `campaigns/[nid]/reportback` endpoints.  This won't be enabled on production, but has been added for SMS flow, when we're ready.

Removes the `reportback/save` resource from `dosomething_reportback` module
