### PR TITLE
Donate Form: Display confirmation within block content

### DIFF
--- a/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
+++ b/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
@@ -58,13 +58,20 @@ function dosomething_payment_block_view($delta = '') {
   switch ($delta) {
     case 'donate_form':
       $config = array(
-        'confirm_msg' => variable_get('dosomething_payment_donate_confirm_msg'),
         'submit_label' => t("Donate"),
       );
       // This is a bit of a hack to get two different variables.
       // Use the block's subject as the form header.
       $block['subject'] = variable_get('dosomething_payment_donate_form_header');
-      $block['content'] = drupal_get_form('dosomething_payment_form', $config);
+      // Check for confirmation query string:
+      if (isset($_GET['donated'])) {
+        $msg = variable_get('dosomething_payment_donate_confirm_msg');
+        $block['content'] = $msg;
+      }
+      // Else render the Payment Form.
+      else {
+         $block['content'] = drupal_get_form('dosomething_payment_form', $config);
+      }
       break;
   }
   return $block;
@@ -169,16 +176,6 @@ function dosomething_payment_form($form, &$form_state, $config = array()) {
     $submit = $config['submit_label'];
   }
 
-  // Check if confirmation has been set.
-  $confirm_msg = t("Thanks!");
-  if (isset($config['confirm_msg'])) {
-    $form['confirm_msg'] = array(
-      '#type' => 'hidden',
-      '#default_value' => $confirm_msg,
-      '#access' => FALSE,
-    );
-  }
-
   // Check if we are in secret testing mode.
   // @todo: Remove this code when we're ready to go live.
   if (isset($_GET['testing']) && is_numeric($_GET['testing'])) {
@@ -210,7 +207,13 @@ function dosomething_payment_form_submit($form, &$form_state) {
   $values['amount'] = $values['amount'] * 100;
   // Send Payment request to Stripe API.
   if (dosomething_payment_post_payment_stripe($values)) {
-    drupal_set_message($values['confirm_msg']);
+    // Redirect to current page with query string.
+    $form_state['redirect'] = array(
+      drupal_get_path_alias(),
+      array(
+        'query' => array('donated' => 1),
+      ),
+    );
   }
 }
 
@@ -294,7 +297,7 @@ function dosomething_payment_get_stripe_test_values($email, $amount = 2000) {
   return array(
     'email' => $email,
     'number' => '4242424242424242',
-    'exp_month' => 5,
+    'exp_month' => '05',
     'exp_year' => 2015,
     'amount' => $amount,
   );

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/block/block--dosomething_payment--donate_form.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/block/block--dosomething_payment--donate_form.tpl.php
@@ -2,18 +2,32 @@
 /**
  * Available variables:
  * - $block->subject: Block title.
- * - $content: The rendered Payment Form.
+ * - $content: The rendered Payment Form, or a confirmation message.
+ *
+ * @see dosomething_payment_block_view().
  */
 ?>
 
 <div class="cta">
   <div class="wrapper">
-    <a href="#" data-modal-href="#modal--donate-form" class="btn">
-      <?php print t("Donate"); ?>
-    </a>
-    <div data-modal id="modal--donate-form" role="dialog" class="donate--payment">
-      <h2 class="donate--header"><?php print $block->subject; ?></h2>
-      <?php print $content; ?>
-    </div>
+
+    <?php // If query string present, display confirmation message. ?>
+    <?php if (isset($_GET['donated'])): ?>
+
+      <h2><?php print $content; ?></h2>
+
+    <?php // Else: display Donate Form into modal, and a link to it. ?>
+    <?php else: ?>
+
+      <a href="#" data-modal-href="#modal--donate-form" class="btn">
+        <?php print t("Donate"); ?>
+      </a>
+      <div data-modal id="modal--donate-form" role="dialog" class="donate--payment">
+        <h2 class="donate--header"><?php print $block->subject; ?></h2>
+        <?php print $content; ?>
+      </div>
+
+    <?php endif; ?>
+
   </div>
 </div>


### PR DESCRIPTION
Redirects to current page that form is rendered on, with a `?donated=1` query string.  

If query string is present, display confirmation message instead of the Donate Form.
