### PR TITLE
Update message_broker_producer module

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -10,3 +10,70 @@
 function dosomething_mbp_update_7001(&$sandbox) {
   variable_del('dosomething_mbp_send_campaign_api');
 }
+
+ /**
+ * Creates default production entries in message_broker_producer
+ */
+function dosomething_mbp_update_7002(&$sandbox) {
+
+  $productions = array();
+
+  $productions[0]['target_production'] = 'transactional_user_register';
+  $productions[0]['exchange'] = 'transactionalExchange';
+  $productions[0]['queues'][] = 'transactionalQueue';
+  $productions[0]['queues'][] = 'loggingQueue';
+  $productions[0]['queues'][] = 'activityStatsQueue';
+  $productions[0]['queues'][] = 'mailchimpCampaignSignupQueue';
+  $productions[0]['queues'][] = 'mobileCommonsQueue';
+  $productions[0]['queues'][] = 'userAPIRegistrationQueue';
+  $productions[0]['routing_key'] = 'user.registration.transactional';
+  $productions[0]['status'] = 1;
+
+  $productions[1]['target_production'] = 'transactional_user_password';
+  $productions[1]['exchange'] = 'transactionalExchange';
+  $productions[1]['queues'][] = 'transactionalQueue';
+  $productions[1]['queues'][] = 'loggingQueue';
+  $productions[1]['queues'][] = 'activityStatsQueue';
+  $productions[1]['queues'][] = 'mobileCommonsQueue';
+  $productions[1]['queues'][] = 'userAPICampaignActivityQueue';
+  $productions[1]['routing_key'] = 'user.password_reset.transactional';
+  $productions[1]['status'] = 1;
+
+  $productions[2]['target_production'] = 'transactional_campaign_signup';
+  $productions[2]['exchange'] = 'transactionalExchange';
+  $productions[2]['queues'][] = 'transactionalQueue';
+  $productions[2]['queues'][] = 'loggingQueue';
+  $productions[2]['queues'][] = 'activityStatsQueue';
+  $productions[2]['queues'][] = 'mailchimpCampaignSignupQueue';
+  $productions[2]['queues'][] = 'userCampaignActivityQueue';
+  $productions[2]['queues'][] = 'userAPICampaignActivityQueue';
+  $productions[2]['routing_key'] = 'campaign.signup.transactional';
+  $productions[2]['status'] = 1;
+
+  $productions[3]['target_production'] = 'transactional_campaign_group_signup';
+  $productions[3]['exchange'] = 'transactionalExchange';
+  $productions[3]['queues'][] = 'transactionalQueue';
+  $productions[3]['queues'][] = 'loggingQueue';
+  $productions[3]['queues'][] = 'activityStatsQueue';
+  $productions[3]['queues'][] = 'mailchimpCampaignSignupQueue';
+  $productions[3]['queues'][] = 'userCampaignActivityQueue';
+  $productions[3]['queues'][] = 'userAPICampaignActivityQueue';
+  $productions[3]['routing_key'] = 'campaign.signup.transactional';
+  $productions[3]['status'] = 1;
+
+  $productions[4]['target_production'] = 'transactional_campaign_reportback';
+  $productions[4]['exchange'] = 'transactionalExchange';
+  $productions[4]['queues'][] = 'transactionalQueue';
+  $productions[4]['queues'][] = 'loggingQueue';
+  $productions[4]['queues'][] = 'activityStatsQueue';
+  $productions[4]['queues'][] = 'userCampaignActivityQueue';
+  $productions[4]['queues'][] = 'userAPICampaignActivityQueue';
+  $productions[4]['routing_key'] = 'campaign.report_back.transactional';
+  $productions[4]['status'] = 1;
+
+  foreach($productions as $production) {
+    message_broker_producer_production_crud($production['target_production'] , 'create', $production);
+    message_broker_producer_production_crud($production['target_production'] , 'update', $production);
+  }
+
+}

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -18,7 +18,7 @@ function dosomething_mbp_update_7002(&$sandbox) {
 
   $productions = array();
 
-  $productions[0]['target_production'] = 'transactional_user_register';
+  $productions[0]['machine_name'] = 'transactional_user_register';
   $productions[0]['exchange'] = 'transactionalExchange';
   $productions[0]['queues'][] = 'transactionalQueue';
   $productions[0]['queues'][] = 'loggingQueue';
@@ -29,7 +29,7 @@ function dosomething_mbp_update_7002(&$sandbox) {
   $productions[0]['routing_key'] = 'user.registration.transactional';
   $productions[0]['status'] = 1;
 
-  $productions[1]['target_production'] = 'transactional_user_password';
+  $productions[1]['machine_name'] = 'transactional_user_password';
   $productions[1]['exchange'] = 'transactionalExchange';
   $productions[1]['queues'][] = 'transactionalQueue';
   $productions[1]['queues'][] = 'loggingQueue';
@@ -39,7 +39,7 @@ function dosomething_mbp_update_7002(&$sandbox) {
   $productions[1]['routing_key'] = 'user.password_reset.transactional';
   $productions[1]['status'] = 1;
 
-  $productions[2]['target_production'] = 'transactional_campaign_signup';
+  $productions[2]['machine_name'] = 'transactional_campaign_signup';
   $productions[2]['exchange'] = 'transactionalExchange';
   $productions[2]['queues'][] = 'transactionalQueue';
   $productions[2]['queues'][] = 'loggingQueue';
@@ -50,7 +50,7 @@ function dosomething_mbp_update_7002(&$sandbox) {
   $productions[2]['routing_key'] = 'campaign.signup.transactional';
   $productions[2]['status'] = 1;
 
-  $productions[3]['target_production'] = 'transactional_campaign_group_signup';
+  $productions[3]['machine_name'] = 'transactional_campaign_group_signup';
   $productions[3]['exchange'] = 'transactionalExchange';
   $productions[3]['queues'][] = 'transactionalQueue';
   $productions[3]['queues'][] = 'loggingQueue';
@@ -61,7 +61,7 @@ function dosomething_mbp_update_7002(&$sandbox) {
   $productions[3]['routing_key'] = 'campaign.signup.transactional';
   $productions[3]['status'] = 1;
 
-  $productions[4]['target_production'] = 'transactional_campaign_reportback';
+  $productions[4]['machine_name'] = 'transactional_campaign_reportback';
   $productions[4]['exchange'] = 'transactionalExchange';
   $productions[4]['queues'][] = 'transactionalQueue';
   $productions[4]['queues'][] = 'loggingQueue';
@@ -72,8 +72,7 @@ function dosomething_mbp_update_7002(&$sandbox) {
   $productions[4]['status'] = 1;
 
   foreach($productions as $production) {
-    message_broker_producer_production_crud($production['target_production'] , 'create', $production);
-    message_broker_producer_production_crud($production['target_production'] , 'update', $production);
+    message_broker_producer_production_create($production);
   }
 
 }

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -99,6 +99,8 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
       $payload['merge_vars'] = array(
         'FNAME' => $params['first_name'],
       );
+      $payload['email_template'] = 'mb-general-signup';
+      $payload['email_tag'] = 'drupal_user_register';
       break;
 
     case 'user_password':
@@ -107,6 +109,8 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
         'USERNAME' => $params['username'],
         'RESET_LINK' => $params['reset_link'],
       );
+      $payload['email_template'] = 'mb-password-reset';
+      $payload['email_tag'] = 'drupal_user_password';
       break;
 
     case 'campaign_signup':
@@ -115,11 +119,15 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
       $payload['merge_vars']['STEP_ONE'] = $params['step_one'];
       $payload['merge_vars']['STEP_TWO'] = $params['step_two'];
       $payload['merge_vars']['STEP_THREE'] = $params['step_three'];
+      $payload['email_template'] = 'mb-campaign-signup';
+      $payload['email_tag'] = 'drupal_campaign_signup';
       break;
       
     case 'campaign_group_signup':
       dosomething_mbp_get_common_campaign_payload($payload, $params);
       $payload['merge_vars']['CAMPAIGN_COPY'] = $params['transactional_email_copy'];
+      $payload['email_template'] = 'mb-group-campaign-signup';
+      $payload['email_tag'] = 'drupal_campaign_group_signup';
       break;
 
     case 'campaign_reportback':
@@ -132,6 +140,8 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
         'IMPACT_NOUN' => $params['impact_noun'],
         'REPORTBACK_IMAGE_MARKUP' => $params['image_markup'],
       );
+      $payload['email_template'] = 'mb-campaign-report-back';
+      $payload['email_tag'] = 'drupal_campaign_reportback';
       break;
 
   }

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -35,23 +35,29 @@ function dosomething_mbp_menu() {
  */
 function dosomething_mbp_request($origin, $params = NULL) {
 
-  $production_type = NULL;
+  $production = NULL;
   switch ($origin) {
     case 'user_register':
-    case 'user_password':
-    case 'campaign_signup':
-    case 'campaign_group_signup':
-    case 'campaign_reportback':
-      $production_type = 'produceTransactional';
-      $payload = dosomething_mbp_get_transactional_payload($origin, $params);
+      $production = 'transactional_user_register';
       break;
-
+    case 'user_password':
+      $production = 'transactional_user_password';
+      break;
+    case 'campaign_signup':
+      $production = 'transactional_campaign_signup';
+      break;
+    case 'campaign_group_signup':
+      $production = 'transactional_campaign_group_signup';
+      break;
+    case 'campaign_reportback':
+      $production = 'transactional_campaign_reportback';
+      break;
   }
   if (variable_get('dosomething_mbp_log')) {
     watchdog('dosomething_mbp', json_encode($payload));
   }
   try {
-    return message_broker_producer_request($production_type, $payload);
+    return message_broker_producer_request($production, $payload);
   }
   catch (Exception $e) {
     watchdog('dosomething_mbp', $e, array(), WATCHDOG_ERROR);

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -223,8 +223,6 @@ projects[conductor_sms][subdir] = "contrib"
 projects[message_broker_producer][type] = "module"
 projects[message_broker_producer][download][type] = "git"
 projects[message_broker_producer][download][url] = "https://github.com/DoSomething/message_broker_producer.git"
-; Pin to 0.1.21+aug25 pending 0.2.x development
-projects[message_broker_producer][download][revision] = "40e8d9892e378846adf5cb9b295f53c8a533f123"
 projects[message_broker_producer][subdir] = "contrib"
 
 


### PR DESCRIPTION
Fixes #3239
Fixes #2051

The `message_broker_producer.module () has been updated to v0.2.0.`dosomething_mbp,module` needs to updated to integrate the new functionality.
- [x] "Unpin" release version in `drupal-org.make` by removing:

```
; Pin to 0.1.21+aug25 pending 0.2.x development
projects[message_broker_producer][download][revision] = "40e8d9892e378846adf5cb9b295f53c8a533f123"
```
- [x] Add `hook_update` function to `dosomething_mbp` to create `message_broker_producer` production entries. The "production" entries will define exchange, queues and routing_keys values for each production specific to the $origin value defined in the `dosomething_mbp_request()`.
- [x] Update `dosomething_mbp.module` to call `message_broker_producer_request(<production>, <payload>)` where <production> referers to the values defined in the `dosomething_mbp.module -`hook_update()` function.
  - [x] Update `dosomething_mbp_request()` to define the `$production` value based on the values defined in the `dosomething_mbp.module -`hook_update()` function.
  - [x] Update `dosomething_mbp_get_transactional_payload()` to define Mandrill templates in payload based on $origin.
  - [x] Update `dosomething_mbp_get_transactional_payload()` to define Mandrill tags in payload based on $origin.

Related:
https://github.com/DoSomething/message_broker_producer/pull/81
