### PR TITLE
Issue3365 add production

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -98,8 +98,10 @@ function dosomething_mbp_update_7003(&$sandbox) {
   $productions[0]['machine_name'] = 'transactional_user_profile_update';
   $productions[0]['exchange'] = 'transactionalExchange';
   $productions[0]['queues'][] = 'userAPIProfileQueue';
+  $productions[0]['queues'][] = 'userProfileMailchimpQueue';
   $productions[0]['routing_key'] = 'user.profile.update';
   $productions[0]['status'] = 1;
+
 
   foreach($productions as $production) {
     message_broker_producer_production_create($production);

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -85,3 +85,24 @@ function dosomething_mbp_update_7002(&$sandbox) {
   }
 
 }
+
+ /**
+ * Creates production entry in message_broker_producer for user profile updates
+ */
+function dosomething_mbp_update_7003(&$sandbox) {
+  // Only run this if Message Broker Producer is enabled.
+  if (!module_exists('message_broker_producer')) {
+    return;
+  }
+
+  $productions[0]['machine_name'] = 'transactional_user_profile_update';
+  $productions[0]['exchange'] = 'transactionalExchange';
+  $productions[0]['queues'][] = 'userAPIProfileQueue';
+  $productions[0]['routing_key'] = 'user.profile.update';
+  $productions[0]['status'] = 1;
+
+  foreach($productions as $production) {
+    message_broker_producer_production_create($production);
+  }
+
+}


### PR DESCRIPTION
Adds production entry to `message_broker_producer` to support triggering a transaction message being sent to Message Broker when a user updates their profile settings. The message will be distributed the following queues:
- userAPIProfileQueue: Consumer will update the user document in `mb-user`
- userProfileMailchimpQueue: Consumer will update Mailchimp with any change to the user email subscription preference.

**To Test**
- pull down this branch
- `ds build` - this should include a fresh copy of the `messagebroker-config` repo with an update mb_config.json file.
- `ds pull stage`
- `drush updb`
- Confirm the new production entry `transactional_user_profile_update` with the `userAPIProfileQueue` and `userProfileMailchimpQueue` assigned to the `tranactionalExchange`.
