### PR TITLE
UK SSO: Store Postal Code in local database.

### DIFF
--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
@@ -268,12 +268,14 @@ function dosomething_uk_new_user_from_remote($name, $password, $sso_user) {
 
   $dob = new DateObject($sso_user['dob']);
   $fields = array(
-    'birthdate'  => $dob->format(DATE_FORMAT_DATE),
-    'first_name' => $sso_user['first_name'],
-    'last_name'  => $sso_user['last_name'],
+    'birthdate'   => $dob->format(DATE_FORMAT_DATE),
+    'first_name'  => $sso_user['first_name'],
+    'last_name'   => $sso_user['last_name'],
+    'postal_code' => $sso_user['postcode'],
     'user_registration_source' => DosomethingUkSsoUser::REGISTRATION_SOURCE,
   );
   _dosomething_uk_utility_set_user_fields($edit, $fields);
+
   try {
     $account = user_save('', $edit);
   }
@@ -313,9 +315,18 @@ function _dosomething_uk_utility_set_user_fields(&$values, $fields) {
     if (empty($field_value)) {
       continue;
     }
-    $name = 'field_' . $field_key;
-    $values[$name] = array(LANGUAGE_NONE => array(
-      0 => array('value' => $field_value),
-    ));
+    switch ($field_key) {
+      case 'postal_code':
+        $values['field_address'][LANGUAGE_NONE][0] = array(
+          'postal_code' => $field_value,
+        );
+        break;
+
+      default:
+        $values['field_' . $field_key] = array(LANGUAGE_NONE => array(
+          array('value' => $field_value),
+        ));
+        break;
+    }
   }
 }

--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
@@ -319,6 +319,7 @@ function _dosomething_uk_utility_set_user_fields(&$values, $fields) {
       case 'postal_code':
         $values['field_address'][LANGUAGE_NONE][0] = array(
           'postal_code' => $field_value,
+          'country' => DosomethingUkSsoUser::COUNTRY,
         );
         break;
 

--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
@@ -272,9 +272,10 @@ function dosomething_uk_new_user_from_remote($name, $password, $sso_user) {
     'first_name'  => $sso_user['first_name'],
     'last_name'   => $sso_user['last_name'],
     'postal_code' => $sso_user['postcode'],
+    'country'     => DosomethingUkSsoUser::COUNTRY,
     'user_registration_source' => DosomethingUkSsoUser::REGISTRATION_SOURCE,
   );
-  _dosomething_uk_utility_set_user_fields($edit, $fields);
+  dosomething_user_set_fields($edit, $fields);
 
   try {
     $account = user_save('', $edit);
@@ -306,28 +307,6 @@ function dosomething_uk_remote_errors_to_local_form($error_messages, &$form) {
       $human_name = ucwords(preg_replace('/[^\da-z]/i', ' ', $field_name));
       $error_text = $human_name . ': ' . $error;
       form_set_error($field_name, $error_text);
-    }
-  }
-}
-
-function _dosomething_uk_utility_set_user_fields(&$values, $fields) {
-  foreach ($fields as $field_key => $field_value) {
-    if (empty($field_value)) {
-      continue;
-    }
-    switch ($field_key) {
-      case 'postal_code':
-        $values['field_address'][LANGUAGE_NONE][0] = array(
-          'postal_code' => $field_value,
-          'country' => DosomethingUkSsoUser::COUNTRY,
-        );
-        break;
-
-      default:
-        $values['field_' . $field_key] = array(LANGUAGE_NONE => array(
-          array('value' => $field_value),
-        ));
-        break;
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_user.inc
+++ b/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_user.inc
@@ -14,6 +14,7 @@ class DosomethingUkSsoUser {
 
 
   // Local drupal user.
+  const COUNTRY = 'UK';
   const REGISTRATION_SOURCE = 'dosomething_uk';
 
   // ---------------------------------------------------------------------
@@ -282,6 +283,17 @@ class DosomethingUkSsoUser {
   public function getPhoneNumber()
   {
     return $this->phone_number;
+  }
+
+  /**
+   * Gets the user's country.
+   *
+   * @return string.
+   *   Always returns DosomethingUkSsoUser::COUNTRY.
+   */
+  public function getCountry()
+  {
+    return self::COUNTRY;
   }
 
   /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -878,6 +878,40 @@ function dosomething_user_get_field_last_name($field_value, $format = 'ucwords')
   return dosomething_user_format_string($field_value, $format);
 }
 
+
+/**
+ * Helper function to prepare an array of user fields.
+ *
+ * Extends existing array of user form values with Entity API's fields.
+ * The fields will be added to &$edit array prefixed with `field_`.
+ * All from this flow exceprions will be processed so &$edit is ready for
+ * user_save() execution.
+ *
+ * @param  array $edit
+ *   The array of the user form values.
+ * @param  array $fields
+ *   The array of the user fields.
+ */
+function dosomething_user_set_fields(&$edit, $fields) {
+  foreach ($fields as $key => $value) {
+    if (empty($value)) {
+      continue;
+    }
+
+    switch ($key) {
+      case 'country':
+      case 'postal_code':
+        $edit['field_address'][LANGUAGE_NONE][0][$key] = $value;
+        break;
+
+      default:
+        $edit['field_' . $key][LANGUAGE_NONE][0]['value'] = $value;
+        break;
+    }
+  }
+}
+
+
 /**
  * Helper function to format strings.
  *


### PR DESCRIPTION
#### What's this PR do?
- Saves Postal Code to the local database during automation creation of local users from remote SSO
- <ins>ADDED: Implicitly specifies county in users' address</ins>
#### How should this be manually tested?
- `drush en dosomething_uk`, setup 
- Set `dosomething_uk_oauth_url`, `dosomething_uk_oauth_key`, `dosomething_uk_oauth_secret` variables
- Register and check your profile
  ![screen shot 2014-10-06 at 11 18 35 pm](https://cloud.githubusercontent.com/assets/672669/4532807/8b1ccf82-4d96-11e4-8601-367c9985ec8c.png)
#### Any background context you want to provide?
- <del>it still not possible to see or edit it on the profile edit form</del>
- <del>as a side effect it hides Country: US from UK users</del>
#### What are the relevant tickets?

Part of refactoring [#DS-381](https://jira.dosomething.org/browse/DS-381).
