### PR TITLE
DS API: Get Member Count

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -84,6 +84,11 @@ function dosomething_api_default_services_endpoint() {
           'enabled' => '1',
         ),
       ),
+      'actions' => array(
+        'get_member_count' => array(
+          'enabled' => '1',
+        ),
+      ),
     ),
   );
   $endpoint->debug = 0;

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -24,6 +24,18 @@ function _member_resource_defintion() {
         'access callback' => '_member_resource_access',
       ),
     ),
+    'actions' => array(
+      'get_member_count' => array(
+        'help' => 'Returns current member count.',
+        'file' => array(
+          'type' => 'inc',
+          'module' => 'dosomething_api',
+          'name' => 'resources/member.resource',
+        ),
+        'callback' => '_member_resource_get_member_count',
+        'access callback' => '_member_resource_access',
+      ),
+    ),
   );
   return $member_resource;
 }
@@ -101,4 +113,17 @@ function _member_resource_create($account) {
   catch (Exception $e) {
     services_error($e);
   }
+}
+
+/**
+ * Callback for the get_member_count resource.
+ *
+ * @return array
+ *   Associative array of the member count, in different formats.
+ */
+function _member_resource_get_member_count() {
+  return array(
+    'formatted' => dosomething_user_get_member_count(),
+    'readable' => dosomething_user_get_member_count($readable = TRUE),
+  );
 }


### PR DESCRIPTION
Closes https://jira.dosomething.org/browse/DS-444

Provides an endpoint to get the Member Count.  Must use POST, as its a custom Services resource action.  Will update wiki upon merge.

**POST** http://dev.dosomething.org:8888/api/v1/users/get_member_count.json

Result:

```
    {
       "formatted": "2,900,343",
       "readable": "2.9 million"
    }
```
