### PR TITLE
Fixes Pitch Page view bug

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -546,21 +546,17 @@ function dosomething_campaign_is_pitch_page($node) {
   if (dosomething_campaign_get_campaign_type($node) != 'campaign') {
     return FALSE;
   }
+  // If campaign is closed, no pitch page.
+  elseif (dosomething_campaign_is_closed($node)) {
+    return FALSE;
+  }
+
+  // If we've made it this far, the campaign is active.
 
   // Anonymous users are always shown pitch page.
-  // @todo: Will need additional check here for if the campaign $node is closed.
   if (!user_is_logged_in()) {
     return TRUE;
   }
-
-  if (dosomething_user_is_staff()) {
-    // Return whether or not we're on the staff-only pitch page URL.
-    // @see dosomething_campaign_menu().
-    // This check also allows staff to bypass the Pitch Page to view Action Page
-    // regardless of whether or not they're signed up for the campaign.
-    return (current_path() == 'node/' . $node->nid . '/pitch');
-  }
-
   // The $node is a pitch page if you haven't signed up yet.
   return (!dosomething_signup_exists($node->nid));
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -30,8 +30,6 @@ function dosomething_campaign_preprocess_node(&$vars) {
 
   $pitch_path = 'node/' . $node->nid . '/pitch';
   if ($pitch_path == $current_path || dosomething_campaign_is_pitch_page($node)) {
-    // Use the pitch page template to theme.
-    $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'] . '__pitch';
     // Gather vars for pitch page.
     dosomething_campaign_preprocess_pitch_page($vars, $wrapper);
     return;
@@ -54,15 +52,11 @@ function dosomething_campaign_preprocess_node(&$vars) {
   $closed_path = 'node/' . $node->nid . '/closed';
   // If the campaign node is closed or we're on the closed path:
   if (dosomething_campaign_is_closed($node) || $current_path == $closed_path) {
-    // Use the campaign closed template to theme.
-    $vars['theme_hook_suggestions'][] = 'node__campaign__closed';
     dosomething_campaign_run_preprocess_closed($vars);
     return;
   }
 
   if (dosomething_campaign_get_campaign_type($node) == 'sms_game') {
-    // Use the SMS Game template to theme.
-    $vars['theme_hook_suggestions'][] = 'node__campaign__sms_game';
     dosomething_campaign_preprocess_sms_game($vars, $wrapper);
     return;
   }
@@ -316,6 +310,8 @@ function dosomething_campaign_preprocess_shipment_form(&$vars) {
  *   The corresponding entity wrapper for the node in $vars.
  */
 function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
+  // Use the pitch page template to theme.
+  $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'] . '__pitch';
   // Track that we're viewing a pitch page.
   $vars['campaign']->is_pitch_page = TRUE;
   // Check for a signup button copy override.
@@ -346,6 +342,8 @@ function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
  *   The corresponding entity wrapper for the node in $vars.
  */
 function dosomething_campaign_preprocess_sms_game(&$vars, &$wrapper) {
+  // Use the SMS Game template to theme.
+  $vars['theme_hook_suggestions'][] = 'node__campaign__sms_game';
   $vars['signup_form'] = $vars['content']['signup_form'];
   $vars['starter_header'] = $wrapper->field_starter_statement_header->value();
   drupal_add_js('//cdn.optimizely.com/js/1158700146.js', 'external');

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -28,23 +28,24 @@ function dosomething_campaign_preprocess_node(&$vars) {
   // Add inline css based on vars.
   dosomething_helpers_add_inline_css($vars);
 
-  // Check if current path is active path.
-  // @see dosomething_campaign_menu().
-  $active_path = 'node/' . $node->nid . '/active';
-  if ($current_path == $active_path) {
-    // Preprocess common vars between all campaign types.
-    dosomething_campaign_preprocess_common_vars($vars, $wrapper);
-    // Preprocess the vars for the campaign action page.
-    dosomething_campaign_preprocess_action_page($vars, $wrapper);
-    return;
-  }
-
   $pitch_path = 'node/' . $node->nid . '/pitch';
   if ($pitch_path == $current_path || dosomething_campaign_is_pitch_page($node)) {
     // Use the pitch page template to theme.
     $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'] . '__pitch';
     // Gather vars for pitch page.
     dosomething_campaign_preprocess_pitch_page($vars, $wrapper);
+    return;
+  }
+
+  // Preprocess common vars between all campaign types for non-pitch templates.
+  dosomething_campaign_preprocess_common_vars($vars, $wrapper);
+
+  // Check if current path is active path.
+  // @see dosomething_campaign_menu().
+  $active_path = 'node/' . $node->nid . '/active';
+  if ($current_path == $active_path) {
+    // Preprocess the vars for the campaign action page.
+    dosomething_campaign_preprocess_action_page($vars, $wrapper);
     return;
   }
 
@@ -56,13 +57,8 @@ function dosomething_campaign_preprocess_node(&$vars) {
     // Use the campaign closed template to theme.
     $vars['theme_hook_suggestions'][] = 'node__campaign__closed';
     dosomething_campaign_run_preprocess_closed($vars);
-    // Preprocess common vars between all campaign types.
-    dosomething_campaign_preprocess_common_vars($vars, $wrapper);
     return;
   }
-
-  // Preprocess common vars between all campaign types.
-  dosomething_campaign_preprocess_common_vars($vars, $wrapper);
 
   if (dosomething_campaign_get_campaign_type($node) == 'sms_game') {
     // Use the SMS Game template to theme.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -39,6 +39,15 @@ function dosomething_campaign_preprocess_node(&$vars) {
     return;
   }
 
+  $pitch_path = 'node/' . $node->nid . '/pitch';
+  if ($pitch_path == $current_path || dosomething_campaign_is_pitch_page($node)) {
+    // Use the pitch page template to theme.
+    $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'] . '__pitch';
+    // Gather vars for pitch page.
+    dosomething_campaign_preprocess_pitch_page($vars, $wrapper);
+    return;
+  }
+
   // Check if current path is closed path.
   // @see dosomething_campaign_menu().
   $closed_path = 'node/' . $node->nid . '/closed';
@@ -52,18 +61,8 @@ function dosomething_campaign_preprocess_node(&$vars) {
     return;
   }
 
-  if (dosomething_campaign_is_pitch_page($node)) {
-    // Use the pitch page template to theme.
-    $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'] . '__pitch';
-    // Gather vars for pitch page.
-    dosomething_campaign_preprocess_pitch_page($vars, $wrapper);
-    return;
-  }
-
   // Preprocess common vars between all campaign types.
   dosomething_campaign_preprocess_common_vars($vars, $wrapper);
-
-
 
   if (dosomething_campaign_get_campaign_type($node) == 'sms_game') {
     // Use the SMS Game template to theme.
@@ -74,8 +73,6 @@ function dosomething_campaign_preprocess_node(&$vars) {
 
   // Preprocess the vars for the campaign action page.
   dosomething_campaign_preprocess_action_page($vars, $wrapper);
-
-
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -14,6 +14,9 @@ include_once 'dosomething_campaign_run.features.inc';
 function dosomething_campaign_run_preprocess_closed(&$vars) {
   if (!isset($vars['nid'])) { return; }
 
+  // Use the campaign closed template to theme.
+  $vars['theme_hook_suggestions'][] = 'node__campaign__closed';
+
   // If a closed Campaign Run node exists:
   if ($closed_run_nid = dosomething_campaign_run_get_closed_run_nid($vars['nid'])) {
     // Load the closed campaign_run.


### PR DESCRIPTION
Fixes #3220 - When a campaign is closed, the pitch page view does not display for the staff-only `node/*/pitch` page.

Cleans up preprocess functions in the meantime, DRY for preprocessing common variables, and moves the `theme_hook_suggestions` declarations into the relevant preprocess functions, to help make `dosomething_campaign_preprocess_node` a little more readable.
