### PR TITLE
Enable System set_variable resource in DS API

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -44,19 +44,9 @@ function dosomething_api_default_services_endpoint() {
       'actions' => array(
         'login' => array(
           'enabled' => '1',
-          'settings' => array(
-            'services' => array(
-              'resource_api_version' => '1.0',
-            ),
-          ),
         ),
         'logout' => array(
           'enabled' => '1',
-          'settings' => array(
-            'services' => array(
-              'resource_api_version' => '1.0',
-            ),
-          ),
         ),
         'token' => array(
           'enabled' => '1',
@@ -81,6 +71,9 @@ function dosomething_api_default_services_endpoint() {
     'system' => array(
       'actions' => array(
         'connect' => array(
+          'enabled' => '1',
+        ),
+        'set_variable' => array(
           'enabled' => '1',
         ),
       ),

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1129,14 +1129,3 @@ function dosomething_user_save_school_id($school_id) {
 function dosomething_user_get_member_count() {
   return variable_get('dosomething_user_member_count');
 }
-
-/**
- * Sets the Member Count variable.
- *
- * @param int $value
- *   Number of members.
- */
-function dosomething_user_set_member_count($value) {
-  //@todo Validate that $value is numeric?  Need to define usage.
-  variable_set('dosomething_user_member_count', $value);
-}


### PR DESCRIPTION
@sergii-tkachenko Can you review?

Enables the built-in Services `set_variable` resource to allow other apps to authenticate and then set a Drupal variable.

Removes `dosomething_user_set_member_count` function as this variable will only be set via the API (or could just be set via `variable_get`)
