### PR TITLE
UK SSO: Implement administration form.

### DIFF
--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.admin.inc
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.admin.inc
@@ -35,8 +35,10 @@ function dosomething_uk_admin_settings() {
     '#title'         => t('OAuth Host URL'),
     '#default_value' => $api_url,
     '#required'      => TRUE,
-    '#description'   => 'Example: https://api.twitter.com.<br />' .
-                        'No trailing slash or /oauth path needed.',
+    '#attributes'    => array(
+      'placeholder' => 'https://api.twitter.com'
+    ),
+    '#description'   => 'No trailing slash or /oauth path needed.',
   );
   $form_oauth['dosomething_uk_oauth_key'] = array(
     '#type'          => 'textfield',

--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.admin.inc
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.admin.inc
@@ -1,0 +1,65 @@
+<?php
+
+// -----------------------------------------------------------------------
+// Forms
+
+/**
+ * Provides system settings form for DoSomething UK OAuth integration settings.
+ *
+ * @return array
+ *   The system settings form.
+ */
+function dosomething_uk_admin_settings() {
+  $form = array();
+
+  // Required OAuth setting variables.
+  $api_url    = variable_get('dosomething_uk_oauth_url', '');
+  $api_key    = variable_get('dosomething_uk_oauth_key', '');
+  $api_secret = variable_get('dosomething_uk_oauth_secret', '');
+
+  // Verify if all required OAuth setting variables present.
+  $enabled = !empty($api_url) && !empty($api_key) && !empty($api_secret);
+  $status_text = $enabled ? t('Enabled') : t('Disabled');
+
+  // Fieldset.
+  $form['dosomething_uk_oauth'] = array(
+    '#type'        => 'fieldset',
+    '#title'       => t('OAuth settings'),
+    '#description' => t('Status: %status.', array('%status' => $status_text)),
+  );
+  $form_oauth = &$form['dosomething_uk_oauth'];
+
+  // Required OAuth setting fields.
+  $form_oauth['dosomething_uk_oauth_url'] = array(
+    '#type'          => 'textfield',
+    '#title'         => t('OAuth Host URL'),
+    '#default_value' => $api_url,
+    '#required'      => TRUE,
+    '#description'   => 'Example: https://api.twitter.com.<br />' .
+                        'No trailing slash or /oauth path needed.',
+  );
+  $form_oauth['dosomething_uk_oauth_key'] = array(
+    '#type'          => 'textfield',
+    '#title'         => t('OAuth Key'),
+    '#default_value' => $api_key,
+    '#required'      => TRUE,
+  );
+  $form_oauth['dosomething_uk_oauth_secret'] = array(
+    '#type'          => 'textfield',
+    '#title'         => t('OAuth Secret'),
+    '#default_value' => $api_secret,
+    '#required'      => TRUE,
+  );
+
+  // Optional OAuth setting fields.
+  $api_callback = variable_get('dosomething_uk_oauth_callback', '');
+  $form_oauth['dosomething_uk_oauth_callback'] = array(
+    '#type'          => 'textfield',
+    '#title'         => t('OAuth Callback URL'),
+    '#default_value' => $api_callback,
+  );
+
+  return system_settings_form($form);
+}
+
+// -----------------------------------------------------------------------

--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.info
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.info
@@ -2,8 +2,9 @@ name = DoSomething UK
 description = Provides functionality specific to DoSomething UK international affiliate
 core = 7.x
 package = DoSomething
-version = 7.x-0.3
+version = 7.x-0.4
 project = dosomething_uk
+configure = admin/config/dosomething/dosomething_uk
 
 ; Core
 dependencies[] = user

--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
@@ -13,6 +13,22 @@ define('DOSOMETHING_UK_WATCHDOG', 'dosomething_uk');
 // Hook implementations.
 
 /**
+ * Implements hook_menu().
+ */
+function  dosomething_uk_menu() {
+  $items = array();
+  $items['admin/config/dosomething/dosomething_uk'] = array(
+    'title'            => 'DoSomething UK',
+    'description'      => 'Setup DoSomething UK integration settings',
+    'page callback'    => 'drupal_get_form',
+    'page arguments'   => array('dosomething_uk_admin_settings'),
+    'file'             => 'dosomething_uk.admin.inc',
+    'access arguments' => array('administer modules'),
+   );
+  return $items;
+}
+
+/**
  * Implements hook_preprocess_page().
  */
 function dosomething_uk_preprocess_page(&$vars) {


### PR DESCRIPTION
#### What's this PR do?
- Provides system settings form for DoSomething UK OAuth integration settings 
#### How should this be manually tested?
- `drush en dosomething_uk`
- Set `dosomething_uk_oauth_url`, `dosomething_uk_oauth_key`, `dosomething_uk_oauth_secret` variables
- Clear the cache `drush cc all`
- Go to [modules administration](http://dev.dosomething.org:8888/admin/modules) and search for `UK`
- Click `Configure` button on `DoSomething UK` module
- It should bring you to [the form](http://dev.dosomething.org:8888/admin/config/dosomething/dosomething_uk):
  ![screen shot 2014-10-02 at 10 12 48 pm](https://cloud.githubusercontent.com/assets/672669/4496705/9074a3d2-4a68-11e4-90dc-d117a65a21bf.png)
#### What are the relevant tickets?
- Part of UK SSO refactoring: [#DS-377](https://jira.dosomething.org/browse/DS-377)
