### PR TITLE
Allow admins to create dummy reportbacks for Close Gallery

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -435,6 +435,9 @@ function dosomething_reportback_gallery_form_submit($form, &$form_state) {
     $flagging->field_image_description[LANGUAGE_NONE][0]['value'] = $item['caption'];
     flagging_save($flagging);
   }
+  // Update gallery cache.
+  // @todo Delete specific cache entry for this nid, not all.
+  dosomething_reportback_cache_clear_all();
   drupal_set_message(t("Gallery updated."));
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -660,7 +660,7 @@ function dosomething_reportback_get_gallery_item_ids($nid, $num_items = NULL) {
   // Set the flag fid to query for.
   $flag_id = $flag->fid;
 
-  $sql = "SELECT flagging_id, flagging.fid as 'flag_id', rbf.fid, rbf.rbid, file.uid, field_weight_value
+  $sql = "SELECT flagging_id, flagging.fid as 'flag_id', rbf.fid, rbf.rbid, rb.uid, field_weight_value
     FROM flagging
     JOIN dosomething_reportback_file rbf ON flagging.entity_id = rbf.fid
     JOIN dosomething_reportback rb ON rb.rbid = rbf.rbid

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -855,9 +855,9 @@ function dosomething_reportback_services_resources() {
  * Implements hook_flag_flag().
  */
 function dosomething_reportback_flag_flag($flag, $entity_id, $account, $flagging) {
-    if ($flag->name == 'promoted') {
-      dosomething_reportback_cache_clear_all();
-    }
+  if ($flag->name == 'promoted') {
+    dosomething_reportback_cache_clear_all();
+  }
 
 }
 


### PR DESCRIPTION
Closes #3514 

The `admin/users/reportbacks/add` form introduced in #3469 is working fine, however the SQL query which displays promoted Reportbacks was grabbing the User uid from the File, and not the Reportback.  This was causing the admin name to display instead of the user associated with the reportback.
