### PR TITLE
Canada SSO: adapt login to common flow provided in external_auth.

### DIFF
--- a/lib/modules/dosomething/dosomething_canada/dosomething_canada.info
+++ b/lib/modules/dosomething/dosomething_canada/dosomething_canada.info
@@ -2,18 +2,21 @@ name = DoSomething Canada
 description = Provides functionality specific to our Canadian friends.
 core = 7.x
 package = DoSomething
-version = 7.x-0.1
+version = 7.x-0.3
 project = dosomething_canada
 
 ; Core
+dependencies[] = date_api
 dependencies[] = user
-dependencies[] = date
 
 ; Contrib
-
+dependencies[] = external_auth
 
 ; Custom
 dependencies[] = dosomething_user
 
 ; Includes
 files[] = includes/CanadaSSOClient.php
+
+files[] = includes/dosomething_canada_login_controller.inc
+files[] = includes/dosomething_canada_register_controller.inc

--- a/lib/modules/dosomething/dosomething_canada/dosomething_canada.install
+++ b/lib/modules/dosomething/dosomething_canada/dosomething_canada.install
@@ -8,11 +8,10 @@
  * Implements hook_install().
  */
 function dosomething_canada_install() {
-
-  variable_set('dosomething_canada_sso_url', getenv('DS_CANADA_SSO_URL'));
+  // Setup OAuth access.
+  variable_set('dosomething_canada_sso_url',   getenv('DS_CANADA_SSO_URL'));
   variable_set('dosomething_canada_sso_appid', getenv('DS_CANADA_SSO_APPID'));
-  variable_set('dosomething_canada_sso_key', getenv('DS_CANADA_SSO_KEY'));
-
+  variable_set('dosomething_canada_sso_key',   getenv('DS_CANADA_SSO_KEY'));
 }
 
 /**
@@ -34,4 +33,11 @@ function dosomething_canada_uninstall() {
  */
 function dosomething_canada_update_7002() {
   dosomething_user_set_address_administrative_area_options('CA');
+}
+
+/**
+ * Enables External Auth module.
+ */
+function dosomething_canada_update_7003() {
+  module_enable(array('external_auth'));
 }

--- a/lib/modules/dosomething/dosomething_canada/dosomething_canada.module
+++ b/lib/modules/dosomething/dosomething_canada/dosomething_canada.module
@@ -14,148 +14,24 @@ define('DOSOMETHING_CANADA_MSG_FAILED_LOGIN', "Sorry, we don't recognize that em
 
 
 // -----------------------------------------------------------------------
-// Hook implementations.
+// Hook implementations
 
 /**
- * Implements hook_module_implements_alter().
- *
- * Moves the hook_form_alter() implementation to the bottom.
- * That way we ensure to run last and have the final word in form callbacks
- * altering.
+ * Implements hook_external_auth_method().
  */
-function dosomething_canada_module_implements_alter(&$implementations, $hook) {
-  if ($hook == 'form_alter' && isset($implementations['dosomething_canada'])) {
-    $group = $implementations['dosomething_canada'];
-    unset($implementations['dosomething_canada']);
-    $implementations['dosomething_canada'] = $group;
-  }
-}
-
-/**
- * Implements hook_form_FORM_ID_alter().
- *
- * Form user_login.
- */
-function dosomething_canada_form_user_login_alter(&$form, &$form_state, $form_id) {
-  array_unshift($form['#validate'], 'dosomething_canada_login_validate');
-}
-
-/**
- * Implements hook_form_FORM_ID_alter().
- *
- * Form user_login_block.
- */
-function dosomething_canada_form_user_login_block_alter(&$form, &$form_state) {
-  array_unshift($form['#validate'], 'dosomething_canada_login_validate');
-}
-
-
-// -----------------------------------------------------------------------
-// Callbacks.
-
-/**
- * Validates user_login_form. Handles two possible cases:
- *
- * 1. The user exists locally, and/or remotely; and
- * 2. The doesn't exist locally
- */
-function dosomething_canada_login_validate($form, &$form_state) {
-  $values = &$form_state['values'];
-
-  // Fallback to default validation when name or pass not set.
-  if (empty($values['name']) || empty($values['pass'])) {
-    return;
-  }
-
-  $name = $values['name'];
-  $pass = $values['pass'];
-
-  // Check whether local account exists.
-  $account = dosomething_user_get_user_by_email($name);
-
-  // Process user with existing local account:
-  if ($account) {
-    dosomething_canada_process_existing_user($name, $pass, $account);
-  }
-  else {
-    $account = dosomething_canada_process_new_user($name, $pass);
-    form_set_value($form['name'], $account->name, $form_state);
-  }
-}
-
-
-// -----------------------------------------------------------------------
-// SSO integration functions.
-
-/**
- * Try to authenticate an existing, local user against the API. Failing that,
- * try to create it as a remote user.
- *
- * @param string $email
- * @param string $pass
- * @param stdClass $account
- */
-function dosomething_canada_process_existing_user($email, $pass, $account) {
-
-  // Check whether remote account with requested email exists:
-  try {
-    $sso = dosomething_canada_get_sso();
-
-    if ($sso->authenticate($email, $pass)) {
-      $remote_account = $sso->getRemoteUser();
-    }
-  }
-  catch (Exception $e) {
-
-    // The only users that exist locally but not remotely should be admin
-    // accounts that were created before SSO integration. These should be
-    // created remotely as well.
-
-    return $sso->propagateLocalUser(
-      $email,
-      $pass,
-      dosomething_canada_create_sso_user($email, $pass, $account)
-    );
-  }
-}
-
-/**
- * Authenticate a user against the API.
- *
- * @param $email
- * @param $pass
- * @return bool|stdClass
- */
-function dosomething_canada_process_new_user($email, $pass) {
-
-  $remote_account = null;
-
-  // Check whether remote account with requested email exists:
-  try {
-    $sso = dosomething_canada_get_sso();
-
-    if ($sso->authenticate($email, $pass)) {
-      $remote_account = $sso->getRemoteUser();
-    }
-  }
-  catch (Exception $e) {
-    form_set_error('name', t(DOSOMETHING_CANADA_MSG_FAILED_LOGIN));
-    return FALSE;
-  }
-
-  if (!$remote_account) {
-    // Todo: link to forgot password page.
-    form_set_error('name', t(DOSOMETHING_CANADA_MSG_FAILED_LOGIN));
-    return FALSE;
-  }
-
-  $account = dosomething_canada_new_user_from_remote($email, $pass, $remote_account);
-
-  return (empty($account)) ? FALSE : $account;
+function dosomething_canada_external_auth_method() {
+  $items = array();
+  $items[] = array(
+    'title'               => 'DoSomething Canada',
+    'description'         => 'Authenticates using TGI API.',
+    'login controller'    => 'DosomethingCanadaLoginController',
+    'register controller' => 'DosomethingCanadaRegisterController',
+   );
+  return $items;
 }
 
 // -----------------------------------------------------------------------
-// SSO helpers.
+// SSO helpers
 
 /**
  * Create an SSO client instance as a singleton.
@@ -173,43 +49,6 @@ function dosomething_canada_get_sso() {
     );
   }
   return $sso;
-}
-
-/**
- * Given a remote user object, create the local Drupal user.
- *
- * @param string $name
- * @param string $pass
- * @param object $remote_account
- * @return bool|stdClass
- */
-function dosomething_canada_new_user_from_remote($name, $pass, $remote_account) {
-  $edit = array(
-    'mail'    => $name,
-    'name'    => $name,
-    'pass'    => $pass,
-    'status'  => 1,
-    'created' => REQUEST_TIME,
-  );
-
-  $dob = new DateObject($remote_account->DOB);
-
-  $fields = array(
-    'birthdate'  => $dob->format(DATE_FORMAT_DATE),
-    'first_name' => $remote_account->Name,
-    'user_registration_source' => DOSOMETHING_CANADA_USER_SOURCE,
-  );
-
-  _dosomething_canada_utility_set_user_fields($edit, $fields);
-
-  try {
-    $account = user_save('', $edit);
-  }
-  catch (Exception $e) {
-    watchdog_exception(DOSOMETHING_CANADA_WATCHDOG, $e);
-  }
-
-  return $account;
 }
 
 /**
@@ -246,22 +85,3 @@ function dosomething_canada_create_sso_user($email, $pass, $account) {
 }
 
 // -----------------------------------------------------------------------
-// Miscellaneous.
-
-/**
- * Prepare the user array for submission to user_save().
- *
- * @param array $values
- * @param array $fields
- */
-function _dosomething_canada_utility_set_user_fields(&$values, $fields) {
-  foreach ($fields as $field_key => $field_value) {
-    if (empty($field_value)) {
-      continue;
-    }
-    $name = 'field_' . $field_key;
-    $values[$name] = array(LANGUAGE_NONE => array(
-      0 => array('value' => $field_value),
-    ));
-  }
-}

--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Canada Login Controller.
+ */
+class DosomethingCanadaLoginController implements ExternalAuthLoginController {
+
+  // ---------------------------------------------------------------------
+  // Instance variables
+
+  /**
+   * The email of the user.
+   *
+   * @var string
+   */
+  private $email;
+
+  /**
+   * The password of the user.
+   *
+   * @var string
+   */
+  private $password;
+
+  /**
+   * The fully-loaded $user object.
+   *
+   * @var object
+   */
+  private $local_account;
+
+  /**
+   * The remote user object.
+   */
+  private $remote_account;
+
+  /**
+   * The SSO controller.
+   */
+  private $sso;
+
+  // ---------------------------------------------------------------------
+  // Public: interface implementation
+
+  public function setup(Array $form_state) {
+    $this->email    = $form_state['values']['name'];
+    $this->password = $form_state['values']['pass'];
+    $this->local_account  = dosomething_user_get_user_by_email($this->email);
+    return $this;
+  }
+
+  // Check whether local account exists.
+  public function loginExists() {
+    return (bool) $this->local_account;
+  }
+
+  /**
+   * Processes existing user during login.
+   *
+   * @return boolean
+   *   Whether the processing was successful.
+   */
+  public function loginExistingUser() {
+
+    // Check whether remote account with requested email exists:
+    try {
+      $this->sso = dosomething_canada_get_sso();
+
+      if ($this->sso->authenticate($this->email, $this->password)) {
+        $this->remote_account = $this->sso->getRemoteUser();
+      }
+    }
+    catch (Exception $e) {
+
+      // The only users that exist locally but not remotely should be admin
+      // accounts that were created before SSO integration. These should be
+      // created remotely as well.
+      $this->sso->propagateLocalUser(
+        $this->email,
+        $this->password,
+        dosomething_canada_create_sso_user($this->email, $this->password, $this->local_account)
+      );
+    }
+    return TRUE;
+  }
+
+  public function getRemoteUser() {
+    $this->sso = dosomething_canada_get_sso();
+
+    if ($this->sso->authenticate($this->email, $this->password)) {
+      $this->remote_account = $this->sso->getRemoteUser();
+    }
+    return $this->remote_account;
+  }
+
+  /**
+   * Create new local user based on remote SSO user during login.
+   *
+   * @return object|false
+   *   A fully-loaded $user object upon successful save or FALSE.
+   */
+  public function createFromRemote() {
+    $edit = array(
+      'mail'    => $this->email,
+      'name'    => $this->email,
+      'pass'    => $this->password,
+      'status'  => 1,
+      'created' => REQUEST_TIME,
+    );
+
+    $dob = new DateObject($this->remote_account->DOB);
+    $fields = array(
+      'birthdate'                => $dob->format(DATE_FORMAT_DATE),
+      'first_name'               => $this->remote_account->Name,
+      'user_registration_source' => DOSOMETHING_CANADA_USER_SOURCE,
+    );
+    dosomething_user_set_fields($edit, $fields);
+
+    try {
+      $account = user_save('', $edit);
+    }
+    catch (Exception $e) {
+      watchdog_exception(DOSOMETHING_CANADA_WATCHDOG, $e);
+      return FALSE;
+    }
+
+    $this->local_account = $account;
+    return $this->local_account;
+  }
+
+  // ---------------------------------------------------------------------
+
+}

--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
@@ -86,9 +86,13 @@ class DosomethingCanadaLoginController implements ExternalAuthLoginController {
 
   public function getRemoteUser() {
     $this->sso = dosomething_canada_get_sso();
-
-    if ($this->sso->authenticate($this->email, $this->password)) {
-      $this->remote_account = $this->sso->getRemoteUser();
+    try {
+      if ($this->sso->authenticate($this->email, $this->password)) {
+        $this->remote_account = $this->sso->getRemoteUser();
+      }
+    } catch (Exception $e) {
+      // Login failed.
+      return FALSE;
     }
     return $this->remote_account;
   }

--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_register_controller.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_register_controller.inc
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Canada Registration Controller.
+ *
+ * @todo: Implement registration.
+ */
+class DosomethingCanadaRegisterController implements ExternalAuthRegisterController {
+
+  // ---------------------------------------------------------------------
+  // Instance variables
+
+  // ---------------------------------------------------------------------
+  // Public: interface implementation
+
+  public function setup(Array $form_state) {
+    return $this;
+  }
+
+  public function signup() {
+    return TRUE;
+  }
+
+  public function processSignupErrors(Array $form) {}
+
+  // ---------------------------------------------------------------------
+
+}

--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.install
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.install
@@ -24,7 +24,7 @@ function dosomething_uk_update_7003() {
 }
 
 /**
- * Sets Login and Registration form variable.
+ * Enables External Auth module.
  */
 function dosomething_uk_update_7005() {
   module_enable(array('external_auth'));


### PR DESCRIPTION
#### What's this PR do?
- Adapts Dosomething Canada module: use login flow provided in [`external_auth`](/dosomething/drupal-external-auth)
#### How should this be manually tested?
- Enable and setup Dosomething Canada module
- Setup `DS_CA_USER` and `DS_CA_PASS` variables in VM `/etc/environment`
- Run `ds test canada`  
  ![image](https://cloud.githubusercontent.com/assets/672669/4670890/0fd9da76-557b-11e4-968a-5290b327875a.png)
#### What are the relevant tickets?
- Part of [#DS-379](https://jira.dosomething.org/browse/DS-379): Move functionality common to UK and Canada to the new nodule
- #3174: UK SSO: adapt login/signup to common flow provided in external_auth
- dosomething/drupal-external-auth#2
