### PR TITLE
DS build: Revert only overridden features.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -261,7 +261,7 @@ function build_helper {
   drush --script-path=$BASE_PATH/bin/ php-script enable_modules.php
 
   echo 'Reverting Features'
-  drush fra -y --force
+  drush fra -y
 
   echo 'Clearing caches...'
   drush cc all


### PR DESCRIPTION
This PR is to avoid possible circular dependencies when reverting features.
#### What's this PR do?
- Makes DS script revert only features that are clearly overridden instead of reverting everything
