### PR TITLE
Use mosaic gallery tpl for Campaign Group

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
@@ -25,29 +25,15 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
       ),
     );
 
-    // Initialize variable assuming Campaign Group is pre-launch state.
-    $pre_launch = TRUE;
-    $vars['campaign_gallery'] = NULL;
-    // If campaign have been added to this Campaign Group:
-    if (!empty($vars['node']->field_campaigns)) {
-      // Store the nids for rendering the Campaign gallery.
-      $nids = array();
-      foreach ($vars['node']->field_campaigns[LANGUAGE_NONE] as $delta => $value) {
-        $campaign = $value['entity'];
-        $nids[] = $campaign->nid;
-        // If the campaign is published:
-        if ($campaign->status) {
-          // The Campaign Group is not in pre-launch.
-          $pre_launch = FALSE;
-        }
-      }
-      $size = '400x400';
-      $source = 'node/' . $vars['node']->nid;
-      $campaign_gallery = dosomething_campaign_get_campaign_gallery($nids, $size, $source);
-      $vars['campaign_gallery']= $campaign_gallery;
-    }
+    // Determine Campaign Group attributes based on its children.
+    $campaign_group_data = dosomething_campaign_group_get_child_data($vars['node']);
 
-    if ($pre_launch) {
+    // Store child nid's to render within the theme.
+    $vars['campaigns'] = $campaign_group_data['nids'];
+
+    // If Campaign Group is in pre-launch state:
+    if ($campaign_group_data['pre_launch']) {
+      // Add relevant fields to set as template vars.
       $template_vars['text'][] = 'pre_launch_copy';
       $template_vars['text'][] = 'pre_launch_title';
     }
@@ -154,6 +140,34 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
     $vars['zendesk_form'] = drupal_get_form('dosomething_zendesk_form', $node);
 
   }
+}
+
+/**
+ * For a given campaign_group $node, get child nids and determine if pre_launch.
+ *
+ * @param object $node
+ *   Loaded campaign_group Node.
+ *
+ * @return array
+ */
+function dosomething_campaign_group_get_child_data($node) {
+  // Initalize return array.
+  $data = array(
+    'pre_launch' => TRUE,
+    'nids' => array(),
+  );
+  if (!empty($node->field_campaigns)) {
+    foreach ($node->field_campaigns[LANGUAGE_NONE] as $delta => $value) {
+      // Add the child nid to nid's array.
+      $data['nids'][] = $value['entity']->nid;
+      // If the node is published:
+      if ($value['entity']->status) {
+        // The Campaign Group node is not in pre-launch.
+        $data['pre_launch'] = FALSE;
+      }
+    }
+  }
+  return $data;
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -225,7 +225,7 @@ function paraneue_dosomething_get_node_gallery_item($nid, $source = NULL) {
   $title = $node->title;
   if ($node->status == 0) {
     $title = t('Stay Tuned');
-    $classes_array[] = 'unpublished';
+    $classes_array[] = '-unpublished';
   }
 
   // If the node has a Cover Image:

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -269,6 +269,9 @@ function paraneue_dosomething_get_campaign_gallery($nids, $source = NULL) {
     $item['classes_array'][] = 'tile--campaign';
     $items[] = paraneue_dosomething_get_gallery_item($item['content'], 'tile', TRUE, $item['classes_array']);
   }
-  $gallery_classes = array('-featured');
+  // If 5 items or more, the tiles should appear with a featured tile.
+  if (count($items) > 4) {
+    $gallery_classes = array('-featured');
+  }
   return paraneue_dosomething_get_gallery($items, 'mosaic', $gallery_classes);
 }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -223,7 +223,7 @@ function paraneue_get_gallery_item_content($nid, $source = NULL) {
   // If the node has a Cover Image:
   if (!empty($node->field_image_campaign_cover)) {
     // Presets for the node's Cover Image display.
-    $ratio = 'landscape';
+    $ratio = 'square';
     $default = '400x400';
     $large = '768x768';
     // Get the Cover Image node nid.

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -246,3 +246,15 @@ function paraneue_get_gallery_item_content($nid, $source = NULL) {
     'is_staff_pick' => $node->field_staff_pick[LANGUAGE_NONE][0]['value'],
   );
 }
+
+/**
+ * Returns a themed mosaic gallery with campaign tiles for given $nids.
+ */
+function paraneue_dosomething_get_campaign_gallery($nids, $source = NULL) {
+  $items = array();
+  foreach ($nids as $delta => $nid) {
+    $content = paraneue_get_gallery_item_content($nid, $source);
+    $items[] = paraneue_get_gallery_item($content, 'tile', TRUE, 'tile--campaign');
+  }
+  return paraneue_get_gallery($items, 'mosaic', '-featured');
+}

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -213,11 +213,19 @@ function paraneue_dosomething_get_search_gallery($results) {
  * @param string $source
  *   The source query string to append to the link.
  */
-function paraneue_get_gallery_item_content($nid, $source = NULL) {
+function paraneue_dosomething_get_gallery_item($nid, $source = NULL) {
+  $classes = '';
+
   $node = node_load($nid);
   $link = drupal_get_path_alias('node/' . $nid);
   if ($source) {
     $link .= '?source=' . $source;
+  }
+
+  $title = $node->title;
+  if ($node->status == 0) {
+    $title = t('Stay Tuned');
+    $classes = 'unpublished';
   }
 
   // If the node has a Cover Image:
@@ -237,13 +245,17 @@ function paraneue_get_gallery_item_content($nid, $source = NULL) {
     $image = dosomething_image_get_themed_image($nid_image, $ratio, $default, $node->title, $attributes);
   }
 
-  return array(
+  $content = array(
     'link' => $link,
-    'title' => $node->title,
+    'title' => $title,
     'tagline' => $node->field_call_to_action[LANGUAGE_NONE][0]['value'],
     'status' => $node->status,
     'image' => $image,
     'is_staff_pick' => $node->field_staff_pick[LANGUAGE_NONE][0]['value'],
+  );
+  return array(
+    'content' => $content,
+    'classes' => $classes,
   );
 }
 
@@ -253,8 +265,9 @@ function paraneue_get_gallery_item_content($nid, $source = NULL) {
 function paraneue_dosomething_get_campaign_gallery($nids, $source = NULL) {
   $items = array();
   foreach ($nids as $delta => $nid) {
-    $content = paraneue_get_gallery_item_content($nid, $source);
-    $items[] = paraneue_get_gallery_item($content, 'tile', TRUE, 'tile--campaign');
+    $item = paraneue_dosomething_get_gallery_item($nid, $source);
+    $item['classes'] .= ' tile--campaign';
+    $items[] = paraneue_get_gallery_item($item['content'], 'tile', TRUE, $item['classes']);
   }
   return paraneue_get_gallery($items, 'mosaic', '-featured');
 }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -213,8 +213,8 @@ function paraneue_dosomething_get_search_gallery($results) {
  * @param string $source
  *   The source query string to append to the link.
  */
-function paraneue_dosomething_get_gallery_item($nid, $source = NULL) {
-  $classes = '';
+function paraneue_dosomething_get_node_gallery_item($nid, $source = NULL) {
+  $classes_array = array();
 
   $node = node_load($nid);
   $link = drupal_get_path_alias('node/' . $nid);
@@ -225,7 +225,7 @@ function paraneue_dosomething_get_gallery_item($nid, $source = NULL) {
   $title = $node->title;
   if ($node->status == 0) {
     $title = t('Stay Tuned');
-    $classes = 'unpublished';
+    $classes_array[] = 'unpublished';
   }
 
   // If the node has a Cover Image:
@@ -255,7 +255,7 @@ function paraneue_dosomething_get_gallery_item($nid, $source = NULL) {
   );
   return array(
     'content' => $content,
-    'classes' => $classes,
+    'classes_array' => $classes_array,
   );
 }
 
@@ -265,9 +265,10 @@ function paraneue_dosomething_get_gallery_item($nid, $source = NULL) {
 function paraneue_dosomething_get_campaign_gallery($nids, $source = NULL) {
   $items = array();
   foreach ($nids as $delta => $nid) {
-    $item = paraneue_dosomething_get_gallery_item($nid, $source);
-    $item['classes'] .= ' tile--campaign';
-    $items[] = paraneue_get_gallery_item($item['content'], 'tile', TRUE, $item['classes']);
+    $item = paraneue_dosomething_get_node_gallery_item($nid, $source);
+    $item['classes_array'][] = 'tile--campaign';
+    $items[] = paraneue_dosomething_get_gallery_item($item['content'], 'tile', TRUE, $item['classes_array']);
   }
-  return paraneue_get_gallery($items, 'mosaic', '-featured');
+  $gallery_classes = array('-featured');
+  return paraneue_dosomething_get_gallery($items, 'mosaic', $gallery_classes);
 }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/patterns.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/patterns.inc
@@ -14,16 +14,16 @@
  *   - $content['impact']: Reportback impact (string).
  *   - $content['image']: Image markup to display (string).
  *   - $content['url']: Url to link to (string).
- *
  * @param string $type
  *   The pattern that the content should be themed by.
- *
  * @param boolean $use_default
  *   If the template should use a default image if it can't find one.
+ * @param array $classes_array
+ *   Array of classes to add to the gallery item template.
  *
  * @return string
  */
-function paraneue_get_gallery_item($content, $type = 'figure', $use_default = TRUE, $classes = NULL) {
+function paraneue_dosomething_get_gallery_item($content, $type = 'figure', $use_default = TRUE, $classes_array = array()) {
   // If no image is provided and we want to use a default, then set the default image here.
   if (empty($content['image']) && $use_default) {
     $content['image'] = "<img src='/" . path_to_theme() . "/bower_components/neue/dist/assets/images/apple-touch-icon-precomposed.png' />";
@@ -32,8 +32,8 @@ function paraneue_get_gallery_item($content, $type = 'figure', $use_default = TR
   $variables = array(
     'content' => $content,
   );
-  if (isset($classes)) {
-    $variables['classes'] = $classes;
+  if (isset($classes_array)) {
+    $variables['classes'] = implode(' ', $classes_array);
   }
 
   $tpl = 'paraneue_' . $type;
@@ -47,27 +47,30 @@ function paraneue_get_gallery_item($content, $type = 'figure', $use_default = TR
  *   An array of themed content to go into each <li>.
  * @param string $layout
  *   The type of gallery.
- * @param string $classes
- *   Any additional classes to append to the <ul> classes.
+ * @param array $classes_array
+ *   Any additional classes to add to the <ul>.
  *
  * @return string
  */
-function paraneue_get_gallery($content, $layout = 'triad', $classes = NULL) {
+function paraneue_dosomething_get_gallery($content, $layout = 'triad', $classes_array = NULL) {
   if (empty($content)) {
     return '';
   }
   $items = array();
   foreach ($content as $delta => $item) {
     $items[$delta]['content'] = $item;
+    // Get the class to apply to this <li>.
     $class = paraneue_dosomething_get_gallery_item_order_class($delta, $layout);
-    $items[$delta]['class'] = $class;
+    if ($class) {
+      $items[$delta]['class'] = $class;
+    }
   }
 
   // Prepare variables to send to gallery theme functions.
   $variables = array(
     'items' => $items,
     'layout' => $layout,
-    'classes' => $classes,
+    'classes' => implode(' ', $classes_array),
   );
   return theme('paraneue_gallery', $variables);
 }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -218,6 +218,7 @@ function paraneue_dosomething_preprocess_node(&$vars) {
       break;
 
     case "campaign_group":
+      paraneue_dosomething_preprocess_node_campaign_group($vars);
       paraneue_dosomething_preprocess_field_partners($vars);
       break;
 
@@ -362,6 +363,17 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
 }
 
 /**
+ * Preprocesses a Campaign Group node.
+ *
+ * @see paraneue_dosomething_preprocess_node().
+ */
+function paraneue_dosomething_preprocess_node_campaign_group(&$vars) {
+  // Source to append to Campaign Gallery links.
+  $source = 'node/' . $vars['nid'];
+  $vars['campaign_gallery'] = paraneue_dosomething_get_campaign_gallery($vars['campaigns'], $source);
+}
+
+/**
  * Sets a $campaign_scholarship variable based on $vars.
  *
  * @see paraneue_dosomething_preprocess_node().
@@ -445,15 +457,9 @@ function paraneue_dosomething_preprocess_field_partners(&$vars) {
  * Implements template_preprocess_taxonomy_term().
  */
 function paraneue_dosomething_preprocess_taxonomy_term(&$vars) {
-  // Get Campaign tiles.
-  $items = array();
-  // Source to append to Tile links.
+  // Source to append to Campaign Gallery links.
   $source = 'taxonomy/term/' . $vars['tid'];
-  foreach ($vars['campaigns'] as $delta => $nid) {
-    $content = paraneue_get_gallery_item_content($nid, $source);
-    $items[] = paraneue_get_gallery_item($content, 'tile', TRUE, 'tile--campaign');
-  }
-  $vars['campaign_gallery'] = paraneue_get_gallery($items, 'mosaic', '-featured');
+  $vars['campaign_gallery'] = paraneue_dosomething_get_campaign_gallery($vars['campaigns'], $source);
 
   // Adds sponsor logos.
   paraneue_dosomething_preprocess_field_partners($vars);

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -490,9 +490,9 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
         'image' => $image,
         'description' => $value['call_to_action'],
       );
-      $doing_items[$delta] = paraneue_get_gallery_item($item, 'figure');
+      $doing_items[$delta] = paraneue_dosomething_get_gallery_item($item, 'figure');
     }
-    $vars['doing_gallery'] = paraneue_get_gallery($doing_items, 'triad');
+    $vars['doing_gallery'] = paraneue_dosomething_get_gallery($doing_items, 'triad');
   }
 
   // Get an array of reportbacks.
@@ -506,11 +506,11 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
         'image' => $value->img,
         'impact' => $value->impact,
       );
-      $reportback_items[$delta] = paraneue_get_gallery_item($item, 'media');
+      $reportback_items[$delta] = paraneue_dosomething_get_gallery_item($item, 'media');
     }
   }
   // Theme a gallery of reportbacks, and give the user profile template access to it.
-  $vars['reportback_gallery'] = paraneue_get_gallery($reportback_items, 'duo');
+  $vars['reportback_gallery'] = paraneue_dosomething_get_gallery($reportback_items, 'duo');
 }
 
 /**
@@ -527,9 +527,9 @@ function paraneue_dosomething_preprocess_node_notfound(&$vars) {
         'image' => $image,
         'description' => $value['call_to_action'],
       );
-      array_push($gallery_items, paraneue_get_gallery_item($item, 'figure'));
+      array_push($gallery_items, paraneue_dosomething_get_gallery_item($item, 'figure'));
     }
-    $vars['campaign_results'] = paraneue_get_gallery($gallery_items, 'triad');
+    $vars['campaign_results'] = paraneue_dosomething_get_gallery($gallery_items, 'triad');
   }
   else if (isset($vars['raw_search_results'])){
     // Theme the set of results as duo gallery.

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/gallery.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/gallery.tpl.php
@@ -16,7 +16,7 @@
 <ul class="gallery -<?php print $layout; ?> <?php print $classes; ?>">
   <?php if (!empty($items)): ?>
     <?php foreach ($items as $item): ?>
-      <li class="<?php print $item['class']; ?>">
+      <li <?php if (!empty($item['class'])): print 'class="' . $item['class'] . '"'; endif; ?>>
         <?php print $item['content']; ?>
       </li>
     <?php endforeach; ?>


### PR DESCRIPTION
Refs #3474

Uses the `gallery.tpl.php` and `tile.tpl.php` functions for the Campaign Group gallery.

The only thing that's off here is that the`<li>` no longer have the "campaign" or "-published" / "-unpublished" classes.  I am adding the "-unpublished"  class into the `<article>` and not the `<li>`... as its way trickier to get it in the `<li>` .  

Need to look into this with @weerd to figure out whether or not we can use this approach instead of setting the class on the `<li>`

Example: What happens is the gray background is not applied since the "-unpublished" class doesn't live on the `<li>`.

![screen shot 2014-11-20 at 4 06 49 pm](https://cloud.githubusercontent.com/assets/1236811/5133023/8d0ff1aa-70cf-11e4-8fc6-0e766122113c.png)

Once this is approved and merged I will remove the `campaign-gallery.tpl.php` template and functions to close out #3474 and DRY
