### PR TITLE
Shipment Form - Conditionally prevent Old People from submitting

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -99,11 +99,22 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
       '#default_value' => $vars['shipment_form_submitted_copy'],
       '#size' => 20,
     );
+    $form['shipment']['shipment_form_prevent_old_people_submit'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Prevent Old People from submitting'),
+      '#default_value' => $vars['shipment_form_prevent_old_people_submit'],
+      '#description' => t('If checked, Old People will be unable to submit the form.'),
+    );
     $form['shipment']['shipment_form_old_people_copy'] = array(
       '#type' => 'textarea',
       '#title' => t('Old People Copy'),
       '#default_value' => $vars['shipment_form_old_people_copy'],
-      '#size' => 20,
+      '#description' => t('The copy displayed in the modal form for Old People.'),
+      '#states' => array(
+        'visible' => array(
+          ':input[name="shipment_form_prevent_old_people_submit"]' => array('checked' => TRUE),
+        ),
+      ),
     );
   }
   $form['actions'] = array(
@@ -148,6 +159,7 @@ function dosomething_helpers_get_variable_names() {
     'shipment_form_header',
     'shipment_form_link_text',
     'shipment_form_old_people_copy',
+    'shipment_form_prevent_old_people_submit',
     'shipment_form_submit_label',
     'shipment_form_submitted_copy',
     'shipment_item',

--- a/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.forms.inc
+++ b/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.forms.inc
@@ -38,8 +38,8 @@ function dosomething_shipment_form($form, &$form_state, $config) {
     '#markup' => $config['shipment_form_header'],
     '#suffix' => '</h2>',
   );
-  // If old person:
-  if (dosomething_user_is_old_person()) {
+  // If old people can't submit form and logged user is an old person:
+  if ($config['shipment_form_prevent_old_people_submit'] && dosomething_user_is_old_person()) {
     $form['copy'] = array(
       '#prefix' => '<p>',
       '#markup' => $config['shipment_form_old_people_copy'],


### PR DESCRIPTION
Adds a checkbox config variable to determine whether or not an Old Person can submit a Shipment form.

Fixes #3166
