### PR TITLE
Campaign Collections

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_group/README.md
+++ b/lib/modules/dosomething/dosomething_campaign_group/README.md
@@ -1,18 +1,6 @@
-# DoSomething Campaign Group
+Provides the Campaign Collection node type and functionality.
 
-This module defines the Grouped Campaign content type (machine name `campaign_group`).
+Documentation:
 
-A Grouped Campaign contains an entityreference field, `field_campaigns`, which 
-determines which Campaign nodes belong to the Grouped Campaign.
+[https://github.com/DoSomething/dosomething/wiki/DoSomething-Campaign-Group](https://github.com/DoSomething/dosomething/wiki/DoSomething-Campaign-Group)
 
-## Signups
-
-The `field_display_signup_form` field configures whether or not to display a 
-Signup form on the Grouped Campaign node template.
-
-This Signup form will store a signup for the Grouped Campaign nid.  A Grouped
-Campaign may be configured to subscribe the user to third-party services such as
-Mailchimp and Mobilecommons via the DoSomething Signup admin form.
-
-When a user signs up for a Campaign within the Grouped Campaign, a Signup will 
-also be created for the Grouped Campaign the Campaign belongs to.  See `dosomething_signup_entity_insert`. 

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
@@ -1207,6 +1207,7 @@ function dosomething_campaign_group_field_default_field_instances() {
       ),
       'search_index' => array(
         'label' => 'hidden',
+        'module' => 'list',
         'settings' => array(),
         'type' => 'list_default',
         'weight' => 28,

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.inc
@@ -22,9 +22,9 @@ function dosomething_campaign_group_ctools_plugin_api($module = NULL, $api = NUL
 function dosomething_campaign_group_node_info() {
   $items = array(
     'campaign_group' => array(
-      'name' => t('Grouped Campaign'),
+      'name' => t('Campaign Collection'),
       'base' => 'node_content',
-      'description' => t('A grouping of campaigns, which can be configured to collect signups.'),
+      'description' => t('A collection of campaigns, which can be configured to collect signups and pre-signups.'),
       'has_title' => '1',
       'title_label' => t('Title'),
       'help' => '',

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.field_group.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.field_group.inc
@@ -29,12 +29,13 @@ function dosomething_campaign_group_field_group_info() {
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(
-      'formatter' => 'collapsible',
+      'label' => 'Additional Text',
       'instance_settings' => array(
-        'description' => '',
-        'classes' => 'group-additional-text field-group-fieldset',
         'required_fields' => 1,
+        'classes' => 'group-additional-text field-group-fieldset',
+        'description' => '',
       ),
+      'formatter' => 'collapsed',
     ),
   );
   $export['group_additional_text|node|campaign_group|form'] = $field_group;
@@ -89,12 +90,13 @@ function dosomething_campaign_group_field_group_info() {
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(
-      'formatter' => 'collapsible',
+      'label' => 'Intro',
       'instance_settings' => array(
-        'description' => '',
-        'classes' => 'group-intro field-group-fieldset',
         'required_fields' => 1,
+        'classes' => 'group-intro field-group-fieldset',
+        'description' => '',
       ),
+      'formatter' => 'collapsed',
     ),
   );
   $export['group_intro|node|campaign_group|form'] = $field_group;
@@ -117,12 +119,13 @@ function dosomething_campaign_group_field_group_info() {
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(
-      'formatter' => 'collapsible',
+      'label' => 'Post Sign Up',
       'instance_settings' => array(
-        'description' => '',
-        'classes' => 'group-post-sign-up field-group-fieldset',
         'required_fields' => 1,
+        'classes' => 'group-post-sign-up field-group-fieldset',
+        'description' => '',
       ),
+      'formatter' => 'collapsed',
     ),
   );
   $export['group_post_signup|node|campaign_group|form'] = $field_group;
@@ -145,12 +148,13 @@ function dosomething_campaign_group_field_group_info() {
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(
-      'formatter' => 'collapsible',
+      'label' => 'Pre Launch',
       'instance_settings' => array(
-        'description' => '',
-        'classes' => 'group-pre-launch field-group-fieldset',
         'required_fields' => 1,
+        'classes' => 'group-pre-launch field-group-fieldset',
+        'description' => '',
       ),
+      'formatter' => 'collapsed',
     ),
   );
   $export['group_pre_launch|node|campaign_group|form'] = $field_group;
@@ -170,16 +174,16 @@ function dosomething_campaign_group_field_group_info() {
     'children' => array(
       0 => 'field_signup_confirm_msg',
       1 => 'field_display_signup_form',
-      2 => 'field_signup_form_button_text',
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(
-      'formatter' => 'collapsible',
+      'label' => 'Signup Form',
       'instance_settings' => array(
-        'description' => '',
-        'classes' => 'group-signup-form field-group-fieldset',
         'required_fields' => 1,
+        'classes' => 'group-signup-form field-group-fieldset',
+        'description' => '',
       ),
+      'formatter' => 'collapsed',
     ),
   );
   $export['group_signup_form|node|campaign_group|form'] = $field_group;
@@ -205,12 +209,13 @@ function dosomething_campaign_group_field_group_info() {
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(
-      'formatter' => 'collapsible',
+      'label' => 'Taxonomy and Discovery',
       'instance_settings' => array(
-        'description' => '',
-        'classes' => 'group-taxonomy field-group-fieldset',
         'required_fields' => 1,
+        'classes' => 'group-taxonomy field-group-fieldset',
+        'description' => '',
       ),
+      'formatter' => 'collapsed',
     ),
   );
   $export['group_taxonomy|node|campaign_group|form'] = $field_group;
@@ -233,12 +238,13 @@ function dosomething_campaign_group_field_group_info() {
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(
-      'formatter' => 'collapsible',
+      'label' => 'Timing',
       'instance_settings' => array(
-        'description' => '',
-        'classes' => 'group-timing field-group-fieldset',
         'required_fields' => 1,
+        'classes' => 'group-timing field-group-fieldset',
+        'description' => '',
       ),
+      'formatter' => 'collapsed',
     ),
   );
   $export['group_timing|node|campaign_group|form'] = $field_group;

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.strongarm.inc
@@ -97,7 +97,7 @@ function dosomething_campaign_group_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'node_preview_campaign_group';
-  $strongarm->value = '1';
+  $strongarm->value = '0';
   $export['node_preview_campaign_group'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -168,7 +168,7 @@ function dosomething_signup_get_opt_in_config_form_helpers_vars() {
     'helpers_vars' => $helpers_var_names['campaign'],
   );
   $vars['campaign_group'] = array(
-    'title' => t("Grouped Campaigns"),
+    'title' => t("Campaign Collections"),
     'node_vars' => dosomething_helpers_get_node_vars('campaign_group'),
     // A Campaign Group uses the same helpers variables as a standard Campaign.
     'helpers_vars' => $helpers_var_names['campaign'],


### PR DESCRIPTION
@sergii-tkachenko Would you mind reviewing?
- Changes human readable name of the `campaign_group` content type to "Campaign Collections"
- Collapses field groups in the node edit form
- Replaces README contents with link to the Github wiki
