### PR TITLE
Provides an option to bypass JS validation of user's postcode.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -307,7 +307,9 @@ function dosomething_user_add_validation_attributes_to_address_fields($form, &$f
   $address['address']['street_block']['premise']['#attributes']['data-validate'] = 'address2';
   $address['address']['locality_block']['locality']['#attributes']['data-validate'] = 'city';
   $address['address']['locality_block']['administrative_area']['#attributes']['data-validate'] = 'state';
-  $address['address']['locality_block']['postal_code']['#attributes']['data-validate'] = 'zipcode';
+
+  $zip_validation = theme_get_setting('user_validate_js_postcode') ? 'zipcode' : '';
+  $address['address']['locality_block']['postal_code']['#attributes']['data-validate'] = $zip_validation;
 
   return $form;
 }

--- a/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
+++ b/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
@@ -66,6 +66,9 @@ Sexy Financials|node/540
 International|node/523'
 settings[footer_links_third_column_class] = 'about'
 
+; User
+settings[user_validate_js_postcode] = 1
+
 ;Exclude
 ;javascript
 exclude[js][] = 'misc/jquery.js'

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -62,6 +62,7 @@ function paraneue_dosomething_form_system_theme_settings_alter(&$form, &$form_st
   // Lets break this up a little.
   _paraneue_dosomething_theme_settings_header($form, $form_state);
   _paraneue_dosomething_theme_settings_footer($form, $form_state);
+  _paraneue_dosomething_theme_settings_user($form, $form_state);
 
   if (!isset($form['#submit'])) {
     $form['#submit'] = array();
@@ -320,5 +321,27 @@ function _paraneue_dosomething_theme_settings_footer(&$form, $form_state) {
     );
 
   }
+
+}
+
+function _paraneue_dosomething_theme_settings_user(&$form, $form_state) {
+  $form['user'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('User'),
+  );
+  $form_user = &$form['user'];
+
+  // Validaions.
+  $form_user['validations'] = array(
+    '#type'        => 'fieldset',
+    '#title'       => t('JS Validations'),
+    '#collapsible' => TRUE,
+    '#collapsed'   => TRUE
+  );
+  $form_user['validations']['user_validate_js_postcode'] = array(
+    '#type'          => 'checkbox',
+    '#title'         => t('Validate Post Code'),
+    '#default_value' => theme_get_setting('user_validate_js_postcode'),
+  );
 
 }


### PR DESCRIPTION
#### What's this PR do?
- Provides a theme setting to bypass JS validation of user's postcode
#### How should this be manually tested?
- Open [Paraneue Settings](http://dev.dosomething.org:8888/admin/appearance/settings/paraneue_dosomething)
- Turn off `Validate Post Code`
  ![image](https://cloud.githubusercontent.com/assets/672669/4941452/3ec48840-65e3-11e4-9899-1a07bec7ef48.png)
- Go to [Yeah, Science!](http://dev.dosomething.org:8888/campaigns/yeah-science)
- Click 'Get this banner, yo.'
- Fill in `M5H 3H1` to `Postal code` field. The field must not be highlighted in red after that
  ![image](https://cloud.githubusercontent.com/assets/672669/4941442/1fd8a9c0-65e3-11e4-96d6-4d142b255ec1.png)
#### What are the relevant tickets?

Closes #3329 
