### PR TITLE
DS-354 Login subheader styles

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_auth.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_auth.scss
@@ -44,6 +44,11 @@
   }
 }
 
+.auth--subheader {
+  text-align: center;
+  color: $med-gray;
+}
+
 .auth--toggle-link {
   text-align: center;
   margin: 18px 0;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -128,7 +128,7 @@
     .container__body {
       text-align: center;
 
-      @include media($desktop) {
+      @include media($tablet) {
         text-align: left;
       }
     }


### PR DESCRIPTION
## Changes
- Add styling for login subheader. (Requires DoSomething/neue#339 for an alignment fix.)
- Fixes unrelated alignment issue ([centered text](https://cloud.githubusercontent.com/assets/583202/4169262/9550fd36-3525-11e4-9089-a991d94f188f.png) on tablet) in Prove It step on campaign template.
## Screenshot

![screen shot 2014-09-05 at 1 42 34 pm](https://cloud.githubusercontent.com/assets/583202/4169233/5c588d3c-3525-11e4-87aa-40e6ecd23f1f.png)
