### PR TITLE
DS Build: echo debug line with drush working directory

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -250,6 +250,9 @@ function build_helper {
     redis-cli --raw keys "$CACHE_PREFIX:*" | xargs -n1 redis-cli del
   fi
 
+  echo -n 'Running drush from directory '
+  pwd
+
   echo 'Drush status:'
   drush status
 


### PR DESCRIPTION
This PR is to ensure drush commands are executed from the right directory during international deployments.
