### PR TITLE
Adds revision setting for message_broker_producer

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -212,6 +212,8 @@ projects[conductor_sms][subdir] = "contrib"
 projects[message_broker_producer][type] = "module"
 projects[message_broker_producer][download][type] = "git"
 projects[message_broker_producer][download][url] = "https://github.com/DoSomething/message_broker_producer.git"
+; Pin to 0.1.21+aug25 pending 0.2.x development
+projects[message_broker_producer][download][revision] = "40e8d9892e378846adf5cb9b295f53c8a533f123"
 projects[message_broker_producer][subdir] = "contrib"
 
 


### PR DESCRIPTION
Fixes #3126 

Current development on `message_broker_producer` results in merges into master in the repo. These changes should not be included in the current DS builds until the module is ready for the next release -> 0.2.x. A release is used rather than the recommend "tag" by @sergii-tkachenko as the needed state for the DS build is past the last tag. 
