### PR TITLE
Views Data Export

### DIFF
--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -55,6 +55,7 @@ dependencies[] = variable
 dependencies[] = varnish
 dependencies[] = view_unpublished
 dependencies[] = views
+dependencies[] = views_data_export
 dependencies[] = views_ui
 dependencies[] = xmlsitemap
 dependencies[] = xmlsitemap_custom

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -189,6 +189,10 @@ projects[view_unpublished][patch][] = "https://drupal.org/files/view_unpublished
 projects[views][version] = "3.8"
 projects[views][subdir] = "contrib"
 
+; Views Data Export
+projects[views_data_export][version] = "3.0-beta8"
+projects[views_data_export][subdir] = "contrib"
+
 ; XML Sitemap
 projects[xmlsitemap][version] = "2.0"
 projects[xmlsitemap][subdir] = "contrib"


### PR DESCRIPTION
Adds contrib module into repo, and enables for all sites.

Tested locally and confirmed module's working properly with the `node_signups` view.

Closes https://jira.dosomething.org/browse/DS-304

Allows views to be added for https://jira.dosomething.org/browse/DS-443
