### PR TITLE
Campaign Tile image: data-src-large attribute

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -225,14 +225,14 @@ function paraneue_get_gallery_item_content($nid, $source = NULL) {
     // Presets for the node's Cover Image display.
     $ratio = 'landscape';
     $default = '400x400';
-    $high_res = '768x768';
+    $large = '768x768';
     // Get the Cover Image node nid.
     $nid_image = $node->field_image_campaign_cover[LANGUAGE_NONE][0]['target_id'];
     // Get its high-res URL.
-    $high_res_url = dosomething_image_get_themed_image_url($nid_image, $ratio, $high_res);
+    $large_url = dosomething_image_get_themed_image_url($nid_image, $ratio, $large);
     // Set attributes to pass to the themed image.
     $attributes = array(
-      'data-src-large' => $high_res_url,
+      'data-src-large' => $large_url,
     );
     $image = dosomething_image_get_themed_image($nid_image, $ratio, $default, $node->title, $attributes);
   }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -214,16 +214,29 @@ function paraneue_dosomething_get_search_gallery($results) {
  *   The source query string to append to the link.
  */
 function paraneue_get_gallery_item_content($nid, $source = NULL) {
-  $size = '400x400';
   $node = node_load($nid);
   $link = drupal_get_path_alias('node/' . $nid);
   if ($source) {
     $link .= '?source=' . $source;
   }
+
+  // If the node has a Cover Image:
   if (!empty($node->field_image_campaign_cover)) {
+    // Presets for the node's Cover Image display.
+    $ratio = 'landscape';
+    $default = '400x400';
+    $high_res = '768x768';
+    // Get the Cover Image node nid.
     $nid_image = $node->field_image_campaign_cover[LANGUAGE_NONE][0]['target_id'];
-    $image = dosomething_image_get_themed_image($nid_image, 'landscape', $size, $node->title);
+    // Get its high-res URL.
+    $high_res_url = dosomething_image_get_themed_image_url($nid_image, $ratio, $high_res);
+    // Set attributes to pass to the themed image.
+    $attributes = array(
+      'data-src-large' => $high_res_url,
+    );
+    $image = dosomething_image_get_themed_image($nid_image, $ratio, $default, $node->title, $attributes);
   }
+
   return array(
     'link' => $link,
     'title' => $node->title,


### PR DESCRIPTION
Adds the `768x768` image URL as a `data-src-large` attribute to allow fenders to begin fix for #3267.

Note: This will only appear upon cache clear, as the DS Image cache will need to be truncated to see the new attributes.

Output:
![screen shot 2014-11-20 at 12 50 00 pm](https://cloud.githubusercontent.com/assets/1236811/5129897/6ed86b4c-70b4-11e4-8c71-21032fd1a983.png)
