### PR TITLE
Adding proximity boost to enable search phrases

### DIFF
--- a/lib/modules/dosomething/dosomething_search/dosomething_search.module
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.module
@@ -80,16 +80,9 @@ function dosomething_search_apachesolr_query_alter(DrupalSolrQueryInterface $que
     $params['q'] = '*:*';
   }
 
-  $boosts = array(
-    'bs_high_season' => '1.0',
-    'bs_field_staff_pick' => '5.0',
-    'bs_sponsored' => '4.0',
-  );
-  foreach ($boosts as $field => $boost) {
-    $params['bq'][] = "{$field}:true^$boost";
-  }
-
-  $params['bq'][] = "bundle:campaign^100.0";
+  // Add a term proximity boost so that multiple search terms
+  // are treated as one phrase.
+  $params['pf'] = 'content~2^1000';
 
   if ($query) {
     $query->addParams($params);

--- a/lib/modules/dosomething/dosomething_search/dosomething_search.module
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.module
@@ -78,6 +78,16 @@ function dosomething_search_apachesolr_query_alter(DrupalSolrQueryInterface $que
   $query_params = $query->getParams();
   if (!isset($query_params['q'])) {
     $params['q'] = '*:*';
+    $boosts = array(
+      'bs_high_season' => '1.0',
+      'bs_field_staff_pick' => '5.0',
+      'bs_sponsored' => '4.0',
+    );
+    foreach ($boosts as $field => $boost) {
+      $params['bq'][] = "{$field}:true^$boost";
+    }
+
+    $params['bq'][] = "bundle:campaign^100.0";
   }
 
   // Add a term proximity boost so that multiple search terms

--- a/lib/modules/dosomething/dosomething_search/dosomething_search.module
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.module
@@ -74,7 +74,9 @@ function dosomething_search_apachesolr_query_alter(DrupalSolrQueryInterface $que
   );
 
   // Add a 'q' param to apachesolr_views queries to enable the
-  // elevate.xml to work properly.
+  // elevate.xml to work properly. This also needs to be here
+  // so that these boots are applied to the /campaigns or any
+  // other apachesolr views.
   $query_params = $query->getParams();
   if (!isset($query_params['q'])) {
     $params['q'] = '*:*';


### PR DESCRIPTION
Removing campaign boosts and adding term proximity boosts so that content with the entire search phrase shows up closer to the top regardless of content type.

Fixes #3209 

@angaither @aaronschachter 
