### PR TITLE
Add Privacy Policy link to Registration legal copy

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
@@ -8,8 +8,34 @@
  * System settings form for DoSomething Shipment specific variables.
  */
 function dosomething_user_admin_config_form($form, &$form_state) {
+  $var_name = 'dosomething_user_node_terms_service';
+  $form[$var_name] = array(
+    '#type' => 'entity_autocomplete',
+    '#title' => t('Terms of Service'),
+    '#entity_type' => 'node',
+    '#bundles' => array('static_content'),
+    '#description' => t("Select the node which provides site Terms of Service."),
+    '#required' => TRUE,
+    '#default_value' => variable_get($var_name),
+  );
+  $var_name = 'dosomething_user_node_privacy_policy';
+  $form[$var_name] = array(
+    '#type' => 'entity_autocomplete',
+    '#title' => t('Privacy Policy'),
+    '#entity_type' => 'node',
+    '#bundles' => array('static_content'),
+    '#description' => t("Select the node which provides site Privacy Policy."),
+    '#required' => TRUE,
+    '#default_value' => variable_get($var_name),
+  );
+  $form['devel'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Development'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
   $var_name = 'dosomething_user_enable_clean_slate';
-  $form['log'][$var_name] = array(
+  $form['devel']['log'][$var_name] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable Clean Slate Form.'),
     '#default_value' => variable_get($var_name, FALSE),

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.install
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.install
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Populates Terms Service and Privacy Policy node variables.
+ */
+function dosomething_user_update_7001() {
+  variable_set('dosomething_user_node_terms_service', 1049);
+  variable_set('dosomething_user_node_privacy_policy', 1050);
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function dosomething_user_uninstall() {
+  $vars = array(
+    'dosomething_user_enable_clean_slate',
+    'dosomething_user_node_privacy_policy',
+    'dosomething_user_node_terms_service',
+    'dosomething_user_ups_access_license_number',
+    'dosomething_user_ups_password',
+    'dosomething_user_ups_test_integration',
+    'dosomething_user_ups_username',
+  );
+  foreach ($vars as $var) {
+    variable_del($var);
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
@@ -40,9 +40,14 @@ function paraneue_dosomething_form_alter_register(&$form, &$form_state, $form_id
       '#weight' => 500,
     );
 
-    $copy = t("Creating an account means you agree to our !link & to receive our weekly update. Message & data rates may apply. Text STOP to opt-out, HELP for help", array(
-      //@todo: Make this nid a variable.
-      '!link' => l(t('Terms of Service'), "node/1049")
+    $terms_nid = variable_get('dosomething_user_node_terms_service', 1049);
+    $terms_link = l(t('Terms of Service'), 'node/' . $terms_nid);
+    $privacy_nid = variable_get('dosomething_user_node_privacy_policy', 1050);
+    $privacy_link = l(t('Privacy Policy'), 'node/' . $privacy_nid);
+
+    $copy = t("Creating an account means you agree to our !terms & to receive our weekly update. Message & data rates may apply. Text STOP to opt-out, HELP for help", array(
+      '!terms' => $terms_link,
+      '!privacy' => $privacy_link,
     ));
     $form['legal-text'] = array(
       '#type' => 'item',


### PR DESCRIPTION
@sergii-tkachenko  Can you review? 

Closes https://jira.dosomething.org/browse/DS-311
- Adds variables to set the Privacy Policy and Terms of Service nodes, to avoid hardcoded node nid's.
- Makes a token available to link to the Privacy Policy in the Registration Form legal text, to allow for UK request to add it to the legal copy via translation.
