### PR TITLE
Use module names as menu titles

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -26,9 +26,9 @@ function dosomething_campaign_form_campaign_node_form_alter(&$form, &$form_state
  */
 function dosomething_campaign_menu() {
   $items = array();
-  // Admin campaign status page.
+  // Admin campaign configuration page.
   $items['admin/config/dosomething/dosomething_campaign'] = array(
-    'title' => 'Campaign settings',
+    'title' => 'DoSomething Campaign',
     'description' => 'Admin form to set campaign variables.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_campaign_admin_config_form'),

--- a/lib/modules/dosomething/dosomething_notfound/dosomething_notfound.module
+++ b/lib/modules/dosomething/dosomething_notfound/dosomething_notfound.module
@@ -20,7 +20,7 @@ function dosomething_notfound_menu() {
     );
   // 404 page settings
   $items['admin/config/dosomething/dosomething_notfound'] = array(
-   'title' => '404 page settings',
+   'title' => 'DoSomething Notfound',
    'description' => 'Admin form to set 404 page variables.',
    'page callback' => 'drupal_get_form',
    'page arguments' => array('dosomething_notfound_admin_config_form'),

--- a/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
+++ b/lib/modules/dosomething/dosomething_sms/dosomething_sms.module
@@ -20,7 +20,7 @@ function dosomething_sms_menu() {
   );
   $admin_path = DOSOMETHING_SMS_WORKFLOW_ADMIN_PATH;
   $items[$admin_path] = array(
-    'title' => 'SMS Workflows',
+    'title' => 'DoSomething SMS',
     'description' => 'Overview of all SMS Workflows',
     'page callback' => 'dosomething_sms_workflow_overview_page',
     'access callback' => 'user_access',


### PR DESCRIPTION
Cleans up the DS config menu to make it easier for devs to know what variables are used where. 

![screen shot 2014-11-07 at 9 46 02 am](https://cloud.githubusercontent.com/assets/1236811/4954469/d66cf5c0-668c-11e4-977d-a3f04f8a8b6e.png)

Third Party variables is the odd one here, mainly because it shouldn't live on the DoSomething Signup admin page, since the `communications team` needs access to set Third Party variables but should not have access to configure the DoSomething Signup variables.
