### PR TITLE
Setup the User's Birthday field to accept input in local format.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.features.field_instance.inc
@@ -103,7 +103,7 @@ function dosomething_user_field_default_field_instances() {
       'module' => 'date',
       'settings' => array(
         'increment' => 15,
-        'input_format' => 'm/d/Y - H:i:s',
+        'input_format' => 'site-wide',
         'input_format_custom' => '',
         'label_position' => 'above',
         'text_parts' => array(),


### PR DESCRIPTION
#### What's this PR do?
- Configures the User's Birthday field to accept date in the format specific to site language setting
#### How should this be manually tested?
1. Check that user registration works with birthday in US date format, e.g. `05/28/1988`
2. As an admin [change](http://dev.dosomething.org:8888/admin/config/regional/date-time) site's short date format to the EU format, e.g. `18/09/2014 - 00:37`
3. Check that user registration works with birthday in EU date format, e.g. `28/05/1988`
4. Optional: reset the format, install `en-gb` language, switch to it, repeat step 3
#### Any background context you want to provide?

This change utilizes undocumented Date module functionality by changing date input format to hardcoded value `site-wide`. It can be found in `date_elements.inc:618`:

``` php
/**
 * Determine the input format for this element.
 */
function date_input_format($element, $field, $instance) {
  if (!empty($instance['widget']['settings']['input_format_custom'])) {
    return $instance['widget']['settings']['input_format_custom'];
  }
  elseif (!empty($instance['widget']['settings']['input_format'])
              && $instance['widget']['settings']['input_format'] != 'site-wide') {
    return $instance['widget']['settings']['input_format'];
  }
  return variable_get('date_format_short', 'm/d/Y - H:i');
}
```

As you can see `site-wide` value makes date field determine its input format from site's short date format setting. This settings is changing automatically when changing site's default language.

> Note: When extra languages installed, it's also possible to [manage](http://dev.dosomething.org:8888/admin/config/regional/date-time/locale) date settings per each language. In this case the date format is determined from the values set on the form that represents site's current language.
#### Warning

At the moment when date field format is set to magic `site-wide` value, but it's not represented on field's configuration form. If form saved manually, the magic value will be lost.

It's not THAT critical, but it'd great to legitimize this magic value by providing new option on field's configuration. I will create a ticket on drupal.org and provide a patch to utilize this functionality properly.
##### Progress:
1. [x] Issue reported to drupal.org
2. [ ] Patch provided
3. [ ] Code included to Date module dev version
4. [ ] Code released in Date module stable version
#### What are the relevant tickets?

Reference: [#DS-335](https://jira.dosomething.org/browse/DS-335)
