### PR TITLE
Campaign Group cleanup

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
@@ -140,7 +140,7 @@ function dosomething_campaign_group_field_default_field_instances() {
         'rows' => 5,
       ),
       'type' => 'text_textarea',
-      'weight' => 8,
+      'weight' => 13,
     ),
   );
 
@@ -191,7 +191,7 @@ function dosomething_campaign_group_field_default_field_instances() {
         'size' => 60,
       ),
       'type' => 'entityreference_autocomplete',
-      'weight' => 9,
+      'weight' => 14,
     ),
   );
 
@@ -238,7 +238,7 @@ function dosomething_campaign_group_field_default_field_instances() {
         'size' => 60,
       ),
       'type' => 'text_textfield',
-      'weight' => 7,
+      'weight' => 12,
     ),
   );
 
@@ -585,7 +585,7 @@ function dosomething_campaign_group_field_default_field_instances() {
       'module' => 'field_collection',
       'settings' => array(),
       'type' => 'field_collection_embed',
-      'weight' => 3,
+      'weight' => 10,
     ),
   );
 
@@ -632,7 +632,7 @@ function dosomething_campaign_group_field_default_field_instances() {
       'module' => 'field_collection',
       'settings' => array(),
       'type' => 'field_collection_embed',
-      'weight' => 12,
+      'weight' => 15,
     ),
   );
 
@@ -840,7 +840,7 @@ function dosomething_campaign_group_field_default_field_instances() {
         'size' => 60,
       ),
       'type' => 'entityreference_autocomplete',
-      'weight' => 10,
+      'weight' => 9,
     ),
   );
 
@@ -941,7 +941,7 @@ function dosomething_campaign_group_field_default_field_instances() {
       'module' => 'field_collection',
       'settings' => array(),
       'type' => 'field_collection_embed',
-      'weight' => 13,
+      'weight' => 7,
     ),
   );
 
@@ -997,7 +997,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'bundle' => 'campaign_group',
     'default_value' => NULL,
     'deleted' => 0,
-    'description' => 'The Post Signup fields are displayed if the user has signed up for the Grouped Campaign.',
+    'description' => 'The Post Signup fields are displayed if the user has signed up for this node.',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -1422,7 +1422,7 @@ function dosomething_campaign_group_field_default_field_instances() {
       'module' => 'field_collection',
       'settings' => array(),
       'type' => 'field_collection_embed',
-      'weight' => 9,
+      'weight' => 8,
     ),
   );
 
@@ -1458,7 +1458,7 @@ function dosomething_campaign_group_field_default_field_instances() {
   t('Signup Confirmation Message');
   t('Sponsors and Partners');
   t('Tags');
-  t('The Post Signup fields are displayed if the user has signed up for the Grouped Campaign.');
+  t('The Post Signup fields are displayed if the user has signed up for this node.');
   t('The Pre Launch Title and Copy fields will be displayed if there are no child campaigns which are published.');
   t('This copy will be pulled into the transactional email template when a user signs up for the campaign group.');
   t('Transactional Email Copy');

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.field_group.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.field_group.inc
@@ -20,16 +20,18 @@ function dosomething_campaign_group_field_group_info() {
   $field_group->mode = 'form';
   $field_group->parent_name = '';
   $field_group->data = array(
-    'label' => 'Additional Text',
-    'weight' => '9',
+    'label' => 'Additional Info',
+    'weight' => '5',
     'children' => array(
-      0 => 'field_additional_text',
-      1 => 'field_additional_text_title',
-      2 => 'field_additional_text_image',
+      0 => 'field_gallery',
+      1 => 'field_additional_text',
+      2 => 'field_additional_text_title',
+      3 => 'field_scholarship_amount',
+      4 => 'field_additional_text_image',
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(
-      'label' => 'Additional Text',
+      'label' => 'Additional Info',
       'instance_settings' => array(
         'required_fields' => 1,
         'classes' => 'group-additional-text field-group-fieldset',
@@ -82,12 +84,13 @@ function dosomething_campaign_group_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Intro',
-    'weight' => '2',
+    'weight' => '1',
     'children' => array(
-      0 => 'field_intro',
-      1 => 'field_intro_image',
-      2 => 'field_intro_title',
-      3 => 'field_video',
+      0 => 'field_faq',
+      1 => 'field_intro',
+      2 => 'field_intro_image',
+      3 => 'field_intro_title',
+      4 => 'field_video',
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(
@@ -105,6 +108,34 @@ function dosomething_campaign_group_field_group_info() {
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
   $field_group->api_version = 1;
+  $field_group->identifier = 'group_partners|node|campaign_group|form';
+  $field_group->group_name = 'group_partners';
+  $field_group->entity_type = 'node';
+  $field_group->bundle = 'campaign_group';
+  $field_group->mode = 'form';
+  $field_group->parent_name = '';
+  $field_group->data = array(
+    'label' => 'Sponsors and Partners',
+    'weight' => '9',
+    'children' => array(
+      0 => 'field_partners',
+    ),
+    'format_type' => 'fieldset',
+    'format_settings' => array(
+      'label' => 'Sponsors and Partners',
+      'instance_settings' => array(
+        'required_fields' => 1,
+        'classes' => 'group-partners field-group-fieldset',
+        'description' => '',
+      ),
+      'formatter' => 'collapsed',
+    ),
+  );
+  $export['group_partners|node|campaign_group|form'] = $field_group;
+
+  $field_group = new stdClass();
+  $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
+  $field_group->api_version = 1;
   $field_group->identifier = 'group_post_signup|node|campaign_group|form';
   $field_group->group_name = 'group_post_signup';
   $field_group->entity_type = 'node';
@@ -112,15 +143,15 @@ function dosomething_campaign_group_field_group_info() {
   $field_group->mode = 'form';
   $field_group->parent_name = '';
   $field_group->data = array(
-    'label' => 'Post Sign Up',
-    'weight' => '6',
+    'label' => 'Post Signup',
+    'weight' => '3',
     'children' => array(
       0 => 'field_post_signup_title',
       1 => 'field_post_signup_copy',
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(
-      'label' => 'Post Sign Up',
+      'label' => 'Post Signup',
       'instance_settings' => array(
         'required_fields' => 1,
         'classes' => 'group-post-sign-up field-group-fieldset',
@@ -142,7 +173,7 @@ function dosomething_campaign_group_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Pre Launch',
-    'weight' => '8',
+    'weight' => '4',
     'children' => array(
       0 => 'field_pre_launch_copy',
       1 => 'field_pre_launch_title',
@@ -171,7 +202,7 @@ function dosomething_campaign_group_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Signup Configuration',
-    'weight' => '5',
+    'weight' => '2',
     'children' => array(
       0 => 'field_signup_confirm_msg',
       1 => 'field_display_signup_form',
@@ -202,7 +233,7 @@ function dosomething_campaign_group_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Taxonomy and Discovery',
-    'weight' => '14',
+    'weight' => '8',
     'children' => array(
       0 => 'field_cause',
       1 => 'field_action_type',
@@ -234,7 +265,7 @@ function dosomething_campaign_group_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Timing',
-    'weight' => '10',
+    'weight' => '6',
     'children' => array(
       0 => 'field_display_end_date',
       1 => 'field_high_season',

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.info
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.info
@@ -34,6 +34,7 @@ features[field_base][] = field_transactional_email_copy
 features[field_group][] = group_additional_text|node|campaign_group|form
 features[field_group][] = group_header|node|campaign_group|form
 features[field_group][] = group_intro|node|campaign_group|form
+features[field_group][] = group_partners|node|campaign_group|form
 features[field_group][] = group_post_signup|node|campaign_group|form
 features[field_group][] = group_pre_launch|node|campaign_group|form
 features[field_group][] = group_signup_form|node|campaign_group|form

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.strongarm.inc
@@ -41,19 +41,19 @@ function dosomething_campaign_group_strongarm() {
     'extra_fields' => array(
       'form' => array(
         'metatags' => array(
-          'weight' => '18',
+          'weight' => '13',
         ),
         'title' => array(
           'weight' => '2',
         ),
         'path' => array(
-          'weight' => '17',
+          'weight' => '12',
         ),
         'redirect' => array(
-          'weight' => '16',
+          'weight' => '11',
         ),
         'xmlsitemap' => array(
-          'weight' => '15',
+          'weight' => '10',
         ),
       ),
       'display' => array(),

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -361,12 +361,6 @@ function dosomething_signup_entity_insert($entity, $type) {
  * Sends third-party subscription requests for given $account and $node.
  */
 function dosomething_signup_third_party_subscribe($account, $node) {
-  // If this $node belongs to a Campaign Group:
-  if ($parent_nid = dosomething_campaign_group_get_parent_nid($node->nid)) {
-    // Exit out of function.
-    // The third_party_subscribe will be called by the parent signup.
-    return;
-  }
   $var_name  = 'mobilecommons_opt_in_path';
   // Is there an override set on this campaign?
   $opt_in = dosomething_helpers_get_variable($node->nid, $var_name);


### PR DESCRIPTION
@sergii-tkachenko Can you review?
- Cleanup Campaign Group form
- For the Hunt (first campaign group), we didn't send child campaign third-party opt-ins.  For Grandparents Gone Wired (a new campaign group), we do want it turned on.  @mikefantini and I are discussing re-working the use for when we use Campaign Group node types, so for now, the easiest thing is to restore child third-party opt-ins and then revisit making this configurable via a Drupal field (if we need it)

Related comment is here: https://jira.dosomething.org/browse/DS-373?focusedCommentId=10672&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-10672 -- For the hunt
