### PR TITLE
DS-389 Adds signup source to reportback confirmation links

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
@@ -25,6 +25,10 @@ function dosomething_campaign_reportback_confirmation_page($node) {
     'recommended' => NULL,
     'redeem_form' => NULL,
   );
+  // Image size to pass to campaign block.
+  $image_size = '740x480';
+  // Signup source to pass to campaign block.
+  $source = dosomething_campaign_get_confirmation_path($node->nid);
 
   // Set variables for anonymous user:
   if (!user_is_logged_in()) {
@@ -72,7 +76,7 @@ function dosomething_campaign_reportback_confirmation_page($node) {
     // This could happen for a SMS Game, where the confirmation page can be
     // viewed by anonymous user, so we don't have a signup to filter out.
     if ($nid != $node->nid) {
-      $rec_vars[] = dosomething_campaign_get_campaign_block_vars($nid);
+      $rec_vars[] = dosomething_campaign_get_campaign_block_vars($nid, $image_size, $source);
     }
   }
   // We only want to display 3 campaigns blocks - we might have 4.


### PR DESCRIPTION
@sergii-tkachenko Do you mind reviewing?

Tracks confirmation pages as signup sources.

![screen shot 2014-09-12 at 2 00 06 pm](https://cloud.githubusercontent.com/assets/1236811/4254040/e6bffd26-3aa6-11e4-87db-e209920ab200.png)
