### PR TITLE
Casper fail screenshots

### DIFF
--- a/tests/scripts/common.js
+++ b/tests/scripts/common.js
@@ -142,6 +142,11 @@ casper.timestampCapture = function(label) {
   casper.capture(ROOT + "/tmp/tests/screenshots/" + filename);
 }
 
+// Take a screenshot when a test fails
+casper.test.on("fail", function(failure) {
+  casper.timestampCapture("fail");
+});
+
 // We want to clear session after every test.
 // @NOTE: You'll have to do this manually if you override the tearDown
 //        method on a particular test.

--- a/tests/scripts/common.js
+++ b/tests/scripts/common.js
@@ -132,6 +132,16 @@ casper.logout = function() {
   });
 }
 
+// Capture a screenshot with timestamp to tmp directory.
+casper.timestampCapture = function(label) {
+  label = (typeof label === "string" ? label : "");
+
+  var timestamp = new Date().getTime();
+  var filename = timestamp + "-" + label + ".png";
+  casper.echo("Captured screenshot to `tmp/tests/screenshots/" + filename + "`.", "PARAMETER");
+  casper.capture(ROOT + "/tmp/tests/screenshots/" + filename);
+}
+
 // We want to clear session after every test.
 // @NOTE: You'll have to do this manually if you override the tearDown
 //        method on a particular test.


### PR DESCRIPTION
# Changes
- Adds a `casper.timestampHelper` method which saves a screenshot with timestamp and optional label.
- Take a screenshot on all test failures for help debugging.
