### PR TITLE
Adds missing Campaigns container

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/taxonomy/taxonomy-term.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/taxonomy/taxonomy-term.tpl.php
@@ -42,7 +42,9 @@
   <?php endif; ?>
 
   <?php if (!empty($campaign_gallery)): ?>
-    <?php print $campaign_gallery; ?>
+    <section class="container container--campaigns">
+      <?php print $campaign_gallery; ?>
+    </section>
   <?php endif; ?>
 
   <section class="container additional-text">


### PR DESCRIPTION
Missed this in #3485, as the Taxonomy Term now uses the `gallery.tpl.php` instead of `campaign-gallery.tpl.php`.  I'm working on refactoring the theme layer to remove the `campaign-gallery.tpl.php` completely (need to update Campaign Group template next)
