### PR TITLE
DS-326: Fixes bad Exception instantiation

### DIFF
--- a/lib/modules/dosomething/dosomething_canada/includes/CanadaSSOClient.php
+++ b/lib/modules/dosomething/dosomething_canada/includes/CanadaSSOClient.php
@@ -183,7 +183,7 @@ class CanadaSSOClient {
       return true;
     }
 
-    throw new Exception("Can't understand response: %s", $response);
+    throw new Exception(sprintf("Can't understand response: %s", $response));
   }
 
 /**


### PR DESCRIPTION
Missed a `sprintf()` in there.
