### PR TITLE
Bug fix to resolve sending transactional requests to MB

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -53,9 +53,11 @@ function dosomething_mbp_request($origin, $params = NULL) {
       $production = 'transactional_campaign_reportback';
       break;
   }
+  $payload = dosomething_mbp_get_transactional_payload($origin, $params);
   if (variable_get('dosomething_mbp_log')) {
     watchdog('dosomething_mbp', json_encode($payload));
   }
+
   try {
     return message_broker_producer_request($production, $payload);
   }


### PR DESCRIPTION
Fixes #3303

Fixes regression of `message_broker_producer_request()` not containing `$payload` values.
