### PR TITLE
UK SSO: Map SSO `contactable` field to the local `field_opt_in_email`.

### DIFF
--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
@@ -108,11 +108,19 @@ function dosomething_uk_register_validate($form, &$form_state) {
     'email'      => $values['mail'],
     'dob'        => $dob,
     'last_name'  => $values['field_last_name'][LANGUAGE_NONE][0]['value'],
-    // @todo: add postcode field to the registration form.
+    // @todo save cell.
+    // 'phone_number' => $values['field_mobile'][LANGUAGE_NONE][0]['value'],
+    // @todo add postcode field to the registration form.
     // Until then everybody is living in Torchwood.
     'postcode'   => 'CF10 5AN',
   );
   $sso_user = DosomethingUkSsoUser::fromArray($user_data);
+
+  // Determines whether the user agreed to receive e-mail newsletter.
+  if (!empty($values['field_opt_in_email'][LANGUAGE_NONE][0]['value'])) {
+    $sso_user->setContactable(TRUE);
+  }
+
   $sso = DosomethingUkSsoController::signup($sso_user);
   $result = $sso->getLastResult();
 

--- a/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_user.inc
+++ b/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_user.inc
@@ -73,6 +73,13 @@ class DosomethingUkSsoUser {
    */
   private $screen_name;
 
+  /**
+   * A boolean determines whether the user agreed to receive e-mail newsletter.
+   *
+   * @var boolean
+   */
+  private $contactable;
+
   // ---------------------------------------------------------------------
   // Constructor and factories
 
@@ -102,6 +109,9 @@ class DosomethingUkSsoUser {
     $this->postcode   = $postcode;
     $this->email      = $email;
     $this->dob        = $dob;
+
+    // Defaults for optional fields.
+    $this->contactable = FALSE;
 
     // Figured from reals generated screen names on UK SSO.
     $this->screen_name = strtolower($this->first_name) . time();
@@ -150,6 +160,11 @@ class DosomethingUkSsoUser {
 
     // Must be the same as user's password.
     $fields['password_confirmation'] = $this->password;
+
+    // Optional user settings.
+    if ($this->contactable) {
+      $fields['contactable'] = 1;
+    }
 
     // Must be 1 to indicate acceptance of the terms & conditions of vInspired.
     // You should make sure to present these terms to the user.
@@ -226,6 +241,33 @@ class DosomethingUkSsoUser {
   public function getScreenName()
   {
     return $this->screen_name;
+  }
+
+  /**
+   * Determines whether the user agreed to receive e-mail newsletter.
+   *
+   * @return boolean
+   */
+  public function isContactable()
+  {
+    return $this->contactable;
+  }
+
+  // ---------------------------------------------------------------------
+  // Public: field mutators
+
+  /**
+   * Sets user's agreement for newsletter e-mails.
+   *
+   * @param boolean
+   *   $contactable A boolean correspondent to the user's agreement.
+   *
+   * @return $this
+   */
+  public function setContactable($contactable)
+  {
+    $this->contactable = $contactable;
+    return $this;
   }
 
   // ---------------------------------------------------------------------


### PR DESCRIPTION
#### What's this PR do?
- Integrates local `field_opt_in_email`\* with SSO `contactable` field
- Signup: sets new SSO user's `contactable` field with respect to the choice local user made on the [registration from](http://dev.dosomething.org:8888/user/register)

> \* Subscribe to our email newsletter
#### Manual Testing
##### Before

New SSO users were not contactable be default
![screen shot 2014-09-09 at 10 59 23 pm](https://cloud.githubusercontent.com/assets/672669/4208124/307c05dc-385d-11e4-84e0-71a00e2737d6.png)
##### After

New SSO user created by the local registration form, with checkbox `field_opt_in_email`

1) **Checked**
   ![screen shot 2014-09-09 at 10 59 58 pm](https://cloud.githubusercontent.com/assets/672669/4208353/634c76d4-385f-11e4-80d6-ba56a6bf870c.png)  
2) **Unchecked**
    ![image](https://cloud.githubusercontent.com/assets/672669/4208396/aa8efe54-385f-11e4-8b86-44ae297fb7b3.png)
#### What are the relevant tickets?
- This PR is the first part of Jira task [#DOS-363](https://jira.dosomething.org/browse/DS-363): "Send new registration fields to UK SSO"
- The remote field described in Jira task [#DOS-309](https://jira.dosomething.org/browse/DS-309)
- The local field implemented in #3054: "User Opt In Fields"
