### PR TITLE
Pitch Page updates

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -301,10 +301,9 @@ function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
   $vars['campaign']->is_pitch_page = TRUE;
   // Check for a signup button copy override.
   $label = $vars['campaign']->variables['signup_form_submit_label'];
-  // Adds signup_button_primary variable.
-  dosomething_signup_preprocess_signup_button($vars, $label, NULL, 'primary');
-  // Adds signup_button_secondary variable.
-  dosomething_signup_preprocess_signup_button($vars, $label, NULL, 'secondary');
+  // Adds signup_button_primary and signup_button_secondary variables.
+  $ids = array('primary', 'secondary');
+  dosomething_signup_preprocess_signup_button($vars, $label, NULL, $ids);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -301,7 +301,10 @@ function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
   $vars['campaign']->is_pitch_page = TRUE;
   // Check for a signup button copy override.
   $label = $vars['campaign']->variables['signup_form_submit_label'];
-  dosomething_signup_preprocess_signup_button($vars, $label);
+  // Adds signup_button_primary variable.
+  dosomething_signup_preprocess_signup_button($vars, $label, NULL, 'primary');
+  // Adds signup_button_secondary variable.
+  dosomething_signup_preprocess_signup_button($vars, $label, NULL, 'secondary');
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -6,6 +6,25 @@
  */
 
 /**
+ * Implements hook_forms().
+ *
+ * Allows dosomething_signup_form to render multiple times on auth pitch page.
+ */
+function dosomething_signup_forms($form_id, $args) {
+  // If this is one of multiple signup forms rendered on the page:
+  if (strpos($form_id, 'dosomething_signup_form_') === 0) {
+    // Set its callback and callback arguments:
+    $forms[$form_id] = array(
+      // Set the callback as dosomething_signup_form.
+      'callback' => 'dosomething_signup_form',
+      // Pass the relevant $args to it.
+      'callback arguments' => $args,
+    );
+  }
+  return $forms;
+}
+
+/**
  * Form constructor for user signup form.
  *
  * Displayed for an authenticated user to signup for a node.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
@@ -16,27 +16,35 @@
  * @param string $label
  *   The label to display fon the button.
  * @param string $presignup
- *   Optional - If TRUE, get the presignup form, else regular signup form.
+ *   (optional) If TRUE, get the presignup form, else regular signup form.
+ * @param string $id
+ *   (optional) The identifier of the signup form, if multiple forms are rendered.
  */
-function dosomething_signup_preprocess_signup_button(&$vars, $label = "Sign Up", $presignup = FALSE) {
+function dosomething_signup_preprocess_signup_button(&$vars, $label = "Sign Up", $presignup = FALSE, $id = NULL) {
   // In case we were passed a NULL value for $label:
   if ($label == NULL) {
     $label = "Sign Up";
   }
   $label = t($label);
+  $var_name = 'signup_button';
+  $form_id = 'dosomething_signup_form';
+  if ($id) {
+    $var_name .= '_' . $id;
+    $form_id .= '_' . $id;
+  }
+  // If this is a presignup form:
+  if ($presignup) {
+    $form_id = 'dosomething_signup_presignup_form';
+  }
   // If user is logged in:
   if (user_is_logged_in()) {
-    $form_id = 'dosomething_signup_form';
-    if ($presignup) {
-      $form_id = 'dosomething_signup_presignup_form';
-    }
     // Render button as sign up form.
-    $vars['signup_button'] = drupal_get_form($form_id, $vars['nid'], $label);
+    $vars[$var_name] = drupal_get_form($form_id, $vars['nid'], $label);
   }
   // Otherwise, for anonymous user:
   else {
     // Render button as link to open up the login modal.
-    $vars['signup_button'] = array(
+    $vars[$var_name] = array(
       '#markup' => dosomething_user_get_login_modal_link_markup($label),
     );
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
@@ -17,10 +17,10 @@
  *   The label to display fon the button.
  * @param string $presignup
  *   (optional) If TRUE, get the presignup form, else regular signup form.
- * @param string $id
- *   (optional) The identifier of the signup form, if multiple forms are rendered.
+ * @param array $ids
+ *   (optional) Array of each signup form id, if multiple forms are rendered.
  */
-function dosomething_signup_preprocess_signup_button(&$vars, $label = "Sign Up", $presignup = FALSE, $id = NULL) {
+function dosomething_signup_preprocess_signup_button(&$vars, $label = "Sign Up", $presignup = FALSE, $ids = array()) {
   // In case we were passed a NULL value for $label:
   if ($label == NULL) {
     $label = "Sign Up";
@@ -28,24 +28,39 @@ function dosomething_signup_preprocess_signup_button(&$vars, $label = "Sign Up",
   $label = t($label);
   $var_name = 'signup_button';
   $form_id = 'dosomething_signup_form';
-  if ($id) {
-    $var_name .= '_' . $id;
-    $form_id .= '_' . $id;
-  }
   // If this is a presignup form:
   if ($presignup) {
     $form_id = 'dosomething_signup_presignup_form';
   }
+  // If we have an array of signup forms to render:
+  if (!empty($ids)) {
+    // Loop through each id:
+    foreach ($ids as $id) {
+      // Append the $id to the end of the variable and form_id.
+      $multi_var_name = $var_name . '_' . $id;
+      $multi_form_id = $form_id . '_' . $id;
+      // Add signup_button_$id as a variable to $vars.
+      $vars[$multi_var_name] = dosomething_signup_get_signup_button($label, $vars['nid'], $multi_form_id);
+    }
+  }
+  // else if no multiples:
+  else {
+    // Just add the 'signup_button' variable to $vars.
+    $vars[$var_name] = dosomething_signup_get_signup_button($label, $vars['nid'], $form_id);
+  }
+}
+
+/**
+ * Returns signup button array to be rendered within a template file.
+ */
+function dosomething_signup_get_signup_button($label, $nid, $form_id) {
   // If user is logged in:
   if (user_is_logged_in()) {
-    // Render button as sign up form.
-    $vars[$var_name] = drupal_get_form($form_id, $vars['nid'], $label);
+    // Return signup form array to be rendered.
+    return drupal_get_form($form_id, $nid, $label);
   }
-  // Otherwise, for anonymous user:
-  else {
-    // Render button as link to open up the login modal.
-    $vars[$var_name] = array(
-      '#markup' => dosomething_user_get_login_modal_link_markup($label),
-    );
-  }
+  // Otherwise, for anonymous user, return a #markup array to be rendered.
+  return array(
+    '#markup' => dosomething_user_get_login_modal_link_markup($label),
+  );
 }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -15,9 +15,9 @@
     <div class="wrapper">
       <?php print $campaign_headings; ?>
 
-      <?php if (isset($signup_button)): ?>
+      <?php if (isset($signup_button_primary)): ?>
         <div class="__signup">
-          <?php print render($signup_button); ?>
+          <?php print render($signup_button_primary); ?>
           <?php print $campaign_scholarship; ?>
         </div>
       <?php endif; ?>
@@ -59,7 +59,9 @@
     <div class="cta">
       <div class="wrapper">
         <h2 class="__message"><?php print $campaign->secondary_call_to_action; ?></h2>
-        <?php print render($signup_button); ?>
+        <?php if (isset($signup_button_secondary)): ?>
+          <?php print render($signup_button_secondary); ?>
+        <?php endif; ?>
       </div>
     </div>
   <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -39,4 +39,13 @@
 
   </div>
 
+  <?php if (isset($campaign->secondary_call_to_action)): ?>
+  <div class="cta">
+    <div class="wrapper">
+      <h2 class="__message"><?php print $campaign->secondary_call_to_action; ?></h2>
+      <?php print render($signup_button); ?>
+    </div>
+  </div>
+  <?php endif; ?>
+
 </section>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -5,7 +5,7 @@
  * Available Variables
  * - $campaign: A campaign object. @see dosomething_campaign_load()
  * - $classes: Additional classes passed for output (string).
- * - $scholarship: Scholarship amount (string).
+ * - $campaign_scholarship: Scholarship amount (string).
  */
 ?>
 
@@ -26,26 +26,51 @@
     </div>
   </header>
 
-  <div class="wrapper">
-
-    <div class="container container--tagline">
+  <?php if (isset($campaign->value_proposition)): ?>
+    <div class="container">
       <div class="wrapper">
-        <p class="__tagline">
-          <?php print t('A DoSomething.org Campaign. Join over 2.5 million young people taking action. Any cause, anytime, anywhere.'); ?>
-          <em><?php print t('*Mic drop'); ?></em>
-        </p>
-      </div>
-    </div>
+        <div class="container__body">
+          <div class="-columned -odd">
+            <h3><?php print t('The Problem'); ?></h3>
+            <p><?php print $campaign->fact_problem['fact']; ?></p>
 
-  </div>
+            <h3><?php print t('The Solution'); ?></h3>
+            <?php // @TODO: DRY this logic with action page via $campaign ?>
+            <?php if (isset($campaign->fact_solution)): ?>
+              <p><?php print $campaign->fact_solution['fact']; ?></p>
+            <?php elseif (isset($campaign->solution_copy)): ?>
+              <?php print $campaign->solution_copy; ?>
+            <?php endif; ?>
+
+            <?php if (isset($campaign->solution_support)): ?>
+              <?php print $campaign->solution_support; ?>
+            <?php endif; ?>
+          </div>
+          <div class="-columned -even">
+            <h3 class="__title"><?php print t('What You Get'); ?></h3>
+            <p class="__copy"><?php print $campaign->value_proposition; ?></p>
+          </div>
+        </div>
+      </div><!-- .wrapper -->
+    </div><!-- .container -->
+  <?php endif; ?>
 
   <?php if (isset($campaign->secondary_call_to_action)): ?>
-  <div class="cta">
+    <div class="cta">
+      <div class="wrapper">
+        <h2 class="__message"><?php print $campaign->secondary_call_to_action; ?></h2>
+        <?php print render($signup_button); ?>
+      </div>
+    </div>
+  <?php endif; ?>
+
+  <div class="container container--tagline">
     <div class="wrapper">
-      <h2 class="__message"><?php print $campaign->secondary_call_to_action; ?></h2>
-      <?php print render($signup_button); ?>
+      <p class="__tagline">
+        <?php print t('A DoSomething.org Campaign. Join over 2.5 million young people taking action. Any cause, anytime, anywhere.'); ?>
+        <em><?php print t('*Mic drop'); ?></em>
+      </p>
     </div>
   </div>
-  <?php endif; ?>
 
 </section>


### PR DESCRIPTION
Outputs new fields and alters Pitch Page markup per https://jira.dosomething.org/browse/DS-16
- Implements `hook_forms` to render the signup button twice on the pitch page, once as `signup_button_primary` and again as `signup_button_secondary`
- Only outputs the new fields (`field_secondary_call_to_action` and `field_value_proposition`) if they have been set
