### PR TITLE
Deployments: flush the Redis cache before running drush.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -239,7 +239,15 @@ function build_helper {
   then
     # Flush only country-specific cache during international deployments.
     echo "Flush Redis cache on $SITE."
-    redis-cli --raw keys "$SITE:*" | xargs -n1 redis-cli del
+
+    # Solve Redis cache prefix.
+    case $DS_ENVIRONMENT in
+     "local") CACHE_PREFIX="ds" ;;
+     *) CACHE_PREFIX=$SITE ;;
+    esac
+
+    # Redis CLI connection settings must be preset.
+    redis-cli --raw keys "$CACHE_PREFIX:*" | xargs -n1 redis-cli del
   fi
 
   echo 'Adding role to admin user...'

--- a/bin/ds
+++ b/bin/ds
@@ -233,6 +233,17 @@ function build_helper {
 
   fi
 
+  # Before running drush it's required to flush Redis cache to avoid
+  # a race condition state between DB and cache.
+  if [[ $SITE == "default" ]]
+  then
+    # Flush everything when building US.
+    redis-cli flushall
+  else
+    # Flush only country-specific cache during intl deployments.
+    redis-cli --raw keys "$SITE:*" | xargs -n1 redis-cli del
+  fi
+
   echo 'Adding role to admin user...'
   drush user-add-role 'administrator' 1
 

--- a/bin/ds
+++ b/bin/ds
@@ -235,12 +235,10 @@ function build_helper {
 
   # Before running drush it's required to flush Redis cache to avoid
   # a race condition state between DB and cache.
-  if [[ $SITE == "default" ]]
+  if [[ $SITE != "default" ]]
   then
-    # Flush everything when building US.
-    redis-cli flushall
-  else
-    # Flush only country-specific cache during intl deployments.
+    # Flush only country-specific cache during international deployments.
+    echo "Flush Redis cache on $SITE."
     redis-cli --raw keys "$SITE:*" | xargs -n1 redis-cli del
   fi
 


### PR DESCRIPTION
This PR is to avoid  a race condition state between DB and cache, which causes features recreation to fail during international deployments. See #3211.
#### What's this PR do?
- Brings new step into `ds build` that clears Redis cache **before** running any `drush` command
  - All cache is flushed during US deployments
  - Only country-specific during international deployments
#### What are the relevant tickets?

Fixes #3211.
