### PR TITLE
Fixes passing override arguments to the test runner.

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -36,36 +36,37 @@ program
 
 // Load a configuration file from the tests/config directory:
 if(program.args.length) {
-  config = require("../tests/config/" + program.args[0] + ".json");
+  configPath = program.args[0];
 } else {
-  console.log("Running tests with `default` configuration.".bold.blue)
-  config = require("../tests/config/default.json");
+  configPath = "default";
 }
 
-// Set or override unit tests with --unit [test]:
-if(program.mocha) {
+console.log("Running tests with '%s' configuration.".bold.blue, configPath);
+config = require("../tests/config/" + configPath + ".json");
+
+// Set or override unit tests with --mocha [test]:
+if(!_.isUndefined(program.mocha)) {
   config.mocha = program.mocha;
 }
 
-// Set or override integration tests with --integration [test]:
-if(program.casperjs) {
-  integrationFiles = getFiles("tests/integration" + program.casperjs + ".{js,coffee}");
-  console.log(integrationFiles);
+// Set or override integration tests with --casperjs [test]:
+if(!_.isUndefined(program.casperjs)) {
+  config.casperjs = [program.casperjs];
 }
 
 // Toggle verbose output with --verbose:
 if(program.url) {
-  config.url = program.url;  
+  config.url = program.url;
 }
 
 // Toggle XUnit XML output with --xunit:
 if(program.xunit) {
-  config.xunit = true;  
+  config.xunit = true;
 }
 
 // Set or override CasperJS URL with --url [url]:
 if(program.verbose) {
-  config.verbose = true;  
+  config.verbose = true;
 }
 
 // Start 'er up.

--- a/bin/test
+++ b/bin/test
@@ -97,7 +97,7 @@ function runUnitTests(callback) {
     }
 
     if(config.xunit) {
-      fs.writeFileSync(__dirname + '/../tmp/mocha-test-results.xml', output);
+      fs.writeFileSync(__dirname + '/../tmp/tests/mocha-test-results.xml', output);
       console.log("Wrote Mocha test results to file.".bold.blue);
     }
 
@@ -144,7 +144,7 @@ function runIntegrationTests() {
 
   var _casperXUnit = "";
   if(config.verbose) {
-    _casperXUnit = "--xunit=" + __dirname + "../tmp/integration-test-results.xml";
+    _casperXUnit = "--xunit=" + __dirname + "../tmp/tests/integration-test-results.xml";
   }
 
   var casperCmd = [

--- a/tests/scripts/config.js
+++ b/tests/scripts/config.js
@@ -8,8 +8,8 @@ var url = casper.cli.get('url');
 casper.options.viewportSize = { width: 1280, height: 1024 };
 
 var CAMPAIGN = {
-  nid: 1535,
-  url: url + "/node/" + 1535,
+  nid: 1485,
+  url: url + "/node/" + 1485,
   data: require(ROOT + "/tests/fixtures/campaign.json")
 }
 


### PR DESCRIPTION
# Changes
- I wasn't setting CasperJS overrides correctly, so you couldn't override from the command line with `ds test --casperjs="user/**/*"` for example. Now you can. :cake: 
