### PR TITLE
Canada SSO: fixes users address country.

### DIFF
--- a/lib/modules/dosomething/dosomething_canada/dosomething_canada.install
+++ b/lib/modules/dosomething/dosomething_canada/dosomething_canada.install
@@ -12,6 +12,9 @@ function dosomething_canada_install() {
   variable_set('dosomething_canada_sso_url',   getenv('DS_CANADA_SSO_URL'));
   variable_set('dosomething_canada_sso_appid', getenv('DS_CANADA_SSO_APPID'));
   variable_set('dosomething_canada_sso_key',   getenv('DS_CANADA_SSO_KEY'));
+
+  // Setup user.
+  variable_set('dosomething_user_address_country', 'CA');
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_canada/dosomething_canada.module
+++ b/lib/modules/dosomething/dosomething_canada/dosomething_canada.module
@@ -7,7 +7,6 @@
 
 define('DOSOMETHING_CANADA_WATCHDOG', 'dosomething_canada');
 define('DOSOMETHING_CANADA_USER_SOURCE', 'dosomething_canada');
-define('DOSOMETHING_CANADA_USER_COUNTRY', 'CA');
 
 // In lieu of a future, global management solution, standardize feedback
 // messages here.

--- a/lib/modules/dosomething/dosomething_canada/dosomething_canada.module
+++ b/lib/modules/dosomething/dosomething_canada/dosomething_canada.module
@@ -7,6 +7,7 @@
 
 define('DOSOMETHING_CANADA_WATCHDOG', 'dosomething_canada');
 define('DOSOMETHING_CANADA_USER_SOURCE', 'dosomething_canada');
+define('DOSOMETHING_CANADA_USER_COUNTRY', 'CA');
 
 // In lieu of a future, global management solution, standardize feedback
 // messages here.

--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
@@ -116,6 +116,7 @@ class DosomethingCanadaLoginController implements ExternalAuthLoginController {
     $fields = array(
       'birthdate'                => $dob->format(DATE_FORMAT_DATE),
       'first_name'               => $this->remote_account->Name,
+      'country'                  => DOSOMETHING_CANADA_USER_COUNTRY,
       'user_registration_source' => DOSOMETHING_CANADA_USER_SOURCE,
     );
     dosomething_user_set_fields($edit, $fields);

--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
@@ -116,7 +116,7 @@ class DosomethingCanadaLoginController implements ExternalAuthLoginController {
     $fields = array(
       'birthdate'                => $dob->format(DATE_FORMAT_DATE),
       'first_name'               => $this->remote_account->Name,
-      'country'                  => DOSOMETHING_CANADA_USER_COUNTRY,
+      'country'                  => variable_get('dosomething_user_address_country'),
       'user_registration_source' => DOSOMETHING_CANADA_USER_SOURCE,
     );
     dosomething_user_set_fields($edit, $fields);

--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_register_controller.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_register_controller.inc
@@ -26,6 +26,17 @@ class DosomethingCanadaRegisterController implements ExternalAuthRegisterControl
   public function setup(Array $form, Array &$form_state) {
     $this->account_values = $form_state['values'];
     $this->sso = dosomething_canada_get_sso();
+
+    // Set users address country.
+    form_set_value(
+      $form['field_address'],
+      array(LANGUAGE_NONE => array(array(
+        'postal_code' => '',
+        'country'     => DOSOMETHING_CANADA_USER_COUNTRY,
+      ))),
+      $form_state
+    );
+
     return $this;
   }
 

--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_register_controller.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_register_controller.inc
@@ -31,8 +31,7 @@ class DosomethingCanadaRegisterController implements ExternalAuthRegisterControl
     form_set_value(
       $form['field_address'],
       array(LANGUAGE_NONE => array(array(
-        'postal_code' => '',
-        'country'     => DOSOMETHING_CANADA_USER_COUNTRY,
+        'country' => variable_get('dosomething_user_address_country'),
       ))),
       $form_state
     );

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -636,9 +636,9 @@ function _dosomething_user_register_display_fields(&$form) {
     // Adds form element for postal code only to the register form.
     $form['#after_build'][] = 'dosomething_user_address_field_postal_code_only';
   }
-  // Else unset corresponding form field.
+  // Else deny access to the corresponding form field.
   else {
-    unset($form[$field_name]);
+    $form[$field_name]['#access'] = FALSE;
   }
 
 }


### PR DESCRIPTION
#### What's this PR do?
- Changes user's address on DS Canada so new users created during login and registration have 'CA' in country field
- Changes `dosomething_user`: `_dosomething_user_register_display_fields` now doens't unset address, but restrict access to it 
#### How should this be manually tested?
- Run tests after cloning this branch
- Test that functionality works ad before after `dosomething_user` change: `ds test default`
  ![screen shot 2014-10-23 at 6 42 11 pm](https://cloud.githubusercontent.com/assets/672669/4770188/0d3b4eb8-5b83-11e4-91e1-1ee624861772.png)
- Enable and setup DoSomething  Canada module
- Test Canada-specific functionality: `ds test canada`
  ![screen shot 2014-10-23 at 6 44 29 pm](https://cloud.githubusercontent.com/assets/672669/4770218/716cca9c-5b83-11e4-964b-58cce419e45e.png)
#### What are the relevant tickets?

Fixes #3217 — Save CA as address country for DS Canada User Registration
