### PR TITLE
Adding query string to search form

### DIFF
--- a/lib/modules/dosomething/dosomething_notfound/dosomething_notfound.module
+++ b/lib/modules/dosomething/dosomething_notfound/dosomething_notfound.module
@@ -152,5 +152,5 @@ function dosomething_notfound_form_search_form_alter(&$form, &$form_state, $form
   // Get the query string from the form state.
   $query_string = $form_state['build_info']['args']['query_string'];
   // Use the query as the default text in the search form.
-  $form['basic']['keys']['#default_value'] = t($query_string);
+  $form['basic']['keys']['#default_value'] = $query_string;
 }

--- a/lib/modules/dosomething/dosomething_notfound/dosomething_notfound.module
+++ b/lib/modules/dosomething/dosomething_notfound/dosomething_notfound.module
@@ -152,5 +152,7 @@ function dosomething_notfound_form_search_form_alter(&$form, &$form_state, $form
   // Get the query string from the form state.
   $query_string = $form_state['build_info']['args']['query_string'];
   // Use the query as the default text in the search form.
-  $form['basic']['keys']['#default_value'] = $query_string;
+  if (!empty($query_string)) {
+    $form['basic']['keys']['#default_value'] = $query_string;
+  }
 }

--- a/lib/modules/dosomething/dosomething_notfound/dosomething_notfound.module
+++ b/lib/modules/dosomething/dosomething_notfound/dosomething_notfound.module
@@ -130,11 +130,27 @@ function dosomething_notfound_preprocess_node(&$vars)  {
 
   // Theme the set of results as duo gallery.
   $vars['search_results_gallery'] = paraneue_dosomething_get_search_gallery($vars['results']);
-
+  // Pass the query string used in the search to the search form.
+  $form_state = array(
+    'build_info' => array(
+      'args' => array(
+        'query_string' => $query_string,
+      ),
+    ),
+  );
+  $search_form = drupal_build_form('search_form', $form_state);
   // Make the search form availabe to the page.
-  $search_form = drupal_get_form('search_form');
   $vars['search_form'] = drupal_render($search_form);
-
   // Search header text.
   $vars['search_header'] = t('We did a quick search, here is some similar content that we do have.');
+}
+
+/**
+* Implementation of hook_form_FORM_ID_alter()
+*/
+function dosomething_notfound_form_search_form_alter(&$form, &$form_state, $form_id) {
+  // Get the query string from the form state.
+  $query_string = $form_state['build_info']['args']['query_string'];
+  // Use the query as the default text in the search form.
+  $form['basic']['keys']['#default_value'] = t($query_string);
 }


### PR DESCRIPTION
Fixes #3426 . Adding the query string used in the 404 search to the text field in the search form displayed on the 404 page. 

@aaronschachter @deadlybutter 
