### PR TITLE
Downgrade node-glob dependency in DS test suite due to #3440.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "chai": "~1.7.0",
     "commander": "^2.3.0",
-    "glob": "^4.0.6",
+    "glob": "4.0.*",
     "lodash": "^2.4.1",
     "mocha": "~1.12.0",
     "phantomcss": "^0.7.2",


### PR DESCRIPTION
Temporarily fixes tests failure described in #3440.
