### PR TITLE
School finder front end

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -471,6 +471,7 @@ function dosomething_campaign_add_signup_data_form_vars(&$node) {
     // If form is configured to include a skip button:
     if ($config['required_allow_skip']) {
       // Include the skip form:
+      $node->skippable_signup_data_form = 1;
       $node->content['skip_signup_data_form'] = drupal_get_form('dosomething_signup_user_skip_signup_data_form', $signup);
     }
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -337,16 +337,21 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       '#type' => 'select',
       '#options' => dosomething_user_get_administrative_area_options(),
       '#title' => t("Select state"),
+      '#attributes' => array(
+        'data-validate' => 'state',
+      ),
     );
+
     $form['school_id'] = array(
-      // @todo: Make me a hidden element for front-end autocomplete.
-      '#type' => 'textfield',
+      '#type' => 'hidden',
       '#title' => t("School ID"),
     );
+    
     $label = $config['school_not_affiliated_label'];
     if (empty($label)) {
       $label = t("I am not affiliated with a school.");
     }
+
     $form['school_not_affiliated'] = array(
       '#type' => 'checkbox',
       '#title' => $label,
@@ -355,6 +360,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       '#type' => 'item',
       '#markup' => $config['school_not_affiliated_confirm_msg'],
     );
+
     $form['#validate'][] = 'dosomething_signup_user_signup_data_form_validate_school';
   }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -333,7 +333,15 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
 
   // If we are collecting User school:
   if ($config['collect_user_school']) {
-    $form['school_administrative_area'] = array(
+    $form['school_finder'] = array(
+      '#type' => 'fieldset',
+      '#attributes' => array(
+        'data-validate' => 'school_finder',
+        'data-validate-required' => 'true',
+      ),
+    );
+
+    $form['school_finder']['school_administrative_area'] = array(
       '#type' => 'select',
       '#options' => dosomething_user_get_administrative_area_options(),
       '#title' => t("Select state"),
@@ -342,15 +350,16 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       ),
     );
 
-    $form['school_id'] = array(
+    $form['school_finder']['school_id'] = array(
       '#type' => 'hidden',
       '#title' => t("School ID"),
     );
 
-    $form['school_name'] = array(
+    $form['school_finder']['school_name'] = array(
       // Used for front-end autocomplete.
-      '#type' => 'textfield',
+      '#type' => 'markup',
       '#title' => t("School Name"),
+      '#markup' => '<input type="search" placeholder="' . t('Find your school by name...') . '" class="js-schoolfinder-search"><ul class="schoolfinder-results js-schoolfinder-results"></ul>',
     );
     
     $label = $config['school_not_affiliated_label'];
@@ -358,14 +367,14 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       $label = t("I am not affiliated with a school.");
     }
 
-    $form['school_not_affiliated'] = array(
+    $form['school_finder']['school_not_affiliated'] = array(
       '#type' => 'checkbox',
       '#title' => $label,
     );
 
-    $form['school_not_affiliated_confirm_msg'] = array(
+    $form['school_finder']['school_not_affiliated_confirm_msg'] = array(
       '#type' => 'item',
-      '#prefix' => '<div class="checkbox-validation-message">',
+      '#prefix' => '<div class="js-school-not-affiliated-confirmation fade-in-up checkbox-validation-message" style="display: none;">',
       '#markup' => $config['school_not_affiliated_confirm_msg'],
       '#suffix' => '</div>',
     );

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -361,6 +361,17 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       '#title' => t("School Name"),
       '#markup' => '<input type="search" placeholder="' . t('Find your school by name...') . '" class="js-schoolfinder-search"><ul class="schoolfinder-results js-schoolfinder-results"></ul>',
     );
+
+    $form['school_finder']['help_link'] = array(
+      // Used for front-end autocomplete.
+      '#type' => 'markup',
+      '#markup' => '<a href="#" class="secondary js-schoolfinder-help">Need help locating your school?</a></p>',
+    );
+
+    $form['school_finder']['help_text'] = array(
+      '#type' => 'markup',
+      '#markup' => '<div class="schoolfinder-help js-schoolfinder-help-content" style="display: none;"><p>Here are some tricks to help you find your school:</p><ol><li>Abbreviations. If "St. Mary\'s" doesn\'t work, try "Saint Mary\'s" and vice versa. Same with JFK vs. John F. Kennedy.</li><li>You need to search for a specific school, not a whole district.</li></ol><p>Still having issues? <a href="#" data-modal-href="#modal-contact-form">Contact us</a>.</div>',
+    );
     
     $label = $config['school_not_affiliated_label'];
     if (empty($label)) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -346,6 +346,12 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       '#type' => 'hidden',
       '#title' => t("School ID"),
     );
+
+    $form['school_name'] = array(
+      // Used for front-end autocomplete.
+      '#type' => 'textfield',
+      '#title' => t("School Name"),
+    );
     
     $label = $config['school_not_affiliated_label'];
     if (empty($label)) {
@@ -356,9 +362,12 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       '#type' => 'checkbox',
       '#title' => $label,
     );
+
     $form['school_not_affiliated_confirm_msg'] = array(
       '#type' => 'item',
+      '#prefix' => '<div class="checkbox-validation-message">',
       '#markup' => $config['school_not_affiliated_confirm_msg'],
+      '#suffix' => '</div>',
     );
 
     $form['#validate'][] = 'dosomething_signup_user_signup_data_form_validate_school';

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -15,12 +15,12 @@ include_once 'dosomething_user.theme.inc';
  * Implements hook_preprocess_page.
  */
 function dosomething_user_preprocess_page(&$vars) {
-  $schoolFinderAPIEndpoint = variable_get('dosomething_user_school_api_endpoint', 'http://lofischools.herokuapp.com/search');
+  $school_api_endpoint = variable_get('dosomething_user_school_api_endpoint', 'http://lofischools.herokuapp.com/search');
   
   drupal_add_js(
     array('dosomethingUser' =>
       array(
-        'schoolFinderAPIEndpoint' => $schoolFinderAPIEndpoint,
+        'schoolFinderAPIEndpoint' => $school_api_endpoint,
       )
     ),
     'setting'

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -10,6 +10,23 @@ include_once 'dosomething_user.profile.inc';
 include_once 'dosomething_user_valid_address.inc';
 include_once 'dosomething_user.theme.inc';
 
+
+/**
+ * Implements hook_preprocess_page.
+ */
+function dosomething_user_preprocess_page(&$vars) {
+  $schoolFinderAPIEndpoint = variable_get('dosomething_user_school_api_endpoint', 'http://lofischools.herokuapp.com/search');
+  
+  drupal_add_js(
+    array('dosomethingUser' =>
+      array(
+        'schoolFinderAPIEndpoint' => $schoolFinderAPIEndpoint,
+      )
+    ),
+    'setting'
+  );
+}
+
 /**
  * Implements hook_init().
  */

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -306,7 +306,15 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
   if (isset($vars['node']->required_signup_data_form)) {
     // Add JS to open the signup data form modal.
     $id = 'modal-signup-data-form';
-    $js = 'require(["neue/modal"], function(Modal) { Modal.open( jQuery("#' . $id . '"), {animated: false, closeButton: "skip", skipForm: "#dosomething-signup-user-skip-signup-data-form"}); });';
+    $closeButton = 'false';
+    $skipForm = '#dosomething-signup-user-skip-signup-data-form';
+
+    // Add skip button if setting is enabled
+    if (isset($vars['node']->skippable_signup_data_form)) {
+      $closeButton = 'skip';
+    }
+
+    $js = 'require(["neue/modal"], function(Modal) { Modal.open( jQuery("#' . $id . '"), {animated: false, closeButton: "' . $closeButton . '", skipForm: "' . $skipForm . '"}); });';
     drupal_add_js($js, 'inline');
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/js/app.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/app.js
@@ -11,6 +11,7 @@ define("app", function(require) {
 
   // Initialize modules on load
   require("neue/main");
+  require("campaign/SchoolFinder");
   require("campaign/sources");
   require("campaign/tips");
   require("campaign/tabs");
@@ -22,11 +23,11 @@ define("app", function(require) {
   require("tiles");
 
   $(document).ready(function() {
-    var $form = $(".js-finder-form");
-    var $results = $(".js-campaign-results");
-    var $blankSlate = $(".js-campaign-blankslate");
-    if( $(".js-finder-form").length ) {
-      Finder.init($form, $results, $blankSlate);
+    var $campaignFinderForm = $(".js-finder-form");
+    if( $campaignFinderForm.length ) {
+      var $results = $(".js-campaign-results");
+      var $blankSlate = $(".js-campaign-blankslate");
+      Finder.init($campaignFinderForm, $results, $blankSlate);
     }
   });
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
@@ -6,7 +6,7 @@ define(function(require) {
   var Validation = require("neue/validation");
 
   var shouldValidateForm = true;
-  var resultTpl = _.template("<li><a data-gsid='<%- gsid %>' href='#'><span><%- name %></span> <em><%- city %>, <%- state %></em></a></li>");
+  var resultTpl = _.template("<li><a class='js-schoolfinder-result' data-gsid='<%- gsid %>' href='#'><span><%- name %></span> <em><%- city %>, <%- state %></em></a></li>");
 
   var getResults = function(state, query, callback) {
     if(_.isEmpty(query) || _.isEmpty(state)) return callback([]);
@@ -23,6 +23,10 @@ define(function(require) {
       $el.append(resultTpl(result));
     });
 
+    if(results.length === 0) {
+      $el.append("<div class='messages error'>Hmm, we couldn't find your school based on how the name was entered. But it may still be there! Click on the link below for tips on finding your school.</div>");
+    }
+
     $el.show();
   };
 
@@ -35,7 +39,7 @@ define(function(require) {
     var $notAffiliatedConfirmationMessage = $schoolSignupForm.find(".js-school-not-affiliated-confirmation");
 
     var savedStateFieldState = "";
-    var getResultsThrottled = _.throttle(getResults, 1000, { leading: false });
+    var getResultsThrottled = _.throttle(getResults, 1000);
 
     // Set the form to default state.
     $schoolSearchField.hide();
@@ -47,6 +51,9 @@ define(function(require) {
     $stateField.on("change", function() {
       // Show the school name field once user has chosen a state.
       var stateSelected = $(this).val() !== "";
+      $schoolSignupForm.find(".messages").hide();
+      $schoolSearchField.val("");
+      $schoolSearchField.trigger("keyup");
       $schoolSearchField.toggle(stateSelected);
 
       if(stateSelected) {
@@ -58,21 +65,25 @@ define(function(require) {
      * Event handler for school search field text input.
      */
     $schoolSearchField.on("keyup", function() {
+      $schoolSignupForm.find(".messages").hide();
       var val = $(this).val();
 
       if(val !== "") {
+        $schoolSearchField.addClass("loading");
         getResultsThrottled( $stateField.val(), val, function(res) {
           displayResults($schoolSearchResults, res);
+          $schoolSearchField.removeClass("loading");
         });
       } else {
         $schoolSearchResults.hide();
+        $schoolIDField.val("");
       }
     });
 
     /**
      * Event handler for clicking a result.
      */
-    $schoolSearchResults.on("click", "a", function(e) {
+    $schoolSearchResults.on("click", ".js-schoolfinder-result", function(e) {
       e.preventDefault();
 
       var $this = $(this);
@@ -104,6 +115,10 @@ define(function(require) {
       $stateField.trigger("focus").trigger("change").trigger("blur");
       $schoolSignupForm.find("input[type='submit']").trigger("focus");
     });
+
+    $schoolSignupForm.find(".js-schoolfinder-help").on("click", function() {
+      $(".js-schoolfinder-help-content").toggle();
+    });
   };
 
   $(document).ready(function() {
@@ -117,10 +132,21 @@ define(function(require) {
    * Custom validation for the School Finder.
    */
   Validation.registerValidationFunction("school_finder", function($el, done) {
-    if(shouldValidateForm) {
+    var $schoolID = $el.find("[name='school_id']");
+
+    if(!shouldValidateForm) {
+      // User has selected "I'm not affiliated" checkbox. Skip validation.
+      return done({ success: true });
+    }
+
+    if($schoolID.val() === "") {
+      // User has not selected a school.
+      $el.addClass("shake");
+      $el.append("<div class='messages error'>You haven't entered your school. Find your school by entering your state and then selecting a school from the search results.</div>");
       return done({ success: false });
     }
 
+    // User has selected a school.
     return done({ success: true });
   });
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
@@ -6,29 +6,43 @@ define(function(require) {
 
   var shouldValidateForm = true;
 
+  $(document).ready(function() {
+    var $schoolSignupForm = $("#dosomething-signup-user-signup-data-form");
+    if( $schoolSignupForm ) {
+      var $schoolIDContainer = $schoolSignupForm.find(".form-item-school-id");
+      var $schoolNameContainer = $schoolSignupForm.find(".form-item-school-name");
+      var $stateField = $("#edit-school-administrative-area");
+      var $schoolIDField = $("#edit-school-id");
+      var $schoolNameField = $("#edit-school-name");
+      var $notAffiliatedField = $("#edit-school-not-affiliated");
+      var $notAffiliatedConfirmationMessage = $("#edit-school-not-affiliated-confirm-msg");
 
-  var $schoolSignupForm = $("#dosomething-signup-user-signup-data-form");
-  if( $schoolSignupForm ) {
-    var $schoolIDContainer = $schoolSignupForm.find(".form-item-school-id");
-    var $schoolNameContainer = $schoolSignupForm.find(".form-item-school-name");
-    var $stateField = $("#edit-school-administrative-area");
-    var $schoolIDField = $("#edit-school-id");
-    var $schoolNameField = $("#edit-school-name");
-    var $notAffiliatedField = $("#edit-school-not-affiliated");
+      $schoolIDContainer.hide();
+      $schoolNameContainer.hide();
+      $notAffiliatedConfirmationMessage.hide();
 
-    $schoolIDContainer.hide();
-    $schoolNameContainer.hide();
+      $stateField.on("change", function() {
+        // Show the school name field once user has chosen a state.
+        if($(this).val() !== "") {
+          $schoolNameContainer.show();
+          $schoolNameField.focus();
+        } else {
+          $schoolNameContainer.hide();
+        }
+      });
 
-    $stateField.on("change", function() {
-      $schoolNameContainer.show();
-      $schoolNameField.focus();
-    });
+      $notAffiliatedField.on("change", function() {
+        // If user is not entering a school, don't validate form.
+        shouldValidateForm = !this.checked;
 
-    $notAffiliatedField.on("change", function() {
-      // If user is not entering a school, don't validate form
-      shouldValidateForm = !this.checked;
-    });
-  }
+        if(this.checked) {
+          $notAffiliatedConfirmationMessage.show();
+        } else {
+          $notAffiliatedConfirmationMessage.hide();
+        }
+      });
+    }
+  });
 
   /**
    * Custom validation for the School Finder.

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
@@ -1,0 +1,45 @@
+define(function(require) {
+  "use strict";
+
+  var $ = require("jquery");
+  var Validation = require("neue/validation");
+
+  var shouldValidateForm = true;
+
+
+  var $schoolSignupForm = $("#dosomething-signup-user-signup-data-form");
+  if( $schoolSignupForm ) {
+    var $schoolIDContainer = $schoolSignupForm.find(".form-item-school-id");
+    var $schoolNameContainer = $schoolSignupForm.find(".form-item-school-name");
+    var $stateField = $("#edit-school-administrative-area");
+    var $schoolIDField = $("#edit-school-id");
+    var $schoolNameField = $("#edit-school-name");
+    var $notAffiliatedField = $("#edit-school-not-affiliated");
+
+    $schoolIDContainer.hide();
+    $schoolNameContainer.hide();
+
+    $stateField.on("change", function() {
+      $schoolNameContainer.show();
+      $schoolNameField.focus();
+    });
+
+    $notAffiliatedField.on("change", function() {
+      // If user is not entering a school, don't validate form
+      shouldValidateForm = !this.checked;
+    });
+  }
+
+  /**
+   * Custom validation for the School Finder.
+   */
+  Validation.registerValidationFunction("school_finder", function($el, done) {
+    if(shouldValidateForm) {
+      return done({ success: false });
+    }
+
+
+    return done({ success: true });
+  });
+
+});

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
@@ -72,7 +72,9 @@ define(function(require) {
     /**
      * Event handler for clicking a result.
      */
-    $schoolSearchResults.on("click", "a", function() {
+    $schoolSearchResults.on("click", "a", function(e) {
+      e.preventDefault();
+
       var $this = $(this);
       $schoolIDField.val( $this.data("gsid") );
       $schoolSearchField.val( $this.find("span").text() );

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
@@ -9,9 +9,17 @@ define(function(require) {
   var resultTpl = _.template("<li><a class='js-schoolfinder-result' data-gsid='<%- gsid %>' href='#'><span><%- name %></span> <em><%- city %>, <%- state %></em></a></li>");
 
   var getResults = function(state, query, callback) {
+    var endpoint;
     if(_.isEmpty(query) || _.isEmpty(state)) return callback([]);
 
-    $.getJSON("http://lofischools.herokuapp.com/search?state=" + state + "&query=" + query, function(data) {
+    try {
+      // Use Drupal dateFormat validation format if available
+      endpoint = Drupal.settings.dosomethingUser.schoolFinderAPIEndpoint;
+    } catch(e) {
+      endpoint = "http://lofischools.herokuapp.com/search";
+    }
+
+    $.getJSON(endpoint + "?state=" + state + "&query=" + query, function(data) {
       callback(data.results);
     });
   };

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
@@ -2,45 +2,112 @@ define(function(require) {
   "use strict";
 
   var $ = require("jquery");
+  var _ = require("lodash");
   var Validation = require("neue/validation");
 
   var shouldValidateForm = true;
+  var resultTpl = _.template("<li><a data-gsid='<%- gsid %>' href='#'><span><%- name %></span> <em><%- city %>, <%- state %></em></a></li>");
+
+  var getResults = function(state, query, callback) {
+    if(_.isEmpty(query) || _.isEmpty(state)) return callback([]);
+
+    $.getJSON("http://lofischools.herokuapp.com/search?state=" + state + "&query=" + query, function(data) {
+      callback(data.results);
+    });
+  };
+
+  var displayResults = function($el, results) {
+    $el.empty();
+
+    _.each(results, function(result) {
+      $el.append(resultTpl(result));
+    });
+
+    $el.show();
+  };
+
+  var initializeSchoolFinder = function($schoolSignupForm) {
+    var $stateField = $("#edit-school-administrative-area");
+    var $schoolIDField = $schoolSignupForm.find("[name='school_id']");
+    var $schoolSearchField = $schoolSignupForm.find(".js-schoolfinder-search");
+    var $schoolSearchResults = $schoolSignupForm.find(".js-schoolfinder-results");
+    var $notAffiliatedField = $("#edit-school-not-affiliated");
+    var $notAffiliatedConfirmationMessage = $schoolSignupForm.find(".js-school-not-affiliated-confirmation");
+
+    var savedStateFieldState = "";
+    var getResultsThrottled = _.throttle(getResults, 1000, { leading: false });
+
+    // Set the form to default state.
+    $schoolSearchField.hide();
+    $schoolSearchResults.hide();
+
+    /**
+     * Event handler for the state select field.
+     */
+    $stateField.on("change", function() {
+      // Show the school name field once user has chosen a state.
+      var stateSelected = $(this).val() !== "";
+      $schoolSearchField.toggle(stateSelected);
+
+      if(stateSelected) {
+        $schoolSearchField.focus();
+      }
+    });
+
+    /**
+     * Event handler for school search field text input.
+     */
+    $schoolSearchField.on("keyup", function() {
+      var val = $(this).val();
+
+      if(val !== "") {
+        getResultsThrottled( $stateField.val(), val, function(res) {
+          displayResults($schoolSearchResults, res);
+        });
+      } else {
+        $schoolSearchResults.hide();
+      }
+    });
+
+    /**
+     * Event handler for clicking a result.
+     */
+    $schoolSearchResults.on("click", "a", function() {
+      var $this = $(this);
+      $schoolIDField.val( $this.data("gsid") );
+      $schoolSearchField.val( $this.find("span").text() );
+
+      $this.addClass("is-selected");
+      $this.parent("li").siblings().hide();
+    });
+
+    /**
+     * Event handler for the "I'm not affiliated with a school" checkbox.
+     */
+    $notAffiliatedField.on("change", function() {
+      // If user is not entering a school, don't validate form.
+      shouldValidateForm = !this.checked;
+      $notAffiliatedConfirmationMessage.toggle(this.checked);
+
+      if(this.checked) {
+        savedStateFieldState = $stateField.val();
+        $stateField.val("");
+        $schoolSearchField.val("");
+        $schoolSearchField.trigger("keyup");
+      } else {
+        $stateField.val(savedStateFieldState);
+        $notAffiliatedConfirmationMessage.hide();
+      }
+
+      $stateField.trigger("focus").trigger("change").trigger("blur");
+      $schoolSignupForm.find("input[type='submit']").trigger("focus");
+    });
+  };
 
   $(document).ready(function() {
     var $schoolSignupForm = $("#dosomething-signup-user-signup-data-form");
     if( $schoolSignupForm ) {
-      var $schoolIDContainer = $schoolSignupForm.find(".form-item-school-id");
-      var $schoolNameContainer = $schoolSignupForm.find(".form-item-school-name");
-      var $stateField = $("#edit-school-administrative-area");
-      var $schoolIDField = $("#edit-school-id");
-      var $schoolNameField = $("#edit-school-name");
-      var $notAffiliatedField = $("#edit-school-not-affiliated");
-      var $notAffiliatedConfirmationMessage = $("#edit-school-not-affiliated-confirm-msg");
-
-      $schoolIDContainer.hide();
-      $schoolNameContainer.hide();
-      $notAffiliatedConfirmationMessage.hide();
-
-      $stateField.on("change", function() {
-        // Show the school name field once user has chosen a state.
-        if($(this).val() !== "") {
-          $schoolNameContainer.show();
-          $schoolNameField.focus();
-        } else {
-          $schoolNameContainer.hide();
-        }
-      });
-
-      $notAffiliatedField.on("change", function() {
-        // If user is not entering a school, don't validate form.
-        shouldValidateForm = !this.checked;
-
-        if(this.checked) {
-          $notAffiliatedConfirmationMessage.show();
-        } else {
-          $notAffiliatedConfirmationMessage.hide();
-        }
-      });
+      initializeSchoolFinder($schoolSignupForm);
     }
   });
 
@@ -51,7 +118,6 @@ define(function(require) {
     if(shouldValidateForm) {
       return done({ success: false });
     }
-
 
     return done({ success: true });
   });

--- a/lib/themes/dosomething/paraneue_dosomething/js/config.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/config.js
@@ -14,9 +14,9 @@ require.config({
     "jquery": "../bower_components/jquery/jquery",
     "jquery-once": "../bower_components/jquery-once/jquery.once",
     "jquery-unveil": "../bower_components/unveil/jquery.unveil",
-    "neue": "../bower_components/neue/js",
-    "mailcheck": "../bower_components/mailcheck/src/mailcheck",
     "lodash": "../bower_components/lodash/dist/lodash",
+    "mailcheck": "../bower_components/mailcheck/src/mailcheck",
+    "neue": "../bower_components/neue/js",
     "text": "../bower_components/requirejs-text/text"
   },
   stubModules: ["text"],

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
@@ -62,11 +62,13 @@ define(function(require) {
   // ## Birthday
   // Validates correct date input, reasonable birthdate, and says a nice message.
   Validation.registerValidationFunction("birthday", function(string, done) {
-    var birthday, birthMonth, birthDay, birthYear;
+    var birthday, birthMonth, birthDay, birthYear, format;
 
-    var format = "MM/DD/YYYY";
-    if (Drupal.settings.dsValidation !== null && Drupal.settings.dsValidation.dateFormat !== null) {
+    try {
+      // Use Drupal dateFormat validation format if available
       format = Drupal.settings.dsValidation.dateFormat;
+    } catch(e) {
+      format = "MM/DD/YYYY";
     }
 
     // parse date from string

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/auth.js
@@ -65,7 +65,7 @@ define(function(require) {
     var birthday, birthMonth, birthDay, birthYear;
 
     var format = "MM/DD/YYYY";
-    if (Drupal.settings.dsValidation != null && Drupal.settings.dsValidation.dateFormat != null) {
+    if (Drupal.settings.dsValidation !== null && Drupal.settings.dsValidation.dateFormat !== null) {
       format = Drupal.settings.dsValidation.dateFormat;
     }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -38,6 +38,7 @@ $asset-path: "";
 @import "content/confirmation";
 @import "content/modal-address";
 @import "content/modal-reportback";
+@import "content/modal-schoolfinder";
 @import "content/modal-creator";
 @import "content/static";
 @import "content/fact-page";

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/modal-schoolfinder.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/modal-schoolfinder.scss
@@ -1,0 +1,7 @@
+.checkbox-validation-message {
+  display: block;
+  font-size: 16px;
+  color: $purple;
+  font-weight: $weight-sbold;
+  margin: 6px 0;
+}

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/modal-schoolfinder.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/modal-schoolfinder.scss
@@ -5,3 +5,56 @@
   font-weight: $weight-sbold;
   margin: 6px 0;
 }
+
+.schoolfinder-results {
+  list-style: none;
+  margin: 16px 0;
+  padding: 0;
+
+  a {
+    display: block;
+    padding: 8px 0;
+
+    @include media($tablet) {
+      padding: 0;
+    }
+
+    &:hover { 
+      text-decoration: none;
+
+      span {
+        text-decoration: underline;
+      }
+    }
+
+    &.is-selected {
+      span {
+        color: #000;
+
+        &:before {
+          content: "\2713\00a0";
+          color: $purple;
+        }
+      }
+
+      &:hover span {
+        text-decoration: none;
+      }
+    }
+  }
+
+  em {
+    display: block;
+    color: $med-gray;
+    font-weight: $weight-normal;
+    font-style: normal;
+
+    @include media($tablet) {
+      display: inline;
+
+      &:before {
+        content: "\00a0\2014\00a0"; // em-dash
+      }
+    }
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/modal-schoolfinder.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/modal-schoolfinder.scss
@@ -19,7 +19,7 @@
       padding: 0;
     }
 
-    &:hover { 
+    &:hover {
       text-decoration: none;
 
       span {
@@ -56,5 +56,16 @@
         content: "\00a0\2014\00a0"; // em-dash
       }
     }
+  }
+}
+
+.schoolfinder-help {
+  border: 1px solid $light-gray;
+  border-radius: $sm-border-radius;
+  margin-bottom: 16px;
+  padding: 16px;
+
+  ol {
+    margin: 0 0 27px;
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/watch.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/watch.js
@@ -1,11 +1,11 @@
 module.exports = {
   sass: {
     files: ["scss/**/*.{scss,sass}"],
-    tasks: ["lint:css", "copy:source", "sass:prod", "test:css"]
+    tasks: ["lint:css", "sass:prod", "test:css"]
   },
   js: {
     files: ["js/**/*.js", "tests/**/*.js"],
-    tasks: ["lint:js", "copy:source", "requirejs:debug", "test:js"]
+    tasks: ["lint:js", "requirejs:dev"]
   },
   assets: {
     files: ["assets/**/*", "bower_components/**/*"],

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/watch.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/watch.js
@@ -1,7 +1,7 @@
 module.exports = {
   sass: {
     files: ["scss/**/*.{scss,sass}"],
-    tasks: ["lint:css", "sass:prod", "test:css"]
+    tasks: ["lint:css", "sass:prod", "lint:css"]
   },
   js: {
     files: ["js/**/*.js", "tests/**/*.js"],


### PR DESCRIPTION
# Changes
- **New:** Adds [School Finder](https://sites.google.com/a/dosomething.org/dosomethinguxwiki/home/product-archive/school-finder) signup data form interface for campaigns.
- **Fix:** Fixes a bug where modal skip button would appear even if "Allow Skip" was unset. ([DS-451](https://jira.dosomething.org/browse/DS-451))
- **Fix:** Fixes a reference to the wrong SCSS linting task after removing testing from Grunt task runner.
- **Enhancement:** Refactor checking for `Drupal.setting` in phone number validator, since previous solution relied on non-strict equality checking.

Fixes [DS-436](https://jira.dosomething.org/browse/DS-436), [DS-437](https://jira.dosomething.org/browse/DS-437), [DS-447](https://jira.dosomething.org/browse/DS-447), [DS-451](https://jira.dosomething.org/browse/DS-451), [DS-453](https://jira.dosomething.org/browse/DS-453).
For review: @DoSomething/front-end, @mikefantini 
# Known Issues
- School Finder will not work without disabling CORS protection in your browser. This is a [known issue](https://github.com/DoSomething/dosomething/issues/3133) waiting on a fix.
# Screencast

![screencast](http://cl.ly/XuHL/Screen%20Recording%202014-10-06%20at%2002.31%20PM.gif)
