### PR TITLE
Fixes automatic signups from pitch page.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -618,7 +618,7 @@ function _dosomething_user_register_display_fields(&$form) {
     // If variable is set to NOT display:
     if (!$display) {
       // Unset the corresponding form field.
-      unset($form[$field_name]);
+      $form[$field_name]['#access'] = FALSE;
     }
     // Else if set to display:
     else {


### PR DESCRIPTION
#### What's this PR do?
- Fixes automatic signups from pitch page
#### Any background context you want to provide?

During smoke tests of [v0.3.6](https://github.com/DoSomething/dosomething/compare/v0.3.1...v0.3.6) release we found out that users are not signed automatically when registred on a pitch page. After manual tests, we found that when `_dosomething_user_register_display_fields()` function runs above `_dosomething_user_add_signup_data()`, `$form['nid']['#value']` (which contains the association with the campaign page) is getting lost. This lead to temporary fix #3070.

I was assigned to find the real cause of this issue. I discovered that `_dosomething_user_register_display_fields()` unsets address field data so JS form validation receives an error from the backend and user is redirected to `/user/register` page under the hood. That's why the [function](https://github.com/DoSomething/dosomething/blob/346247ffeeaddbe29682ceb06aabb3624c5cd91d/lib/modules/dosomething/dosomething_signup/dosomething_signup.module#L632) that determines campaign nid of a pitch page can't detected it. User considered to be on the registration page, not the pitch page.

Removing access to the address field instead of unsetting it fixes the issue. 
#### How should this be manually tested?
- Go back to pre-temporary fix commit 8908c60d29f63
- Apply this PR as a patch
- Go to a Pitch page and sign up there
- Make sure you are redirected to the full campaign page after registration
#### What are the relevant tickets?
- Fixes [#DOS-385](https://jira.dosomething.org/browse/DS-385)
- Original temporary fix #3070 
#### Additional

It's also possible that DoSomething UK is affected with the same bug due to [same unsets](https://github.com/DoSomething/dosomething/blob/346247ffeeaddbe29682ceb06aabb3624c5cd91d/lib/modules/dosomething/dosomething_user/dosomething_user.module#L642-L648) in the registration form address fields. I will check it and create a separate PR if so.
