### PR TITLE
DS-303 Update validation to accept any country code & spacing.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -175,7 +175,7 @@ function dosomething_user_get_staff_only_types() {
   *   True if valid, else false.
   */
 function dosomething_user_valid_mobile($number) {
-  preg_match('#^(?:\+?1([\-\s\.]{1})?)?\(?([0-9]{3})\)?(?:[\-\s\.]{1})?([0-9]{3})(?:[\-\s\.]{1})?([0-9]{4})#', $number, $valid);
+  preg_match('#^(?:\+?([0-9]{1,3})([\-\s\.]{1})?)?\(?([0-9]{3})\)?(?:[\-\s\.]{1})?([0-9]{3})(?:[\-\s\.]{1})?([0-9]{4})#', preg_replace('#\-\s\.#', '', $number), $valid);
   preg_match('#([0-9]{1})\1{9,}#', preg_replace('#[^0-9]+#', '', $number), $repeat);
   return !empty($valid) && empty($repeat);
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -175,7 +175,7 @@ function dosomething_user_get_staff_only_types() {
   *   True if valid, else false.
   */
 function dosomething_user_valid_mobile($number) {
-  preg_match('#^(?:\+?([0-9]{1,3})([\-\s\.]{1})?)?\(?([0-9]{3})\)?(?:[\-\s\.]{1})?([0-9]{3})(?:[\-\s\.]{1})?([0-9]{4})#', preg_replace('#\-\s\.#', '', $number), $valid);
+  preg_match('#^(?:\+?([0-9]{1,3})([\-\s\.]{1})?)?\(?([0-9]{3})\)?(?:[\-\s\.]{1})?([0-9]{3})(?:[\-\s\.]{1})?([0-9]{4})#', preg_replace('#[\-\s\.]#', '', $number), $valid);
   preg_match('#([0-9]{1})\1{9,}#', preg_replace('#[^0-9]+#', '', $number), $repeat);
   return !empty($valid) && empty($repeat);
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.test
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.test
@@ -26,6 +26,8 @@ class DosomethingUserUnitTestCase extends DrupalUnitTestCase {
     $country = '1-718-224-9982';
     $stuff = '1 (718) 224.9982';
     $plus = '+1 (718) 224-9982';
+    $international_number = '07708 200 305';
+    $international_number_with_country_code = '+44 07708 200 305';
     $too_short = '718-224';
     $even_worse = 'abcdefg';
     $bad_punctuation = '718#224_9982';
@@ -36,6 +38,8 @@ class DosomethingUserUnitTestCase extends DrupalUnitTestCase {
     $this->assertTrue(dosomething_user_valid_mobile($country));
     $this->assertTrue(dosomething_user_valid_mobile($stuff));
     $this->assertTrue(dosomething_user_valid_mobile($plus));
+    $this->assertTrue(dosomething_user_valid_mobile($international_number));
+    $this->assertTrue(dosomething_user_valid_mobile($international_number_with_country_code));
     $this->assertFalse(dosomething_user_valid_mobile($too_short));
     $this->assertFalse(dosomething_user_valid_mobile($even_worse));
     $this->assertFalse(dosomething_user_valid_mobile($bad_punctuation));

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.test
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.test
@@ -26,7 +26,6 @@ class DosomethingUserUnitTestCase extends DrupalUnitTestCase {
     $country = '1-718-224-9982';
     $stuff = '1 (718) 224.9982';
     $plus = '+1 (718) 224-9982';
-    $bad = '718-555-2234';
     $too_short = '718-224';
     $even_worse = 'abcdefg';
     $bad_punctuation = '718#224_9982';
@@ -37,7 +36,6 @@ class DosomethingUserUnitTestCase extends DrupalUnitTestCase {
     $this->assertTrue(dosomething_user_valid_mobile($country));
     $this->assertTrue(dosomething_user_valid_mobile($stuff));
     $this->assertTrue(dosomething_user_valid_mobile($plus));
-    $this->assertFalse(dosomething_user_valid_mobile($bad));
     $this->assertFalse(dosomething_user_valid_mobile($too_short));
     $this->assertFalse(dosomething_user_valid_mobile($even_worse));
     $this->assertFalse(dosomething_user_valid_mobile($bad_punctuation));

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
@@ -192,8 +192,10 @@ define(function(require) {
   // Matches validation performed in dosomething_user.module.
   Validation.registerValidationFunction("phone", function(string, done) {
     // Matches server-side validation from `dosomething_user_valid_cell()` in `dosomething_user.module`.
+    var numberWithoutFormatting = string.replace(/[\-\s\.]/g, "");
+    var isValidFormat = /^(?:\+?([0-9]{1,3})([\-\s\.]{1})?)?\(?([0-9]{3})\)?(?:[\-\s\.]{1})?([0-9]{3})(?:[\-\s\.]{1})?([0-9]{4})/.test(numberWithoutFormatting);
+
     var sanitizedNumber = string.replace(/[^0-9]/g, "");
-    var isValidFormat = /^(?:\+?1([\-\s\.]{1})?)?\(?([0-9]{3})\)?(?:[\-\s\.]{1})?([0-9]{3})(?:[\-\s\.]{1})?([0-9]{4})/.test(string);
     var allRepeatingDigits = /([0-9]{1})\1{9,}/.test(sanitizedNumber);
 
     if(isValidFormat && !allRepeatingDigits) {

--- a/tests/unit/validation.js
+++ b/tests/unit/validation.js
@@ -191,6 +191,18 @@ describe("Validation", function(){
         assert.isFalse(result.success);
       });
     });
+
+    it("should accept number with non-US formatting", function() {
+      Validations.phone.fn("44 07708 200 305", function(result) {
+        assert.isTrue(result.success);
+      });
+    });
+
+    it("should accept number with non-US country code", function() {
+      Validations.phone.fn("44 07708 200 305", function(result) {
+        assert.isTrue(result.success);
+      });
+    });
   });
 
 


### PR DESCRIPTION
## Changes
- Client-side and server-side phone number validation now (optionally) accepts any three-digit country code.
- Validation no longer checks for US-centric `### ### ####` grouping of digits, to allow for alternative spacing like `#### ### ###` for our brethren across the pond.

This addresses [DS-303](https://jira.dosomething.org/browse/DS-303), although we probably want to make a second pass at this in the future to validate specific country codes for each international region.
## How do I test this?

Try to break each validation function. Client-side validation function passes test suite, and can be manually tested by entering text into the phone number field in browser. The server-side validation function should be able to be tested with Drush.
