### PR TITLE
showing h1 at all breakpoints and hiding h2 at mobile breakpoint on home...

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_affiliate.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_affiliate.scss
@@ -1,7 +1,13 @@
 body.-affiliate {
   .home--hero {
     .header {
+      .title {
+        @include visually-restored();
+      }
+
       .subtitle {
+        @include visually-hidden();
+
         @include media($tablet) {
           @include visually-restored();
         }


### PR DESCRIPTION
# Homepage (Affiliates only)
- Reveals `<h1>` tag on all breakpoints
- Hides `<h2>` at mobile breakpoint

Resolves [DS-320](https://jira.dosomething.org/browse/DS-320)
