### PR TITLE
Fixes sporadic timing-related test failures.

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/modal-links.tpl.php
+++ b/lib/modules/dosomething/dosomething_helpers/modal-links.tpl.php
@@ -19,7 +19,6 @@
 
 <?php if (isset($modals['faq'])): ?>
 <div data-modal id="modal-faq" role="dialog">
-  <a href="#" class="js-close-modal modal-close-button white">×</a>
   <h2 class="banner"><?php print t('FAQs'); ?></h2>
   <?php foreach ($modals['faq'] as $item): ?>
     <h4 class="faq-header"><?php print $item['header']; ?></h4>
@@ -31,7 +30,6 @@
 
 <?php if (isset($modals['more_facts'])): ?>
 <div data-modal id="modal-facts" role="dialog">
-  <a href="#" class="js-close-modal modal-close-button white">×</a>
   <h2 class="banner"><?php print t('Facts'); ?></h2>
   <ul>
   <?php foreach ($modals['more_facts']['facts'] as $key => $fact): ?>
@@ -54,7 +52,6 @@
 <?php if (isset($modals['partner_info'])): ?>
   <?php foreach ($modals['partner_info'] as $delta => $partner): ?>
     <div data-modal id="modal-partner-<?php print $delta; ?>" role="dialog">
-      <a href="#" class="js-close-modal modal-close-button white">×</a>
       <h2 class="banner"><?php print t('We &lt;3 @partner', array('@partner' => $partner['name'])); ?></h2>
       <?php print $partner['copy']; ?>
       <?php if (isset($partner['video'])): print $partner['video']; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/js/app.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/app.js
@@ -29,4 +29,8 @@ define("app", function(require) {
       Finder.init($form, $results, $blankSlate);
     }
   });
+
+  $(document).ready(function() {
+    $("html").addClass("js-ready");
+  });
 });

--- a/tests/integration/campaign/action.js
+++ b/tests/integration/campaign/action.js
@@ -72,7 +72,7 @@ casper.test.begin("Test action page is rendered and functions correctly", {
       this.click("#modal-faq .js-close-modal");
 
       this.waitWhileVisible("#modal-faq", function() {
-        test.assert(true, "Clicking the close button hides the modal.")
+        test.assert(true, "Clicking the close button hides the FAQ modal.")
       });
     });
 
@@ -86,6 +86,10 @@ casper.test.begin("Test action page is rendered and functions correctly", {
 
     casper.then(function() {
       this.click("#modal-facts .js-close-modal");
+
+      this.waitWhileVisible("#modal-facts", function() {
+        test.assert(true, "Clicking the close button hides the Fact modal.")
+      });
     });
     
     // ## Do It
@@ -114,6 +118,10 @@ casper.test.begin("Test action page is rendered and functions correctly", {
 
     casper.then(function() {
       casper.click("#modal-contact-form .js-close-modal");
+
+      this.waitWhileVisible("#modal-contact-form", function() {
+        test.assert(true, "Clicking the close button hides the Contact Form modal.")
+      });
     });
 
     // ## Report Back

--- a/tests/integration/campaign/action.js
+++ b/tests/integration/campaign/action.js
@@ -28,7 +28,6 @@ casper.test.begin("Test action page is rendered and functions correctly", {
     casper.login(user.email, user.password);
     
     // ## Header 
-
     casper.thenOpenWhenReady(CAMPAIGN.url, function() {
       // We expect to see the title and subtitle of the CAMPAIGN
       test.assertSelectorHasText("header[role='banner'].-hero .__title", CAMPAIGN.data.title, "Title of campaign is printed in H1.");
@@ -59,7 +58,6 @@ casper.test.begin("Test action page is rendered and functions correctly", {
     });
 
     // ## Know It
-
     casper.thenOpenWhenReady(CAMPAIGN.url, function() {
       test.assertNotVisible("[data-modal]", "Modals are hidden on page load.");
 

--- a/tests/integration/campaign/action.js
+++ b/tests/integration/campaign/action.js
@@ -130,11 +130,8 @@ casper.test.begin("Test action page is rendered and functions correctly", {
           "why_participated": "Test response."
         }, true);
       });
-    });
 
-    // Confirmation page
-    casper.then(function() {
-      this.waitUntilVisible(".page-campaigns-confirmation", function() {
+      casper.waitForUrl(/confirmation/, function() {
         test.assertSelectorHasText("header[role='banner'] .__title", "You did it!", "Confirmation page shown after report back.");
         test.assertSelectorHasText("header[role='banner'] .__subtitle", CAMPAIGN.data.reportback_confirm_msg, "Campaign confirmation message is shown in subtitle.");
 
@@ -143,7 +140,7 @@ casper.test.begin("Test action page is rendered and functions correctly", {
     });
 
     // Check that reportback submitted successfully.
-    casper.thenOpen(CAMPAIGN.url, function() {
+    casper.thenOpenWhenReady(CAMPAIGN.url, function() {
       test.assertSelectorHasText("#link--report-back", "Update Submission", "Report back button changed to 'Update Submission'.");
       casper.click("#link--report-back");
       this.waitUntilVisible("[data-modal]", function() {

--- a/tests/integration/campaign/action.js
+++ b/tests/integration/campaign/action.js
@@ -28,7 +28,8 @@ casper.test.begin("Test action page is rendered and functions correctly", {
     casper.login(user.email, user.password);
     
     // ## Header 
-    casper.thenOpen(CAMPAIGN.url, function() {
+
+    casper.thenOpenWhenReady(CAMPAIGN.url, function() {
       // We expect to see the title and subtitle of the CAMPAIGN
       test.assertSelectorHasText("header[role='banner'].-hero .__title", CAMPAIGN.data.title, "Title of campaign is printed in H1.");
       test.assertSelectorHasText("header[role='banner'].-hero .__subtitle", CAMPAIGN.data.call_to_action, "Subtitle of campaign is printed in H2.");
@@ -58,31 +59,35 @@ casper.test.begin("Test action page is rendered and functions correctly", {
     });
 
     // ## Know It
-    casper.thenOpen(CAMPAIGN.url, function() {
-      casper.waitWhileVisible("[data-modal]", function() {
-        test.assertNotVisible("[data-modal]", "Modals are hidden on page load.")
-      });
 
-      this.wait(1000, function() { // let's make sure JS has loaded before clicking modal link
-        casper.click(x('//*[text()="Check out our FAQs"]'));
-        this.waitUntilVisible("#modal-faq", function() {
-          test.assertSelectorHasText("#modal-faq", CAMPAIGN.data.faq[0].header, "FAQ displays in modal on click.");
-        });
+    casper.thenOpenWhenReady(CAMPAIGN.url, function() {
+      test.assertNotVisible("[data-modal]", "Modals are hidden on page load.");
+
+      this.click(x('//*[text()="Check out our FAQs"]'));
+
+      this.waitUntilVisible("#modal-faq", function() {
+        test.assertSelectorHasText("#modal-faq", CAMPAIGN.data.faq[0].header, "FAQ displays in modal on click.");
       });
     });
 
     casper.then(function() {
-      casper.click("#modal-faq .js-close-modal");
+      this.click("#modal-faq .js-close-modal");
+
       this.waitWhileVisible("#modal-faq", function() {
         test.assert(true, "Clicking the close button hides the modal.")
       });
     });
 
     casper.then(function() {
-      casper.click(x('//*[text()="Learn more about ' + CAMPAIGN.data.issue + '"]'));
+      this.click(x('//*[text()="Learn more about ' + CAMPAIGN.data.issue + '"]'));
+      
       this.waitUntilVisible("#modal-facts", function() {
         test.assertSelectorHasText("#modal-facts", CAMPAIGN.data.facts[0].title, "Fact displays in modal on click.");
       });
+    });
+
+    casper.then(function() {
+      this.click("#modal-facts .js-close-modal");
     });
     
     // ## Do It
@@ -93,7 +98,7 @@ casper.test.begin("Test action page is rendered and functions correctly", {
       test.assertExists(tab1_active, "First tip is visible on page load.");
       test.assertDoesntExist(tab2_active, "Second tip is hidden on page load.");
 
-      casper.click("#tips-during [data-tab='2']");
+      this.click("#tips-during [data-tab='2']");
     });
 
     casper.then(function() {
@@ -118,17 +123,14 @@ casper.test.begin("Test action page is rendered and functions correctly", {
       casper.click(x('//*[text()="Submit Your Pic"]'));
       this.waitUntilVisible("#modal-report-back", function() {
         test.assertSelectorHasText("#modal-report-back", "Prove It", "Report Back modal displays on click.");
+        
+        this.fill("#dosomething-reportback-form", {
+          "files[reportback_file]": ROOT + "/tests/fixtures/reportback-image.png",
+          "quantity": "10",
+          "why_participated": "Test response."
+        }, true);
       });
     });
-
-    casper.then(function() {
-      this.fill("#dosomething-reportback-form", {
-        "files[reportback_file]": ROOT + "/tests/fixtures/reportback-image.png",
-        "quantity": "10",
-        "why_participated": "Test response."
-      }, true);
-    });
-
 
     // Confirmation page
     casper.then(function() {

--- a/tests/integration/campaign/loggedInSignup.js
+++ b/tests/integration/campaign/loggedInSignup.js
@@ -20,7 +20,7 @@ casper.test.begin("Test that a logged-in user can sign up for a campaign.", 1, {
     casper.start(url);
     casper.login(user.email, user.password);
 
-    casper.thenOpen(CAMPAIGN.url, function(){
+    casper.thenOpenWhenReady(CAMPAIGN.url, function() {
       // We expect to see a sign up button, and to be able to click it to sign up.
       casper.waitForSelector("#dosomething-signup-form-primary input[type='submit']", function() {
         this.click("#dosomething-signup-form-primary input[type='submit']");

--- a/tests/integration/campaign/loggedOutSignup.js
+++ b/tests/integration/campaign/loggedOutSignup.js
@@ -18,7 +18,9 @@ casper.test.begin("Test that a logged-out user can log in & sign up for a campai
 
 
   test: function(test) {
-    casper.start(CAMPAIGN.url, function(){
+    casper.start(CAMPAIGN.url);
+
+    casper.thenWhenReady(function() {
       // We expect to see a sign up button, and to be able to click it to sign up.
       this.waitUntilVisible("#link--campaign-signup-login", function() {
         this.click("#link--campaign-signup-login");

--- a/tests/integration/campaign/pitch.js
+++ b/tests/integration/campaign/pitch.js
@@ -18,9 +18,9 @@ casper.test.begin("Test pitch page is rendered correctly", 2, {
    * Test that pitch page is rendered correctly.
    */
   test: function(test) {
-    casper.start(url);
-
-    casper.thenOpen(CAMPAIGN.url, function(){
+    casper.start(CAMPAIGN.url);
+    
+    casper.thenWhenReady(function(){
       // We expect to see the title of the campaign, "Test Campaign"
       test.assertSelectorHasText("header[role='banner'].-hero .__title", CAMPAIGN.data.title, "Title of campaign is printed in H1.");
 

--- a/tests/integration/campaign/registerSignup.js
+++ b/tests/integration/campaign/registerSignup.js
@@ -18,13 +18,11 @@ casper.test.begin("Test that an unregistered user can register & sign up for a c
   },
 
   test: function(test) {
-    casper.start(url);
-
     // We expect to see a sign up button, and to be able to click it to sign up.
-    casper.thenOpen(CAMPAIGN.url, function(){
-      this.waitUntilVisible("#link--campaign-signup-login", function() {
-        this.click("#link--campaign-signup-login");
-      });
+    casper.start(CAMPAIGN.url);
+
+    casper.thenWhenReady(function(){
+      this.click("#link--campaign-signup-login");
     });
 
     // There should be a link to the registration form within the sign-in modal.

--- a/tests/integration/user/login.js
+++ b/tests/integration/user/login.js
@@ -21,7 +21,9 @@ casper.test.begin('Test that a user can authenticate correctly.', 5, {
    * Test that a user can authenticate correctly.
    */
   test: function(test) {
-    casper.start(url, function() {
+    casper.start(url);
+
+    casper.thenWhenReady(function() {
       // We reference the login link's ID to avoid a crazy selector.
       test.assertExists("#link--login", "Login link exists on page for anonymous user");
     });
@@ -49,7 +51,7 @@ casper.test.begin('Test that a user can authenticate correctly.', 5, {
       });
     });
 
-    casper.thenOpen(url, function() {
+    casper.thenOpenWhenReady(url, function() {
       // Now let's go back home and login using the login modal.
       this.waitUntilVisible("#link--login", function() {
         this.click("#link--login");
@@ -68,7 +70,7 @@ casper.test.begin('Test that a user can authenticate correctly.', 5, {
       });
     });
 
-    casper.thenOpen(url, function() {
+    casper.thenOpenWhenReady(url, function() {
       // Let's log out using the logout button.
       this.click("#link--logout");
       

--- a/tests/integration/user/register.js
+++ b/tests/integration/user/register.js
@@ -20,7 +20,7 @@ casper.test.begin("Test that a user can create an account.", 4, {
   test: function(test) {
     casper.start(url);
 
-    casper.then(function() {
+    casper.thenWhenReady(function() {
       // We reference the login link's ID to avoid a crazy selector.
       test.assertExists("#link--login", "Login link exists on page for anonymous user");
 

--- a/tests/scripts/common.js
+++ b/tests/scripts/common.js
@@ -209,6 +209,9 @@ casper.on("page.error", function(msg, trace) {
 // Set default viewport for all tests.
 casper.options.viewportSize = { width: 1280, height: 1024 };
 
+// Increase default timeout from 5s to 10s.
+casper.options.waitTimeout = 10000;
+
 // We want to clear session after every test.
 // @NOTE: You'll have to do this manually if you override the tearDown
 //        method on a particular test.

--- a/tests/scripts/common.js
+++ b/tests/scripts/common.js
@@ -203,7 +203,7 @@ casper.test.on("fail", function(failure) {
 
 // Output JavaScript errors to CasperJS log.
 casper.on("page.error", function(msg, trace) {
-  this.echo("Error: " + msg, "ERROR");
+  this.echo("Page Error: " + msg, "ERROR");
 });
 
 // Set default viewport for all tests.

--- a/tests/scripts/common.js
+++ b/tests/scripts/common.js
@@ -12,6 +12,28 @@ casper.logAction = function(action) {
 }
 
 /**
+ * Wait until JavaScript is finished executing and page is ready.
+ * @param {function} callback - Code to execute after page is ready
+ */
+casper.thenWhenReady = function(fn) {
+    casper.then(function() {;
+      this.waitUntilVisible("html.js-ready");
+    });
+    
+    casper.then(fn);
+};
+
+/**
+ * Wait until JavaScript is finished executing and page is ready.
+ * @param {function} callback - Code to execute after page is ready
+ */
+casper.thenOpenWhenReady = function(url, fn) {
+  casper.thenOpen(url);
+  casper.thenWhenReady(fn);
+};
+
+
+/**
  * Remove test IPs from flood table (preventing tests from failing after repeated failed logins).
  */
 casper.clearFloodTable = function() {

--- a/tests/scripts/common.js
+++ b/tests/scripts/common.js
@@ -202,8 +202,12 @@ casper.test.on("fail", function(failure) {
 });
 
 // Output JavaScript errors to CasperJS log.
-casper.on("page.error", function(msg, trace) {
-  this.echo("Page Error: " + msg, "ERROR");
+casper.on("page.error", function(msg, stack) {
+  casper.echo("Page Error: " + msg, "ERROR");
+  stack.forEach(function(trace) {
+    var line = trace.file + ": Line " + trace.line + " ( " + trace.function + ")";
+    casper.echo(line, "WARNING");
+  });
 });
 
 // Set default viewport for all tests.


### PR DESCRIPTION
# Changes
- Adds `thenWhenReady` and `thenOpenWhenReady` classes, which wait for `js-ready` class to be added to the `<html`> element. This fixes sporadic test failures if JavaScript (in particular modal initialization) did not finish in time for tests.
- Updates tests to use these new helpers

![screen shot 2014-09-29 at 4 06 31 pm](https://cloud.githubusercontent.com/assets/583202/4449839/34202322-481f-11e4-9ae7-6fd7a0eece94.png)
