### PR TITLE
Fixes paraneue namespace for search results

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -198,11 +198,11 @@ function paraneue_dosomething_get_search_gallery($results) {
   // Theme each result with the media pattern.
   if ($results_variables) {
     foreach ($results_variables as $delta => $value) {
-      $result_items[$delta] = paraneue_get_gallery_item($value, 'media', TRUE);
+      $result_items[$delta] = paraneue_dosomething_get_gallery_item($value, 'media', TRUE);
     }
   }
   // Theme the set of results as duo gallery.
-  return paraneue_get_gallery($result_items, 'duo');
+  return paraneue_dosomething_get_gallery($result_items, 'duo');
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/gallery.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/gallery.tpl.php
@@ -10,7 +10,7 @@
  *   - $item['class']: The class to apply to the li (string).
  *   - $item['content']: Themed item content (string).
  *
- * @see paraneue_get_gallery()
+ * @see paraneue_dosomething_get_gallery()
  */
 ?>
 <ul class="gallery -<?php print $layout; ?> <?php print $classes; ?>">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/media.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/media.tpl.php
@@ -11,7 +11,7 @@
  *    - $image: Thumbnail image.
  *    - $link: Link to the item.
  *
- * @see paraneue_get_gallery_item()
+ * @see paraneue_dosomething_get_gallery_item()
  */
 ?>
 <article class="media">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/tile.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/tile.tpl.php
@@ -13,7 +13,7 @@
  *    - $image: Rendered image (string).
  *    - $link: Link to the item.
  *
- * @see paraneue_get_gallery_item()
+ * @see paraneue_dosomething_get_gallery_item()
  */
 ?>
 


### PR DESCRIPTION
Missed these in https://github.com/aaronschachter/dosomething/commit/85deb888bcfa00d8e4df3e4d232d8ddd6297c8a9

Heads up @sbsmith86 that all theme functions should start with `paraneue_dosomething_[function]`
