### PR TITLE
DS build: Add drush status.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -250,6 +250,9 @@ function build_helper {
     redis-cli --raw keys "$CACHE_PREFIX:*" | xargs -n1 redis-cli del
   fi
 
+  echo 'Drush status:'
+  drush status
+
   echo 'Adding role to admin user...'
   drush user-add-role 'administrator' 1
 


### PR DESCRIPTION
This PR makes `ds` build display drush status in order to provide additional debug information during international deployments.
