### PR TITLE
Fixes Signup Form PHP Notice

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -20,8 +20,8 @@ function dosomething_signup_forms($form_id, $args) {
       // Pass the relevant $args to it.
       'callback arguments' => $args,
     );
+    return $forms;
   }
-  return $forms;
 }
 
 /**


### PR DESCRIPTION
Fixes https://jira.dosomething.org/browse/DS-440

Stops the millions of "Notice: Undefined variable: forms in dosomething_signup_forms() (line 24 of /var/www/vagrant/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc)." messages I've flooded our logs with :(
