### PR TITLE
Fix Mocha XUnit test output.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -523,7 +523,7 @@ function unit_tests {
   printf "\n\033[1;33mRunning JavaScript unit tests with Mocha...\033[00m\n"
   if [[ $DS_MOCHA_OUTPUT == "xunit" ]]
   then
-    mocha-phantomjs $TEST_PATH/unit/index.html -R xunit -f $BASE_PATH/tmp/mocha.xml
+    mocha-phantomjs $TEST_PATH/unit/index.html -R xunit > $BASE_PATH/tmp/mocha.xml
     printf "\n\033[1;33mOutputted results to $BASE_PATH/tmp/mocha.xml\033[00m\n"
   else
     mocha-phantomjs $TEST_PATH/unit/index.html -R spec


### PR DESCRIPTION
# Changes
- Fixes Mocha test output on QA. The `-f` option for mocha-phantomjs is broken on the XUnit reporter. So, BASH it is.
