### PR TITLE
Clear cache perms to Communication Team

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.features.user_permission.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.features.user_permission.inc
@@ -337,6 +337,7 @@ function dosomething_user_user_default_permissions() {
     'name' => 'flush caches',
     'roles' => array(
       'administrator' => 'administrator',
+      'communications team' => 'communications team',
     ),
     'module' => 'admin_menu',
   );


### PR DESCRIPTION
SMS Reportback paths are inaccessible until cache is cleared.  This allows Communication Team self-serve access.

cc @tongxiang 
