### PR TITLE
Fixes race hook_update bug with message_broker_producer update

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -16,6 +16,11 @@ function dosomething_mbp_update_7001(&$sandbox) {
  */
 function dosomething_mbp_update_7002(&$sandbox) {
 
+  if (!db_table_exists('message_broker_producer_productions')) {
+    $message_broker_producer_productions_schema = drupal_get_schema_unprocessed('message_broker_producer', 'message_broker_producer_productions');
+    db_create_table('message_broker_producer_productions', $message_broker_producer_productions_schema);
+  }
+
   $productions = array();
 
   $productions[0]['machine_name'] = 'transactional_user_register';


### PR DESCRIPTION
Fixes #3303 

`drush updb` produces a race condition between `dosomething_mbp_update_7002` and message_broker_producer_update_7002`. This fix ensures the`message_broker_producer_productions`database table is in place when running the`dosomehting_mbp` update.
