### PR TITLE
Cleans up users adderssfield country

### DIFF
--- a/lib/modules/dosomething/dosomething_canada/dosomething_canada.info
+++ b/lib/modules/dosomething/dosomething_canada/dosomething_canada.info
@@ -14,6 +14,7 @@ dependencies[] = external_auth
 
 ; Custom
 dependencies[] = dosomething_user
+dependencies[] = dosomething_settings
 
 ; Includes
 files[] = includes/CanadaSSOClient.php

--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
@@ -116,7 +116,7 @@ class DosomethingCanadaLoginController implements ExternalAuthLoginController {
     $fields = array(
       'birthdate'                => $dob->format(DATE_FORMAT_DATE),
       'first_name'               => $this->remote_account->Name,
-      'country'                  => variable_get('dosomething_user_address_country'),
+      'country'                  => dosomething_settings_get_affiliate_country_code(),
       'user_registration_source' => DOSOMETHING_CANADA_USER_SOURCE,
     );
     dosomething_user_set_fields($edit, $fields);

--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_register_controller.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_register_controller.inc
@@ -26,16 +26,6 @@ class DosomethingCanadaRegisterController implements ExternalAuthRegisterControl
   public function setup(Array $form, Array &$form_state) {
     $this->account_values = $form_state['values'];
     $this->sso = dosomething_canada_get_sso();
-
-    // Set users address country.
-    form_set_value(
-      $form['field_address'],
-      array(LANGUAGE_NONE => array(array(
-        'country' => variable_get('dosomething_user_address_country'),
-      ))),
-      $form_state
-    );
-
     return $this;
   }
 

--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.info
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.info
@@ -18,6 +18,7 @@ dependencies[] = oauth_common
 
 ; Custom
 dependencies[] = dosomething_user
+dependencies[] = dosomething_settings
 
 files[] = includes/dosomething_uk_sso_controller.inc
 files[] = includes/dosomething_uk_sso_impersonator.inc

--- a/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_register_controller.inc
+++ b/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_register_controller.inc
@@ -74,18 +74,6 @@ class DosomethingUkRegisterController implements ExternalAuthRegisterController 
       );
     }
 
-    // If the postal code is validated remotely, save also the country.
-    if ($this->remote_account->getPostcode()) {
-      form_set_value(
-        $form['field_address'],
-        array(LANGUAGE_NONE => array(array(
-          'postal_code' => $this->remote_account->getPostcode(),
-          'country' => $this->remote_account->getCountry(),
-        ))),
-        $form_state
-      );
-    }
-
     return $this;
   }
 

--- a/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_user.inc
+++ b/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_user.inc
@@ -14,7 +14,6 @@ class DosomethingUkSsoUser {
 
 
   // Local drupal user.
-  const COUNTRY = 'UK';
   const REGISTRATION_SOURCE = 'dosomething_uk';
 
   // ---------------------------------------------------------------------
@@ -308,7 +307,7 @@ class DosomethingUkSsoUser {
    */
   public function getCountry()
   {
-    return self::COUNTRY;
+    return dosomething_settings_get_affiliate_country_code();
   }
 
   /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.features.field_instance.inc
@@ -55,6 +55,7 @@ function dosomething_user_field_default_field_instances() {
           'US' => 'US',
         ),
         'format_handlers' => array(
+          'dosomething-affiliate-country' => 'dosomething-affiliate-country',
           'address' => 'address',
           'address-hide-country' => 'address-hide-country',
           'organisation' => 0,

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -46,6 +46,15 @@ function dosomething_user_init() {
 }
 
 /**
+ * Implements hook_ctools_plugin_directory().
+ */
+function dosomething_user_ctools_plugin_directory($module, $plugin) {
+  if ($module == 'addressfield') {
+    return 'plugins/' . $plugin;
+  }
+}
+
+/**
  * Implements hook_menu().
  */
 function dosomething_user_menu() {
@@ -1069,8 +1078,8 @@ function dosomething_user_info_form_submit($form, &$form_state) {
   // Overwrite City/State if values are present.
   $edit['field_address'][LANGUAGE_NONE][0]['locality'] = $values['city'];
   $edit['field_address'][LANGUAGE_NONE][0]['administrative_area'] = $values['state'];
-  // Hardcoded to 'merica for now.
-  $edit['field_address'][LANGUAGE_NONE][0]['country'] = 'US';
+  $country_code = dosomething_settings_get_affiliate_country_code();
+  $edit['field_address'][LANGUAGE_NONE][0]['country'] = $country_code;
   $file = NULL;
   // If a file was uploaded:
   if (!empty($values['upload'])) {

--- a/lib/modules/dosomething/dosomething_user/plugins/format/dosomething-affiliate-country.inc
+++ b/lib/modules/dosomething/dosomething_user/plugins/format/dosomething-affiliate-country.inc
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Provides an option to override address country with affiliate country.
+ */
+
+$plugin = array(
+  'title' => t('Dosomething Affiliate Country'),
+  'format callback' => 'dosomething_user_format_address_country',
+  'type' => 'address',
+  'weight' => -200,
+);
+
+function dosomething_user_format_address_country(&$format, &$address, $context = array()) {
+  $address['country'] = dosomething_settings_get_affiliate_country_code();
+}


### PR DESCRIPTION
#### What's this PR do?
- Provides addressfield option to override address country with affiliate country
- Adds the option to chain of users address filters
- Changes registration form: replaces hardcoded country with affiliate country
- UK and Canada registration: removes hardcoded country in favor of common solution
- UK and Canada user creation on login: replaces hardcoded country with affiliate country
#### What are the relevant tickets?
- Closes #3328 
  ![screen shot 2014-11-11 at 11 34 03 pm](https://cloud.githubusercontent.com/assets/672669/5001244/b8bba1b6-69fc-11e4-8297-9d1843629106.png)
  ![screen shot 2014-11-11 at 11 33 33 pm](https://cloud.githubusercontent.com/assets/672669/5001243/b26ea38a-69fc-11e4-83b1-07fbd408e55b.png)
- Closes #3341
  ![screen shot 2014-11-11 at 11 35 07 pm](https://cloud.githubusercontent.com/assets/672669/5001248/be71a51a-69fc-11e4-89ba-239646794b28.png)
  ![screen shot 2014-11-11 at 11 50 46 pm](https://cloud.githubusercontent.com/assets/672669/5001355/9bc495b2-69fd-11e4-846b-1094faeb4f27.png)
