### PR TITLE
Adds Title to Administrative Area options variable

### DIFF
--- a/lib/modules/dosomething/dosomething_canada/dosomething_canada.install
+++ b/lib/modules/dosomething/dosomething_canada/dosomething_canada.install
@@ -58,3 +58,12 @@ function dosomething_canada_update_7004() {
 function dosomething_canada_update_7005() {
   variable_set('dosomething_user_address_country', 'CA');
 }
+
+/**
+ * Updates dosomething_user_address_administrative_area_options() for CA site.
+ *
+ * New variable is an array, including title ("Province").
+ */
+function dosomething_canada_update_7006() {
+  dosomething_user_set_address_administrative_area_options('CA');
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -340,11 +340,14 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
         'data-validate-required' => 'true',
       ),
     );
+    $administrative_area = dosomething_user_get_address_administrative_area_options();
 
     $form['school_finder']['school_administrative_area'] = array(
       '#type' => 'select',
-      '#options' => dosomething_user_get_address_administrative_area_options(),
-      '#title' => t("Select state"),
+      '#options' => $administrative_area['options'],
+      '#title' => t("Select @label", array(
+        '@label' => $administrative_area['title'],
+      )),
       '#attributes' => array(
         'data-validate' => 'state',
       ),

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
@@ -189,7 +189,10 @@ function dosomething_user_get_addressfield_administrative_area_options($country 
   if ($country == 'US') {
     dosomething_user_remove_extra_us_states($options);
   }
-  return $options;
+  return array(
+    'title' => $format['locality_block']['administrative_area']['#title'],
+    'options' => $options,
+  );
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.install
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.install
@@ -37,6 +37,17 @@ function dosomething_user_update_7004() {
 }
 
 /**
+ * Updates dosomething_user_address_administrative_area_options() for US site.
+ *
+ * New variable is an array, including title ("State").
+ */
+function dosomething_user_update_7005() {
+  if (!dosomething_settings_is_affiliate()) {
+    dosomething_user_set_address_administrative_area_options();
+  }
+}
+
+/**
  * Implements hook_uninstall().
  */
 function dosomething_user_uninstall() {


### PR DESCRIPTION
We store Addressfield's State/Province options in a variable that `dosomething_user_set_address_administrative_area_options` sets.

This PR stores refactors this variable to be stored as a multi-dimensional array which includes the title to use, (e.g. "State", "Provice") to close #3248 for Canada TFJ
