### PR TITLE
Drop local database before pulling stage DB

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -464,8 +464,10 @@ function pull_db {
     if [[ ${#alias[@]} == 1 ]]
     then
       cd $WEB_PATH
+
       echo "Dropping local DB"
-      drush sql-drop
+      drush -y sql-drop
+
       echo "Pulling down db from staging"
       drush -y sql-sync @ds.staging @self
 

--- a/bin/ds
+++ b/bin/ds
@@ -86,12 +86,12 @@ ds grunt [--watch]
   Continues watching for changes and recompiles assets as necessary.
 
 ds pull [stage|stage.$AFFILIATE|prod] [--db|--files]
-  Pulls database and files from given environment down onto your local build.
+  Drops your local database and pulls database and files from given environment down onto your local build.
   Note: Running 'ds pull stage' will destroy any affiliate sites.
   Run  Run 'ds pull stage.$AFFILIATE' to preserve the folders and
 
   --db
-    Pulls down database only.
+    Drops your local database and pulls down db from given environment.
 
   --files
     Pulls down files only. If pulling from an affiliate site, only the files directory
@@ -463,8 +463,10 @@ function pull_db {
   then
     if [[ ${#alias[@]} == 1 ]]
     then
-      echo "Pulling down db from staging"
       cd $WEB_PATH
+      echo "Dropping local DB"
+      drush sql-drop
+      echo "Pulling down db from staging"
       drush -y sql-sync @ds.staging @self
 
       echo "Enabling Stage File Proxy..."


### PR DESCRIPTION
To help promote sanity when debugging "tables existing" errors.

Note: This will prompt you "Are you sure?".  I'm into leaving this warning in, to further notify a developer "Hey you're' about to lose any of your DB work" ... but, could be open to adding the `-y` option in.

```
vagrant@dev:/var/www/vagrant$ bin/ds pull stage --db
Dropping local DB
Do you really want to drop all tables in the database dosomething? (y/n): y
Pulling down db from staging
```
