### PR TITLE
Adding a no results state to 404 pages

### DIFF
--- a/lib/modules/dosomething/dosomething_notfound/dosomething_notfound.module
+++ b/lib/modules/dosomething/dosomething_notfound/dosomething_notfound.module
@@ -154,9 +154,8 @@ function dosomething_notfound_preprocess_node(&$vars)  {
 */
 function dosomething_notfound_form_search_form_alter(&$form, &$form_state, $form_id) {
   // Get the query string from the form state.
-  $query_string = $form_state['build_info']['args']['query_string'];
-  // Use the query as the default text in the search form.
-  if (!empty($query_string)) {
+  if (!empty($form_state['build_info']['args']['query_string'])) {
+    $query_string = $form_state['build_info']['args']['query_string'];
     $form['basic']['keys']['#default_value'] = $query_string;
   }
 }

--- a/lib/modules/dosomething/dosomething_notfound/dosomething_notfound.module
+++ b/lib/modules/dosomething/dosomething_notfound/dosomething_notfound.module
@@ -94,33 +94,23 @@ function dosomething_notfound_preprocess_node(&$vars)  {
 
   // For path specific results.
   if (isset($copy)) {
-    // Create class for themeing path specific pages.
+    // Create class for theming path specific pages.
     $vars['notfound_page_type'] = "path-specific";
     // Sets the copy above the results.
     $vars['results_copy'] = check_markup($copy, 'markdown');
-
-    // Get recommended campaigns.
-    $rec_nids = dosomething_campaign_get_recommended_campaign_nids(NULL, NULL, 3);
-    $rec_vars = array();
-    foreach ($rec_nids as $nid) {
-      $rec_vars[] = dosomething_campaign_get_campaign_block_vars($nid);
-    }
     // Raw results is themed in preprocessing and stored as $campaign_results.
-    $vars['raw_campaign_results'] = $rec_vars;
+    $vars['raw_campaign_results'] = dosomething_notfound_get_recommended_campaigns();
     return;
   }
 
   $invalid_chars = array("/", "-", "_"); // request_path() shouldn't return a string with question marks and other chars we don't need
   $formatted_terms = explode(" ", str_replace($invalid_chars, " ", $raw_url));
 
-  if (count($formatted_terms) <= 1) {
-    // @TODO: Issue 3428 
-    return;
-  }
-
+  // Get a list of terms that we don't want to search by.
   $filter_words = explode(",", variable_get('dosomething_notfound_search_filter'));
   $query_string = "";
   $total = count($formatted_terms);
+  // Create the query string.
   for ($i = 0; $i < $total; $i++) {
     $term = $formatted_terms[$i];
     if (!in_array($term, $filter_words)) {
@@ -128,26 +118,35 @@ function dosomething_notfound_preprocess_node(&$vars)  {
     }
   }
 
-  $vars['raw_search_results'] = apachesolr_search_search_execute($query_string);
+  // For 404 pages with search.
+  if (!empty($query_string)) {
+    $vars['raw_search_results'] = apachesolr_search_search_execute($query_string);
+    if (count($vars['raw_search_results']) != 0) {
+      // Pass the query string used in the search to the search form.
+      $form_state = array(
+        'build_info' => array(
+          'args' => array(
+            'query_string' => $query_string,
+          ),
+        ),
+      );
+      $search_form = drupal_build_form('search_form', $form_state);
 
-  if (count($vars['raw_search_results']) == 0) {
-    return;
+      // Make the search form availabe to the page.
+      $vars['search_form'] = drupal_render($search_form);
+      // Search header text.
+      $vars['results_copy'] = t('We did a quick search, here is some similar content that we do have.');
+      return;
+    }
   }
 
-  // Pass the query string used in the search to the search form.
-  $form_state = array(
-    'build_info' => array(
-      'args' => array(
-        'query_string' => $query_string,
-      ),
-    ),
-  );
-  $search_form = drupal_build_form('search_form', $form_state);
-
-  // Make the search form availabe to the page.
+  // Defaults for 404 pages when no results are found or all the terms used are not allowed.
+  $search_form = drupal_get_form('search_form');
   $vars['search_form'] = drupal_render($search_form);
-  // Search header text.
-  $vars['results_copy'] = t('We did a quick search, here is some similar content that we do have.');
+  $vars['results_copy'] = t('We couldn\'t find what you were looking for, but try searching our site for something similar.');
+  $vars['suggestions_header'] = t('Or join a campaign');
+  // Raw results is themed in preprocessing and stored as $campaign_results.
+  $vars['raw_campaign_results'] = dosomething_notfound_get_recommended_campaigns();
 }
 
 /**
@@ -160,4 +159,16 @@ function dosomething_notfound_form_search_form_alter(&$form, &$form_state, $form
   if (!empty($query_string)) {
     $form['basic']['keys']['#default_value'] = $query_string;
   }
+}
+
+/**
+* Get recommended campaigns
+*/
+function dosomething_notfound_get_recommended_campaigns() {
+  $rec_nids = dosomething_campaign_get_recommended_campaign_nids(NULL, NULL, 3);
+  $rec_vars = array();
+  foreach ($rec_nids as $nid) {
+    $rec_vars[] = dosomething_campaign_get_campaign_block_vars($nid);
+  }
+  return $rec_vars;
 }

--- a/lib/themes/dosomething/paraneue_dosomething/bower.json
+++ b/lib/themes/dosomething/paraneue_dosomething/bower.json
@@ -20,7 +20,7 @@
     "tests"
   ],
   "dependencies": {
-    "neue": "DoSomething/neue#~5.3.1",
+    "neue": "DoSomething/neue#~5.3.3",
     "jquery": "1.8.3",
     "mailcheck": "~1.0.3",
     "html5shiv": "~3.7.0",

--- a/lib/themes/dosomething/paraneue_dosomething/templates/notfound/node--notfound.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/notfound/node--notfound.tpl.php
@@ -33,6 +33,11 @@
         <?php if (!empty($search_form)): ?>
           <?php print $search_form; ?>
         <?php endif; ?>
+        <?php if (!empty($suggestions_header)): ?>
+          <h3 class="search-results-header">
+            <?php print $suggestions_header; ?>
+          </h3>
+        <?php endif; ?>
         <?php if (isset($campaign_results)): ?>
           <?php print $campaign_results; ?>
         <?php endif; ?>


### PR DESCRIPTION
I refactored the code a little to basically set a default version of the page to take into account when there were no results found, or if the path they hit happened to also be a term we are filtering, like /actnow, for example. This way the 404 page will always show something, unless of course, we disable the 404 functionality in rare cases. 

Fixes #3428 

@aaronschachter @deadlybutter 
