### PR TITLE
Delete all user data upon user delete

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
@@ -202,7 +202,7 @@ function dosomething_user_clean_slate_form_submit($form, &$form_state) {
   $msg = t("Clean Slate form submitted for User %uid", array(
     '%uid' => $user->uid,
   ));
-  watchdog('dosomething_user_clean_slate', $msg);
+  watchdog('dosomething_user', $msg);
   // Go git em.
-  dosomething_user_clean_slate($user->uid);
+  dosomething_user_delete_all_data($user->uid);
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1144,7 +1144,7 @@ function dosomething_user_delete_all_data($uid, $display_messages = TRUE) {
       if ($display_messages) {
         drupal_set_message($msg);
       }
-      watchdog('dosomething_user_clean_slate', $msg);
+      watchdog('dosomething_user', $msg);
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1100,14 +1100,21 @@ function dosomething_user_get_records($tbl_name, $uid) {
 }
 
 /**
- * Deletes all entities for a given user $uid a clean slate.
+ * Implements hook_user_delete().
+ */
+function dosomething_user_user_delete($account) {
+  dosomething_user_delete_all_data($account->uid);
+}
+
+/**
+ * Deletes all entities for a given user $uid.
  *
  * To be used with great responsibility.
  *
  * @param int $uid
  *   The user $uid to delete records for.
  */
-function dosomething_user_clean_slate($uid, $display_messages = TRUE) {
+function dosomething_user_delete_all_data($uid, $display_messages = TRUE) {
   // List of all entities users can create, and their identifiers.
   $entity_list = array(
     'signup' => 'sid',


### PR DESCRIPTION
Renames `dosomething_user_delete_all_data` as `dosomething_user_delete_all_data`, and calls it within a `hook_user_delete`.  

Will be super useful for cleaning up test data international sites.
