### PR TITLE
Remove Grunt test task (now handled by ds utility).

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -7,7 +7,6 @@
     "url": "https://github.com/DoSomething/dosomething.git"
   },
   "devDependencies": {
-    "glob": "^3.2.9",
     "grunt": "~0.4.1",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-coffee": "~0.7.0",
@@ -15,7 +14,6 @@
     "grunt-contrib-cssmin": "~0.7.0",
     "grunt-contrib-imagemin": "~0.5.0",
     "grunt-contrib-jshint": "~0.7.1",
-    "grunt-contrib-qunit": "~0.3.0",
     "grunt-contrib-requirejs": "^0.4.3",
     "grunt-contrib-uglify": "~0.2.4",
     "grunt-contrib-watch": "~0.5.3",
@@ -24,7 +22,6 @@
     "grunt-shell": "~0.6.1",
     "jshint-stylish": "~0.1.4",
     "load-grunt-config": "^0.8.0",
-    "path": "^0.4.9",
     "time-grunt": "^0.3.1"
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/default.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/default.js
@@ -1,3 +1,3 @@
 module.exports = function(grunt) {
-  grunt.registerTask("default", ["lint", "build", "test", "watch"]);
+  grunt.registerTask("default", ["lint", "build", "watch"]);
 };

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/qunit.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/qunit.js
@@ -1,6 +1,0 @@
-module.exports = {
-  options: {
-    console: false
-  },
-  all: ["tests/*.html"]
-}

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/test.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/test.js
@@ -1,6 +1,0 @@
-module.exports = function(grunt) {
-  grunt.registerTask("test", ["test:css", "test:js"]);
-
-  grunt.registerTask("test:css", []);
-  grunt.registerTask("test:js", ["qunit:all"]);
-}


### PR DESCRIPTION
## Changes
- Fixes issue where `test` Grunt task was pointing to old test directory.
- Removes some extra node modules we no longer need to specify.
## How do I test?

Pull down this branch, go to the `paraneue_dosomething` directory and run `grunt`. Things should not explode.
