### PR TITLE
Add an option to use NFS for Vagrant rather than SSHFS.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,8 +10,14 @@ Vagrant.configure("2") do |config|
   # SSH Agent forwarding
   config.ssh.forward_agent = true
 
-  # SSHFS -- reverse mount from within Vagrant box
-  config.sshfs.paths = { "/var/www/vagrant" => "../dosomething-mount" }
+  if ENV['DS_VAGRANT_MOUNT_NFS']
+    # NFS
+    config.vm.network :private_network, ip: "10.11.12.13"
+    config.vm.synced_folder ".", "/var/www/vagrant", type: "nfs"
+  else
+    # SSHFS -- reverse mount from within Vagrant box
+    config.sshfs.paths = { "/var/www/vagrant" => "../dosomething-mount" }
+  end
 
   # Bare Apache httpd (http and https)
   config.vm.network :forwarded_port, guest: 8888, host: 8888


### PR DESCRIPTION
# Changes
- **Enhancement:** Adds option to use NFS for mounting Vagrant box, rather than using SSHFS, if `DS_VAGRANT_MOUNT_NFS` environment variable is set.

For review: @mshmsh5000, @sergii-tkachenko 
# Why?

SSHFS has been crashing multiple times a day for me, and I'd rather trade a little bit of VM performance for the "me" performance lost when restarting Vagrant and force-unmounting drives all day. I've been testing this on my own machine for a few days and it seems to be working better for me. If the `DS_VAGRANT_MOUNT_NFS` environment variable is not set, **this will not change anything** for anyone else.
