### PR TITLE
Allow Signup Data Form reset

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -405,3 +405,42 @@ function dosomething_signup_node_unsignup_form_submit($form, &$form_state) {
   drupal_set_message("There was an error with your request.");
 }
 
+/**
+ * Form constructor for Reset Signup Data Form.
+ *
+ * Sets the given Signup's signup_data_form_timestamp to NULL.
+ *
+ * @param int $sid
+ *   The Signup $sid.
+ */
+function dosomething_signup_reset_signup_data_form($form, &$form_state, $sid) {
+  $form['sid'] = array(
+    '#type' => 'hidden',
+    '#value' => $sid,
+    '#access' => FALSE,
+  );
+  $form['reset'] = array(
+    '#type' => 'fieldset',
+    '#title' => t("Reset Signup Data Form"),
+  );
+  $form['reset']['header'] = array(
+    '#markup' => '<p>' . t("Submitting this form will allow the user to submit their Signup Data Form again.") . '</p><p>' . ("Warning: This cannot be done. Do not submit unless you really really mean it.") . '</p>',
+  );
+  $form['reset']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t("Reset"),
+  );
+  return $form;
+}
+
+/**
+ * Form submit handler for dosomething_signup_reset_signup_data_form().
+ */
+function dosomething_signup_reset_signup_data_form_submit($form, &$form_state) {
+  $signup = signup_load($form_state['values']['sid']);
+  // Set all signup data form values back to NULL.
+  $signup->signup_data_form_timestamp = NULL;
+  $signup->signup_data_form_response = NULL;
+  entity_save('signup', $signup);
+  drupal_set_message(t("The Signup data form has been reset."));
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -113,6 +113,7 @@ function dosomething_signup_view_entity($entity) {
 function dosomething_signup_admin_paths() {
   $paths = array(
     'node/*/signups' => TRUE,
+    'signup/*' => TRUE,
   );
   return $paths;
 }

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.inc
@@ -33,7 +33,7 @@ class SignupEntityController extends EntityAPIController {
     $build = parent::buildContent($entity, $view_mode, $langcode, $content);
     $build['nid'] = array(
       '#type' => 'markup',
-      '#markup' => '<p>Nid: ' . l($entity->nid, 'node/' . $entity->nid) . '</p>',
+      '#markup' => '<p>Nid: ' . l($entity->nid, 'node/' . $entity->nid . '/signups') . '</p>',
     );
     $build['username'] = array(
       '#type' => 'markup',
@@ -47,13 +47,15 @@ class SignupEntityController extends EntityAPIController {
       $build['signup_data_form_submitted'] = array(
         '#type' => 'markup',
         '#markup' => '<p>Signup Data Form Submitted: ' . format_date($entity->signup_data_form_timestamp, 'short') . '</p>',
-      );    
-    }
-    if ($entity->signup_data_form_response != NULL) {
-      $build['signup_data_form_response'] = array(
-        '#type' => 'markup',
-        '#markup' => '<p>Signup Data Form Response: ' . $entity->signup_data_form_response . '</p>',
-      );    
+      );
+      if ($entity->signup_data_form_response != NULL) {
+        $build['signup_data_form_response'] = array(
+          '#type' => 'markup',
+          '#markup' => '<p>Signup Data Form Response: ' . $entity->signup_data_form_response . '</p>',
+        );
+      }
+      $reset_form = drupal_get_form('dosomething_signup_reset_signup_data_form', $entity->sid);
+      $build['reset_form'] = $reset_form;
     }
     if ($entity->why_signedup) {
       $build['why_signedup'] = array(


### PR DESCRIPTION
Adds a Reset Signup Data Form to the Signup view (visible only to staff). 

Allows staff to manually reset the signup data form, allowing a user to re-submit the signup data form if they want to change their answer.
