### PR TITLE
UK SSO: Map SSO `phone_number` field to the local `phone_number`.

### DIFF
--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
@@ -100,7 +100,7 @@ function dosomething_uk_register_validate($form, &$form_state) {
   }
   $values = &$form_state['values'];
 
-  // User data.
+  // -- Required user data. --
   $dob = new DateObject($values['field_birthdate'][LANGUAGE_NONE][0]['value']);
   $user_data = array(
     'first_name' => $values['field_first_name'][LANGUAGE_NONE][0]['value'],
@@ -108,15 +108,38 @@ function dosomething_uk_register_validate($form, &$form_state) {
     'email'      => $values['mail'],
     'dob'        => $dob,
     'last_name'  => $values['field_last_name'][LANGUAGE_NONE][0]['value'],
-    // @todo save cell.
-    // 'phone_number' => $values['field_mobile'][LANGUAGE_NONE][0]['value'],
     'postcode'   => $values['field_address'][LANGUAGE_NONE][0]['postal_code'],
   );
   $sso_user = DosomethingUkSsoUser::fromArray($user_data);
 
+  // -- Optional user data. --
   // Determines whether the user agreed to receive e-mail newsletter.
   if (!empty($values['field_opt_in_email'][LANGUAGE_NONE][0]['value'])) {
     $sso_user->setContactable(TRUE);
+  }
+
+  // Use unpreprocessed cell number.
+  // Actual value is unset during validation of the number format,
+  // @see dosomething_user_register_validate().
+  // However, it's fine to use the raw value since it will be validated on SSO
+  // anyways. Appropriate error message will be rendered on validation fail.
+  //
+  // WARNING! If you are copying this block, please be aware that
+  // $form_state['input'] is not the same as $form_state['values'] and may
+  // contain unsafe data values.
+  //
+  // @todo: use normal value when the international phone validator is ready.
+  if (!empty($form_state['input']['field_mobile'][LANGUAGE_NONE][0]['value'])) {
+    $phone = $form_state['input']['field_mobile'][LANGUAGE_NONE][0]['value'];
+    $sso_user->setPhoneNumber($phone);
+
+    // Save the phone number as is to the local DB only
+    // when it passed the remote validation.
+    form_set_value(
+      $form['field_mobile'],
+      array(LANGUAGE_NONE => array(0 => array('value' => $phone))),
+      $form_state
+    );
   }
 
   $sso = DosomethingUkSsoController::signup($sso_user);

--- a/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_user.inc
+++ b/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_user.inc
@@ -68,13 +68,26 @@ class DosomethingUkSsoUser {
    *
    * UK SSO unique user's sting identifier.
    * Must be between 4 and 20 chars, must be unique to the SSO.
+   * Generated automatically.
    *
    * @var string
    */
   private $screen_name;
 
   /**
+   * The mobile phone number.
+   *
+   * Optional, defaults to FALSE.
+   * The phone number must be valid UK phone number.
+   *
+   * @var string
+   */
+  private $phone_number;
+
+  /**
    * A boolean determines whether the user agreed to receive e-mail newsletter.
+   *
+   * Optional.
    *
    * @var boolean
    */
@@ -112,6 +125,7 @@ class DosomethingUkSsoUser {
 
     // Defaults for optional fields.
     $this->contactable = FALSE;
+    $this->phone_number = FALSE;
 
     // Figured from reals generated screen names on UK SSO.
     $this->screen_name = strtolower($this->first_name) . time();
@@ -148,6 +162,7 @@ class DosomethingUkSsoUser {
 
   public function toFormFields()
   {
+    // -- Required user data. --
     $fields = array(
       'first_name'  => $this->first_name,
       'last_name'   => $this->last_name,
@@ -161,9 +176,14 @@ class DosomethingUkSsoUser {
     // Must be the same as user's password.
     $fields['password_confirmation'] = $this->password;
 
-    // Optional user settings.
+    // -- Optional user data. --
+    // User's agreement to the email newsletter.
     if ($this->contactable) {
       $fields['contactable'] = 1;
+    }
+    // User's mobile phone number.
+    if ($this->phone_number) {
+      $fields['phone_number'] = $this->phone_number;
     }
 
     // Must be 1 to indicate acceptance of the terms & conditions of vInspired.
@@ -244,7 +264,30 @@ class DosomethingUkSsoUser {
   }
 
   /**
+   * Gets the mobile phone number.
+   *
+   * This field is optional for new users.
+   *
+   * @return string|false
+   *   The mobile phone number or FALSE when the number is not available.
+   *
+   *   The number is consistent with UK phone number format. It could be either
+   *   the international format starting with the UK telephone country code +44
+   *   or local formatted number with the country code omitted.
+   *
+   *   Refer to Wikipedia article "Telephone numbers in the United Kingdom"
+   *   http://en.wikipedia.org/wiki/Telephone_numbers_in_the_United_Kingdom
+   *   for more details.
+   */
+  public function getPhoneNumber()
+  {
+    return $this->phone_number;
+  }
+
+  /**
    * Determines whether the user agreed to receive e-mail newsletter.
+   *
+   * This field is optional for new users and defaults to FALSE.
    *
    * @return boolean
    */
@@ -255,6 +298,20 @@ class DosomethingUkSsoUser {
 
   // ---------------------------------------------------------------------
   // Public: field mutators
+
+  /**
+   * Sets the mobile phone number.
+   *
+   * @param string
+   *   $phone_number The phone number consistent with UK phone number format.
+   *
+   * @return $this
+   */
+  public function setPhoneNumber($phone_number)
+  {
+    $this->phone_number = $phone_number;
+    return $this;
+  }
 
   /**
    * Sets user's agreement for newsletter e-mails.


### PR DESCRIPTION
#### What's this PR do?
- Fixes an issue with the cell number on the [registration from](http://dev.dosomething.org:8888/user/register) not being sent to the SSO
- Integrates local `phone_number` field with SSO `phone_number` field
#### Testing

New users, created on SSO now have Phone Number  set to actual data provided with the local registration form:  
![image](https://cloud.githubusercontent.com/assets/672669/4224425/04d3cfbe-3925-11e4-9df0-3fe8b3bedd27.png)

The number saved as is to the DS database:
![image](https://cloud.githubusercontent.com/assets/672669/4224440/30949d18-3925-11e4-9be3-2cea826c7972.png)
#### What are the relevant tickets?
- This PR is the third and the final part of Jira task [#DOS-363](https://jira.dosomething.org/browse/DS-363): "Send new registration fields to UK SSO"
