### PR TITLE
Fixes non-working reportback cache clear

### DIFF
--- a/lib/modules/dosomething/dosomething_image/dosomething_image.module
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.module
@@ -185,6 +185,6 @@ function dosomething_image_cache_clear_all() {
 /**
  * Implements hook_flush_caches().
  */
-function dosomething_flush_caches() {
+function dosomething_image_flush_caches() {
   return array('cache_dosomething_image');
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -867,3 +867,11 @@ function dosomething_reportback_flag_flag($flag, $entity_id, $account, $flagging
 function dosomething_reportback_cache_clear_all() {
   cache_clear_all('*', 'cache_dosomething_reportback', TRUE);
 }
+
+
+/**
+ * Implements hook_flush_caches().
+ */
+function dosomething_reportback_flush_caches() {
+  return array('cache_dosomething_reportback');
+}


### PR DESCRIPTION
Found this bug while testing the Campaign Closed reportback gallery.
