### PR TITLE
United Kingdom: Push new user registrations to vInspired SSO.

### DIFF
--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.info
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.info
@@ -2,12 +2,12 @@ name = DoSomething UK
 description = Provides functionality specific to DoSomething UK international affiliate
 core = 7.x
 package = DoSomething
-version = 7.x-0.2
+version = 7.x-0.3
 project = dosomething_uk
 
 ; Core
 dependencies[] = user
-dependencies[] = date
+dependencies[] = date_api
 
 ; Contrib
 dependencies[] = oauth_common
@@ -18,4 +18,5 @@ dependencies[] = http_client_oauth
 dependencies[] = dosomething_user
 
 files[] = includes/dosomething_uk_sso_controller.inc
-files[] = includes/dosomething_uk_sso_user_impersonator.inc
+files[] = includes/dosomething_uk_sso_impersonator.inc
+files[] = includes/dosomething_uk_sso_user.inc

--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
@@ -5,7 +5,9 @@
  * TODO: set oauth_common_enable_provider = false;
  */
 define('DOSOMETHING_UK_WATCHDOG', 'dosomething_uk');
-define('DOSOMETHING_UK_USER_SOURCE', 'dosomething_uk');
+
+// @todo: define debugging mode.
+// require_once dirname(__FILE__) . '/misc/dosomething_uk-example.inc';
 
 // -----------------------------------------------------------------------
 // Hook implementations.
@@ -26,30 +28,31 @@ function dosomething_uk_module_implements_alter(&$implementations, $hook) {
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
- *
- * Form user_login.
+ * Implements hook_form_FORM_ID_alter() form user_login_form().
  */
 function dosomething_uk_form_user_login_alter(&$form, &$form_state, $form_id) {
-  array_unshift($form['#validate'], 'dosomething_uk_login_validate');
+  _dosomething_alter_login($form);
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
- *
- * Form user_login_block.
+ * Implements hook_form_FORM_ID_alter() form user_login_block_form().
  */
 function dosomething_uk_form_user_login_block_alter(&$form, &$form_state) {
-  array_unshift($form['#validate'], 'dosomething_uk_login_validate');
+  _dosomething_alter_login($form);
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
- *
- * Form user_register.
+ * Implements hook_form_FORM_ID_alter() form user_register_form().
  */
 function dosomething_uk_form_user_register_form_alter(&$form, $form_state) {
-  array_unshift($form['#submit'], 'dosomething_uk_register_validate');
+  _dosomething_alter_registration($form);
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() form user_profile_form().
+ */
+function dosomething_uk_form_user_profile_form_alter(&$form, $form_state) {
+  // @todo Implement profile sync.
 }
 
 // -----------------------------------------------------------------------
@@ -67,18 +70,24 @@ function dosomething_uk_login_validate($form, &$form_state) {
   }
 
   $name = $values['name'];
-  $pass = $values['pass'];
+  $password = $values['pass'];
 
   // Check whether local account exists.
   $account = dosomething_user_get_user_by_email($name);
 
   // Process user with existing local account:
   if ($account) {
-    dosomething_uk_process_existing_user($name, $pass, $account);
+    dosomething_uk_process_existing_user($name, $password, $account);
   }
   else {
-    $account = dosomething_uk_process_new_user($name, $pass);
-    form_set_value($form['name'], $account->name, $form_state);
+    $account = dosomething_uk_process_new_user($name, $password);
+    if ($account) {
+      form_set_value($form['name'], $account->name, $form_state);
+    }
+    else {
+      // @todo: Log unexpected response.
+      // form_set_error('name', t('Something went wrong.'));
+    }
   }
 }
 
@@ -86,17 +95,52 @@ function dosomething_uk_login_validate($form, &$form_state) {
  * Validates user_register.
  */
 function dosomething_uk_register_validate($form, &$form_state) {
-  // var_dump($form_state['values']); die();
-  // Todo: save.
+  if (form_get_errors()) {
+    return FALSE;
+  }
+  $values = &$form_state['values'];
+
+  // User data.
+  $dob = new DateObject($values['field_birthdate'][LANGUAGE_NONE][0]['value']);
+  $user_data = array(
+    'first_name' => $values['field_first_name'][LANGUAGE_NONE][0]['value'],
+    'password'   => $values['pass'],
+    'email'      => $values['mail'],
+    'dob'        => $dob,
+    // $values['field_last_name'][LANGUAGE_NONE][0]['value']
+    // @todo: add last_name field to the registration form.
+    'last_name'  => 'Harkness',
+    // @todo: add postcode field to the registration form.
+    // Until then everybody is living in Torchwood.
+    'postcode'   => 'CF10 5AN',
+  );
+  $sso_user = DosomethingUkSsoUser::fromArray($user_data);
+  $sso = DosomethingUkSsoController::signup($sso_user);
+  $result = $sso->getLastResult();
+
+  if (!$result) {
+    if ($error_messages = $sso->getErrorMessages()) {
+      dosomething_uk_remote_errors_to_local_form($error_messages, $form);
+    }
+
+    if (!form_get_errors()) {
+      // @todo: Log unexpected response.
+      // form_set_error('form', t('Something went wrong.'));
+      throw new Exception("Response messages parsing error ");
+    }
+    return FALSE;
+  }
+
+  return TRUE;
 }
 
 // -----------------------------------------------------------------------
 // OAuth processing.
 
-function dosomething_uk_process_existing_user($name, $pass, $account) {
+function dosomething_uk_process_existing_user($name, $password, $account) {
   // Check whether the user is already authrorized on SSO.
-  $sso = DosomethingUkSsoController::initForUser($account->uid);
-  if ($sso->isAuthrizedForRemoteApi()) {
+  $sso = DosomethingUkSsoController::initForLocalUser($account->uid);
+  if ($sso->remoteUserAdmitted()) {
     // Todo: update local password and/or profile data.
     return TRUE;
   }
@@ -105,24 +149,24 @@ function dosomething_uk_process_existing_user($name, $pass, $account) {
   return TRUE;
 }
 
-function dosomething_uk_process_new_user($name, $pass) {
+function dosomething_uk_process_new_user($name, $password) {
   // Check whether remote account with requested name exists:
   try {
     $sso = DosomethingUkSsoController::init()->authorizeRemoteRedirect();
-    $remote_account = dosomething_uk_authorize_remote_user($name, $pass, $sso);
+    $sso_user = dosomething_uk_authorize_remote_user($name, $password, $sso);
   }
   catch (Exception $e) {
     form_set_error('name', t('Unexpected login error.'));
     return FALSE;
   }
 
-  if (!$remote_account) {
+  if (!$sso_user) {
     // Todo: link to forgot password page.
     form_set_error('name', t('Sorry, unrecognized username or password.'));
     return FALSE;
   }
 
-  $account = dosomething_uk_new_user_from_remote($name, $pass, $remote_account);
+  $account = dosomething_uk_new_user_from_remote($name, $password, $sso_user);
   if (!$account) {
     return FALSE;
   }
@@ -133,43 +177,51 @@ function dosomething_uk_process_new_user($name, $pass) {
 // -----------------------------------------------------------------------
 // OAuth helpers.
 
-function dosomething_uk_authorize_remote_user($name, $pass, $sso) {
+function dosomething_uk_authorize_remote_user($name, $password, $sso) {
   $url = $sso->getAuthorizationUrl(TRUE, TRUE);
   if (!$url) {
     throw new Exception('Unexpected login error: request token.');
   }
 
-  // Authorize remote user with given credentials:
-  $result = DosomethingUkUserImpersonator::init($name, $pass)->authorize($url);
-  if (!$result) {
+  // Impersonate remote user logged into SSO.
+  $impersonator = DosomethingUkSsoImpersonator::login($name, $password);
+
+  if (!$impersonator->isLoggedIn()) {
     // Todo: link to forgot password page.
     // Remote login failed: wrong credentials.
     return FALSE;
   }
 
-  // Retrieve remote account:
-  $remote_account = $sso->authorizeAccessToken()->getRemoteUser();
-  if (!$remote_account) {
+  // Accept OAuth authorization impersonating SSO user.
+  if (!$impersonator->acceptRemoteOAuth($url)) {
+    // Todo: session expired.
+    // @see /includes/form.inc:1173
+    throw new Exception('The form has become outdated.');
+  }
+
+  // Retrieve SSO user data.
+  $sso_user = $sso->authorizeAccessToken()->getRemoteUser();
+  if (!$sso_user) {
     throw new Exception('Unexpected login error: request token.');
   }
-  return $remote_account;
+  return $sso_user;
 }
 
-function dosomething_uk_new_user_from_remote($name, $pass, $remote_account) {
+function dosomething_uk_new_user_from_remote($name, $password, $sso_user) {
   $edit = array(
     'mail'    => $name,
     'name'    => $name,
-    'pass'    => $pass,
+    'pass'    => $password,
     'status'  => 1,
     'created' => REQUEST_TIME,
   );
 
-  $dob = new DateObject($remote_account['dob']);
+  $dob = new DateObject($sso_user['dob']);
   $fields = array(
     'birthdate'  => $dob->format(DATE_FORMAT_DATE),
-    'first_name' => $remote_account['first_name'],
-    'last_name'  => $remote_account['last_name'],
-    'user_registration_source' => DOSOMETHING_UK_USER_SOURCE,
+    'first_name' => $sso_user['first_name'],
+    'last_name'  => $sso_user['last_name'],
+    'user_registration_source' => DosomethingUkSsoUser::REGISTRATION_SOURCE,
   );
   _dosomething_uk_utility_set_user_fields($edit, $fields);
   try {
@@ -183,6 +235,28 @@ function dosomething_uk_new_user_from_remote($name, $pass, $remote_account) {
 
 // -----------------------------------------------------------------------
 // Miscellaneous.
+
+function _dosomething_alter_login(&$form) {
+  // Run login validator **BEFORE** everything else.
+  array_unshift($form['#validate'], 'dosomething_uk_login_validate');
+}
+
+function _dosomething_alter_registration(&$form) {
+  // Run registration validator **AFTER** everything else.
+  array_push($form['#validate'], 'dosomething_uk_register_validate');
+}
+
+function dosomething_uk_remote_errors_to_local_form($error_messages, &$form) {
+  foreach ($error_messages as $field_name => $field_errors) {
+    foreach ($field_errors as $error) {
+      // @todo Map and assign fields.
+      // @todo Fix message 'Sorry, but vinspired is only for 14 to 25 year olds'
+      $human_name = ucwords(preg_replace('/[^\da-z]/i', ' ', $field_name));
+      $error_text = $human_name . ': ' . $error;
+      form_set_error($field_name, $error_text);
+    }
+  }
+}
 
 function _dosomething_uk_utility_set_user_fields(&$values, $fields) {
   foreach ($fields as $field_key => $field_value) {

--- a/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_controller.inc
+++ b/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_controller.inc
@@ -26,7 +26,8 @@ class DosomethingUkSsoController {
   const AUTHORIZED_USER_ACCESS     = 5;
 
   // Endpoints.
-  const ENDPOINT_CURRENT_USER = '/users/current';
+  const ENDPOINT_USER_SHOW_CURRENT = '/users/current';
+  const ENDPOINT_USER_CREATE       = '/signup';
 
   // Other.
   const DEBUG                      = 1;
@@ -68,7 +69,7 @@ class DosomethingUkSsoController {
 
   /**
    * [$parser description]
-   * @var HttpClientBaseFormatter
+   * @var HttpClientFormatter
    */
   private $parser;
 
@@ -115,16 +116,22 @@ class DosomethingUkSsoController {
   private $http_client;
 
   /**
-   * [$last description]
+   * [$last_result description]
    * @var string
    */
-  private $last;
+  private $last_result;
+
+  /**
+   * [$error_messages description]
+   * @var string
+   */
+  private $error_messages;
 
   // ---------------------------------------------------------------------
   // Constructor and factories
 
   /**
-   *
+   * Constructs a DosomethingUkSsoController object.
    */
   public function __construct()
   {
@@ -133,30 +140,34 @@ class DosomethingUkSsoController {
     global $base_url;
 
     // OAuth credentials.
-    $this->url = variable_get('dosomething_uk_oauth_url');
-    $this->key      = variable_get('dosomething_uk_oauth_key');
-    $this->secret   = variable_get('dosomething_uk_oauth_secret');
+    $this->url    = variable_get('dosomething_uk_oauth_url');
+    $this->key    = variable_get('dosomething_uk_oauth_key');
+    $this->secret = variable_get('dosomething_uk_oauth_secret');
     if (!$this->url || !$this->key || !$this->secret) {
       throw new OAuthException("Insufficient OAuth configuration.");
     }
 
     // Optional callback.
-    $this->callback = variable_get('dosomething_uk_oauth_callback', $url);
+    $this->callback = variable_get('dosomething_uk_oauth_callback', $base_url);
 
     // HTTP client settings.
     $this->cipher = DrupalOAuthClient::signatureMethod(self::SIGNATURE_METHOD);
     $this->parser = new HttpClientBaseFormatter(self::PARSE_METHOD);
 
     // Defaults.
-    $this->uid         = FALSE;
-    $this->http_client = FALSE;
+    $this->keymaker       = FALSE;
+    $this->consumer       = FALSE;
+    $this->request_token  = FALSE;
+    $this->access_token   = FALSE;
+    $this->uid            = FALSE;
+    $this->clearance      = self::AUTHORIZED_NONE;
+    $this->http_client    = FALSE;
+    $this->last_result    = FALSE;
+    $this->error_messages = FALSE;
   }
 
   /**
-   * Initialize class using saved user's access token.
-   *
-   * @param int $uid
-   *   Integer specifying the user ID to load access for.
+   *  Static class builder.
    *
    * @return static
    */
@@ -174,13 +185,106 @@ class DosomethingUkSsoController {
    *
    * @return static
    */
-  public static function initForUser($uid) {
+  public static function initForLocalUser($uid) {
     $instance = new self();
     $instance->uid = $uid;
     $instance->authorize($uid);
     return $instance;
   }
 
+public static function signup(DosomethingUkSsoUser $sso_user) {
+    $instance = new self();
+    $instance->setupConsumer();
+    $instance->setupRemoteClient();
+    // @todo: Find a place to keep the user.
+    $user = $instance->createRemoteUser($sso_user);
+    // @todo: Assign perishable token.
+    return $instance;
+  }
+
+  // ---------------------------------------------------------------------
+  // Public: remote API calls
+
+  public function remoteUserAdmitted()
+  {
+    return !!$this->http_client;
+  }
+
+  public function getRemoteUser()
+  {
+    return $this->getRemote(self::ENDPOINT_USER_SHOW_CURRENT);
+  }
+
+  public function createRemoteUser(DosomethingUkSsoUser $sso_user)
+  {
+    $sso_user = $this->createRemote(
+      self::ENDPOINT_USER_CREATE, $sso_user->toFormFields()
+    );
+    return $sso_user;
+  }
+
+  /**
+   * Performs a GET request to the remote API.
+   *
+   * @param  string $path
+   *   Endpoint path on the remote server.
+   *
+   * @return mixed
+   *   Remote response parsed to PHP compound type
+   */
+  public function getRemote($path)
+  {
+    if (!$this->remoteUserAdmitted()) {
+      return FALSE;
+    }
+
+    $this->error_messages = FALSE;
+    $this->last_result    = FALSE;
+
+    try {
+      $this->last_result = $this->http_client->get($this->apiPath($path));
+      // @todo: parse result like it's done in createRemote().
+    }
+    catch (Exception $e) {
+      $this->logExeption($e);
+    }
+    return $this->last_result;
+  }
+
+  /**
+   * Performs a POST request to the remote API.
+   *
+   * @param  string $path
+   *   Endpoint path on the remote server.
+   *
+   * @return mixed
+   *   Remote response parsed to PHP compound type
+   */
+  public function createRemote($path, $data)
+  {
+    if (!$this->remoteUserAdmitted()) {
+      return FALSE;
+    }
+
+    $this->error_messages = FALSE;
+    $this->last_result    = FALSE;
+
+    try {
+      $this->last_result = $this->http_client->post($this->apiPath($path), NULL, $data);
+    }
+    catch (HttpClientException $e) {
+      $this->processResponseErrorMessages($e);
+      if (!$this->error_messages) {
+        // Abnormal response: unexpected HTTP code or no body.
+        $this->logExeption($e);
+      }
+    }
+    catch (Exception $e) {
+      $this->logExeption($e);
+    }
+
+    return $this->last_result;
+  }
 
   // ---------------------------------------------------------------------
   // Public: getters
@@ -196,6 +300,16 @@ class DosomethingUkSsoController {
   public function getClearance()
   {
     return $this->clearance;
+  }
+
+  public function getLastResult()
+  {
+    return $this->last_result;
+  }
+
+  public function getErrorMessages()
+  {
+    return $this->error_messages;
   }
 
   public function getAuthorizationUrl($relative = FALSE, $skip_callback = FALSE)
@@ -222,58 +336,19 @@ class DosomethingUkSsoController {
     return $parsed['path'] . '?' . $parsed['query'];
   }
 
-  public function isAuthrizedForRemoteApi()
-  {
-    return !!$this->http_client;
-  }
-
-  // ---------------------------------------------------------------------
-  // Public: remote API calls
-
-  /**
-   * Performs a GET request to the remote API.
-   *
-   * @param  string $path
-   *   Endpoint path on the remote server.
-   *
-   * @return mixed
-   *   Remote response parsed to PHP compound type
-   */
-  public function get($path)
-  {
-    if (!$this->isAuthrizedForRemoteApi()) {
-      return FALSE;
-    }
-
-    $result = FALSE;
-    try {
-      $result = $this->http_client->get($this->apiPath($path));
-    }
-    catch (Exception $e) {
-      $this->logExeption($e);
-    }
-    $this->last = $result;
-    return $result;
-  }
-
-  public function getRemoteUser()
-  {
-    return $this->get(self::ENDPOINT_CURRENT_USER);
-  }
-
   // ---------------------------------------------------------------------
   // Public: auth flow
 
   public function authorize()
   {
-    $this->initOAuthConsumer();
-    $this->initClearance();
+    $this->setupConsumer();
+    $this->checkClearance();
 
     if ($this->clearance < self::AUTHORIZED_ACCESS_TOKEN) {
-      $this->initKeymaker();
+      $this->setupKeymaker();
     }
     else {
-      $this->enableApiCalls();
+      $this->admitRemoteUser();
     }
     return $this;
   }
@@ -372,7 +447,7 @@ class DosomethingUkSsoController {
     $this->request_token->delete();
     $this->destroyProdigalUserSession();
     $this->clearance = self::AUTHORIZED_ACCESS_TOKEN;
-    $this->enableApiCalls();
+    $this->admitRemoteUser();
     return $this;
   }
 
@@ -395,7 +470,7 @@ class DosomethingUkSsoController {
   // ---------------------------------------------------------------------
   // Private: initialization
 
-  private function initClearance()
+  private function checkClearance()
   {
     // Check if self::AUTHORIZED_USER_ACCESS. From saved user access token:
     if ($this->uid) {
@@ -429,7 +504,17 @@ class DosomethingUkSsoController {
     return TRUE;
   }
 
-  private function initKeymaker()
+  private function admitRemoteUser()
+  {
+    if ($this->clearance < self::AUTHORIZED_ACCESS_TOKEN) {
+      // Todo: watchdog.
+      return FALSE;
+    }
+
+    $this->setupRemoteClient();
+  }
+
+  private function setupKeymaker()
   {
     switch ($this->clearance) {
       case self::AUTHORIZED_USER_RETURNED:
@@ -443,7 +528,7 @@ class DosomethingUkSsoController {
     }
   }
 
-  private function initOAuthConsumer()
+  private function setupConsumer()
   {
     if ($this->consumer) {
       return FALSE;
@@ -465,21 +550,19 @@ class DosomethingUkSsoController {
     return TRUE;
   }
 
-  // ---------------------------------------------------------------------
-  // Private: utilities
-
-  private function enableApiCalls()
+  private function setupRemoteClient()
   {
-    if ($this->clearance < self::AUTHORIZED_ACCESS_TOKEN) {
-      // Todo: watchdog.
-      return FALSE;
-    }
+    $oauth = new HttpClientOAuth(
+      $this->consumer, $this->access_token, $this->cipher, FALSE, TRUE
+    );
 
-    $authentication = new HttpClientOAuth(
-        $this->consumer, $this->access_token, $this->cipher, TRUE, TRUE);
-
-    $this->http_client = new HttpClient($authentication, $this->parser);
+    $this->http_client = new HttpClient();
+    $this->http_client->setFormatter($this->parser);
+    $this->http_client->setAuthentication($oauth);
   }
+
+  // ---------------------------------------------------------------------
+  // Private: getters/setters
 
   private function getStoredRequestToken($request_token_key)
   {
@@ -521,6 +604,38 @@ class DosomethingUkSsoController {
   {
     $_SESSION[self::PRODIGAL_USER_SESSION_NAME] = null;
     unset($_SESSION[self::PRODIGAL_USER_SESSION_NAME]);
+  }
+
+  // ---------------------------------------------------------------------
+  // Private: utilities
+
+  private function processResponseErrorMessages(HttpClientException $http_error) {
+    // Allow the following HTTP codes:
+    // - 422 Unprocessable Entity
+    $allowed_http_codes = array(422);
+    if (!in_array($http_error->getCode(), $allowed_http_codes)) {
+      return FALSE;
+    }
+
+    // Retrieve HTTP response body text.
+    $response = $http_error->getResponse();
+    if (!is_object($response) || empty($response->body)) {
+      return FALSE;
+    }
+
+    self::logDebug('Response error messages: ' . $response->body);
+
+    // Process response to PHP data types.
+    try {
+      $this->error_messages = $this->parser->unserialize($response->body);
+    }
+    catch (Exception $e) {
+      // Deserialization failed.
+      // @see HttpClientBaseFormatter::unserialize()
+      throw new HttpClientException($e->getMessage(), 0, $response, $e);
+    }
+
+    return TRUE;
   }
 
   private function apiPath($path) {

--- a/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_impersonator.inc
+++ b/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_impersonator.inc
@@ -3,7 +3,7 @@
 /**
  * A http client.
  */
-class DosomethingUkUserImpersonator {
+class DosomethingUkSsoImpersonator {
 
 
   // ---------------------------------------------------------------------
@@ -24,7 +24,7 @@ class DosomethingUkUserImpersonator {
 
   // Other.
   const USER_AGENT  = 'Drupal (+https://www.dosomething.org/)';
-  const LOGGER_NAME = 'DosomethingUkUserImpersonator';
+  const LOGGER_NAME = 'DosomethingUkSsoImpersonator';
 
 
   // ---------------------------------------------------------------------
@@ -59,7 +59,7 @@ class DosomethingUkUserImpersonator {
   // Constructor and factories
 
   /**
-   *
+   * Constructs a DosomethingUkSsoImpersonator object.
    */
   public function __construct()
   {
@@ -69,45 +69,50 @@ class DosomethingUkUserImpersonator {
     $this->last    = new stdClass();
   }
 
-  public static function init($login, $password) {
+  /**
+   * Returns remotely authorized impersonator.
+   *
+   * @param string $login
+   *   The login of the remote user.
+   * @param string $password
+   *   The password of the remote user.
+   *
+   * @return static
+   */
+  public static function login($login, $password) {
     $instance = new self();
-    $instance->login($login, $password);
+    $instance->impersonateRemoteUser($login, $password);
     return $instance;
   }
 
   // ---------------------------------------------------------------------
-  // Public: getters
+  // Public: field accessors
 
-
-  public function isAuthorized()
+  public function isLoggedIn()
   {
-    return !empty($this->session);
+    return (bool) $this->session;
   }
 
   // ---------------------------------------------------------------------
   // Public: remote API calls
 
-  /**
-   *
-   */
-  public function get($path)
+  public function getRemote($path)
   {
-    if (!$this->isAuthorized()) {
+    if (!$this->isLoggedIn()) {
       return FALSE;
     }
-    $response = drupal_http_request($this->apiPath($path), $this->options());
+    $response = drupal_http_request($this->apiPath($path), $this->defaults());
     $this->last = $response;
     return $response;
   }
 
-
-  public function authorize($path)
+  public function acceptRemoteOAuth($path)
   {
-    if (!$this->isAuthorized()) {
+    if (!$this->isLoggedIn()) {
       return FALSE;
     }
     $result = FALSE;
-    $response = $this->get($path);
+    $response = $this->getRemote($path);
 
     // Validate result.
     // Success condition: `201 Created`.
@@ -118,13 +123,7 @@ class DosomethingUkUserImpersonator {
     return $result;
   }
 
-  // ---------------------------------------------------------------------
-  // Public: auth flow
-
-  /**
-   *
-   */
-  public function login($login, $password)
+  public function impersonateRemoteUser($login, $password)
   {
     // Reset previous authorization.
     $this->user    = FALSE;
@@ -144,7 +143,7 @@ class DosomethingUkUserImpersonator {
     $data = http_build_query($form_data);
 
     // Prepare request options.
-    $options = $this->options(array(
+    $options = $this->defaults(array(
       'method'  => 'POST',
       'headers' => array('Content-Type' => self::LOGIN_CONTENT_TYPE),
       'data'    => $data,
@@ -170,7 +169,7 @@ class DosomethingUkUserImpersonator {
     if (isset($response->headers) && !empty($response->headers['set-cookie'])) {
       $cookies_string = $response->headers['set-cookie'];
       $this->session = $this->findSessionTokenInCookies($cookies_string);
-      if ($this->isAuthorized()) {
+      if ($this->isLoggedIn()) {
         $this->user = $login;
       }
     }
@@ -219,10 +218,7 @@ class DosomethingUkUserImpersonator {
     return FALSE;
   }
 
-  // ---------------------------------------------------------------------
-  // Private: utilities
-
-  private function options($options = array()) {
+  private function defaults($options = array()) {
     $defaults = array(
       'max_redirects' => 0,
       'headers' => array(
@@ -230,7 +226,7 @@ class DosomethingUkUserImpersonator {
         'User-Agent'   => self::USER_AGENT,
       ),
     );
-    if ($this->isAuthorized()) {
+    if ($this->isLoggedIn()) {
       $session = array(self::SESSION_NAME => $this->session);
       $defaults['headers']['Cookie'] = http_build_query($session);
     }

--- a/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_user.inc
+++ b/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_user.inc
@@ -1,0 +1,237 @@
+<?php
+
+/**
+ * Represents UK SSO user.
+ */
+class DosomethingUkSsoUser {
+
+  // ---------------------------------------------------------------------
+  // Class constants
+
+  // Remote user.
+  const SIGNUP_FORM_CONTAINER        = 'user';
+  const SIGNUP_FORM_BIRTHDATE_FORMAT = 'd/m/Y';
+
+
+  // Local drupal user.
+  const REGISTRATION_SOURCE = 'dosomething_uk';
+
+  // ---------------------------------------------------------------------
+  // Instance variables
+
+  /**
+   * The first name.
+   *
+   * @var string
+   */
+  private $first_name;
+
+  /**
+   * The last name.
+   *
+   * @var string
+   */
+  private $last_name;
+
+  /**
+   * The email.
+   *
+   * @var string
+   */
+  private $email;
+
+  /**
+   * The password.
+   *
+   * @var string
+   */
+  private $password;
+
+  /**
+   * The postcode.
+   *
+   * Must be a valid UK postcode.
+   *
+   * @var string
+   */
+  private $postcode;
+
+  /**
+   * A DateTime object representing user's birthdate.
+   *
+   * @var DateTime
+   */
+  private $dob;
+
+  /**
+   * The screen name.
+   *
+   * UK SSO unique user's sting identifier.
+   * Must be between 4 and 20 chars, must be unique to the SSO.
+   *
+   * @var string
+   */
+  private $screen_name;
+
+  // ---------------------------------------------------------------------
+  // Constructor and factories
+
+  /**
+   * Constructs a DosomethingUkSsoUser object.
+   *
+   * @param string $first_name
+   *   The first name of the user.
+   * @param string $last_name
+   *   The last name of the user.
+   * @param string $email
+   *   The email of the user.
+   * @param string $password
+   *   The password of the user.
+   * @param string $postcode
+   *   The postcode of the user.
+   * @param DateTime $dob
+   *   A DateTime object representing user's birthdate.
+   */
+  public function __construct($first_name, $last_name, $email, $password,
+                              $postcode, DateTime $dob)
+  {
+    // Required fields.
+    $this->first_name = $first_name;
+    $this->last_name  = $last_name;
+    $this->password   = $password;
+    $this->postcode   = $postcode;
+    $this->email      = $email;
+    $this->dob        = $dob;
+
+    // Figured from reals generated screen names on UK SSO.
+    $this->screen_name = strtolower($this->first_name) . time();
+  }
+
+  /**
+   * Builds UK SSO user using an associative array.
+   *
+   * @param array $data
+   *   An associative array containing:
+   *   - first_name: The first name of the user.
+   *   - last_name: The last name of the user.
+   *   - password: The email of the user.
+   *   - postcode: The password of the user.
+   *   - email: The postcode of the user.
+   *   - dob: A DateTime object representing user's birthdate.
+   *
+   * @return static
+   */
+  public static function fromArray($data) {
+    $instance = new self(
+      $data['first_name'],
+      $data['last_name'],
+      $data['email'],
+      $data['password'],
+      $data['postcode'],
+      $data['dob']
+    );
+    return $instance;
+  }
+
+  // ---------------------------------------------------------------------
+  // Public: methods
+
+  public function toFormFields()
+  {
+    $fields = array(
+      'first_name'  => $this->first_name,
+      'last_name'   => $this->last_name,
+      'dob'         => $this->dob->format(self::SIGNUP_FORM_BIRTHDATE_FORMAT),
+      'postcode'    => $this->postcode,
+      'email'       => $this->email,
+      'screen_name' => $this->screen_name,
+      'password'    => $this->password,
+    );
+
+    // Must be the same as user's password.
+    $fields['password_confirmation'] = $this->password;
+
+    // Must be 1 to indicate acceptance of the terms & conditions of vInspired.
+    // You should make sure to present these terms to the user.
+    $fields['terms'] = 1;
+
+    // Wrap form keys in 'user' array.
+    // Must be like that due to the OAuth library limitations.
+    $result = array();
+    foreach ($fields as $key => $value) {
+      $fixed_key = self::SIGNUP_FORM_CONTAINER . '[' . $key . ']';
+      $result[$fixed_key] = $value;
+    }
+    return $result;
+  }
+
+  // ---------------------------------------------------------------------
+  // Public: field accessors
+
+  /**
+   * Returns the first name.
+   *
+   * @return string
+   */
+  public function getFirstName()
+  {
+    return $this->first_name;
+  }
+
+  /**
+   * Returns the last name.
+   *
+   * @return string
+   */
+  public function getLastName()
+  {
+    return $this->last_name;
+  }
+
+  /**
+   * Returns the email.
+   *
+   * @return string
+   */
+  public function getEmail()
+  {
+    return $this->email;
+  }
+
+  /**
+   * Returns the postcode.
+   *
+   * @return string
+   */
+  public function getPostcode()
+  {
+    return $this->postcode;
+  }
+
+  /**
+   * Returns the date of birth.
+   *
+   * @return string
+   */
+  public function getDob()
+  {
+    return $this->dob;
+  }
+
+  /**
+   * Returns the screen name.
+   *
+   * @return string
+   */
+  public function getScreenName()
+  {
+    return $this->screen_name;
+  }
+
+  // ---------------------------------------------------------------------
+  // Private: utilities
+
+
+  // ---------------------------------------------------------------------
+
+}

--- a/lib/modules/dosomething/dosomething_uk/misc/dosomething_uk-example.inc
+++ b/lib/modules/dosomething/dosomething_uk/misc/dosomething_uk-example.inc
@@ -8,12 +8,12 @@
  * Implements hook_menu().
  */
 function dosomething_uk_menu() {
-  $items['sso/request'] = array(
-    'page callback' => 'dosomething_uk_test_request',
+  $items['sso/register'] = array(
+    'page callback' => 'dosomething_uk_test_register',
     'access arguments' => array('access content'),
   );
-  $items['sso/login'] = array(
-    'page callback' => 'dosomething_uk_test_login',
+  $items['sso/request'] = array(
+    'page callback' => 'dosomething_uk_test_request',
     'access arguments' => array('access content'),
   );
   $items['sso/access'] = array(
@@ -31,6 +31,35 @@ function dosomething_uk_menu() {
   return $items;
 }
 
+function dosomething_uk_test_register() {
+  $random_url = 'http://api.randomuser.me/';
+  $randomuser = json_decode(file_get_contents($random_url))->results[0]->user;
+
+  $user_data = array(
+    'first_name' => ucfirst($randomuser->name->first),
+    'last_name'  => ucfirst($randomuser->name->last),
+    'password'   => $randomuser->password . $randomuser->password,
+    'email'      => $randomuser->email,
+    'postcode'   => 'CF10 5AN',
+    'dob'        => new DateTime('1990-05-28T0000Z'),
+  );
+  $sso_user = DosomethingUkSsoUser::fromArray($user_data);
+
+  // Register remotely.
+  $sso = DosomethingUkSsoController::signup($sso_user);
+  $result = $sso->getLastResult();
+
+  if (!$result) {
+    if ($error_messages = $sso->getErrorMessages()) {
+      var_dump($error_messages);
+    }
+    return;
+  }
+
+  var_dump($result);
+  return;
+}
+
 function dosomething_uk_test_request() {
   $sso = DosomethingUkSsoController::init()
   ->authorizeRequestToken()
@@ -40,13 +69,6 @@ function dosomething_uk_test_request() {
   print($authorize_url);
 }
 
-function dosomething_uk_test_login() {
-  $imitator = DosomethingUkUserImpersonator::init('email@example.com', 'password');
-
-  $result = $imitator->getTokenAuthorization('/oauth/authorize?oauth_token=RequestToken');
-  var_dump($imitator, $result);
-}
-
 function dosomething_uk_test_access() {
   global $user;
 
@@ -54,7 +76,7 @@ function dosomething_uk_test_access() {
   ->authorizeAccessToken()
   ->authorizeUserAccess($user->uid);
 
-  if (!$sso->isAuthrizedForRemoteApi()) {
+  if (!$sso->remoteUserAdmitted()) {
     print 'Clearance: ' . $sso->getClearance();
     return;
   }
@@ -65,14 +87,14 @@ function dosomething_uk_test_access() {
 function dosomething_uk_test_get() {
   global $user;
 
-  $sso = DosomethingUkSsoController::initForUser($user->uid);
+  $sso = DosomethingUkSsoController::initForLocalUser($user->uid);
 
-  if (!$sso->isAuthrizedForRemoteApi()) {
+  if (!$sso->remoteUserAdmitted()) {
     print 'Clearance: ' . $sso->getClearance();
     return;
   }
 
-  var_dump($sso->get('/users/current'));
+  var_dump($sso->getRemote('/users/current'));
 }
 
 
@@ -87,15 +109,18 @@ function dosomething_uk_test_flow() {
   }
   print $url . PHP_EOL;
 
-  $login = 'email@example.com';
-  $pass =  'password';
-  $result = DosomethingUkUserImpersonator::init($login, $pass)->authorize($url);
+  // A testee user created on staging for test purposes.
+  $name = 'evelyn.wilson19@example.com';
+  $pass = 'steelersteeler';
+
+  $impersonator = DosomethingUkSsoImpersonator::login($name, $pass);
+  $result = $impersonator->acceptRemoteOAuth($url);
 
   if (!$result) {
     print "Wrong login or pass";
     return;
   }
-  print $login . PHP_EOL;
+  print $result . PHP_EOL;
 
   $remote_user = $sso->authorizeAccessToken()->getRemoteUser();
   if (!$remote_user) {


### PR DESCRIPTION
#### What's this PR do?
- Continues work on bidirectional integration of DoSomething.org UK and vInspired.com
- Provides controller methods to create remote users on remote SSO server using vInspired OAuth
- Provides multiple code improvements and bug fixes in OAuth–Drupal integration
#### Where should the reviewer start?
- Configure OAuth access to [vInspired staging](http://api.staging.eyv.mxmdev.com/).
  - `drush -y vset dosomething_uk_oauth_url http://api.staging.eyv.mxmdev.com`
  - `drush -y vset dosomething_uk_oauth_key OAUTH_KEY`
  - `drush -y vset dosomething_uk_oauth_secret OAUTH_SECRET`
- Enable the module: `drush -y en dosomething_uk`

> `OAUTH_KEY` and `OAUTH_SECRET` values are available on the [Tech Wiki](https://sites.google.com/a/dosomething.org/tech/server/sensitive-config-variables).
#### How should this be manually tested?

TBA
#### Missing features, will be provided separately:
1. Forgot Password functionality
2. Minimal profile sync
#### What are the relevant tickets?
- Jira [#DS-256](https://jira.dosomething.org/browse/DS-256)
- Initial UK SSO implementation: #3031
