### PR TITLE
Dup search results bug

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -158,6 +158,7 @@ function paraneue_dosomething_get_search_vars($results) {
           'image' => $value['display_image'],
           'description' => $value['subtitle'],
         );
+        $result_variables[$delta] = $item;
         break;
       case 'static_content':
       case 'fact_page':
@@ -172,11 +173,11 @@ function paraneue_dosomething_get_search_vars($results) {
           'link' => $value['link'],
           'description' => $value['subtitle'],
         );
+        $result_variables[$delta] = $item;
       break;
       default:
         break;
     }
-    $result_variables[$delta] = $item;
   }
   return $result_variables;
 }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -176,6 +176,12 @@ function paraneue_dosomething_get_search_vars($results) {
         $result_variables[$delta] = $item;
       break;
       default:
+        $item = array(
+          'title' => $value['title'],
+          'link' => $value['link'],
+          'description' => $value['subtitle'],
+        );
+        $result_variables[$delta] = $item;
         break;
     }
   }


### PR DESCRIPTION
Fixes duplicate search results showing #3468 and fixing the `get_search_vars()` function so it sets default variables for anything that is not a campaign or fact page. @aaronschachter 
