### PR TITLE
DS-441 Fixes PHP notices

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
@@ -152,6 +152,12 @@ function dosomething_user_get_administrative_area_options($country = 'US') {
   module_load_include('inc', 'addressfield', 'plugins/format/address');
   $format = array();
   $address['country'] = $country;
-  addressfield_format_address_generate($format, $address);
+  // Initialize $context array to avoid addressfield PHP notices.
+  // @see https://www.drupal.org/node/1678800.
+  $context = array(
+    'countries' => array(),
+    'mode' => 'form',
+  );
+  addressfield_format_address_generate($format, $address, $context);
   return $format['locality_block']['administrative_area']['#options'];
 }


### PR DESCRIPTION
Refs comment in https://jira.dosomething.org/browse/DS-441

Fixes PHP notices in `addressfield` module which occur if the `$context` array is empty when being called in `dosomething_user_get_administrative_area_options`:
- Notice: Undefined index: mode in addressfield_format_address_generate() (line 194 of /var/www/beta.dosomething.org/releases/20140930191003/html/profiles/dosomething/modules/contrib/addressfield/plugins/format/address.inc)
- Notice: Undefined index: countries in addressfield_format_address_generate() (line 523 of /var/www/vagrant/html/profiles/dosomething/modules/contrib/addressfield/plugins/format/address.inc).
