### PR TITLE
Update to allow stepwise show more functionality.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/revealer/Revealer.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/revealer/Revealer.js
@@ -16,28 +16,40 @@ define(function(require) {
     this.$content   = $content;
     this.$button    = $("<button class=\"btn tertiary\">" + Drupal.t("Show More") + "</button>");
     this.category   = category;
+    this.steps      = {
+      // Array of step items to include with each button interaction.
+      items: [],
+
+      // Number of steps.
+      count: 0
+    };
 
     this.init();
   };
 
 
   Revealer.prototype.init = function () {
+    if (this.category === "gallery") {
+      this.prepGalleryItems();
+    }
+    else {
+      this.steps.items.push(this.$content);
+    }
+
+    this.steps.count = this.steps.items.length;
+
     this.detachContent();
     this.enableButton();
   };
 
 
   Revealer.prototype.detachContent = function () {
-    if (this.category === "gallery") {
-      this.$content = this.$content.slice(5);
-    }
-
     this.$content.detach();
   };
 
 
-  Revealer.prototype.reattachContent = function () {
-    this.$container.append(this.$content);
+  Revealer.prototype.reattachContent = function (content) {
+    this.$container.append(content);
   };
 
 
@@ -47,9 +59,35 @@ define(function(require) {
     var _this = this;
 
     this.$button.on("click", function () {
-      _this.reattachContent();
-      _this.$button.remove();
+
+      if (_this.steps.count > 0) {
+        _this.reattachContent(_this.steps.items.shift());
+        _this.steps.count--;
+      }
+
+      if (_this.steps.count === 0) {
+        _this.$button.remove();
+      }
+
     });
+  };
+
+
+  Revealer.prototype.prepGalleryItems = function () {
+    this.$content = this.$content.slice(5);
+    var collection = $.makeArray(this.$content);
+
+    // Multiple step reveals.
+    if (this.$content.length > 8) {
+      while (collection.length > 0) {
+        this.steps.items.push(collection.splice(0, 8));
+      }
+    }
+    else {
+      this.steps.items.push(collection);
+    }
+    
+    collection = null;
   };
 
 


### PR DESCRIPTION
Fully Resolves #3265

Fixes the Revealer so that if a mosaic gallery has more than 5 items, instead of revealing all after clicking the "Show More" button, it will reveal 2 rows at a time until it runs out of rows (wink wink @mikefantini).

@DFurnes 

CC: @barryclark @sbsmith86 
