### PR TITLE
Runs UK and Canada tests on international subdomain.

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -141,7 +141,7 @@ function runIntegrationTests() {
   }
 
   var _casperURL = "http://dev.dosomething.org:8888";
-  if(config.verbose) {
+  if(config.url) {
     _casperURL = config.url;
   }
 

--- a/tests/config/canada.json
+++ b/tests/config/canada.json
@@ -1,5 +1,5 @@
 {
-  "url": "http://dev.dosomething.org:8888",
+  "url": "http://dev.canada.dosomething.org:8888",
   "mocha": "index",
   "casperjs": [
     "canada/**/*"

--- a/tests/config/uk.json
+++ b/tests/config/uk.json
@@ -1,5 +1,5 @@
 {
-  "url": "http://dev.dosomething.org:8888",
+  "url": "http://dev.uk.dosomething.org:8888",
   "mocha": "index",
   "casperjs": [
     "uk/**/*"

--- a/tests/scripts/drush.js
+++ b/tests/scripts/drush.js
@@ -49,6 +49,9 @@ casper.drush = function(command, json) {
     if(json === true) {
       command.push("--format=json");
     }
+
+    // URI of the drupal site run drush at. Needed to run drush on the right
+    // affiliate in the multi-site environment.
     command.push("--uri=" + url);
 
     var DIRECTORY = ROOT + "/html";

--- a/tests/scripts/drush.js
+++ b/tests/scripts/drush.js
@@ -49,6 +49,7 @@ casper.drush = function(command, json) {
     if(json === true) {
       command.push("--format=json");
     }
+    command.push("--uri=" + url);
 
     var DIRECTORY = ROOT + "/html";
     this.log("Running Drush command in " + DIRECTORY + ": " + command.join(' '));


### PR DESCRIPTION
#### What's this PR do?
- Makes UK and Canada integration tests run on international domain so `dosomething_settings_get_affiliate_country_code()` would return right value inside the tests
- Fixes an error in `bin/test` script with url detection
- Makes `casper.drush` take into account an affiliate currently executing test at
  ![image](https://cloud.githubusercontent.com/assets/672669/5051158/a5426c80-6c3d-11e4-8452-b5ad929dc66c.png)
#### Any background context you want to provide?

<del>Now running tests requires an amend to of `/etc/hosts` file that assigns intl hosts to 127.0.0.1, e.g. `127.0.0.1 dev.canada.dosomething.org`.
This will be fixed in the new box build.</del>
