### PR TITLE
DS-384 - Drops data column from dosomething_signup table

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -432,7 +432,7 @@ function dosomething_signup_update_7012() {
   $table = 'dosomething_signup';
   $column = 'nid';
   if (!db_index_exists($table, $column)) {
-      db_add_index($table, $column, array($column));
+    db_add_index($table, $column, array($column));
   }
 }
 
@@ -465,5 +465,19 @@ function dosomething_signup_update_7014() {
   if (!db_field_exists($tbl_name, $field_name)) {
     // Add it per the schema field definition.
     db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
+  }
+}
+
+/**
+ * Drops deprecated data column from the dosomething_signup table.
+ *
+ * See dosomething_signup_update_7001().
+ */
+function dosomething_signup_update_7015() {
+  $tbl_name = 'dosomething_signup';
+  $field_name = 'data';
+  // If the field exists:
+  if (db_field_exists($tbl_name, $field_name)) {
+    db_drop_field($tbl_name, $field_name);
   }
 }


### PR DESCRIPTION
We added the `data` column when importing legacy signups for the Mind on my Money campaign in `dosomething_user_update_7001` and have not used the `data` column since.  

It's currently not used anywhere in the site.
