### PR TITLE
Enables affiliate access to Zendesk

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -95,7 +95,7 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
     $vars['modals'] = theme('modal_links', array('modals' => $modal_links));
   }
   // Zendesk Support Ticket form.
-  if (isset($vars['content']['zendesk_form']) && !dosomething_settings_is_affiliate()) {
+  if (isset($vars['content']['zendesk_form'])) {
     $vars['zendesk_form'] = $vars['content']['zendesk_form'];
   }
 }

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
@@ -105,6 +105,21 @@ function dosomething_zendesk_groups_config_form() {
     );
   }
 
+  // Affiliate sites can route all ZD tickets to just one ZD group.
+  $form['sitewide'] = array(
+    '#title' => t('Sitewide'),
+    '#type' => 'fieldset',
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['sitewide']['dosomething_zendesk_group_id'] = array(
+    '#type' => 'textfield',
+    '#title' => t("Sitewide Zendesk Group ID"),
+    '#size' => 10,
+    '#default_value' => variable_get('dosomething_zendesk_group_id'),
+    '#description' => t("If set, all Zendesk tickets will be sent to this Group.")
+  );
+
   // Store Zendesk group id's for each term in the Cause vocabulary.
   $form['cause'] = array(
     '#title' => t('Terms: Cause'),
@@ -122,7 +137,6 @@ function dosomething_zendesk_groups_config_form() {
     $form['cause'][$var] = array(
       '#type' => 'textfield',
       '#title' => t($term->name),
-      '#required' => TRUE,
       '#size' => 10,
       '#default_value' => variable_get($var),
     );
@@ -170,8 +184,8 @@ function dosomething_zendesk_groups_config_form_validate($form, &$form_state) {
   $group_ids = array_keys(dosomething_zendesk_get_zendesk_groups());
   // Foreach value:
   foreach ($form_state['values'] as $key => $value) {
-    // If the value is not in the group ids:
-    if (!in_array($value, $group_ids)) {
+    // If the value is set, and not in the group ids:
+    if (!empty($value) && !in_array($value, $group_ids)) {
       // Set error.
       form_set_error($key, 'Group_id ' . $value . ' does not exist.');
     }

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.admin.inc
@@ -143,7 +143,6 @@ function dosomething_zendesk_groups_config_form() {
         $var = dosomething_zendesk_get_group_varname('nid', $campaign_group['nid']);
         $form['campaign_group'][$var] = array(
           '#type' => 'textfield',
-          '#required' => TRUE,
           '#title' => t($campaign_group['title']),
           '#default_value' => variable_get($var),
         );

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -154,8 +154,14 @@ function dosomething_zendesk_form($form, &$form_state, $entity = NULL)  {
  * @return
  *   An integer, or NULL.
  */
-function dosomething_zendesk_get_zendesk_group_id($entity) {
+function dosomething_zendesk_get_zendesk_group_id($entity = NULL) {
   $group_id = NULL;
+  // If a sitewide Group ID has been set, tickets are always sent to it.
+  if ($sitewide = variable_get('dosomething_zendesk_group_id')) {
+    if (!empty($sitewide)) {
+      return $sitewide;
+    }
+  }
   // If this is a taxonomy term:
   if (isset($entity->tid)) {
     // Check if this term has its own group.


### PR DESCRIPTION
Gets things set up for enabling Canada Zendesk (#3322)
- Allows for a global `dosomething_zendesk_group_id` variable to be set.  If this is set, route all Zendesk tickets to this group.  We'll set this variable for Canada.
- Removes the check for affiliate in rendering the Zendesk form.  

This means we'll need to disable / uninstall the Dosomething Zendesk module on every affiliate before we push this code (blocked by #3349).

Once all affiliate sites have Zendesk uninstalled and this code is pushed, I will manually enable DoSomething Zendesk module on Canada, set up its auth variables, and set its `dosomething_zendesk_group_id` to the Canada Zendesk group.
