### PR TITLE
force a leading zero on exp month if value is less than 10

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/donate/Donate.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/donate/Donate.js
@@ -5,6 +5,32 @@ define(function(require) {
   var StripeForm = require("StripeForm");
   var $donateForm = $("#dosomething-payment-form");
 
+  /**
+  * Pads a number with a leading zero if less than 10
+  *
+  * @param {String}   string  String to be test pad against
+  * @return {String}
+  */
+  function pad(string) {
+    if (string !== "") {
+      var number = parseInt(string, 10);
+      return number < 10 ? "0" + number : number.toString();
+    }
+  }
+
+  /**
+  * Invokes any function after a given timeout
+  *
+  * @return {function}
+  */
+  var delay = (function() {
+    var timer = 0;
+    return function(callback, ms){
+      clearTimeout(timer);
+      timer = setTimeout(callback, ms);
+    };
+  }());
+
   var Donate = {
     init: function () {
       try {
@@ -13,6 +39,14 @@ define(function(require) {
       } catch(e) {
         $donateForm.html("<div class='messages'>Whoops! Something's not right. Please email us!</div>");
       }
+
+      // check if leading zero is needed to exp month
+      $donateForm.find("[data-stripe='exp-month']").on("keyup", function () {
+        var $this = $(this);
+        delay(function () {
+          $this.val(pad($this.val()));
+        }, 200);
+      });
     }
   };
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/donate/Donate.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/donate/Donate.js
@@ -5,32 +5,6 @@ define(function(require) {
   var StripeForm = require("StripeForm");
   var $donateForm = $("#dosomething-payment-form");
 
-  /**
-  * Pads a number with a leading zero if less than 10
-  *
-  * @param {String}   string  String to be test pad against
-  * @return {String}
-  */
-  function pad(string) {
-    if (string !== "") {
-      var number = parseInt(string, 10);
-      return number < 10 ? "0" + number : number.toString();
-    }
-  }
-
-  /**
-  * Invokes any function after a given timeout
-  *
-  * @return {function}
-  */
-  var delay = (function() {
-    var timer = 0;
-    return function(callback, ms){
-      clearTimeout(timer);
-      timer = setTimeout(callback, ms);
-    };
-  }());
-
   var Donate = {
     init: function () {
       try {
@@ -39,14 +13,6 @@ define(function(require) {
       } catch(e) {
         $donateForm.html("<div class='messages'>Whoops! Something's not right. Please email us!</div>");
       }
-
-      // check if leading zero is needed to exp month
-      $donateForm.find("[data-stripe='exp-month']").on("keyup", function () {
-        var $this = $(this);
-        delay(function () {
-          $this.val(pad($this.val()));
-        }, 200);
-      });
     }
   };
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/donate.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/donate.js
@@ -36,16 +36,6 @@ define(function(require) {
   }
 
   /**
-  * Validates string for at most two digits
-  *
-  * @param {String}   string  String to be test against regex
-  * @return {boolean}
-  */
-  function isMaxTwoDigits(string) {
-    return (/^\d{1,2}$/).test(string);
-  }
-
-  /**
   * Validates string for at least three digits
   *
   * @param {String}   string  String to be test against regex
@@ -62,7 +52,6 @@ define(function(require) {
   * @return {boolean}
   */
   function isValidMonth(string) {
-    //return (/^(0[1-9]|1[0-2])$/).test(string);
     return (/^([1-9]|1[0-2])$/).test(string);
   }
 
@@ -157,7 +146,7 @@ define(function(require) {
   * @return {boolean}
   */
   function validateExpMonth(string, done, success, failure) {
-    if ( isValidMonth(string) && isMaxTwoDigits(string)) {
+    if ( isValidMonth(string)) {
       return done({
         success: true,
         message: success

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/donate.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/donate.js
@@ -52,7 +52,7 @@ define(function(require) {
   * @return {boolean}
   */
   function isValidMonth(string) {
-    return (/^([1-9]|1[0-2])$/).test(string);
+    return (/^(0?[1-9]|1[0-2])$/).test(string);
   }
 
   /**

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/donate.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/donate.js
@@ -36,6 +36,16 @@ define(function(require) {
   }
 
   /**
+  * Validates string for at most two digits
+  *
+  * @param {String}   string  String to be test against regex
+  * @return {boolean}
+  */
+  function isMaxTwoDigits(string) {
+    return (/^\d{1,2}$/).test(string);
+  }
+
+  /**
   * Validates string for at least three digits
   *
   * @param {String}   string  String to be test against regex
@@ -52,7 +62,8 @@ define(function(require) {
   * @return {boolean}
   */
   function isValidMonth(string) {
-    return (/^(0[1-9]|1[0-2])$/).test(string);
+    //return (/^(0[1-9]|1[0-2])$/).test(string);
+    return (/^([1-9]|1[0-2])$/).test(string);
   }
 
   /**
@@ -64,7 +75,6 @@ define(function(require) {
   function isValidYear(string) {
     return (/^[1-9]\d{3,}$/).test(string);
   }
-
 
 
   // @TODO: This will be removed when Neue's validation gets refactored.
@@ -147,7 +157,7 @@ define(function(require) {
   * @return {boolean}
   */
   function validateExpMonth(string, done, success, failure) {
-    if ( isValidMonth(string) ) {
+    if ( isValidMonth(string) && isMaxTwoDigits(string)) {
       return done({
         success: true,
         message: success


### PR DESCRIPTION
Adds a leading zero to exp month if value is less than ten.  This check happens upon keyup after a 200ms delay so that it's not too invasive to the user.

Note: would be ideal to add this support to the validation library.

Resolves #3438 
