### PR TITLE
narrowed msg callout width

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -176,7 +176,8 @@
     form {
       .message-callout {
         margin: 0 auto;
-        width: 270px;
+        text-align: center;
+        width: 215px;
 
         @include media($tablet) {
           margin: 0;


### PR DESCRIPTION
Made width on `.message-callout` on sms campaigns to be more narrow so the text can be closer to the arrow.

Note: enforce content restriction to max out at two lines.

![image](https://cloud.githubusercontent.com/assets/1566749/4380571/457d189a-436b-11e4-85d8-7e11e547abf8.png)

Resolves #2738
