### PR TITLE
Lint fix

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/Gemfile
+++ b/lib/themes/dosomething/paraneue_dosomething/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
-ruby '2.1.1'
-
 gem 'scss-lint', '0.24.1'

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_home.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_home.scss
@@ -96,7 +96,7 @@
     opacity: 0.2;
 
     @include media($tablet) {
-      /* retina sizing, see Image Style preset */
+      // retina sizing, see Image Style preset
       max-width: 125px;
       max-height: 40px;
     }


### PR DESCRIPTION
# Changes
- Updates comment style to fix linting error.
- Remove strict Ruby version requirement from Gemfile. We've been able to remove other Ruby dependencies and SCSS-Lint works fine on 1.9.3+.
