### PR TITLE
Fix Stripe Customer / Charge requests 

### DIFF
--- a/lib/modules/dosomething/dosomething_payment/dosomething_payment.admin.inc
+++ b/lib/modules/dosomething/dosomething_payment/dosomething_payment.admin.inc
@@ -36,8 +36,13 @@ function dosomething_payment_admin_config_form($form, &$form_state) {
   );
   $form['stripe']['dosomething_payment_stripe_api_key'] = array(
     '#type' => 'textfield',
-    '#title' => t('Stripe API key'),
+    '#title' => t('Secret API key'),
     '#default_value' => variable_get('dosomething_payment_stripe_api_key'),
+  );
+  $form['stripe']['dosomething_payment_stripe_api_key_public'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Publishable API key'),
+    '#default_value' => variable_get('dosomething_payment_stripe_api_key_public'),
   );
   return system_settings_form($form);
 }

--- a/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
+++ b/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
@@ -74,6 +74,7 @@ function dosomething_payment_block_view($delta = '') {
  * Form constructor for creating a Payment.
  */
 function dosomething_payment_form($form, &$form_state, $config = array()) {
+  // This JS is needed to create a Stripe token, which is used for API posts. 
   drupal_add_js('https://js.stripe.com/v2/');
   $form['full_name'] = array(
     '#type' => 'textfield',
@@ -147,6 +148,7 @@ function dosomething_payment_form($form, &$form_state, $config = array()) {
       'data-stripe' => 'amount',
     ),
   );
+  // Gets set by the JS request to Stripe API.
   $form['token'] = array(
     '#type' => 'hidden',
   );
@@ -246,21 +248,19 @@ function dosomething_payment_post_payment_stripe($values) {
     form_set_error(NULL, t("Stripe configuration error."));
     return;
   }
+
+  // Create a Stripe customer.
   $customer = dosomething_payment_stripe_create_customer($values);
   if (!$customer) {
     form_set_error(NULL, t("Sorry, there was an error processing your request."));
     return;
   }
-  $card = array(
-    'number' => $values['number'],
-    'exp_month' => $values['exp_month'],
-    'exp_year' => $values['exp_year'],
-  );
+
   try {
+    // Charge the customer.
+    // @see https://stripe.com/docs/tutorials/charges
     Stripe_Charge::create(array(
-      'card' => $card,
-      // @todo: This breaks with test data.
-      // 'customer' => $customer->id,
+      'customer' => $customer->id,
       'amount' => $values['amount'],
       'currency' => 'usd',
       'receipt_email' => $values['email'],
@@ -298,7 +298,8 @@ function dosomething_payment_get_stripe_test_values($email, $amount = 2000) {
  * @param array $values
  *   An associative array containing:
  *   - email: (string).
- *   - name: (string).
+ *   - full_name: (string).
+ *   - token: (string).
  *
  * @return
  *   The newly created customer object, or FALSE if error.
@@ -313,6 +314,7 @@ function dosomething_payment_stripe_create_customer($values) {
     $customer = Stripe_Customer::create(array(
       'email' => $values['email'],
       'card' => $values['token'],
+      'description' => $values['full_name'],
     ));
     return $customer;
   }


### PR DESCRIPTION
Creating a Stripe Customer with the token exposes the `$customer->id` property, fixing broken payment errors.
