### PR TITLE
Redis Client: Use builtin class loader.

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -58,20 +58,16 @@ $conf['varnish_control_key'] = '00c9203c65874ca5b4c359e19f00bf56';
 // This needs to be disabled.
 $conf['page_cache_invoke_hooks'] = FALSE;
 
-require_once DS_MODULES_PATH . '/contrib/redis/redis.autoload.inc';
-
-// Predis autoloader not working. Declare here instead.
-spl_autoload_register(function($classname) {
-  if (0 === strpos($classname, 'Predis\\')) {
-    $filename = DRUPAL_ROOT . '/' . DS_LIBRARIES_PATH . '/predis/lib/';
-    $filename .= str_replace('\\', '/', $classname) . '.php';
-    return (bool)require_once $filename;
-  }
-  return false;
-});
-
-$conf['cache_backends'][] = DS_MODULES_PATH . '/contrib/redis/redis.autoload.inc';
+// Setup Redis cache backend using Predis PHP library.
 $conf['redis_client_interface'] = 'Predis';
+
+// Register Predis classes autoload.
+// @see Redis_Client_Predis::setPredisAutoload().
+define('PREDIS_BASE_PATH', DRUPAL_ROOT . '/' . DS_LIBRARIES_PATH . '/predis/lib/');
+require_once DS_MODULES_PATH . '/contrib/redis/redis.autoload.inc';
+$conf['cache_backends'][] = DS_MODULES_PATH . '/contrib/redis/redis.autoload.inc';
+
+// Redis client settings.
 $conf['redis_client_host'] = getenv('DS_REDIS_HOST') ?: '127.0.0.1';
 $conf['redis_client_port'] = getenv('DS_REDIS_PORT') ?: '6379';
 


### PR DESCRIPTION
#### What's this PR do?
- Gets rid of custom custom anonymous `spl_autoload_register()` callback in `settings.php`
- Defines builtin `Redis_Client_Predis::setPredisAutoload()` as a Predis classloader
#### Where should the reviewer start?

Read [`README.Predis.txt`](/omega8cc/redis/blob/7.x-2.x/README.Predis.txt) of Redis Drupal module.
#### How should this be manually tested?
- Clean all caches: `drush cc all`
- Make sure the frontpage isn't blank
- Log in as admin
- Visit Drupal [status report](http://dev.dosomething.org:8888/admin/reports/status) page
- Make sure Redis monitoring endpoint reports `Connected, using the Predis client.`
#### Any background context you want to provide?

I made this change to Redis loader during experiments with SimpleTest for UK SSO. Originally I tried to fix the [incompatibility](https://www.drupal.org/node/1760256) of SimpleTest and Redis modules. Unfortunately, this didn't solve the issue (as well as Redis module upgrade).

Nevertheless, I found the change useful as is. I think, `settings.php` shouldn't contain anything more complex than PHP control structures. Especially it's not the place for something as complex as lambda abstractions. 
#### What are the relevant tickets?

Improves #3080
