### PR TITLE
UK SSO: Remove hardcoded postcode, populate SSO with real user value.

### DIFF
--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
@@ -110,9 +110,7 @@ function dosomething_uk_register_validate($form, &$form_state) {
     'last_name'  => $values['field_last_name'][LANGUAGE_NONE][0]['value'],
     // @todo save cell.
     // 'phone_number' => $values['field_mobile'][LANGUAGE_NONE][0]['value'],
-    // @todo add postcode field to the registration form.
-    // Until then everybody is living in Torchwood.
-    'postcode'   => 'CF10 5AN',
+    'postcode'   => $values['field_address'][LANGUAGE_NONE][0]['postal_code'],
   );
   $sso_user = DosomethingUkSsoUser::fromArray($user_data);
 


### PR DESCRIPTION
#### What's this PR do?
- Removes temporary hardcoded postcode `CF10 5AN`
- Integrates local `field_address` field with SSO `postcode` field
- Signup: assigns new SSO user's `postcode` to acrual user's input on the [registration from](http://dev.dosomething.org:8888/user/register)
#### Testing

New users, created on SSO now have Postcode set to actual data provided with the local registration form, not hardcoded `CF10 5AN`:  
![image](https://cloud.githubusercontent.com/assets/672669/4208978/d48fb8e2-3864-11e4-9eb1-8230ad41f1f0.png)
#### What are the relevant tickets?
- This PR is the second part of Jira task [#DOS-363](https://jira.dosomething.org/browse/DS-363): "Send new registration fields to UK SSO"
- Local Postcode field has been implemented in #3057: "Registration Form: Display Postal Code config"
- The reason why the Postcode was hardcoded explained in Jira [#DOS-297](https://jira.dosomething.org/browse/DS-297?focusedCommentId=10562&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-10562): "New account creation - fails to create user over vAPI"
- The [mystery](https://github.com/DoSomething/dosomething/pull/3056#issuecomment-54689700) behind the `CF10 5AN`: #3056 "Last Name Registration Form (UK)"
