### PR TITLE
Updates Services contrib module

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -149,7 +149,7 @@ projects[redis][version] = "2.6"
 projects[redis][subdir] = "contrib"
 
 ; Services
-projects[services][version] = "3.7"
+projects[services][version] = "3.10"
 projects[services][subdir] = "contrib"
 
 ; Strongarm


### PR DESCRIPTION
Closes https://jira.dosomething.org/browse/DS-439, gets rid of sad "There are security updates available for one or more of your modules or themes. To ensure the security of your server, you should update immediately! See the available updates page for more information and to install your missing updates." message
