### PR TITLE
Taxonomy term template

### DIFF
--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -23,6 +23,34 @@ function dosomething_taxonomy_menu_alter(&$menu) {
 }
 
 /**
+* Implements hook_preprocess_taxonomy_term().
+*/
+function dosomething_taxonomy_preprocess_taxonomy_term(&$vars) {
+  $campaigns = dosomething_taxonomy_get_campaigns($vars['tid']);
+  $gallery = dosomething_campaign_get_campaign_gallery($campaigns, '400x400', $vars['term_url']);
+  $vars['campaign_gallery'] = $gallery;
+}
+
+/**
+ * Returns array of node nid's with the given Term $tid.
+ *
+ * @param int $tid
+ *   A taxonomy term tid.
+ *
+ * @return array
+ */
+function dosomething_taxonomy_get_campaigns($tid) {
+  $nids = array();
+  $view = views_get_view('campaigns_by_term');
+  $view->set_arguments(array($tid));
+  $view->execute();
+  foreach ($view->result as $record) {
+    $nids[] = $record->nid;
+  }
+  return $nids;
+}
+
+/**
  * Returns data from field_partners field collection for a given $node.
  *
  * @param object $node

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -26,9 +26,20 @@ function dosomething_taxonomy_menu_alter(&$menu) {
 * Implements hook_preprocess_taxonomy_term().
 */
 function dosomething_taxonomy_preprocess_taxonomy_term(&$vars) {
+  $vars['description'] = check_markup($vars['description'], $vars['format']);
   $campaigns = dosomething_taxonomy_get_campaigns($vars['tid']);
   $gallery = dosomething_campaign_get_campaign_gallery($campaigns, '400x400', $vars['term_url']);
   $vars['campaign_gallery'] = $gallery;
+
+  $text_fields = array(
+    'subtitle',
+  );
+  foreach ($text_fields as $label) {
+    $field = "field_{$label}";
+    if (isset($vars['content'][$field])) {
+      $vars[$label] = $vars['content'][$field][0]['#markup'];
+    }
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -26,11 +26,15 @@ function dosomething_taxonomy_menu_alter(&$menu) {
 * Implements hook_preprocess_taxonomy_term().
 */
 function dosomething_taxonomy_preprocess_taxonomy_term(&$vars) {
+  // Term description.
   $vars['description'] = check_markup($vars['description'], $vars['format']);
+
+  // Term campaigns.
   $campaigns = dosomething_taxonomy_get_campaigns($vars['tid']);
   $gallery = dosomething_campaign_get_campaign_gallery($campaigns, '400x400', $vars['term_url']);
   $vars['campaign_gallery'] = $gallery;
 
+  // Term fields:
   $text_fields = array(
     'subtitle',
   );
@@ -40,6 +44,10 @@ function dosomething_taxonomy_preprocess_taxonomy_term(&$vars) {
       $vars[$label] = $vars['content'][$field][0]['#markup'];
     }
   }
+
+  // Cover image.
+  dosomething_helpers_preprocess_hero_images($vars);
+  dosomething_helpers_add_inline_css($vars);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.pages.inc
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.pages.inc
@@ -17,23 +17,8 @@
  *   The page content.
  */
 function dosomething_taxonomy_term_page($term) {
-  $build['description'] = array(
-    '#markup' => check_markup($term->description, $term->format),
-  );
-  $size = '400x400';
-  $source = 'taxonomy/term/' . $term->tid;
-  // Load term's campaigns.
-  $view = views_get_view('campaigns_by_term');
-  $view->set_arguments(array($term->tid));
-  $view->execute();
-  $nids = array();
-  foreach ($view->result as $record) {
-    $nids[] = $record->nid;
-  }
-  // Render campaigns as campaign gallery.
-  $build['campaigns'] = array(
-    '#markup' => dosomething_campaign_get_campaign_gallery($nids, $size, $source),
-    '#items' => $campaigns,
-  );
-  return $build;
+  // This code is somewhat lifted from contrib module:
+  // @see https://www.drupal.org/project/disable_term_node_listings
+  drupal_set_title($term->name);
+  return taxonomy_term_view($term, 'full');
 }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -15,6 +15,7 @@ function paraneue_dosomething_preprocess_html(&$vars) {
  * Implements theme_preprocess_page().
  */
 function paraneue_dosomething_preprocess_page(&$vars) {
+
   // Add theme suggestion for page template based on node.
   if (isset($vars['node']->type)) {
     // If the content type's machine name is "my_machine_name" the file
@@ -90,7 +91,11 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     $header_vars['subtitle'] =  $vars['node']->field_subtitle[LANGUAGE_NONE][0]['safe_value'];
   }
 
-  $vars['header'] = theme('header', $header_vars);
+  // If this is not a taxonomy term page:
+  if ($vars['theme_hook_suggestions'][0] != 'page__taxonomy') {
+    // Add the header.
+    $vars['header'] = theme('header', $header_vars);
+  }
 
 
   /**

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/page.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/page.tpl.php
@@ -12,7 +12,10 @@
 
 <div class="chrome--wrapper">
   <?php print $variables['navigation']; ?>
-  <?php print $variables['header']; ?>
+
+  <?php if (isset($variables['header'])): ?>
+    <?php print $variables['header']; ?>
+  <?php endif; ?>
 
   <main role="main" class="container">
     <div class="wrapper">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/taxonomy/taxonomy-term.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/taxonomy/taxonomy-term.tpl.php
@@ -1,0 +1,10 @@
+<div id="taxonomy-term-<?php print $term->tid; ?>" class="<?php print $classes; ?>">
+
+  <div class="content">
+    <?php print render($content); ?>
+    <?php if (!empty($campaign_gallery)): ?>
+      <?php print $campaign_gallery; ?>
+    <?php endif; ?>
+  </div>
+
+</div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/taxonomy/taxonomy-term.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/taxonomy/taxonomy-term.tpl.php
@@ -1,7 +1,16 @@
 <div id="taxonomy-term-<?php print $term->tid; ?>" class="<?php print $classes; ?>">
 
+  <header role="banner" class="-hero <?php print $classes; ?>">
+    <div class="wrapper">
+      <h1 class="__title"><?php print $term->name; ?></h1>
+      <?php if (isset($subtitle)): ?>
+        <h2 class="__subtitle"><?php print $subtitle; ?></h2>
+      <?php endif; ?>
+    </div>
+  </header>
+
   <div class="content">
-    <?php print render($content); ?>
+    <?php if (isset($description)): print $description; endif; ?>
     <?php if (!empty($campaign_gallery)): ?>
       <?php print $campaign_gallery; ?>
     <?php endif; ?>


### PR DESCRIPTION
Refs #3159
- Refactors `dosomething_taxonomy_term_page` to simply return the full view of a taxonomy term, allowing us to make use of built in Taxonomy term template files and preprocess hooks.
- Adds a `taxonomy-term.tpl.php` into the Paraneue theme.
  - Outputs `field_subtitle` in the header
  - Adds inline css to display cover image if set
