### PR TITLE
Adding gallery field to solr index

### DIFF
--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.features.field_instance.inc
@@ -572,9 +572,16 @@ function dosomething_static_content_field_default_field_instances() {
         'weight' => 4,
       ),
       'search_index' => array(
-        'label' => 'above',
-        'settings' => array(),
-        'type' => 'hidden',
+        'label' => 'hidden',
+        'module' => 'field_collection',
+        'settings' => array(
+          'add' => 'Add',
+          'delete' => 'Delete',
+          'description' => TRUE,
+          'edit' => 'Edit',
+          'view_mode' => 'full',
+        ),
+        'type' => 'field_collection_view',
         'weight' => 4,
       ),
       'teaser' => array(


### PR DESCRIPTION
Searching for Nancy Lublin or other staff members doesn't return any appropriate search results because the gallery fields need to be indexed.  Adding this field to the static content type will index the gallery fields in Solr.

@angaither 

Addresses #3209 
