### PR TITLE
Variable for dosomething_user_address_country

### DIFF
--- a/lib/modules/dosomething/dosomething_canada/dosomething_canada.install
+++ b/lib/modules/dosomething/dosomething_canada/dosomething_canada.install
@@ -48,3 +48,10 @@ function dosomething_canada_update_7003() {
 function dosomething_canada_update_7004() {
   module_enable(array('dosomething_shipment'));
 }
+
+/**
+ * Sets dosomething_user_address_country variable for Canada.
+ */
+function dosomething_canada_update_7005() {
+  variable_set('dosomething_user_address_country', 'CA');
+}

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
@@ -38,6 +38,7 @@ function dosomething_user_address_form_element(&$form, &$form_state) {
       'data-validate-required' => '',
     ),
   );
+  $country = variable_get('dosomething_user_address_country', 'US');
   $form['user_address'] = array(
     '#prefix' => '<div data-validate="ups_address" data-validate-required>',
     '#suffix' => '</div>',
@@ -47,7 +48,7 @@ function dosomething_user_address_form_element(&$form, &$form_state) {
       'address-hide-country' => 'address-hide-country',
     ),
     '#required' => TRUE,
-    '#context' => array('countries' => array('US')),
+    '#context' => array('countries' => array($country)),
     '#default_value' => isset($account->field_address[LANGUAGE_NONE][0]) ? $account->field_address[LANGUAGE_NONE][0] : '',
   );
   // If we are collecting an address, run address validation.

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.install
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.install
@@ -28,16 +28,26 @@ function dosomething_user_update_7003() {
 }
 
 /**
+ * Sets dosomething_user_address_country variable for US site.
+ */
+function dosomething_user_update_7004() {
+  if (!dosomething_settings_is_affiliate()) {
+    variable_set('dosomething_user_address_country', 'US');
+  }
+}
+
+/**
  * Implements hook_uninstall().
  */
 function dosomething_user_uninstall() {
   // This list is alphabetical, please keep it that way!
   $vars = array(
     'dosomething_user_address_administrative_area_options',
-    'dosomething_user_member_count',
+    'dosomething_user_address_country',
     'dosomething_user_enable_clean_slate',
-    'dosomething_user_login_form_display_password_link',
     'dosomething_user_login_form_copy',
+    'dosomething_user_login_form_display_password_link',
+    'dosomething_user_member_count',
     'dosomething_user_node_privacy_policy',
     'dosomething_user_node_terms_service',
     'dosomething_user_profile_subtitle',


### PR DESCRIPTION
This prevents the Shipment Form (and other Signup Data forms that collect addresses) from defaulting to 'US' when creating address field values.

However, we're still in trouble for Teens For Jeans Canada because upon creating, users are created a default value with country "US" because of the DoSomething User field definition: https://jira.dosomething.org/browse/DS-449
