### PR TITLE
Active Campaign preview page

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -57,6 +57,16 @@ function dosomething_campaign_menu() {
     'type' => MENU_LOCAL_TASK,
     'weight' => 60,
   );
+  // Internal active page for staff.
+  $items['node/%node/active'] = array(
+    'title' => 'Active',
+    'page callback' => 'node_page_view',
+    'page arguments' => array(1),
+    'access callback' => '_dosomething_campaign_active_page_access',
+    'access arguments' => array(1),
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 70,
+  );
   // Internal closed page for staff.
   $items['node/%node/closed'] = array(
     'title' => 'Closed',
@@ -246,8 +256,20 @@ function _dosomething_campaign_closed_page_access($node) {
 
   // Only display closed page link if a campaign run exists for node.
   $run_nid = dosomething_campaign_run_get_closed_run_nid($node->nid);
-  // Closed page available if this is a campaign node with a campaign run.
-  return ($node->type == 'campaign' && $run_nid);
+
+  // Closed page available if this is an active campaign node with a campaign run.
+  $is_active = !dosomething_campaign_is_closed($node);
+  return ($node->type == 'campaign' && $run_nid && $is_active);
+}
+
+/*
+ * Determines whether a user has access to the active page callback.
+ */
+function _dosomething_campaign_active_page_access($node) {
+  // Staff only.
+  if (!dosomething_user_is_staff()) { return FALSE; }
+
+  return (dosomething_campaign_is_closed($node));
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -247,7 +247,7 @@ function _dosomething_campaign_pitch_page_access($node) {
   return FALSE;
 }
 
-/*
+/**
  * Determines whether a user has access to the closed page callback.
  */
 function _dosomething_campaign_closed_page_access($node) {
@@ -259,17 +259,18 @@ function _dosomething_campaign_closed_page_access($node) {
 
   // Closed page available if this is an active campaign node with a campaign run.
   $is_active = !dosomething_campaign_is_closed($node);
-  return ($node->type == 'campaign' && $run_nid && $is_active);
+  $closed_page_access = $node->type == 'campaign' && $run_nid && $is_active;
+  return $closed_page_access;
 }
 
-/*
+/**
  * Determines whether a user has access to the active page callback.
  */
 function _dosomething_campaign_active_page_access($node) {
   // Staff only.
   if (!dosomething_user_is_staff()) { return FALSE; }
 
-  return (dosomething_campaign_is_closed($node));
+  return dosomething_campaign_is_closed($node);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -15,6 +15,8 @@ function dosomething_campaign_preprocess_node(&$vars) {
   $vars['campaign'] = dosomething_campaign_load($node);
   $wrapper = entity_metadata_wrapper('node', $node);
 
+  $current_path = current_path();
+
   // Hero Images.
   dosomething_helpers_preprocess_hero_images($vars);
 
@@ -26,11 +28,22 @@ function dosomething_campaign_preprocess_node(&$vars) {
   // Add inline css based on vars.
   dosomething_helpers_add_inline_css($vars);
 
+  // Check if current path is active path.
+  // @see dosomething_campaign_menu().
+  $active_path = 'node/' . $node->nid . '/active';
+  if ($current_path == $active_path) {
+    // Preprocess common vars between all campaign types.
+    dosomething_campaign_preprocess_common_vars($vars, $wrapper);
+    // Preprocess the vars for the campaign action page.
+    dosomething_campaign_preprocess_action_page($vars, $wrapper);
+    return;
+  }
+
   // Check if current path is closed path.
   // @see dosomething_campaign_menu().
   $closed_path = 'node/' . $node->nid . '/closed';
   // If the campaign node is closed or we're on the closed path:
-  if (dosomething_campaign_is_closed($node) || current_path() == $closed_path) {
+  if (dosomething_campaign_is_closed($node) || $current_path == $closed_path) {
     // Use the campaign closed template to theme.
     $vars['theme_hook_suggestions'][] = 'node__campaign__closed';
     dosomething_campaign_run_preprocess_closed($vars);

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -98,7 +98,10 @@ function paraneue_dosomething_get_social_networks() {
  *
  * @return string
  */
-function paraneue_dosomething_get_sponsor_logos($partners_data) {
+function paraneue_dosomething_get_sponsor_logos($partners_data = array()) {
+  if (empty($partners_data)) {
+    return '';
+  }
   $sponsors = array();
   foreach ($partners_data as $delta => $partner) {
     if ($partner['is_sponsor']) {


### PR DESCRIPTION
@sergii-tkachenko Can you review?

If a campaign is closed, you can't preview it's active state without setting its status back to Active.

This PR adds a menu callback, `node/*/active`, which will only display for Closed Campaigns.  The active campaign can be previewed from here.  This page is available to staff only.

Also changes the Closed Campaign preview page link to display only when the Campaign is active, eliminating duplicate links (the regular view page is the same as the Closed page when the Campaign is closed)
