### PR TITLE
Add 'uk_birthday' validator that accepts DD/MM/YYYY format.

### DIFF
--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
@@ -12,6 +12,17 @@ define('DOSOMETHING_UK_WATCHDOG', 'dosomething_uk');
 // -----------------------------------------------------------------------
 // Hook implementations.
 
+function dosomething_uk_preprocess_page(&$vars) {
+  drupal_add_js(
+    array('dosomethingUK' =>
+      array(
+        'use_uk_date_validator' => true 
+      )
+    ),
+    'setting'
+  );
+}
+
 /**
  * Implements hook_module_implements_alter().
  *

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
@@ -47,19 +47,35 @@ define(function(require) {
   // ## Birthday
   // Validates correct date input, reasonable birthdate, and says a nice message.
   Validation.registerValidationFunction("birthday", function(string, done) {
+    validateBirthdayWithFormat(string, done, "MM/DD/YYYY");
+  });
+
+
+  Validation.registerValidationFunction("uk_birthday", function(string, done) {
+    validateBirthdayWithFormat(string, done, "DD/MM/YYYY");
+  });
+
+
+  function validateBirthdayWithFormat(string, done, format) {
     var birthday, birthMonth, birthDay, birthYear;
 
     // parse date from string
-    if( /^\d{1,2}\/\d{1,2}\/\d{4}$/.test(string) ) {
-      // default, typed by user MM/DD/YYYY
+    if( format === "MM/DD/YYYY" && /^\d{1,2}\/\d{1,2}\/\d{4}$/.test(string) ) {
+      // US formatting
       birthday = string.split("/");
       birthMonth = parseInt(birthday[0]);
       birthDay = parseInt(birthday[1]);
       birthYear = parseInt(birthday[2]);
+    } else if( format === "DD/MM/YYYY" && /^\d{1,2}\/\d{1,2}\/\d{4}$/.test(string) ) {
+      // UK formatting
+      birthday = string.split("/");
+      birthDay = parseInt(birthday[0]);
+      birthMonth = parseInt(birthday[1]);
+      birthYear = parseInt(birthday[2]);
     } else {
       return done({
         success: false,
-        message: Drupal.t("Enter your birthday MM/DD/YYYY!")
+        message: Drupal.t("Enter your birthday " + format + "!")
       });
     }
 
@@ -135,7 +151,7 @@ define(function(require) {
         message: Drupal.t("That doesn't seem right.")
       });
     }
-  });
+  };
 
   // ## Email
   // Performs some basic sanity checks on email format (see helper method), and

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
@@ -47,17 +47,16 @@ define(function(require) {
   // ## Birthday
   // Validates correct date input, reasonable birthdate, and says a nice message.
   Validation.registerValidationFunction("birthday", function(string, done) {
-    validateBirthdayWithFormat(string, done, "MM/DD/YYYY");
-  });
+    var birthday, birthMonth, birthDay, birthYear, format;
 
-
-  Validation.registerValidationFunction("uk_birthday", function(string, done) {
-    validateBirthdayWithFormat(string, done, "DD/MM/YYYY");
-  });
-
-
-  function validateBirthdayWithFormat(string, done, format) {
-    var birthday, birthMonth, birthDay, birthYear;
+    try {
+      if(typeof Drupal.settings.dosomethingUK.use_uk_date_validator !== "undefined") {
+        var useUKDateFormatting = Drupal.settings.dosomethingUK.use_uk_date_validator || false;
+        format = (useUKDateFormatting ? "DD/MM/YYYY" : "MM/DD/YYYY");
+      }
+    } catch(e) {
+      format = "MM/DD/YYYY";
+    }
 
     // parse date from string
     if( format === "MM/DD/YYYY" && /^\d{1,2}\/\d{1,2}\/\d{4}$/.test(string) ) {
@@ -151,7 +150,7 @@ define(function(require) {
         message: Drupal.t("That doesn't seem right.")
       });
     }
-  };
+  });
 
   // ## Email
   // Performs some basic sanity checks on email format (see helper method), and


### PR DESCRIPTION
# Changes
- Add 'uk_birthday' validator that accepts DD/MM/YYYY format.
- Add 'use_uk_date_validator` Drupal setting to toggle which date format to use.
