### PR TITLE
Only preprocess campaign_group if full view mode

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
@@ -8,7 +8,7 @@ include_once 'dosomething_campaign_group.features.inc';
 
 
 function dosomething_campaign_group_preprocess_node(&$vars) {
-  if ($vars['type'] == 'campaign_group') {
+  if ($vars['type'] == 'campaign_group' && $vars['view_mode'] == 'full') {
     $content = $vars['content'];
     $template_vars = array(
       'text' => array(


### PR DESCRIPTION
Viewing a taxonomy term that contains a `campaign_group` will break things, with the nasty EntityMetadataWrapperException: Unknown data property field_image_campaign_cover.

The default view displays node teasers.  This is a quick fix to avoid the WSOD
