### PR TITLE
Uk form order

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
@@ -52,19 +52,25 @@ function paraneue_dosomething_form_alter_register(&$form, &$form_state, $form_id
 
     // Customize field elements.
     $form['field_first_name']['#weight'] = '-20';
+    $form['field_first_name']['#attributes']['class'] = array('auth--twocol');
     $form['field_first_name'][LANGUAGE_NONE][0]['value']['#attributes']['placeholder'] = t('What do we call you?');
     $form['field_first_name'][LANGUAGE_NONE][0]['value']['#attributes']['class'] = array('js-validate');
     $form['field_first_name'][LANGUAGE_NONE][0]['value']['#attributes']['data-validate'] = 'name';
     $form['field_first_name'][LANGUAGE_NONE][0]['value']['#attributes']['data-validate-required'] = '';
+    
+    // If last name is shown, make first name full width
+    if (isset($form['field_last_name'])) {
+      $form['field_first_name']['#attributes']['class'] = array();
+    }
 
     // If the last name field is present:
     // @see _dosomething_user_register_display_fields().
     if (isset($form['field_last_name'])) {
       $form['field_last_name']['#weight'] = '-19';
-      $form['field_last_name'][LANGUAGE_NONE][0]['value']['#attributes']['placeholder'] = t('What does your P.E. teacher call you?');
+      $form['field_last_name'][LANGUAGE_NONE][0]['value']['#attributes']['placeholder'] = t('What\'s your P.E. teacher call you?');
       $form['field_last_name'][LANGUAGE_NONE][0]['value']['#attributes']['class'] = array('js-validate');
       $form['field_last_name'][LANGUAGE_NONE][0]['value']['#attributes']['data-validate'] = 'name';
-      $form['field_last_name'][LANGUAGE_NONE][0]['value']['#attributes']['data-validate-required'] = '';   
+      $form['field_last_name'][LANGUAGE_NONE][0]['value']['#attributes']['data-validate-required'] = '';
     }
 
     $form['account']['mail']['#weight'] = 10;
@@ -103,7 +109,8 @@ function paraneue_dosomething_form_alter_register(&$form, &$form_state, $form_id
  *  Modified drupal form.
  */
 function paraneue_dosomething_register_after_build($form, &$form_state) {
-  $form['field_birthdate']['#weight'] = '-19';
+  $form['field_birthdate']['#weight'] = '-18';
+  $form['field_birthdate']['#attributes']['class'] = array('auth--twocol');
   $form['field_birthdate'][LANGUAGE_NONE][0]['#theme_wrappers'] = array('form_element');
   $form['field_birthdate'][LANGUAGE_NONE][0]['value']['date']['#attributes']['placeholder'] = t('MM/DD/YYYY');
   $form['field_birthdate'][LANGUAGE_NONE][0]['value']['date']['#attributes']['class'] = array('js-validate');
@@ -113,6 +120,11 @@ function paraneue_dosomething_register_after_build($form, &$form_state) {
   $form['field_birthdate'][LANGUAGE_NONE][0]['value']['date']['#title'] = t('Birthday');
   unset($form['field_birthdate'][LANGUAGE_NONE][0]['#title']);
   unset($form['field_birthdate'][LANGUAGE_NONE][0]['value']['date']['#description']);
+
+  // If last name is shown, make first name full width
+  if (isset($form['field_last_name'])) {
+    $form['field_birthdate']['#attributes']['class'] = array();
+  }
 
   $form['account']['pass']['pass1']['#attributes']['placeholder'] = t('6+ characters... make it tricky!');
   $form['account']['pass']['pass1']['#attributes']['class'] = array('js-validate');

--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
@@ -57,7 +57,7 @@ function paraneue_dosomething_form_alter_register(&$form, &$form_state, $form_id
     $form['field_first_name'][LANGUAGE_NONE][0]['value']['#attributes']['class'] = array('js-validate');
     $form['field_first_name'][LANGUAGE_NONE][0]['value']['#attributes']['data-validate'] = 'name';
     $form['field_first_name'][LANGUAGE_NONE][0]['value']['#attributes']['data-validate-required'] = '';
-    
+
     // If last name is shown, make first name full width
     if (isset($form['field_last_name'])) {
       $form['field_first_name']['#attributes']['class'] = array();
@@ -69,7 +69,7 @@ function paraneue_dosomething_form_alter_register(&$form, &$form_state, $form_id
       $form['field_last_name']['#weight'] = '-19';
       $form['field_last_name'][LANGUAGE_NONE][0]['value']['#attributes']['placeholder'] = t('What\'s your P.E. teacher call you?');
       $form['field_last_name'][LANGUAGE_NONE][0]['value']['#attributes']['class'] = array('js-validate');
-      $form['field_last_name'][LANGUAGE_NONE][0]['value']['#attributes']['data-validate'] = 'name';
+      $form['field_last_name'][LANGUAGE_NONE][0]['value']['#attributes']['data-validate'] = 'last_name';
       $form['field_last_name'][LANGUAGE_NONE][0]['value']['#attributes']['data-validate-required'] = '';
     }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
@@ -26,22 +26,37 @@ define(function(require) {
     return false;
   }
 
+  // @TODO: This will be removed when Neue's validation gets refactored.
+  function validateNotBlank(string, done, success, failure) {
+    if( string !== "" ) {
+      return done({
+        success: true,
+        message: success
+      });
+    } else {
+      return done({
+        success: false,
+        message: failure
+      });
+    }
+  }
+
   // # Add validation functions...
 
   // ## Name
   // Greets the user when they enter their name.
   Validation.registerValidationFunction("name", function(string, done) {
-    if( string !== "" ) {
-      return done({
-        success: true,
-        message: Drupal.t("Hey, @name!", {"@name": string})
-      });
-    } else {
-      return done({
-        success: false,
-        message: Drupal.t("We need your first name.")
-      });
-    }
+    validateNotBlank(string, done,
+      Drupal.t("Hey, @name!", {"@name": string}),
+      Drupal.t("We need your first name.")
+    );
+  });
+
+  Validation.registerValidationFunction("last_name", function(string, done) {
+    validateNotBlank(string, done,
+      Drupal.t("Got it, @name!", {"@name": string}),
+      Drupal.t("We need your last name.")
+    );
   });
 
   // ## Birthday

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_auth.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_auth.scss
@@ -15,21 +15,11 @@
     margin: 18px 0;
   }
 
-  .field-name-field-first-name {
+  .auth--twocol {
     @include media($tablet) {
       float: left;
       width: 50%;
       padding-right: 9px;
-      @include box-sizing(border-box);
-    }
-  }
-
-  .field-name-field-birthdate {
-    @include media($tablet) {
-      float: left;
-      width: 50%;
-      padding-left: 9px;
-      @include box-sizing(border-box);
     }
   }
 }


### PR DESCRIPTION
# Changes
- Updates to registration form for UK international site. See [DS-410](https://jira.dosomething.org/browse/DS-410).
# How do I test?

Pull down this branch. There should be no visible changes to the registration form. Run `drush en -y dosomething_uk`, and enable the "Last Name" and "ZIP Code" fields under dosomething_user admin panel. You should now see the additional fields and "First Name" and "Birthday" should be shown full-width [like this](https://cloud.githubusercontent.com/assets/583202/4337077/19e3f300-400c-11e4-83eb-f8fd2d00cc2f.png).
# Questions
- I'm not doing post-code alters here, because it seems like that would have to happen inside dosomething_user, and that seems messy. Does anyone have any ideas if there's a clean way to alter that zip code element, but only in the registration form?
