### PR TITLE
Fix Predis libraries autoload.

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -63,7 +63,7 @@ require_once DS_MODULES_PATH . '/contrib/redis/redis.autoload.inc';
 // Predis autoloader not working. Declare here instead.
 spl_autoload_register(function($classname) {
   if (0 === strpos($classname, 'Predis\\')) {
-    $filename = DS_LIBRARIES_PATH . '/predis/lib/';
+    $filename = DRUPAL_ROOT . '/' . DS_LIBRARIES_PATH . '/predis/lib/';
     $filename .= str_replace('\\', '/', $classname) . '.php';
     return (bool)require_once $filename;
   }


### PR DESCRIPTION
This PR fixes very rare ["heisenbug"](http://en.wikipedia.org/wiki/Heisenbug) in Predis autoload code.
I've seen it only few times and it's almost impossible to reproduce it manually.

It looks like this: `Fatal error: require_once(): Failed opening required 'profiles/dosomething/libraries/predis/lib/Predis/Command/TransactionWatch.php'`
I tried to [search for similar issues](https://www.google.com/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=Fatal%20error%20require_once%20predis%20not%20found%20TransactionWatch), but Google (shamefully) returns only DS pages:
![screen shot 2014-09-13 at 12 56 46 am](https://cloud.githubusercontent.com/assets/672669/4274461/4852f83c-3cf4-11e4-9ccb-f38948efc6f8.png)
It also makes debugging very difficult because xDebug sessions tend to get lost after this Fatal error crash:
![screen shot 2014-09-15 at 7 11 42 pm](https://cloud.githubusercontent.com/assets/672669/4274487/6ec637b8-3cf4-11e4-9fe1-d2173eab6480.png)

I don't know why, but it looks like `settings.php` treat Drupal root path somehow wrong.
This PR makes Predis autoload use absolute paths so it implicitly loads only the right libraries.
