### PR TITLE
SSO Canada: registration

### DIFF
--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_register_controller.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_register_controller.inc
@@ -10,15 +10,53 @@ class DosomethingCanadaRegisterController implements ExternalAuthRegisterControl
   // ---------------------------------------------------------------------
   // Instance variables
 
+  /**
+   * The registration form.
+   */
+  private $account_values;
+
+  /**
+   * The SSO controller.
+   */
+  private $sso;
+
   // ---------------------------------------------------------------------
   // Public: interface implementation
 
   public function setup(Array $form_state) {
+    $this->account_values = $form_state['values'];
+    $this->sso = dosomething_canada_get_sso();
     return $this;
   }
 
   public function signup() {
-    return TRUE;
+    $user = new stdClass();
+    $user->email    = $this->account_values['mail'];
+    $user->password = $this->account_values['pass'];
+
+    if (!empty($this->account_values['field_birthdate']['und'][0])) {
+      $user->dob = $this->account_values['field_birthdate']['und'][0]['value'];
+    }
+
+    if (!empty($this->account_values['field_mobile']['und'][0])) {
+      $user->mobile = $this->account_values['field_mobile']['und'][0]['value'];
+    }
+
+    if (!empty($this->account_values['field_first_name']['und'][0])) {
+      $user->firstName = $this->account_values['field_first_name']['und'][0]['value'];
+    }
+
+    if (!empty($this->account_values['field_last_name']['und'][0])) {
+      $user->lastName = $this->account_values['field_last_name']['und'][0]['value'];
+    }
+
+    $result = FALSE;
+    try {
+      $result = $this->sso->propagateLocalUser($this->email, $this->password, $user);
+    } catch (Exception $e) {
+      return FALSE;
+    }
+    return $result;
   }
 
   public function processSignupErrors(Array $form) {}

--- a/tests/integration/canada/sso.coffee
+++ b/tests/integration/canada/sso.coffee
@@ -3,13 +3,48 @@
 # Sometimes SSO server response takes long.
 casper.options.waitTimeout = 10000
 
+# Form selectors.
+FORM = '#user-register-form'
+FIELD_MAIL       = 'mail'
+FIELD_PASS       = 'pass[pass1]'
+FIELD_PASS_2     = 'pass[pass2]'
+FIELD_FIRST_NAME = 'field_first_name[und][0][value]'
+FIELD_BIRTHDATE  = 'field_birthdate[und][0][value][date]'
+
 # Generate user.
-system = require 'system';
-# Temporary. Will be replaced with generated user when SSO registration is ready.
-user =
-  email: system.env.DS_CA_USER
-  password: system.env.DS_CA_PASS
+user = casper.getRandomUser()
 uid = false
+
+# ------------------------------------------------------------------------
+# Test registration form
+
+casper.test.begin "Test that registration form is integrated with SSO", 2, (test) ->
+
+  # Launch browser on registration page.
+  casper.start "#{url}/user/register"
+
+  # Ensure registration form.
+  casper.then -> test.assertExists FORM, 'Registration form found.'
+
+  # Submit valid registration form.
+  casper.then -> fillSignupForm user
+  casper.thenClick '#edit-submit'
+
+  # Check whether the registration is successful.
+  assert_message = 'User is registered can see own profile.'
+  casper.waitForUrl /\/user\/[0-9]+\/edit$/,
+    ->
+      # Success.
+      test.assertExists '.status', assert_message
+      saveUserUid()
+    ->
+      @echo 'Registration form errors:', 'ERROR'
+      @echo @fetchText('.error').trim(), 'WARNING'
+      test.assert false, assert_message
+
+  # Run tests.
+  casper.run -> @test.done()
+  return
 
 # ------------------------------------------------------------------------
 # Test login form
@@ -25,11 +60,10 @@ casper.test.begin "Test that user created from SSO can login", 1, (test) ->
   # Go to the edit profile page.
   # We don't know new uid yet, but user/register will redirect to the page.
   casper.thenOpen "#{url}/user/register"
-  casper.then ->
-    saveUserUid()
+  casper.then -> saveUserUid()
 
-    # Test the nid is present
-    test.assertTruthy uid, "User is found."
+  # Test the nid is present
+  test.assertTruthy uid, "User is found."
 
   # Cleanup after success.
   casper.then ->
@@ -42,6 +76,19 @@ casper.test.begin "Test that user created from SSO can login", 1, (test) ->
 
 # ------------------------------------------------------------------------
 # Utilities
+
+fillSignupForm = (user) ->
+  # Prepare user data.
+  data = {}
+  data[FIELD_MAIL]       = user.email
+  data[FIELD_PASS]       = user.password
+  data[FIELD_PASS_2]     = user.password
+  data[FIELD_FIRST_NAME] = user.first_name
+  data[FIELD_BIRTHDATE]  = user.dob.format "MM/DD/YYYY"
+
+  # Fill in the registration form.
+  casper.fill FORM, data
+  return
 
 # Finds user uid on the profile edit page ans saves it to global variable.
 saveUserUid = ->


### PR DESCRIPTION
#### What's this PR do?
- Utilizes Canada SSO registration in `dosomething_canada` module
- Improves and extends Canada integration tests
#### How should this be manually tested?
- Enable and setup Dosomething Canada module
- Run `ds test canada`  
  ![image](https://cloud.githubusercontent.com/assets/672669/4722067/4394db34-593d-11e4-8fb3-a7f1ffd0321e.png)
#### What are the relevant tickets?
- Part of [#DS-379](https://jira.dosomething.org/browse/DS-379): Move functionality common to UK and Canada to the new nodule
- #3176: Canada SSO: adapt login to common flow provided in external_auth
- #3174: UK SSO: adapt login/signup to common flow provided in external_auth
- dosomething/drupal-external-auth#2
### Known integration issues

Users created not able to login at http://www.tigweb.org/:
- [ ] The User can only restore its own username (which is not same as email) using [TIG Recover Username](https://www.tigweb.org/members/retrieve.html) form. The user will receive email like the following, but it's still not possible to log in using the username and its original password. We think the issue could be in the dash sign in `ds-sergiitest5dosomethingorg`
  ![image](https://cloud.githubusercontent.com/assets/672669/4722195/403dd94e-593e-11e4-9189-ce44fd48dbaa.png)
- [ ] It's not possible to recover password on TIG using both recovered username and original email
- [ ] It's not possible to login on TIG using both recovered username and original email
