### PR TITLE
Campaign gallery

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -313,26 +313,29 @@ function dosomething_campaign_reportback_confirmation_page_access($node) {
  *   An array of variables.
  */
 function dosomething_campaign_get_campaign_block_vars($nid, $image_size = '740x480', $source = NULL) {
-  $wrapper = entity_metadata_wrapper('node', $nid);
-  $path = 'node/' . $nid;
-  $pretty_path = drupal_get_path_alias($path);
+  $node = node_load($nid);
+  $path_alias = drupal_get_path_alias('node/' . $nid);
   if ($source) {
-    $pretty_path .= '?source=' . $source;
+    $path_alias .= '?source=' . $source;
   }
   $image = NULL;
-  $image_nid = $wrapper->field_image_campaign_cover->getIdentifier();
-  if ($image_nid) {
+  if (!empty($node->field_image_campaign_cover)) {
+    $image_nid = $node->field_image_campaign_cover[LANGUAGE_NONE][0]['target_id'];
     $image = dosomething_image_get_themed_image_url($image_nid, 'landscape', $image_size);
   }
+  $cta = NULL;
+  if (!empty($node->field_call_to_action)) {
+    $cta = $node->field_call_to_action[LANGUAGE_NONE][0]['value'];
+  }
   return array(
-    'nid' => $wrapper->getIdentifier(),
-    'title' => $wrapper->label(),
-    'call_to_action' => $wrapper->field_call_to_action->value(),
+    'nid' => $nid,
+    'title' => $node->title,
+    'call_to_action' => $cta,
     'image' => $image,
     'path' => $path,
-    'pretty_path' => $pretty_path,
-    'status' => $wrapper->status->value(),
-    'staff_pick' => $wrapper->field_staff_pick->value(),
+    'path_alias' => $path_alias,
+    'status' => $node->status,
+    'staff_pick' => $node->field_staff_pick[LANGUAGE_NONE][0]['value'],
   );
 }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -375,6 +375,10 @@ function dosomething_campaign_theme($existing, $type, $theme, $path) {
     'submit_campaign_idea' => array(
       'template' => 'submit-campaign-idea',
     ),
+    'campaign_gallery' => array(
+      'template' => 'campaign-gallery',
+      'path' => drupal_get_path('module', 'dosomething_campaign') . '/theme',
+    ),
   );
 }
 
@@ -749,4 +753,19 @@ function dosomething_campaign_form_campaign_node_form_after_build($form, &$form_
   $path = drupal_get_path('module', 'dosomething_campaign');
   drupal_add_js ($path . "/js/campaign_node_form.js");
   return $form;
+}
+
+/**
+ * For given array of objects, return themed Campaign Gallery.
+ *
+ * @param array $campaigns
+ *   Array of objects, each should have a nid.
+ */
+function dosomething_campaign_get_campaign_gallery($campaigns, $size = '400x400', $source = NULL) {
+  $vars['items'] = array();
+  foreach ($campaigns as $campaign) {
+    $campaign_vars = dosomething_campaign_get_campaign_block_vars($campaign->nid, $size, $source);
+    $vars['items'][] = theme('campaign_block', $campaign_vars);
+  }
+  return theme('campaign_gallery', $vars);
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -761,18 +761,30 @@ function dosomething_campaign_form_campaign_node_form_after_build($form, &$form_
 /**
  * For given array of objects, return themed Campaign Gallery.
  *
- * @param array $campaigns
- *   Array of objects, each should have a nid.
+ * @param array $nids
+ *   Array of Campaign node $nid's.
+ * @param string $size
+ *   Size to render Gallery items.
+ * @param string $source
+ *   The signup source param to pass to each campaign link.
+ *
+ * @return string
+ *   HTML of rendered Campaign Gallery.
  */
-function dosomething_campaign_get_campaign_gallery($campaigns, $size = '400x400', $source = NULL) {
+function dosomething_campaign_get_campaign_gallery($nids, $size = '400x400', $source = NULL) {
   $vars['items'] = array();
-  foreach ($campaigns as $delta => $campaign) {
+  foreach ($nids as $delta => $nid) {
+    // Default class as published.
     $vars['items'][$delta]['class'] = 'published';
-    $campaign_vars = dosomething_campaign_get_campaign_block_vars($campaign->nid, $size, $source);
+    // Load vars for this Campaign block.
+    $campaign_vars = dosomething_campaign_get_campaign_block_vars($nid, $size, $source);
+    // If unpublished campaign:
     if ($campaign_vars['status'] == 0) {
+      // Set relevant unpublished vars.
       $vars['items'][$delta]['class'] = 'unpublished';
       $campaign_vars['title'] = t('Stay Tuned');
     }
+    // Add the themed campaign block.
     $vars['items'][$delta]['campaign'] = theme('campaign_block', $campaign_vars);
   }
   return theme('campaign_gallery', $vars);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -763,9 +763,14 @@ function dosomething_campaign_form_campaign_node_form_after_build($form, &$form_
  */
 function dosomething_campaign_get_campaign_gallery($campaigns, $size = '400x400', $source = NULL) {
   $vars['items'] = array();
-  foreach ($campaigns as $campaign) {
+  foreach ($campaigns as $delta => $campaign) {
+    $vars['items'][$delta]['class'] = 'published';
     $campaign_vars = dosomething_campaign_get_campaign_block_vars($campaign->nid, $size, $source);
-    $vars['items'][] = theme('campaign_block', $campaign_vars);
+    if ($campaign_vars['status'] == 0) {
+      $vars['items'][$delta]['class'] = 'unpublished';
+      $campaign_vars['title'] = t('Stay Tuned');
+    }
+    $vars['items'][$delta]['campaign'] = theme('campaign_block', $campaign_vars);
   }
   return theme('campaign_gallery', $vars);
 }

--- a/lib/modules/dosomething/dosomething_campaign/theme/campaign-block.tpl.php
+++ b/lib/modules/dosomething/dosomething_campaign/theme/campaign-block.tpl.php
@@ -7,8 +7,7 @@
  * - $title: Title of campaign (string).
  * - $call_to_action: Call to action text for campaign. (string).
  * - $image: URL path for campaign image (string).
- * - $path: URL path for campaign node (string).
- * - $pretty_path: Pretty URL path for campaign node (string).
+ * - $path_alias: Pretty URL path for campaign node (string).
  * - $staff_pick: Indicate if this campaign a staff pick (boolean).
  * - $source: The signup source to pass as a query string param to the $path.
  */

--- a/lib/modules/dosomething/dosomething_campaign/theme/campaign-gallery.tpl.php
+++ b/lib/modules/dosomething/dosomething_campaign/theme/campaign-gallery.tpl.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Returns the HTML for a Campaign Gallery.
+ *
+ * Available Variables
+ * - $items: The Campaign gallery items to display.
+ */
+?>
+<div>
+  <li>
+  <?php foreach($items as $item): ?>
+    <ul><?php print $item; ?></ul>
+  <?php endforeach; ?>
+  </li>
+</div>

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
@@ -26,6 +26,15 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
     );
 
     $vars['campaigns'] = dosomething_campaign_group_get_campaigns($vars['node']);
+    $vars['campaign_gallery'] = NULL;
+    if (!empty($vars['node']->field_campaigns)) {
+      $nids = array();
+      foreach ($vars['node']->field_campaigns[LANGUAGE_NONE] as $delta => $campaign) {
+        $nids[] = $vars['node']->field_campaigns[LANGUAGE_NONE][$delta]['target_id'];
+      }
+      $campaign_gallery = dosomething_campaign_get_campaign_gallery($nids);
+      $vars['campaign_gallery']= $campaign_gallery;
+    }
 
     // If there are no published campaigns, 
     // Display pre_launch vars and remove campaigns from vars.

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.pages.inc
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.pages.inc
@@ -20,15 +20,19 @@ function dosomething_taxonomy_term_page($term) {
   $build['description'] = array(
     '#markup' => check_markup($term->description, $term->format),
   );
-  $image_size = '400x400';
+  $size = '400x400';
   $source = 'taxonomy/term/' . $term->tid;
   // Load term's campaigns.
   $view = views_get_view('campaigns_by_term');
   $view->set_arguments(array($term->tid));
   $view->execute();
+  $nids = array();
+  foreach ($view->result as $record) {
+    $nids[] = $record->nid;
+  }
   // Render campaigns as campaign gallery.
   $build['campaigns'] = array(
-    '#markup' => dosomething_campaign_get_campaign_gallery($view->result, $image_size, $source),
+    '#markup' => dosomething_campaign_get_campaign_gallery($nids, $size, $source),
     '#items' => $campaigns,
   );
   return $build;

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.pages.inc
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.pages.inc
@@ -26,14 +26,9 @@ function dosomething_taxonomy_term_page($term) {
   $view = views_get_view('campaigns_by_term');
   $view->set_arguments(array($term->tid));
   $view->execute();
-  $campaigns = array();
-  $size = '400x400';
-  foreach ($view->result as $delta => $record) {
-    $campaign_vars = dosomething_campaign_get_campaign_block_vars($record->nid, $size, $source);
-    $campaigns[] = theme('campaign_block', $campaign_vars);
-  }
+  // Render campaigns as campaign gallery.
   $build['campaigns'] = array(
-    '#theme' => 'item_list',
+    '#markup' => dosomething_campaign_get_campaign_gallery($view->result, $image_size, $source),
     '#items' => $campaigns,
   );
   return $build;

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/campaign-block.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/campaign-block.tpl.php
@@ -7,8 +7,7 @@
  * - $title: Title of campaign (string).
  * - $call_to_action: Call to action text for campaign. (string).
  * - $image: URL path for campaign image (string).
- * - $path: URL path for campaign node (string).
- * - $pretty_path: Pretty URL path for campaign node (string).
+ * - $path_alas: Pretty URL path for campaign node (string).
  * - $staff_pick: Indicate if this campaign a staff pick (boolean).
  */
 
@@ -21,7 +20,7 @@
 
 <article class="tile tile--campaign" id="campaign-<?php print $nid; ?>">
   <?php if ($status): ?>
-  <a class="wrapper" href="/<?php print $pretty_path; ?>">
+  <a class="wrapper" href="/<?php print $path_alias; ?>">
   <?php else: ?>
   <div class="wrapper">
   <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/campaign-gallery.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/campaign-gallery.tpl.php
@@ -6,10 +6,10 @@
  * - $items: The Campaign gallery items to display.
  */
 ?>
-<div>
-  <ul>
+<section class="container container--campaigns">
+  <ul class="gallery -mosaic -featured">
   <?php foreach($items as $item): ?>
-    <li><?php print $item; ?></li>
+    <li class="campaign -published"><?php print $item; ?></li>
   <?php endforeach; ?>
-  </ul>
+  </li>
 </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/campaign-gallery.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/campaign-gallery.tpl.php
@@ -9,7 +9,9 @@
 <section class="container container--campaigns">
   <ul class="gallery -mosaic -featured">
   <?php foreach($items as $item): ?>
-    <li class="campaign -published"><?php print $item; ?></li>
+    <li class="campaign -<?php print $item['class'] ?>">
+      <?php print $item['campaign']; ?>
+    </li>
   <?php endforeach; ?>
   </li>
 </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
@@ -114,31 +114,7 @@
     </section>
   <?php endif; ?>
 
-
-  <?php if (!empty($campaigns)): ?>
-    <section class="container container--campaigns">
-      <ul class="gallery -mosaic -featured">
-
-        <?php if (isset($campaigns['published'])): ?>
-          <?php foreach ($campaigns['published'] as $published_campaign): ?>
-            <li class="campaign -published">
-              <?php print render($published_campaign); ?>
-            </li>
-          <?php endforeach; ?>
-        <?php endif; ?>
-
-        <?php if (isset($campaigns['unpublished'])): ?>
-          <?php foreach ($campaigns['unpublished'] as $unpublished_campaign): ?>
-            <li class="campaign -unpublished">
-              <?php print render($unpublished_campaign); ?>
-            </li>
-          <?php endforeach; ?>
-        <?php endif; ?>
-
-      </ul>
-    </section>
-  <?php endif; ?>
-
+  <?php if (!empty($campaign_gallery)): print $campaign_gallery; endif; ?>
 
   <?php if (!empty($additional_text)): ?>
   <section class="container additional-text">


### PR DESCRIPTION
@sergii-tkachenko Can you review?

Refs #3159
- Adds a Campaign Gallery template file, to share between the Campaign Group and Taxonomy Term page templates.
- Refactors Campaign Block vars to call  `node_load` instead of `entity_metadata_wrapper` to avoid Fatal exceptions when fields aren't set.
