### PR TITLE
Registration Form: Display Postal Code config

### DIFF
--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.install
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.install
@@ -30,6 +30,8 @@ function dosomething_uk_update_7003() {
   // Display the Opt-in fields.
   variable_set('dosomething_user_register_form_display_opt_in_email', TRUE);
   variable_set('dosomething_user_register_form_display_opt_in_sms', TRUE);
+  // Display the Postal Code element within field_address.
+  variable_set('dosomething_user_register_form_display_postal_code', TRUE);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
@@ -72,7 +72,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
   $var_name = 'dosomething_user_register_form_display_last_name';
   $form['reg'][$var_name] = array(
     '#type' => 'checkbox',
-    '#title' => t('Display "Last Name" field'),
+    '#title' => t('Collect Last Name'),
     '#default_value' => variable_get($var_name, FALSE),
   );
 
@@ -80,7 +80,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
   $var_name = 'dosomething_user_register_form_display_opt_in_email';
   $form['reg'][$var_name] = array(
     '#type' => 'checkbox',
-    '#title' => t('Display "Opt-In Email" field'),
+    '#title' => t('Collect Opt-in Email'),
     '#default_value' => variable_get($var_name, FALSE),
   );
 
@@ -88,7 +88,15 @@ function dosomething_user_admin_config_form($form, &$form_state) {
   $var_name = 'dosomething_user_register_form_display_opt_in_sms';
   $form['reg'][$var_name] = array(
     '#type' => 'checkbox',
-    '#title' => t('Display "Opt-In SMS" field'),
+    '#title' => t('Collect Opt-In SMS'),
+    '#default_value' => variable_get($var_name, FALSE),
+  );
+
+  // Display Postal Code field.
+  $var_name = 'dosomething_user_register_form_display_postal_code';
+  $form['reg'][$var_name] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Collect Postal Code'),
     '#default_value' => variable_get($var_name, FALSE),
   );
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.features.field_instance.inc
@@ -45,7 +45,7 @@ function dosomething_user_field_default_field_instances() {
     'label' => 'Address',
     'required' => 0,
     'settings' => array(
-      'user_register_form' => 0,
+      'user_register_form' => 1,
     ),
     'widget' => array(
       'active' => 1,

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.install
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.install
@@ -23,6 +23,7 @@ function dosomething_user_uninstall() {
     'dosomething_user_register_form_display_last_name',
     'dosomething_user_register_form_display_opt_in_email',
     'dosomething_user_register_form_display_opt_in_sms',
+    'dosomething_user_register_form_display_postal_code',
     'dosomething_user_ups_access_license_number',
     'dosomething_user_ups_password',
     'dosomething_user_ups_test_integration',

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -593,8 +593,10 @@ function _dosomething_user_register_display_fields(&$form) {
     $var_name = 'dosomething_user_register_form_display_' . $var;
     $display = variable_get($var_name, FALSE);
     $field_name = 'field_' . $var;
+    // For the postal code variable:
     if ($var == 'postal_code') {
-      // The field_address Address field contains the Postal Code element.
+      // Postal code is a form element within the field_address field.
+      // We store 'field_address' as the field_name value to unset.
       $field_name = 'field_address';
     }
     // If variable is set to NOT display:

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -608,8 +608,27 @@ function _dosomething_user_register_display_fields(&$form) {
       if ($var == 'last_name') {
         $form[$field_name]['#required'] = TRUE;
       }
+      elseif ($var == 'postal_code') {
+        $form['#after_build'][] = 'dosomething_user_address_field_postal_code_only';
+      }
     }
   }
+}
+
+/**
+ * After build function to unset all address field elements except postal code.
+ */
+function dosomething_user_address_field_postal_code_only($form, &$form_state) {
+  $element = &$form['field_address'][LANGUAGE_NONE][0]['address'];
+  // Hide the Address field label.
+  unset($element['#title']);
+  // Require Postal Code.
+  $element['locality_block']['postal_code']['#required'] = TRUE;
+  // Remove all other address fields.
+  unset($element['street_block']);
+  unset($element['locality_block']['locality']);
+  unset($element['locality_block']['administrative_area']);
+  return $form;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -586,15 +586,20 @@ function _dosomething_user_register_display_fields(&$form) {
     'last_name',
     'opt_in_email',
     'opt_in_sms',
+    'postal_code',
   );
   // For each display variable:
   foreach ($display_vars as $var) {
     $var_name = 'dosomething_user_register_form_display_' . $var;
     $display = variable_get($var_name, FALSE);
+    $field_name = 'field_' . $var;
+    if ($var == 'postal_code') {
+      // The field_address Address field contains the Postal Code element.
+      $field_name = 'field_address';
+    }
     // If variable is set to NOT display:
     if (!$display) {
       // Unset the corresponding form field.
-      $field_name = 'field_' . $var;
       unset($form[$field_name]);
     }
     // Else if set to display:


### PR DESCRIPTION
@sergii-tkachenko Can you please review?

Displays `field_address` on the Registration Form, but only displays it if the "Display Postal Code" variable is checked with the DS User Admin form.

Closes https://jira.dosomething.org/browse/DS-355 (last configuration variable is now in place)

Closes https://jira.dosomething.org/browse/DS-362 -- Displays Postal Code on register form if the variable is set
