### PR TITLE
Address validation switch

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.address.inc
@@ -40,8 +40,6 @@ function dosomething_user_address_form_element(&$form, &$form_state) {
   );
   $country = variable_get('dosomething_user_address_country', 'US');
   $form['user_address'] = array(
-    '#prefix' => '<div data-validate="ups_address" data-validate-required>',
-    '#suffix' => '</div>',
     '#type' => 'addressfield',
     '#handlers' => array(
       'address' => 'address',
@@ -51,10 +49,14 @@ function dosomething_user_address_form_element(&$form, &$form_state) {
     '#context' => array('countries' => array($country)),
     '#default_value' => isset($account->field_address[LANGUAGE_NONE][0]) ? $account->field_address[LANGUAGE_NONE][0] : '',
   );
-  // If we are collecting an address, run address validation.
-  $form['#validate'][] = 'dosomething_user_address_form_element_validate';
   $form['#after_build'][] = 'dosomething_user_remove_extra_values_from_address_field';
-  $form['#after_build'][] = 'dosomething_user_add_validation_attributes_to_address_fields';
+  // Check if we should be validating addresses.
+  if (variable_get('dosomething_user_validate_address')) {
+    $form['user_address']['#prefix'] = '<div data-validate="ups_address" data-validate-required>';
+    $form['user_address']['#suffix'] = '</div>';
+    $form['#validate'][] = 'dosomething_user_address_form_element_validate';
+    $form['#after_build'][] = 'dosomething_user_add_validation_attributes_to_address_fields';
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
@@ -42,6 +42,15 @@ function dosomething_user_admin_config_form($form, &$form_state) {
     '#default_value' => variable_get($var_name),
   );
 
+  // Display Postal Code field.
+  $var_name = 'dosomething_user_validate_address';
+  $form[$var_name] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Validate Address Field'),
+    '#default_value' => variable_get($var_name, FALSE),
+    '#description' => t("If set, the user's field_address values will be validated against a geolocator API."),
+  );
+
   // Login form settings.
   $form['login'] = array(
     '#type' => 'fieldset',

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.install
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.install
@@ -47,6 +47,16 @@ function dosomething_user_update_7005() {
   }
 }
 
+
+/**
+ * Sets dosomething_user_validate_address variable for US site.
+ */
+function dosomething_user_update_7006() {
+  if (!dosomething_settings_is_affiliate()) {
+    variable_set('dosomething_user_validate_address', 1);
+  }
+}
+
 /**
  * Implements hook_uninstall().
  */
@@ -70,6 +80,7 @@ function dosomething_user_uninstall() {
     'dosomething_user_ups_password',
     'dosomething_user_ups_test_integration',
     'dosomething_user_ups_username',
+    'dosomething_user_validate_address',
   );
   foreach ($vars as $var) {
     variable_del($var);

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -199,6 +199,9 @@ function dosomething_user_is_staff($user = NULL) {
 function dosomething_user_form_alter(&$form, $form_state, $form_id) {
   global $user;
   $account = $user;
+  // Check if we should be validating addresses.
+  $is_validate_address_set = variable_get('dosomething_user_validate_address');
+
   switch ($form_id) {
     case 'user_login_block':
     case 'user_login':
@@ -230,7 +233,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
 
       // Add extra validation on the edit page, for addresses.
       $current_page = $_SERVER['REQUEST_URI'];
-      if (preg_match('/user\/([0-9]+)\/edit/', $current_page)) {
+      if (preg_match('/user\/([0-9]+)\/edit/', $current_page) & $is_validate_address_set) {
         $form['#validate'][] = 'dosomething_user_validate_address_field';
       }
 
@@ -251,7 +254,9 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
       }
 
       $form['#after_build'][] = 'dosomething_user_remove_extra_values_from_address_field';
-      $form['#after_build'][] = 'dosomething_user_add_validation_attributes_to_address_fields'; 
+      if ($is_validate_address_set) {
+        $form['#after_build'][] = 'dosomething_user_add_validation_attributes_to_address_fields'; 
+      }
       // Custom validation & submission handlers.
       $form['#validate'][] = 'dosomething_user_register_validate';
       $form['#submit'][] = 'dosomething_user_login_submit';

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -66,14 +66,13 @@ function dosomething_user_menu() {
     'access callback' => 'user_access',
     'access arguments' => array('administer modules'),
   );
-  $items['admin/config/dosomething/ups-api-settings'] = array(
+  $items['admin/config/dosomething/dosomething_user/ups-api-settings'] = array(
     'title' => t('UPS API Configuration'),
     'description' => t('UPS integration that provices address validation'),
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_user_ups_api_settings'),
     'file' => 'dosomething_user_valid_address.inc',
-    'access callback' => 'user_access',
-    'access arguments' => array('administer UPS address validation'),
+    'access callback' => 'dosomething_user_ups_api_config_access',
   );
   $items['user/%user/info'] = array(
     'title' => 'Edit info',
@@ -101,10 +100,6 @@ function dosomething_user_menu() {
  */
 function dosomething_user_permission() {
   return array(
-    'administer UPS address validation' =>  array(
-      'title' => t('Administer UPS address validation'),
-      'description' => t('Manage UPS api key, username & password'),
-    ),
     'edit user info' =>  array(
       'title' => t('Edit user information'),
       'description' => t('Can edit any user info form.'),
@@ -120,6 +115,19 @@ function dosomething_user_admin_paths() {
     'user/*/info' => TRUE,
   );
   return $paths;
+}
+
+/**
+ * Access callback for UPS API configuration page.
+ *
+ * @see dosomething_user_menu()
+ */
+function dosomething_user_ups_api_config_access() {
+  // If administrator:
+  if (user_access('administer modules')) {
+    // Display page if we are validating addresses.
+    return variable_get('dosomething_user_validate_address');
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -241,7 +241,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
 
       // Add extra validation on the edit page, for addresses.
       $current_page = $_SERVER['REQUEST_URI'];
-      if (preg_match('/user\/([0-9]+)\/edit/', $current_page) & $is_validate_address_set) {
+      if (preg_match('/user\/([0-9]+)\/edit/', $current_page) && $is_validate_address_set) {
         $form['#validate'][] = 'dosomething_user_validate_address_field';
       }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -126,7 +126,7 @@ function dosomething_user_ups_api_config_access() {
   // If administrator:
   if (user_access('administer modules')) {
     // Display page if we are validating addresses.
-    return variable_get('dosomething_user_validate_address');
+    return variable_get('dosomething_user_validate_address', FALSE);
   }
 }
 


### PR DESCRIPTION
Fixes #3344.  Only validate addresses if `dosomething_user_validate_address` variable is set to TRUE.

`dosomething_user_update_7006` will set this to TRUE for US but not set it for all other sites.

Also adds a custom access callback to the UPS API settings page, which checks to see if the variable is TRUE.  Also removes the "administer UPS configuration" permission and just checks for "administer modules' instead, in the interest of simplifying.
