### PR TITLE
Allow editors manage content aliases.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.features.user_permission.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.features.user_permission.inc
@@ -320,6 +320,7 @@ function dosomething_user_user_default_permissions() {
     'name' => 'create url aliases',
     'roles' => array(
       'administrator' => 'administrator',
+      'editor' => 'editor',
     ),
     'module' => 'path',
   );


### PR DESCRIPTION
#### What's this PR do?
- Grants `editors` role a permission to see, create and edit URL paths on content edit form
#### What are the relevant tickets?

Closes [#DS-412](https://jira.dosomething.org/browse/DS-412).
