### PR TITLE
Version banner

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -447,6 +447,9 @@ function pull_db {
       echo "Unsetting Asset Path theme setting..."
       drush php-eval '$theme_settings = variable_get("theme_paraneue_dosomething_settings", array()); $theme_settings["asset_path"] = ""; variable_set("theme_paraneue_dosomething_settings", $theme_settings);'
 
+      echo "Unsetting tagged version variable..."
+      drush variable-delete ds_version -y
+
     else
       echo "Pulling down the db from ${alias[1]} staging"
       drush -y sql-sync @ds.${alias[1]}.staging @ds.${alias[1]}.dev

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -1,6 +1,14 @@
 <?php
 
 /**
+ * Implements theme_preprocess_html().
+ */
+function paraneue_dosomething_preprocess_html(&$vars) {
+  // Used to print current tagged version in page source
+  $vars['ds_version'] = variable_get('ds_version', '[dev]');
+}
+
+/**
  * Implements theme_preprocess_page().
  */
 function paraneue_dosomething_preprocess_page(&$vars) {
@@ -33,7 +41,7 @@ function paraneue_dosomething_preprocess_page(&$vars) {
   if(isset($vars['use_black_navigation']) && $vars['use_black_navigation'] == 1) {
     $modifier_classes = 'black floating';
   }
-  
+
   $navigation_vars = array(
     'base_path'        => $vars['base_path'],
     'modifier_classes' => $modifier_classes,

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -6,6 +6,9 @@
 function paraneue_dosomething_preprocess_html(&$vars) {
   // Used to print current tagged version in page source
   $vars['ds_version'] = variable_get('ds_version', '[dev]');
+
+  // Checks if current site is an international affiliate
+  $vars['is_affiliate'] = dosomething_settings_is_affiliate();
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -14,6 +14,8 @@
 <!--[if IE 9 ]> <html dir="ltr" lang="en-US" class="no-js ie9"> <![endif]-->
 <!--[if (gt IE 9)|!(IE)]><!--><html class="no-js"><!--<![endif]-->
 
+<!-- DoSomething.org Platform <?php print $variables['ds_version'] ?> -->
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -1,12 +1,8 @@
 <?php
-
 /**
  * Generates basic HTML structure.
  * @see https://drupal.org/node/1728208
  **/
-
-  // Checks if current site is an international affiliate
-  $is_affiliate = dosomething_settings_is_affiliate();
 ?>
 
 <!DOCTYPE html>
@@ -46,7 +42,7 @@
   <?php print $head; ?>
 </head>
 
-<body class="<?php print $classes; ?><?php if ($is_affiliate): ?> -affiliate <?php endif; ?>" <?php print $attributes;?>>
+<body class="<?php print $classes; ?><?php if ($variables['is_affiliate']): ?> -affiliate <?php endif; ?>" <?php print $attributes;?>>
   <div class="chrome">
     <!--[if lt IE 8 ]> <div class="messages error">You're using an unsupported browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to make sure everything works nicely!</div>  <![endif]-->
     <?php print $page_top; ?>


### PR DESCRIPTION
## Changes
- Add an HTML comment to each page to show what version of the codebase it was generated from.
- Unset the `ds_version` variable when pulling from stage (so banner will just show `[dev]` as version).
- Unrelated cleanup: Move `$is_affiliate` variable out of template into preprocess function.
## Screenshots

![screen shot 2014-09-05 at 4 05 28 pm](https://cloud.githubusercontent.com/assets/583202/4170956/4d4401c4-3538-11e4-9b34-674ebfce2d9d.png)

![screen shot 2014-09-05 at 4 04 59 pm](https://cloud.githubusercontent.com/assets/583202/4170958/51a26774-3538-11e4-8c71-ce0e3dd9c589.png)
