### PR TITLE
Adds messagebroker-config to make file

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -240,6 +240,10 @@ projects[stage_file_proxy][subdir] = "contrib"
 libraries[messagebroker-phplib][download][type] = "git"
 libraries[messagebroker-phplib][download][url] = "https://github.com/DoSomething/messagebroker-phplib.git"
 
+; Message Broker Configuration
+libraries[messagebroker-config][download][type] = "git"
+libraries[messagebroker-config][download][url] = "https://github.com/DoSomething/messagebroker-config.git"
+
 ; Mobile Commons PHP
 libraries[mobilecommons-php][download][type] = "git"
 libraries[mobilecommons-php][download][url] = "https://github.com/DoSomething/mobilecommons-php.git"


### PR DESCRIPTION
Fixes #3102 

As a part of the Drupal Message Broker refactoring:

https://jira.dosomething.org/browse/MB-45
https://github.com/DoSomething/message_broker_producer/issues/44
- Access to `mb_config.json` from the `messagebroker-config` repo is required for the `message_broker_producer.module`.
