### PR TITLE
Address Administrative Area options variable

### DIFF
--- a/lib/modules/dosomething/dosomething_canada/dosomething_canada.install
+++ b/lib/modules/dosomething/dosomething_canada/dosomething_canada.install
@@ -28,3 +28,10 @@ function dosomething_canada_uninstall() {
     variable_del($var);
   }
 }
+
+/**
+ * Sets dosomething_user_address_administrative_area_options() for Canada site.
+ */
+function dosomething_canada_update_7002() {
+  dosomething_user_set_address_administrative_area_options('CA');
+}

--- a/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.forms.inc
+++ b/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.forms.inc
@@ -66,7 +66,7 @@ function dosomething_shipment_form($form, &$form_state, $config) {
   // Add Address form fields.
   dosomething_user_address_form_element($form, $form_state);
 
-  if ($config['shipment_type'] == 'shirt') {
+  if ($config['shipment_item'] == 'shirt') {
     // Add Shirt form fields.
     dosomething_shipment_shirt_form_element($form, $form_state);   
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -335,7 +335,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
   if ($config['collect_user_school']) {
     $form['school_administrative_area'] = array(
       '#type' => 'select',
-      '#options' => dosomething_user_get_administrative_area_options(),
+      '#options' => dosomething_user_get_address_administrative_area_options(),
       '#title' => t("Select state"),
     );
     $form['school_id'] = array(

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
@@ -146,7 +146,9 @@ function dosomething_user_save_address_values($values) {
 }
 
 /**
- * Removes extra values from given $options of US States.
+ * Returns options of Addressfield module's US States to remove.
+ *
+ * @see https://github.com/DoSomething/dosomething/issues/1807.
  */
 function dosomething_user_get_us_states_to_remove() {
   return array(
@@ -154,6 +156,11 @@ function dosomething_user_get_us_states_to_remove() {
   );
 }
 
+/**
+ * Removes extra values from given Addressfield Form API $options of US States.
+ *
+ * @see dosomething_user_get_us_states_to_remove().
+ */
 function dosomething_user_remove_extra_us_states(&$options) {
   $states_to_remove = dosomething_user_get_us_states_to_remove();
   // Unset the extra state options.

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
@@ -148,7 +148,7 @@ function dosomething_user_save_address_values($values) {
 /**
  * Returns list of administrative areas based on country.
  */
-function dosomething_user_get_administrative_area_options($country = 'US') {
+function dosomething_user_get_addressfield_administrative_area_options($country = 'US') {
   module_load_include('inc', 'addressfield', 'plugins/format/address');
   $format = array();
   $address['country'] = $country;
@@ -160,4 +160,20 @@ function dosomething_user_get_administrative_area_options($country = 'US') {
   );
   addressfield_format_address_generate($format, $address, $context);
   return $format['locality_block']['administrative_area']['#options'];
+}
+
+/**
+ * Sets variable to use for Address adminstrative area options.
+ */
+function dosomething_user_set_address_administrative_area_options($country = 'US') {
+  $options = dosomething_user_get_addressfield_administrative_area_options($country);
+  variable_set('dosomething_user_address_administrative_area_options', $options);
+}
+
+/**
+ * Gets Address adminstrative area options from variable.
+ */
+function dosomething_user_get_address_administrative_area_options() {
+  $options = variable_get('dosomething_user_address_administrative_area_options', array());
+  return $options;
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
@@ -146,6 +146,24 @@ function dosomething_user_save_address_values($values) {
 }
 
 /**
+ * Removes extra values from given $options of US States.
+ */
+function dosomething_user_get_us_states_to_remove() {
+  return array(
+    'AA', 'AE', 'AP', 'AS', 'FM', 'GU', 'MH', 'MP', 'PW', 'VI',
+  );
+}
+
+function dosomething_user_remove_extra_us_states(&$options) {
+  $states_to_remove = dosomething_user_get_us_states_to_remove();
+  // Unset the extra state options.
+  foreach($states_to_remove as $state) {
+    unset($options[$state]);
+  }
+}
+
+
+/**
  * Returns list of administrative areas based on country.
  */
 function dosomething_user_get_addressfield_administrative_area_options($country = 'US') {
@@ -159,7 +177,11 @@ function dosomething_user_get_addressfield_administrative_area_options($country 
     'mode' => 'form',
   );
   addressfield_format_address_generate($format, $address, $context);
-  return $format['locality_block']['administrative_area']['#options'];
+  $options = $format['locality_block']['administrative_area']['#options'];
+  if ($country == 'US') {
+    dosomething_user_remove_extra_us_states($options);
+  }
+  return $options;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.install
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.install
@@ -19,11 +19,19 @@ function dosomething_user_update_7002() {
 }
 
 /**
+ * Executes dosomething_user_set_address_administrative_area_options().
+ */
+function dosomething_user_update_7003() {
+  dosomething_user_set_address_administrative_area_options();
+}
+
+/**
  * Implements hook_uninstall().
  */
 function dosomething_user_uninstall() {
   // This list is alphabetical, please keep it that way!
   $vars = array(
+    'dosomething_user_address_administrative_area_options',
     'dosomething_user_enable_clean_slate',
     'dosomething_user_login_form_display_password_link',
     'dosomething_user_login_form_copy',

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.install
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.install
@@ -19,10 +19,12 @@ function dosomething_user_update_7002() {
 }
 
 /**
- * Executes dosomething_user_set_address_administrative_area_options().
+ * Sets dosomething_user_address_administrative_area_options() for US site.
  */
 function dosomething_user_update_7003() {
-  dosomething_user_set_address_administrative_area_options();
+  if (!dosomething_settings_is_affiliate()) {
+    dosomething_user_set_address_administrative_area_options();
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -299,7 +299,7 @@ function dosomething_user_remove_extra_values_from_address_field($form, &$form_s
   }
   // Pass by ref to ensure changes are made to field.
   $options = &$options['address']['locality_block']['administrative_area']['#options'];
-  //@todo: Only remove states if address country == US.
+  // @todo Only remove states if address country == US.
   dosomething_user_remove_extra_us_states($options);
   return $form;
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -302,7 +302,6 @@ function dosomething_user_remove_extra_values_from_address_field($form, &$form_s
   //@todo: Only remove states if address country == US.
   dosomething_user_remove_extra_us_states($options);
   return $form;
-
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -285,25 +285,22 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
  * Removes all extra state options from the addressfield dropdown.
  */
 function dosomething_user_remove_extra_values_from_address_field($form, &$form_state) {
+  // Forms that use field_address as Form API element.
+  $user_address_form_ids = array(
+    'dosomething_signup_user_signup_data_form',
+    'dosomething_shipment_form',
+  );
   // Get the right form address field.
   if ($form['#form_id'] == 'user_profile_form') {
     $options = &$form['field_address'][LANGUAGE_NONE][0];
   }
-  elseif ($form['#form_id'] == 'dosomething_signup_user_signup_data_form') {
+  elseif (in_array($form['#form_id'], $user_address_form_ids)) {
     $options = &$form['user_address'];
   }
   // Pass by ref to ensure changes are made to field.
   $options = &$options['address']['locality_block']['administrative_area']['#options'];
-
-  $states_to_remove = array(
-    'AA', 'AE', 'AP', 'AS', 'FM', 'GU', 'MH', 'MP', 'PW', 'VI',
-  );
-
-  // Unset the extra state options.
-  foreach($states_to_remove as $state) {
-    unset($options[$state]);
-  }
-
+  //@todo: Only remove states if address country == US.
+  dosomething_user_remove_extra_us_states($options);
   return $form;
 
 }


### PR DESCRIPTION
@sergii-tkachenko Can you please review?

Sets a variable of State options to use in dropdowns where we also collect additional User addresses, to fix bug reported in comments of https://jira.dosomething.org/browse/DS-452

Adds a function `dosomething_user_set_address_administrative_area_options` to use for international sites (e.g. `drush php-eval "dosomething_user_set_address_administrative_area_options('CA')")` will populate the options for Canada.
