### PR TITLE
Fixes IE8 and IE9 CORS issues with School Finder.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/bower.json
+++ b/lib/themes/dosomething/paraneue_dosomething/bower.json
@@ -30,6 +30,7 @@
     "unveil": "~1.3.0",
     "jquery-once": "~1.2.6",
     "respond": "~1.4.2",
-    "almond": "~0.2.9"
+    "almond": "~0.2.9",
+    "jquery.iecors": "*"
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
@@ -19,13 +19,24 @@ define(function(require) {
       endpoint = "http://lofischools.herokuapp.com/search";
     }
 
-    $.getJSON(endpoint + "?state=" + state + "&query=" + query + "&limit=" + limit, function(data) {
+    $.ajax({
+      dataType: "json",
+      url: endpoint + "?state=" + state + "&query=" + query + "&limit=" + limit
+    }).done(function(data) {
       callback(data.results, data.meta.more_results);
+    }).fail(function(err, status, thrown) {
+      callback(false);
     });
   };
 
   var displayResults = function($el, results, canShowMore) {
     $el.empty();
+
+    if(!results) {
+      $el.append("<div class='messages error'>We couldn't load schools. Check your internet connection, or try refreshing the page.</div>");;
+      $el.show();
+      return;
+    }
 
     _.each(results, function(result) {
       $el.append(resultTpl(result));

--- a/lib/themes/dosomething/paraneue_dosomething/js/config.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/config.js
@@ -14,6 +14,7 @@ require.config({
     "jquery": "../bower_components/jquery/jquery",
     "jquery-once": "../bower_components/jquery-once/jquery.once",
     "jquery-unveil": "../bower_components/unveil/jquery.unveil",
+    "jquery-iecors": "../bower_components/jquery.iecors/jquery.iecors",
     "lodash": "../bower_components/lodash/dist/lodash",
     "mailcheck": "../bower_components/mailcheck/src/mailcheck",
     "neue": "../bower_components/neue/js",
@@ -34,6 +35,7 @@ require.config({
         "jquery",
         "jquery-once",
         "jquery-unveil",
+        "jquery-iecors",
         "mailcheck",
         "lodash"
       ]
@@ -46,6 +48,7 @@ require.config({
         "jquery",
         "jquery-once",
         "jquery-unveil",
+        "jquery-iecors",
         "mailcheck",
         "lodash"
       ]


### PR DESCRIPTION
# Changes
- Fixes #3354 by including [jquery.iecors](https://github.com/dkastner/jquery.iecors), which uses XDomainRequest on IE8 and IE9.
- Adds some nicer error handling if request fails, rather than continually spinning.

For review: @weerd 
