### PR TITLE
Canada SSO: simple integration tests.

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -32,8 +32,6 @@ program
     console.log('    test default --integration=specific/test/dir/**/*');
     console.log('    test uk');
     console.log('    test uk --casperjs=uk/sso');
-    console.log('    test canada');
-    console.log('    test canada --casperjs=canada/sso');
     console.log('');
   })
   .parse(process.argv);

--- a/bin/test
+++ b/bin/test
@@ -32,6 +32,8 @@ program
     console.log('    test default --integration=specific/test/dir/**/*');
     console.log('    test uk');
     console.log('    test uk --casperjs=uk/sso');
+    console.log('    test canada');
+    console.log('    test canada --casperjs=canada/sso');
     console.log('');
   })
   .parse(process.argv);

--- a/tests/config/canada.json
+++ b/tests/config/canada.json
@@ -1,0 +1,8 @@
+{
+  "url": "http://dev.dosomething.org:8888",
+  "mocha": "index",
+  "casperjs": [
+    "canada/**/*"
+  ],
+  "xunit": false
+}

--- a/tests/config/default.json
+++ b/tests/config/default.json
@@ -4,6 +4,7 @@
   "casperjs": [
     "**/*",
     "!uk/**/*"
+    "!canada/**/*"
   ],
   "xunit": false
 }

--- a/tests/integration/canada/drupal.coffee
+++ b/tests/integration/canada/drupal.coffee
@@ -1,0 +1,23 @@
+# Drupal
+
+# ------------------------------------------------------------------------
+# Test Drupal configuration
+
+casper.test.begin "Test that Drupal configure for the Canada SSO correctly", 3, (test) ->
+
+  # OAuth Base URL.
+  result = casper.drush ["vget", "dosomething_canada_sso_url"]
+  test.assertTruthy result, 'OAuth Base URL setting present.'
+
+  # OAuth App ID.
+  result = casper.drush ["vget", "dosomething_canada_sso_appid"]
+  test.assertTruthy result, 'OAuth App ID setting present.'
+
+  # OAuth Key.
+  result = casper.drush ["vget", "dosomething_canada_sso_key"]
+  test.assertTruthy result, 'OAuth Key setting present.'
+
+  test.done()
+  return
+
+# ------------------------------------------------------------------------

--- a/tests/integration/canada/sso.coffee
+++ b/tests/integration/canada/sso.coffee
@@ -1,0 +1,50 @@
+# SSO
+
+# Sometimes SSO server response takes long.
+casper.options.waitTimeout = 10000
+
+# Generate user.
+system = require 'system';
+# Temporary. Will be replaced with generated user when SSO registration is ready.
+user =
+  email: system.env.DS_CA_USER
+  password: system.env.DS_CA_PASS
+uid = false
+
+# ------------------------------------------------------------------------
+# Test login form
+
+casper.test.begin "Test that user created from SSO can login", 1, (test) ->
+
+  # Launch browser on registration page.
+  casper.start url
+
+  # Perform the login.
+  casper.then -> @login user.email, user.password
+
+  # Go to the edit profile page.
+  # We don't know new uid yet, but user/register will redirect to the page.
+  casper.thenOpen "#{url}/user/register"
+  casper.then ->
+    saveUserUid()
+
+    # Test the nid is present
+    test.assertTruthy uid, "User is found."
+
+  # Cleanup after success.
+  casper.then ->
+    @logAction "Cleanup:"
+    @deleteUser uid
+
+  # Run tests.
+  casper.run -> @test.done()
+  return
+
+# ------------------------------------------------------------------------
+# Utilities
+
+# Finds user uid on the profile edit page ans saves it to global variable.
+saveUserUid = ->
+  uid = casper.getCurrentUrl().match(/\/user\/([0-9]+)\/edit$/)[1]
+
+# ------------------------------------------------------------------------


### PR DESCRIPTION
#### What's this PR do?
- Provides simple integration tests for Canada SSO setup and login
#### How should this be manually tested?
- Setup `DS_CA_USER` and `DS_CA_PASS` variables in VM `/etc/environment`
- Run `ds test canada`
  ![image](https://cloud.githubusercontent.com/assets/672669/4669668/16692032-5570-11e4-9539-f35357053a80.png)
  * Js error is not relevant to this ticket
#### Any background context you want to provide?

Now SSO test contain only login, will be extended when the registration is ready.
#### What are the relevant tickets?
- Part of [#DS-379](https://jira.dosomething.org/browse/DS-379): Move functionality common to UK and Canada to the new nodule.
