### PR TITLE
Taxonomy Term URL pattern

### DIFF
--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.strongarm.inc
@@ -14,7 +14,7 @@ function dosomething_taxonomy_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'pathauto_taxonomy_term_pattern';
-  $strongarm->value = '';
+  $strongarm->value = 'volunteer/[term:name]';
   $export['pathauto_taxonomy_term_pattern'] = $strongarm;
 
   return $export;


### PR DESCRIPTION
Updates default to `'volunteer/[term:name]'` instead of none.
