### PR TITLE
Reportback Image caption

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -86,6 +86,19 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
       'class' => array('js-image-upload'),
     ),
   );
+  $caption = NULL;
+  if (isset($entity->caption)) {
+    $caption = $entity->caption;
+  }
+  $form['caption'] = array(
+    '#type' => 'textfield',
+    '#required' => TRUE,
+    '#attributes' => array(
+      'data-validate-required' => '',
+    ),
+    '#title' => t("Caption"),
+    '#default_value' => $caption,
+  );
   $form['quantity'] = array(
     '#type' => 'textfield',
     '#required' => TRUE,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -148,7 +148,7 @@ function dosomething_reportback_schema() {
         'default' => 0,
       ),
       'fid' => array(
-        'description' => 'File fid',
+        'description' => 'Original file fid',
         'type' => 'int',
         'unsigned' => TRUE,
         'not null' => TRUE,
@@ -159,6 +159,25 @@ function dosomething_reportback_schema() {
         'type' => 'varchar',
         'length' => 128,
         'not null' => FALSE,
+      ),
+      'caption' => array(
+        'description' => 'File caption.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => FALSE,
+      ),
+      'options_processed' => array(
+        'description' => 'File processing options.',
+        'type' => 'text',
+        'length' => '2048',
+        'not null' => FALSE,
+      ),
+      'fid_processed' => array(
+        'description' => 'Processed file fid',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
       ),
     ),
     'primary key' => array('rbid', 'fid'),
@@ -301,4 +320,23 @@ function dosomething_reportback_update_7009() {
   if (db_field_exists($table, $field)) {
     db_drop_field($table, $field);
   }
- }
+}
+
+/**
+ * Adds new columnns to the dosomething_reportback_file table.
+ */
+function dosomething_reportback_update_7013(&$sandbox) {
+  $tbl_name = 'dosomething_reportback_file';
+  $new_fields = array(
+    'caption',
+    'options_processed',
+    'fid_processed',
+  );
+  $schema = dosomething_reportback_schema();
+  foreach ($new_fields as $fld_name) {
+    if (!db_field_exists($tbl_name, $fld_name)) {
+      // Add it per the schema field definition.
+      db_add_field($tbl_name, $fld_name, $schema[$tbl_name]['fields'][$fld_name]);
+    }
+  }
+}

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -434,6 +434,7 @@ function dosomething_reportback_set_properties(&$entity, $values) {
 function dosomething_reportback_set_files(&$entity, $values) {
   if (isset($values['fid']) && !empty($values['fid'])) {
     $entity->fid = $values['fid'];
+    $entity->caption = $values['caption'];
   }
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -283,13 +283,15 @@ class ReportbackEntityController extends EntityAPIController {
       t('Caption'),
       t('IP'),
       t('Created'),
-      NULL
+      NULL,
     );
     foreach ($entity->getReportbackFileData() as $delta => $record) {
       $fid = $record->fid;
       $image = dosomething_image_get_themed_image_by_fid($fid, 'thumbnail');
       $file = file_load($fid);
-      $file_link = l($fid, 'file/' . $fid);
+      $file_url = file_create_url($file->uri);
+      $file_link = l($fid, $file_url);
+      $image = l($image, $file_url, array('html' => TRUE));
       $created = format_date($file->timestamp, 'short');
       $promoted = NULL;
       // If file has been promoted:

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -136,13 +136,17 @@ class ReportbackEntity extends Entity {
 
   /**
    * Inserts given fid into dosomething_reportback_files table for this entity.
+   *
+   * @param object $values
+   *   Values to write to a dosomething_reportback_file record.
    */
-  public function insertFid($fid) {
+  public function createReportbackFile($values) {
     return db_insert($this->files_table)
       ->fields(array(
-        'rbid' => $this->rbid,
-        'fid' => $fid,
-        'remote_addr' => dosomething_helpers_ip_address(),
+          'rbid' => $this->rbid,
+          'fid' => $values->fid,
+          'caption' => $values->caption,
+          'remote_addr' => dosomething_helpers_ip_address(),
         ))
       ->execute();
   }
@@ -329,7 +333,7 @@ class ReportbackEntityController extends EntityAPIController {
     // If a file fid exists:
     if (isset($entity->fid)) {
       // Add it into the reportback files.
-      $entity->insertFid($entity->fid);
+      $entity->createReportbackFile($entity);
     }
     // Log the write operation.
     $entity->insertLog($op);

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -277,7 +277,14 @@ class ReportbackEntityController extends EntityAPIController {
     );
     // Output Reportback Files.
     $rows = array();
-    $header = array('Fid', 'Image', 'IP', 'Created', NULL);
+    $header = array(
+      t('Fid'),
+      t('Image'),
+      t('Caption'),
+      t('IP'),
+      t('Created'),
+      NULL
+    );
     foreach ($entity->getReportbackFileData() as $delta => $record) {
       $fid = $record->fid;
       $image = dosomething_image_get_themed_image_by_fid($fid, 'thumbnail');
@@ -291,7 +298,14 @@ class ReportbackEntityController extends EntityAPIController {
         $promoted = "Promoted on " . format_date($flagging->timestamp, 'short');
         $promoted .= $caption;
       }
-      $rows[] = array($file_link, $image, $record->remote_addr, $created, $promoted);
+      $rows[] = array(
+        $file_link,
+        $image,
+        $record->caption,
+        $record->remote_addr,
+        $created,
+        $promoted,
+      );
     }
     $build['reportback_files'] = array(
       '#theme' => 'table',


### PR DESCRIPTION
Fixes #3284

Adds a new column for the Reportback Image caption (and also columns we'll need for cropped/processed images).

Adds new form element to Reportback Form to save the Caption along with the Reportback Image.
