### PR TITLE
adds kik meta data for campaign pages

### DIFF
--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -74,12 +74,20 @@ function dosomething_metatag_add_metatag_image_src($node, $field) {
     }
   }
   if ($image) {
-    // Add <link href="[image]" rel="kik-icon"> into the HEAD.
+    // Add social sharing thumbnail meta tag, 
+    // <link rel="image_src" href="[image]"> into the HEAD.
     $attributes = array(
+      'href' => $image, 
+      'rel' => 'image_src',
+    );
+    drupal_add_html_head_link($attributes, TRUE);
+    // Add the kik icon meta tag,
+    // <link  rel="kik-icon" href="[image]"> into the HEAD
+    $attributes_kik = array(
       'href' => $image, 
       'rel' => 'kik-icon',
     );
-    drupal_add_html_head_link($attributes, TRUE);
+    drupal_add_html_head_link($attributes_kik, TRUE);
     // Add the Facebook Open Graph tag into the HEAD.
     $element = array(
       '#tag' => 'meta',

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -74,10 +74,10 @@ function dosomething_metatag_add_metatag_image_src($node, $field) {
     }
   }
   if ($image) {
-    // Add <link img_src="[image]"> into the HEAD.
+    // Add <link href="[image]" rel="kik-icon"> into the HEAD.
     $attributes = array(
       'href' => $image, 
-      'rel' => 'image_src',
+      'rel' => 'kik-icon',
     );
     drupal_add_html_head_link($attributes, TRUE);
     // Add the Facebook Open Graph tag into the HEAD.

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -19,6 +19,7 @@
 
   <title><?php print $head_title; ?></title>
   <script type="text/javascript" src="<?php print NEUE_ASSET_PATH; ?>/js/vendor/modernizr.js"></script>
+  <script src="http://cdn.kik.com/kik/1.0.9/kik.js"></script>
 
   <link rel="stylesheet" href="<?php print NEUE_ASSET_PATH; ?>/dist/neue.css" type="text/css" />
   <link rel="stylesheet" href="<?php print DS_STYLE_PATH; ?>" type="text/css" />
@@ -38,7 +39,6 @@
 
   <link rel="shortcut icon" href="<?php print NEUE_ASSET_PATH; ?>/assets/images/favicon.ico">
   <link rel="apple-touch-icon-precomposed" href="<?php print NEUE_ASSET_PATH; ?>/assets/images/apple-touch-icon-precomposed.png">
-
   <?php print $head; ?>
 </head>
 


### PR DESCRIPTION
Adds Kik meta data on all campaign pages, specifically the custom 'kik-icon' meta tag with the `<head>`:

`<link rel="kik-icon" href="campaign_hero_image.jpg">`

Resolves [DS-360](https://jira.dosomething.org/browse/DS-360)
