### PR TITLE
Adds comment to inform existing database tables will not be wiped

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -440,9 +440,9 @@ function pull_db {
   then
     if [[ ${#alias[@]} == 1 ]]
     then
-      echo "Pulling down db from staging"
+      echo "Pulling down db from staging. Note that existing unique tables in local db will not be removed in sql-sync."
       cd $WEB_PATH
-      drush -y sql-sync @ds.staging @self
+      drush -y --create-db sql-sync @ds.staging @self
 
       echo "Enabling Stage File Proxy..."
       drush -y en stage_file_proxy
@@ -457,8 +457,8 @@ function pull_db {
       drush variable-delete ds_version -y
 
     else
-      echo "Pulling down the db from ${alias[1]} staging"
-      drush -y sql-sync @ds.${alias[1]}.staging @ds.${alias[1]}.dev
+      echo "Pulling down the db from ${alias[1]} staging. Note that existing unique tables in local db will not be removed in sql-sync."
+      drush -y --create-db sql-sync @ds.${alias[1]}.staging @ds.${alias[1]}.dev
     fi
   fi
 }


### PR DESCRIPTION
See https://jira.dosomething.org/browse/INF-41?jql=text%20~%20%22sql-sync%22

The `drush sql-sync` command does not remove additional tables in the local database as expected when using `ds  pull --stage`. 

This is a long standing issue with the `drush sql-sync` command. There has been an issue for several years to add a switch to drop the local unique database tables before sync.

https://github.com/drush-ops/drush/issues/161

This pull request adds the `--create-db` switch as it's expect that this switch will be the solution when this issue is resolved. The related comment the script echos has been updated to warn the user that local tables will have to be dropped rather than expecting the `ds` command to take care of the clean up.
