### PR TITLE
Provide UK-specific integration tests.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -98,13 +98,16 @@ ds pull [stage|stage.$AFFILIATE|prod] [--db|--files]
     can be synced to avoid overwriting the html directory.
 
 ds test
-  Run unit and integration tests.
-  
+  Run unit and US integration tests.
+
   --unit
   Runs unit tests using Mocha.
 
   --integration
   Runs integration tests using CasperJS.
+
+  --intl-integration <affiliate> [test]
+  Runs affiliate-specific integration tests.
 
 ds --help
   Displays this help message.
@@ -518,6 +521,34 @@ function integration_tests {
 }
 
 #=== FUNCTION ==================================================================
+# NAME: intl_integration_tests
+# DESCRIPTION: Runs affiliate-specific integration tests
+#===============================================================================
+function intl_integration_tests {
+  # Make sure latest project NPM dependencies are installed
+  cd $BASE_PATH
+  npm install
+
+  AFFILIATE=$1
+  AFFILIATE_TEST_PATH="$TEST_PATH/integration-intl/$AFFILIATE"
+  if [[ ! -d "$AFFILIATE_TEST_PATH" ]]; then
+    printf "\n\033[1;33mIntegration tests do not exist for $1.\033[00m\n"
+    return 1
+  fi
+
+  # Optionally, specify an individual test or directory to run
+  TEST=$2
+
+  # An alternative test environment can be set using the $DS_TEST_HOSTNAME environment variable
+  DS_TEST_HOSTNAME="${DS_TEST_HOSTNAME:=http://dev.dosomething.org:8888}"
+
+  # Run integration tests.
+  cd $BASE_PATH
+  printf "\n\033[1;33mRunning $AFFILIATE integration tests on $DS_TEST_HOSTNAME...\033[00m\n"
+  casperjs test $AFFILIATE_TEST_PATH/$TEST --fail-fast --url=$DS_TEST_HOSTNAME --includes=$TEST_PATH/scripts/common.js,$TEST_PATH/scripts/drush.js,$TEST_PATH/scripts/randomuser.js --xunit=$BASE_PATH/tmp/integration-intl-test-results.xml
+}
+
+#=== FUNCTION ==================================================================
 # NAME: unit_tests 
 # DESCRIPTION: Runs unit tests using Mocha. 
 #===============================================================================
@@ -650,6 +681,9 @@ then
   elif [[ $2 == "--integration" ]]
   then
     integration_tests $3
+  elif [[ $2 == "--intl-integration" ]]
+  then
+    intl_integration_tests $3 $4
   else
     unit_tests
     integration_tests

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "chai": "~1.7.0",
     "mocha": "~1.12.0",
-    "phantomcss": "^0.7.2"
+    "phantomcss": "^0.7.2",
+    "moment": "^2"
   }
 }

--- a/tests/integration-intl/uk/drupal.coffee
+++ b/tests/integration-intl/uk/drupal.coffee
@@ -1,0 +1,29 @@
+# Drupal
+
+# ------------------------------------------------------------------------
+# Test Drupal configuration
+
+casper.test.begin "Test that Drupal configure for the UK correctly", 4, (test) ->
+
+  # OAuth Base URL.
+  result = casper.drush ["vget", "dosomething_uk_oauth_url"]
+  test.assertTruthy result, 'OAuth Base URL setting present.'
+
+  # OAuth Key.
+  result = casper.drush ["vget", "dosomething_uk_oauth_key"]
+  test.assertTruthy result, 'OAuth Key setting present.'
+
+  # OAuth Secret.
+  result = casper.drush ["vget", "dosomething_uk_oauth_secret"]
+  test.assertTruthy result, 'OAuth Secret setting present.'
+
+  # OAuth Secret.
+  result = casper.drush ["vget", "date_format_short"]
+  test.assertEquals result,
+    """date_format_short: 'd/m/Y - H:i'\n""",
+    'Date format is d/m/Y.'
+
+  test.done()
+  return
+
+# ------------------------------------------------------------------------

--- a/tests/integration-intl/uk/sso.coffee
+++ b/tests/integration-intl/uk/sso.coffee
@@ -1,0 +1,176 @@
+# SSO
+
+# Sometimes SSO server response takes long.
+casper.options.waitTimeout = 10000
+
+# Constants.
+AGE_TOO_OLD = 25
+
+# Form selectors.
+FORM = '#user-register-form'
+FIELD_MAIL       = 'mail'
+FIELD_PASS       = 'pass[pass1]'
+FIELD_PASS_2     = 'pass[pass2]'
+FIELD_FIRST_NAME = 'field_first_name[und][0][value]'
+FIELD_LAST_NAME  = 'field_last_name[und][0][value]'
+FIELD_BIRTHDATE  = 'field_birthdate[und][0][value][date]'
+FIELD_POSTCODE   = 'field_address[und][0][postal_code]'
+
+# Generate user.
+user = casper.getRandomUser()
+uid = false
+
+# ------------------------------------------------------------------------
+# Test registration form
+
+casper.test.begin "Test that registration form is integrated with SSO", 3, (test) ->
+
+  # Launch browser on registration page.
+  casper.start "#{url}/user/register"
+
+  # Ensure registration form.
+  casper.then -> test.assertExists FORM, 'Registration form found.'
+
+  # Check remote validation by providing user with date out of range.
+  casper.then -> growOld user; fillSignupForm user
+  casper.thenClick '#edit-submit'
+
+  # Ensure error message is generated.
+  casper.waitForSelector '.error', ->
+    test.assertSelectorHasText '.error',
+      "You're too old for us now",
+      'SSO validates data remotely, user can see validation error messages.'
+    return
+
+  # Submit valid registration form.
+  casper.then -> rejuvenate user; fillSignupForm user
+  casper.thenClick '#edit-submit'
+
+  # Check whether the registration is successful.
+  assert_message = 'User is registered can see own profile.'
+  casper.waitForUrl /\/user\/[0-9]+\/edit$/,
+    ->
+      # Success.
+      test.assertExists '.status', assert_message
+      saveUserUid()
+    ->
+      @echo 'Registration form errors:', 'ERROR'
+      @echo @fetchText('.error').trim(), 'WARNING'
+      test.assert false, assert_message
+
+  # Run tests.
+  casper.run -> @test.done()
+  return
+
+# ------------------------------------------------------------------------
+# Test user created from SSO
+
+casper.test.begin "Test that user created from SSO has correct data", 6, (test) ->
+
+  # Launch browser on registration page.
+  casper.start url
+
+  # Test the nid is present
+  test.assertTruthy uid, "User id from the signup test found."
+
+  # Delete user account.
+  casper.then ->
+    @logAction "Remove the user to test login using remote account only:"
+    @deleteUser uid
+
+  # Perform the login.
+  login test
+
+  # Go to the edit profile page.
+  # We don't know new uid yet, but user/register will redirect to the page.
+  casper.thenOpen "#{url}/user/register"
+
+  # Ensure user data is consistent with the original one.
+  casper.then ->
+    test.assertField FIELD_FIRST_NAME, user.first_name,
+      "Test if user has correct first name."
+
+    test.assertField FIELD_LAST_NAME, user.last_name,
+      "Test if user has correct last name."
+
+    test.assertField FIELD_BIRTHDATE, user.dob.format("DD/MM/YYYY"),
+      "Test if user has correct birthdate."
+
+    test.assertField FIELD_POSTCODE, user.postcode,
+      "Test if user has correct postcode."
+
+    saveUserUid()
+    return
+
+  # Run tests.
+  casper.run -> @test.done()
+  return
+
+
+# ------------------------------------------------------------------------
+# Test login form
+
+casper.test.begin "Test that user created from SSO can login", 1, (test) ->
+
+  # Launch browser on registration page.
+  casper.start url
+
+  # Perform the login.
+  login test
+
+  # Cleanup after success.
+  casper.then ->
+    @logAction "Cleanup after full success:"
+    @deleteUser uid
+
+  # Run tests.
+  casper.run -> @test.done()
+  return
+
+# ------------------------------------------------------------------------
+# Utilities
+
+fillSignupForm = (user) ->
+  # Override generated postcode with British.
+  user.postcode = "CF10 5AN"
+
+  # Prepare user data.
+  data = {}
+  data[FIELD_MAIL]       = user.email
+  data[FIELD_PASS]       = user.password
+  data[FIELD_PASS_2]     = user.password
+  data[FIELD_FIRST_NAME] = user.first_name
+  data[FIELD_LAST_NAME]  = user.last_name
+  data[FIELD_BIRTHDATE]  = user.dob.format "DD/MM/YYYY"
+  data[FIELD_POSTCODE]   = user.postcode
+
+  # Fill in the registration form.
+  casper.fill FORM, data
+  return
+
+# Sets user's birthrate within validation range.
+rejuvenate = (user) ->
+  user.dob.year moment().subtract(AGE_TOO_OLD - 5, 'years').year()
+
+# Sets user birthrate greater than SSO accepts.
+growOld = (user) ->
+  user.dob.year moment().subtract(AGE_TOO_OLD + 10, 'years').year()
+
+# Finds user uid on the profile edit page ans saves it to global variable.
+saveUserUid = ->
+  uid = casper.getCurrentUrl().match(/\/user\/([0-9]+)\/edit$/)[1]
+
+# Finds user uid on the profile edit page ans saves it to global variable.
+login = (test) ->
+
+  # Login user.
+  casper.then -> @login user.email, user.password
+
+  # Ensure user has landed on its profile page.
+  casper.then ->
+    test.assertSelectorHasText "h1.__title", "Hey, #{user.first_name}",
+      "Test if user is logged in."
+  return
+
+
+# ------------------------------------------------------------------------

--- a/tests/scripts/randomuser.js
+++ b/tests/scripts/randomuser.js
@@ -1,0 +1,31 @@
+
+var moment = require(ROOT + '/node_modules/moment/moment');
+
+var user = {};
+
+// Returns generated random user.
+casper.getRandomUser = function() {
+  return user;
+}
+
+// Generate user asynchronously.
+casper.generateRandomUser = function() {
+  var page = require('webpage').create();
+  page.open('http://api.randomuser.me', function () {
+    var randomUser = JSON.parse(page.plainText)['results'][0]['user'];
+
+    user.first_name = ucfirst(randomUser['name']['first']);
+    user.last_name  = ucfirst(randomUser['name']['last']);
+    user.username   = randomUser['username'];
+    user.email      = randomUser['email'];
+    user.password   = randomUser['username'];
+    user.dob        = moment.unix(randomUser['dob']);
+  });
+}
+// Generate initial user on start.
+casper.generateRandomUser();
+
+// Utilities.
+function ucfirst(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}


### PR DESCRIPTION
#### What's this PR do?
- Provides possibility to create affiliate-specific integration tests: `ds test --intl-integration uk`
- Includes [momentjs](http://momentjs.com/) npm library to simplify work with dates
- Provides random user generation for casper tests
- Provides UK SSO integration failtest:
  - Test that Drupal configure for the UK correctly:
    - OAuth settings must present
    - Date format must be `d/m/y`
  - Test that registration form is integrated with SSO
  - Test that user created from SSO has correct data
  - Test that user created from SSO can login

![image](https://cloud.githubusercontent.com/assets/672669/4343823/67851fd2-4064-11e4-8415-020a0d423eea.png)
#### How should this be manually tested?

Your vagrant have to be updated to the last baseline.
- `drush en dosomething_uk`
- Set `dosomething_uk_oauth_url`, `dosomething_uk_oauth_key`, `dosomething_uk_oauth_secret` variables
- `drush vset date_format_short "d/m/Y - H:i"`
- Login to VM and cd to `/var/www/vagrant`
- Run `bin/ds test --intl-integration uk`
- Wait for tests to finish
#### Any background context you want to provide?

I wrote UK tests in [coffeescript](http://coffeescript.org/) because:
- I was in hurry
- I think casper tests are more compact and readable on coffee
- It's 100% compatible with other test scripts, you can user all js function from `common.js`
- It's already built into `casperjs`, no additional changes is required
- Now we can compare what's more convinient to write scripts.  
  If we agree to not use coffee anymore, I'll just compile tests to pure js and do the readability refactoring
#### What are the relevant tickets?

This tests are to ensure nothing gets broken during [#DS-377](https://jira.dosomething.org/browse/DS-377) and [#DS-379](https://jira.dosomething.org/browse/DS-379).
