### PR TITLE
Fixes #3223.

### DIFF
--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
@@ -42,7 +42,7 @@ class DosomethingCanadaLoginController implements ExternalAuthLoginController {
   // ---------------------------------------------------------------------
   // Public: interface implementation
 
-  public function setup(Array $form_state) {
+  public function setup(Array $form, Array &$form_state) {
     $this->email    = $form_state['values']['name'];
     $this->password = $form_state['values']['pass'];
     $this->local_account  = dosomething_user_get_user_by_email($this->email);

--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_register_controller.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_register_controller.inc
@@ -23,7 +23,7 @@ class DosomethingCanadaRegisterController implements ExternalAuthRegisterControl
   // ---------------------------------------------------------------------
   // Public: interface implementation
 
-  public function setup(Array $form_state) {
+  public function setup(Array $form, Array &$form_state) {
     $this->account_values = $form_state['values'];
     $this->sso = dosomething_canada_get_sso();
     return $this;

--- a/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_login_controller.inc
+++ b/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_login_controller.inc
@@ -46,7 +46,7 @@ class DosomethingUkLoginController implements ExternalAuthLoginController {
   // ---------------------------------------------------------------------
   // Public: interface implementation
 
-  public function setup(Array $form_state) {
+  public function setup(Array $form, Array &$form_state) {
     $this->email    = $form_state['values']['name'];
     $this->password = $form_state['values']['pass'];
     $this->local_account  = dosomething_user_get_user_by_email($this->email);

--- a/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_register_controller.inc
+++ b/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_register_controller.inc
@@ -30,7 +30,7 @@ class DosomethingUkRegisterController implements ExternalAuthRegisterController 
   // ---------------------------------------------------------------------
   // Public: interface implementation
 
-  public function setup(Array $form_state) {
+  public function setup(Array $form, Array &$form_state) {
     $values = &$form_state['values'];
 
     // -- Required user data. --
@@ -70,6 +70,18 @@ class DosomethingUkRegisterController implements ExternalAuthRegisterController 
       form_set_value(
         $form['field_mobile'],
         array(LANGUAGE_NONE => array(0 => array('value' => $phone))),
+        $form_state
+      );
+    }
+
+    // If the postal code is validated remotely, save also the country.
+    if ($this->remote_account->getPostcode()) {
+      form_set_value(
+        $form['field_address'],
+        array(LANGUAGE_NONE => array(array(
+          'postal_code' => $this->remote_account->getPostcode(),
+          'country' => $this->remote_account->getCountry(),
+        ))),
         $form_state
       );
     }

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -204,7 +204,7 @@ projects[xmlsitemap][subdir] = "contrib"
 projects[external_auth][type] = "module"
 projects[external_auth][download][type] = "git"
 projects[external_auth][download][url] = "https://github.com/DoSomething/drupal-external-auth.git"
-projects[external_auth][download][revision] = "577b68c"
+projects[external_auth][download][revision] = "a1d7786"
 projects[external_auth][subdir] = "contrib"
 
 ; Conductor


### PR DESCRIPTION
#### What's this PR do?
- Fixes #3223: UK SSO: newly registered users has wrong country
- Upgrades `external_auth`
#### How should this be manually tested?
- Enable and setup Dosomething UK module
- Run `ds test uk`
  ![image](https://cloud.githubusercontent.com/assets/672669/4761379/b72366cc-5af7-11e4-86e9-0edabb532ca9.png)
#### What are the relevant tickets?
#3223 — UK SSO: newly registered users has wrong country
#3217 — Fix address field country on DS Canada

dosomething/drupal-external-auth#3 — Passes $form argument to controllers' setup method
dosomething/drupal-external-auth#4 — Pass form state by reference.
