### PR TITLE
Stripe form double bind

### DIFF
--- a/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
+++ b/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
@@ -132,6 +132,7 @@ function dosomething_payment_form($form, &$form_state, $config = array()) {
       'data-validate' => 'cvv',
       'data-validate-required' => '',
       'data-stripe' => 'cvc',
+      'autocomplete' => 'off',
     ),
   );
   $form['exp_month'] = array(
@@ -142,6 +143,7 @@ function dosomething_payment_form($form, &$form_state, $config = array()) {
       'data-validate' => 'exp_month',
       'data-validate-required' => '',
       'data-stripe' => 'exp-month',
+      'autocomplete' => 'off',
     ),
   );
   $form['exp_year'] = array(
@@ -152,6 +154,7 @@ function dosomething_payment_form($form, &$form_state, $config = array()) {
       'data-validate' => 'exp_year',
       'data-validate-required' => '',
       'data-stripe' => 'exp-year',
+      'autocomplete' => 'off',
     ),
   );
   $form['amount'] = array(

--- a/lib/themes/dosomething/paraneue_dosomething/js/StripeForm.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/StripeForm.js
@@ -30,10 +30,20 @@ define(function(require) {
       Stripe.setPublishableKey(this.publishKey);
 
       this.$form.on("submit", function (ev) {
-        Stripe.card.createToken(_this.$form, function (status, response) {
-          _this.onFormSubmit(status, response);
-        });
         ev.preventDefault();
+      });
+
+      // attach event listener to submit button to avoid double binding
+      this.$form.find(".form-submit").on("click", function () {
+        // Timeout needed so errors (if any) can render first
+        setTimeout(function () {
+          var isValid = _this.isValid();
+          if (isValid) {
+            Stripe.card.createToken(_this.$form, function (status, response) {
+              _this.onFormSubmit(status, response);
+            });
+          }
+        }, 100);
       });
     },
 
@@ -44,7 +54,6 @@ define(function(require) {
     */
     onFormSubmit: function (status, response) {
       var $form = this.$form;
-
       if (response.error) {
         // Show the errors on the form
         $form.find(".payment-errors").text(response.error.message);
@@ -54,6 +63,14 @@ define(function(require) {
         $form.find("input[name='token']").val(token);
         $form.get(0).submit();
       }
+    },
+
+    /**
+      * Checks for invalid form fields
+      * @returns {boolean} Whether form contains zero errors or not
+    */
+    isValid: function () {
+      return this.$form.find(".error").length === 0;
     }
   };
 


### PR DESCRIPTION
- Provides a workaround to prevent the form "submit" event to fire twice when creating a stripe token
- Disabled autocomplete on credit card fields
