### PR TITLE
Fires custom event on action page. Fixes #3308.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -282,6 +282,11 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     $vars['reportback_link']['label'] = t("Update Submission");
   }
   $vars['reportback_form'] = $vars['content']['reportback_form'];
+
+  // Add analytics custom event on action page.
+  $js = 'if(typeof(_gaq) !== "undefined" && _gaq !== null) { _gaq.push(["_trackEvent", "Action Page View", "' . $vars['title'] . '", null, null, true]); }';
+  drupal_add_js($js, 'inline');
+  
 }
 
 /**


### PR DESCRIPTION
# Changes
- Adds a [custom event](https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide) to the action page. See #3308 for context.
# Question
- Is there a better place for this? This method seemed mostly concerned with preprocessing variables for theming, but it seemed to be the most appropriate place I could find.

For review: @aaronschachter 
