### PR TITLE
Reportback Files API endpoint

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -6,3 +6,4 @@ dependencies[] = services
 features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
+mtime = 1415889493

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -7,6 +7,7 @@
 include_once 'dosomething_api.features.inc';
 include_once 'resources/campaign_resource.inc';
 include_once 'resources/member_resource.inc';
+include_once 'resources/reportback_resource.inc';
 
 /**
  * Implements hook_services_request_postprocess_alter().
@@ -37,5 +38,7 @@ function dosomething_api_services_resources() {
   $resources = array_merge_recursive($resources, _campaign_resource_defintion());
   // Add Member resource.
   $resources = array_merge_recursive($resources, _member_resource_defintion());
+  // Add Reportback resource.
+  $resources = array_merge_recursive($resources, _reportback_resource_defintion());
   return $resources;
 }

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -68,6 +68,13 @@ function dosomething_api_default_services_endpoint() {
         ),
       ),
     ),
+    'reportback_files' => array(
+      'operations' => array(
+        'index' => array(
+          'enabled' => '1',
+        ),
+      ),
+    ),
     'system' => array(
       'actions' => array(
         'connect' => array(

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
@@ -1,0 +1,93 @@
+<?php
+
+function _reportback_resource_defintion() {
+  $resources = array();
+  $resources['reportback_files'] = array(
+    'operations' => array(
+      'index' => array(
+        'help' => 'List all reportback files',
+        'file' => array(
+          'type' => 'inc',
+          'module' => 'dosomething_api',
+          'name' => 'resources/reportback_resource',
+        ),
+        'callback' => '_reportback_file_resource_index',
+        'args' => array(
+          array(
+            'name' => 'page',
+            'optional' => TRUE,
+            'type' => 'int',
+            'description' => 'The zero-based index of the page to get, defaults to 0.',
+            'default value' => 0,
+            'source' => array('param' => 'page'),
+          ),
+          array(
+            'name' => 'parameters',
+            'optional' => TRUE,
+            'type' => 'array',
+            'description' => 'Parameters array',
+            'default value' => array(),
+            'source' => array('param' => 'parameters'),
+          ),
+          array(
+            'name' => 'pagesize',
+            'optional' => TRUE,
+            'type' => 'int',
+            'description' => 'Number of records to get per page.',
+            'default value' => variable_get('services_node_index_page_size', 20),
+            'source' => array('param' => 'pagesize'),
+          ),
+        ),
+        'access arguments' => array('access content'),
+      ),
+    ),
+  );
+  return $resources;
+}
+
+/**
+ * Return an array of optionally paged reportback files based on a set of criteria.
+ *
+ * @param $page
+ *   Page number of results to return (in pages of $pagesize, or 20).
+ * @param $parameters
+ *   An array containing fields and values used to build a sql WHERE clause
+ *   indicating items to retrieve.
+ * @param $page_size
+ *   Integer number of items to be returned.
+ *
+ * @return
+ *   An array of Reportback File objects.
+ */
+function _reportback_file_resource_index($page, $parameters, $page_size) {
+  // Load Services module to use its index_query functions.
+  module_load_include('inc', 'services', 'services.module');
+
+  // Needs to be aliased as t for services_resource_build_index_query to work.
+  $query = db_select('dosomething_reportback_file', 't');
+  if (isset($parameters['nid'])) {
+    $query->join('dosomething_reportback', 'rb', 'rb.rbid = t.rbid');
+    $query->condition('nid', $parameters['nid']);
+  }
+  // @todo Add condition to only display approved Reportback Files.
+  // Show most recent first.
+  $query->orderBy('fid', 'DESC');
+  // Fields to return.
+  $fields = "'rbid', 'fid', 'fid_processed', 'caption'";
+  services_resource_build_index_query($query, $page, $fields, $parameters, $page_size, 'reportbacks');
+
+  $results = services_resource_execute_index_query($query);
+
+  $result = services_resource_build_index_list($results, 'reportbacks', 'rbid');
+  foreach ($result as &$record) {
+    // We'll eventually want to use the fid_processed here.
+    // And also probably won't need to apply an image style, since it
+    // will already be cropped.
+    $record->src = dosomething_image_get_themed_image_url_by_fid($record->fid, '300x300');
+  }
+  // @see http://php.net/manual/en/control-structures.foreach.php:
+  // Reference of a $value and the last array element remain even after
+  // the foreach loop. It is recommended to destroy it by unset().
+  unset($record);
+  return $result;
+}

--- a/lib/modules/dosomething/dosomething_image/dosomething_image.module
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.module
@@ -157,6 +157,22 @@ function dosomething_image_get_themed_image_by_fid($fid, $style, $alt = '') {
 }
 
 /**
+ * Returns a themed image URL for a given File $fid and $style preset.
+ *
+ * @param int $fid
+ *  The File fid.
+ * @param string $style
+ *  The image style preset/size to return the image.
+ *
+ * @return string
+ *  URL of the image source.
+ */
+function dosomething_image_get_themed_image_url_by_fid($fid, $style) {
+  $file = file_load($fid);
+  return image_style_url($style, $file->uri);
+}
+
+/**
  * Implements hook_node_update().
  */
 function dosomething_image_node_update($node) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -815,7 +815,7 @@ function dosomething_reportback_get_noun_and_verb($nid) {
  */
 function dosomething_reportback_services_resources() {
   $resources = array();
-  $resources['reportback'] = array(
+  $resources['reportbacks'] = array(
     'operations' => array(
       'retrieve' => array(
         'help' => 'Retrieve a reportback.',

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -66,6 +66,7 @@ dependencies[] = xmlsitemap_node
 dependencies[] = xmlsitemap_taxonomy
 
 ; DOSOMETHING
+dependencies[] = dosomething_api
 dependencies[] = dosomething_action_guide
 dependencies[] = dosomething_campaign
 dependencies[] = dosomething_campaign_group


### PR DESCRIPTION
Refs #3285

Creates API endpoint for getting Reportback Files, which will be used in the new Reportback Gallery to dynamically load more Reportback Files as users scroll through the gallery.  Borrows heavily from built-in Services functions for paging and page size.

Also enables `dosomething_api` enterprise wide by making it a dependency in the DS profile.  This is because all Campaigns will require this endpoint for displaying this new gallery in the Prove It sections.

Will update the wiki once merged.

Example URLs:

```
http://dev.dosomething.org:8888/api/v1/reportback_files.json?parameters[nid]=362

http://dev.dosomething.org:8888/api/v1/reportback_files.json?parameters[nid]=362&page=10&pagesize=2
```
