### PR TITLE
Fix app.css compilation by improving bower function in ds script.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -367,8 +367,14 @@ function bower {
   if hash bower 2>/dev/null;
   then
     cd $LIB_PATH/themes/dosomething/paraneue_dosomething
-    echo -e "\n\e[4mInstalling bower dependencies for Paraneue_DoSomething...\e[0m"
-    eval "/usr/bin/bower update --config.interactive=false"
+
+    if [[ `ls -A bower_components/ | wc -l` -eq 0 ]]; then
+      echo -e "\n\e[4mInstalling bower dependencies for Paraneue_DoSomething...\e[0m"
+      eval "/usr/bin/bower install --config.interactive=false"
+    else
+      echo -e "\n\e[4mUpdating bower dependencies for Paraneue_DoSomething...\e[0m"
+      eval "/usr/bin/bower update --config.interactive=false"
+    fi
 
     cd $BASE_PATH
 


### PR DESCRIPTION
#### What's this PR do?
- Fixes `app.css` compilation issue:  
  
  ```
  Running "sass:prod" (sass) task
  Warning: /var/www/vagrant/lib/themes/dosomething/paraneue_dosomething/scss/app.scss:17: error: file to import not found or unreadable: "../bower_components/bourbon/dist/bourbon"
  Use --force to continue.
  Aborted due to warnings.
  ```
- Enhances `bower()` function in `ds` script by making it decide automatically whether `bower` packages should be installed or updated
#### How should this be manually tested?

Rebuild your environment as usual:
- `vagrant destroy -f`
- `vagrant up`
- `vagrant ssh`
- `setup-www`
- `cd /var/www/vagrant`
- `bin/ds build`
- Wait for `Installing NPM dependencies...` task and see if it fails
#### Any background context you want to provide?

Suddenly bower stopped download modules to `bower_components` during `update` task, now it does it only on `install`.

I can't figure a reason why and where it started. Here's the list with my suspects:
- last changes to dosomething vagrant box be me
- last release of the neue by @DFurnes 
- changes in the `bower` itself
