### PR TITLE
Updates to hide or show caption field in reportback.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -95,6 +95,7 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     '#required' => TRUE,
     '#attributes' => array(
       'data-validate-required' => '',
+      'placeholder' => t("Write something..."),
     ),
     '#title' => t("Caption"),
     '#default_value' => $caption,

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploader.js
@@ -7,6 +7,18 @@ define(function(require) {
     // Toggle visibility of upload button and hide that guy
     var $imageUploads = $context.find(".js-image-upload");
 
+    // @TODO: Not ideal location; will be refactored during new reportback implementation.
+    // This should actually sit within the Reportback.js code, but would need to implement
+    // an event that can respond to an image being uploaded. Temporarily placed here until
+    // upcoming refactor. (2014.11.18 - Diego)
+    var $caption       = $context.find(".form-item-caption");
+    var submittedImage = $context.find(".submitted-image").length === 0 ? false : true;
+
+    // If no prior submitted image is present, caption should be hidden.
+    if (!submittedImage) {
+      $caption.hide();
+    }
+
     $imageUploads.each(function(i, el) {
       $(el).wrap( $("<div class='image-upload-container'></div>") );
       var $container = $(el).parent(".image-upload-container");
@@ -26,6 +38,10 @@ define(function(require) {
       // Show image preview on upload
       $(el).on("change", function(event) {
         event.preventDefault();
+
+        // New image added, show the caption.
+        submittedImage = true;
+        $caption.show();
 
         // Change button state
         $uploadBtn.text(Drupal.t("Change Pic"));


### PR DESCRIPTION
Resolves #3453

Only hides the caption field is there's not already a previously submitted reportback image. If there is one, it doesn't affect the caption so user can go back and add a caption to prior image :)

@aaronschachter 

CC: @DFurnes 
