### PR TITLE
User Login: Display Forgot Password variable

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
@@ -28,14 +28,31 @@ function dosomething_user_admin_config_form($form, &$form_state) {
     '#required' => TRUE,
     '#default_value' => variable_get($var_name),
   );
+
+  // Login form settings.
+  $form['login'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Login'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
   $var_name = 'dosomething_user_login_form_copy';
-  $form[$var_name] = array(
+  $form['login'][$var_name] = array(
     '#type' => 'textarea',
     '#rows' => 2,
     '#title' => t('Login Form copy'),
     '#description' => t("Copy displayed below the Login Form header. Optional."),
     '#default_value' => variable_get($var_name),
   );
+  $var_name = 'dosomething_user_login_form_display_password_link';
+  $form['login'][$var_name] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Display "Forgot Password" link'),
+    '#default_value' => variable_get($var_name, FALSE),
+    '#description' => t("If unchecked, the link will not be displayed. Helpful for single sign-on implementations that do not yet support password reset."),
+  );
+
+  // Development settings.
   $form['devel'] = array(
     '#type' => 'fieldset',
     '#title' => t('Development'),
@@ -43,7 +60,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
     '#collapsed' => TRUE,
   );
   $var_name = 'dosomething_user_enable_clean_slate';
-  $form['devel']['log'][$var_name] = array(
+  $form['devel'][$var_name] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable Clean Slate Form.'),
     '#default_value' => variable_get($var_name, FALSE),

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.install
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.install
@@ -6,6 +6,7 @@
 function dosomething_user_update_7001() {
   variable_set('dosomething_user_node_terms_service', 1049);
   variable_set('dosomething_user_node_privacy_policy', 1050);
+  variable_set('dosomething_user_login_form_display_password_link', TRUE);
 }
 
 /**
@@ -15,6 +16,7 @@ function dosomething_user_uninstall() {
   // This list is alphabetical, please keep it that way!
   $vars = array(
     'dosomething_user_enable_clean_slate',
+    'dosomething_user_login_form_display_password_link',
     'dosomething_user_login_form_copy',
     'dosomething_user_node_privacy_policy',
     'dosomething_user_node_terms_service',

--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/login.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/login.inc
@@ -43,11 +43,17 @@ function paraneue_dosomething_form_alter_login(&$form, &$form_state, $form_id) {
 
     $copy_create = t("Create a DoSomething.org account");
     $link_create = '<a href="/user/register" id="link--register" data-modal-href="#modal--register">' . $copy_create . '</a>';
-    $copy_forgot = t("Forgot password?");
-    $link_forgot = l($copy_forgot, 'user/password');
+
+    $link_forgot = NULL;
+    // Check if the password link should be displayed.
+    $display_pw = variable_get('dosomething_user_login_form_display_password_link', TRUE);
+    if ($display_pw) {
+      $copy_forgot = t("Forgot password?");
+      $link_forgot = '<br/>' . l($copy_forgot, 'user/password');
+    }
     $form['create-account-link'] = array(
       '#type' => 'item',
-      '#markup' => '<p class="auth--toggle-link">' . $link_create . '<br/>' . $link_forgot . '</p>',
+      '#markup' => '<p class="auth--toggle-link">' . $link_create . $link_forgot . '</p>',
       '#weight' => 500,
     );
 


### PR DESCRIPTION
Closes UK request to hide the "Request Password" link: https://jira.dosomething.org/browse/DS-322

If the variable is unchecked, the "Forgot password" link will not be rendered.  Should be checked on almost all sites, hence the additional `variable_set` in `dosomething_user_update_7001`.
