### PR TITLE
Canada refactor sso client

### DIFF
--- a/lib/modules/dosomething/dosomething_canada/includes/CanadaSSOClient.php
+++ b/lib/modules/dosomething/dosomething_canada/includes/CanadaSSOClient.php
@@ -88,7 +88,7 @@ class CanadaSSOClient {
    * @param $password
    * @return array
    */
-  public function authenticate($email, $password)
+  public function login($email, $password)
   {
 
     $params = array(
@@ -111,18 +111,6 @@ class CanadaSSOClient {
   {
     $params = get_object_vars($user);
     $this->post(self::ENDPOINT_USERS, $params);
-    return $this->getUser();
-  }
-
-  /**
-   * If there was a successful authentication, this array will contain all
-   * the remote user data.
-   *
-   * @return array
-   * @throws Exception
-   */
-  public function getRemoteUser()
-  {
     return $this->getUser();
   }
 

--- a/lib/modules/dosomething/dosomething_canada/includes/CanadaSSOClient.php
+++ b/lib/modules/dosomething/dosomething_canada/includes/CanadaSSOClient.php
@@ -9,6 +9,28 @@
  */
 class CanadaSSOClient {
 
+  // ---------------------------------------------------------------------
+  // Class constants
+
+  // Login form settings.
+  const ENDPOINT_LOGIN = '/login';
+  const ENDPOINT_USERS = '/users';
+
+  // Login form fields.
+  const LOGIN_FIELD_AUTH_LOGIN    = 'email';
+  const LOGIN_FIELD_AUTH_PASSWORD = 'password';
+
+  // Post form settings.
+  const POST_CONTENT_TYPE  = 'application/x-www-form-urlencoded';
+  const POST_HEADER_ACCEPT = 'application/json';
+  const POST_USER_AGENT    = 'Drupal (+https://www.dosomething.org/)';
+
+  // Other.
+  const LOGGER_NAME   = 'CanadaSSOClient';
+
+  // ---------------------------------------------------------------------
+  // Instance variables
+
   /**
    * @var string Base URL of the SSO service.
    */
@@ -25,11 +47,6 @@ class CanadaSSOClient {
   private $ssoAppkey;
 
   /**
-   * @var array Authenticated user, if any.
-   */
-  private $user;
-
-  /**
    * SSO API version, for the base URL.
    *
    * @var string
@@ -37,19 +54,14 @@ class CanadaSSOClient {
   private $ssoVersion = '1';
 
   /**
-   * Base URI for authentication.
+   * Last response.
    *
    * @var string
    */
-  private $loginPath = '/login';
+  private $last;
 
-  /**
-   * Base URI for non-login user methods.
-   *
-   * @var string
-   */
-  private $userPath = '/users';
-
+  // ---------------------------------------------------------------------
+  // Constructor and factories
 
   /**
    * Constructor: requires URL, app ID, and app key for the SSO service.
@@ -65,38 +77,26 @@ class CanadaSSOClient {
     $this->ssoAppkey = $sso_appkey;
   }
 
+  // ---------------------------------------------------------------------
+  // Public: remote API calls
+
   /**
    * Submit to login endpoint. If successful, loads user data
    * into CanadaSSOClient::user.
    *
    * @param $email
    * @param $password
-   * @return bool
+   * @return array
    */
   public function authenticate($email, $password)
   {
 
-    if ($this->get($this->loginPath, array(
-      'email' => $email,
-      'password' => $password,
-    )))
-    {
-      return TRUE;
-    }
-
-    return FALSE;
-  }
-
-  /**
-   * If there was a successful authentication, this array will contain all
-   * the remote user data.
-   *
-   * @return array
-   * @throws Exception
-   */
-  public function getRemoteUser()
-  {
-    return $this->user;
+    $params = array(
+      self::LOGIN_FIELD_AUTH_LOGIN    => $email,
+      self::LOGIN_FIELD_AUTH_PASSWORD => $password,
+    );
+    $this->get(self::ENDPOINT_LOGIN, $params);
+    return $this->getUser();
   }
 
   /**
@@ -110,9 +110,24 @@ class CanadaSSOClient {
   public function propagateLocalUser($user)
   {
     $params = get_object_vars($user);
-
-    return $this->post($this->userPath, $params);
+    $this->post(self::ENDPOINT_USERS, $params);
+    return $this->getUser();
   }
+
+  /**
+   * If there was a successful authentication, this array will contain all
+   * the remote user data.
+   *
+   * @return array
+   * @throws Exception
+   */
+  public function getRemoteUser()
+  {
+    return $this->getUser();
+  }
+
+  // ---------------------------------------------------------------------
+  // Private: utilities
 
   /**
    * Construct base URL for all requests, including API version.
@@ -133,57 +148,39 @@ class CanadaSSOClient {
    * @throws Exception
    * @return bool
    */
-  private function execute($uri, $method='GET', $data)
+  private function execute($uri, $method = 'GET', $data)
   {
-    $headers = array(
-      'X-TiG-Application-Id: ' . $this->ssoAppid,
-      'X-TiG-REST-API-Key: '. $this->ssoAppkey,
-    );
+    // Reset last result.
+    $this->last = FALSE;
 
-    $url = $this->getBaseURL() . $uri;
-    $query = http_build_query($data);
+    // Prepare request options.
+    $data = http_build_query($data);
+    $url  = $this->getBaseURL() . $uri;
+    $options = $this->defaults(array('method' => $method));
 
-    if ('GET' == $method)
-    {
-      $url .= '?' . $query;
+    if ($method === 'POST') {
+      // Adjustments for POST.
+      $options['headers']['Content-Type'] = self::POST_CONTENT_TYPE;
+      $options['data'] = $data;
+    } else if ($method === 'GET') {
+      // Adjustments for GET.
+      $url .= '?' . $data;
     }
 
-    $curlOpts = array(
-      CURLOPT_RETURNTRANSFER => true,
-      CURLOPT_HEADER => true,
-      CURLOPT_HTTPHEADER => $headers,
-      CURLOPT_VERBOSE => true,
-    );
+    // Call the remote endpoint.
+    $response = drupal_http_request($url, $options);
 
-    if ('POST' == $method)
-    {
-      $curlOpts[CURLOPT_POST] = true;
-      $curlOpts[CURLOPT_POSTFIELDS] = $query;
+    // Evaluate results.
+    $success_codes = array(200, 201);
+    if (!$response->code || !in_array($response->code, $success_codes)) {
+      // An error occurred while executing the request.
+      // @todo: log expected errors.
+      self::log("Execution error for: %s", $response->error);
+      return FALSE;
     }
 
-    $ch = curl_init($url);
-    curl_setopt_array($ch, $curlOpts);
-
-    $response = curl_exec($ch);
-
-    $header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-    // $header = trim(substr($response, 0, $header_size));
-    $body = trim(substr($response, $header_size));
-
-    $responseObj = (empty($body)) ? null : json_decode($body);
-
-    if (is_object($responseObj))
-    {
-      if (!empty($responseObj->error))
-      {
-        throw new Exception(sprintf("Execution error for %s on %s: %s", $method, $url, $responseObj->error));
-      }
-
-      $this->user = $responseObj;
-      return true;
-    }
-
-    throw new Exception(sprintf("Can't understand response: %s", $response));
+    $this->last = $response;
+    return TRUE;
   }
 
 /**
@@ -209,4 +206,58 @@ class CanadaSSOClient {
   {
     return $this->execute($uri, 'POST', $data);
   }
+
+  /**
+   * Convenience method decode user recieved in the last request.
+   *
+   * @return array
+   *  The user decoded.
+   */
+  private function getUser()
+  {
+    if (!$this->last || empty($this->last->data)) {
+      return FALSE;
+    }
+
+    $user = json_decode($this->last->data);
+    if (!$user) {
+      return FALSE;
+    }
+
+    return $user;
+  }
+
+  /**
+   * Prepare request options based on the defaults.
+   *
+   * @param  array  $options
+   *   Request options to extend.
+   * @return array
+   *   The array of merged defaults and the options provided.
+   */
+  private function defaults($options = array())
+  {
+    $defaults = array(
+      'max_redirects' => 0,
+      'headers' => array(
+        'Accept'               => self::POST_HEADER_ACCEPT,
+        'User-Agent'           => self::POST_USER_AGENT,
+        'X-TiG-Application-Id' => $this->ssoAppid,
+        'X-TiG-REST-API-Key'   => $this->ssoAppkey,
+      ),
+    );
+    return array_replace_recursive($options, $defaults);
+  }
+
+  private static function log($message, $error)
+  {
+    $variables = array();
+    if (!empty($error)) {
+      $variables['%s'] = $error;
+    }
+    watchdog(self::LOGGER_NAME, $message, $variables, WATCHDOG_NOTICE);
+  }
+
+  // ---------------------------------------------------------------------
+
 }

--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
@@ -66,19 +66,31 @@ class DosomethingCanadaLoginController implements ExternalAuthLoginController {
     // Check whether remote account with requested email exists:
     $remote_account = $this->sso->login($this->email, $this->password);
     if (!$remote_account) {
-      // NOTE: By this point user already passed local authentication?
       // The only users that exist locally but not remotely should be admin
       // accounts that were created before SSO integration. These should be
       // created remotely as well.
-      $local_account = dosomething_canada_create_sso_user(
-        $this->email,
-        $this->password,
-        $this->local_account
-      );
-      $this->sso->propagateLocalUser($local_account);
+
+      // Make sure the user has provided the right password before
+      // creating the remote account.
+      require_once DRUPAL_ROOT . '/' . variable_get('password_inc', 'includes/password.inc');
+      if (!user_check_password($this->password, $this->local_account)) {
+        return FALSE;
+      }
+
+      if (dosomething_user_is_staff($this->local_account)) {
+        $local_account = dosomething_canada_create_sso_user(
+          $this->email,
+          $this->password,
+          $this->local_account
+        );
+        $remote_account = $this->sso->propagateLocalUser($local_account);
+      }
     }
-    $this->remote_account = $remote_account;
-    return TRUE;
+
+    if (!empty($this->remote_account)) {
+      $this->remote_account = $remote_account;
+    }
+    return !!$this->remote_account;
   }
 
   public function getRemoteUser() {

--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_login_controller.inc
@@ -43,9 +43,10 @@ class DosomethingCanadaLoginController implements ExternalAuthLoginController {
   // Public: interface implementation
 
   public function setup(Array $form, Array &$form_state) {
-    $this->email    = $form_state['values']['name'];
-    $this->password = $form_state['values']['pass'];
-    $this->local_account  = dosomething_user_get_user_by_email($this->email);
+    $this->email         = $form_state['values']['name'];
+    $this->password      = $form_state['values']['pass'];
+    $this->local_account = dosomething_user_get_user_by_email($this->email);
+    $this->sso           = dosomething_canada_get_sso();
     return $this;
   }
 
@@ -63,15 +64,9 @@ class DosomethingCanadaLoginController implements ExternalAuthLoginController {
   public function loginExistingUser() {
 
     // Check whether remote account with requested email exists:
-    try {
-      $this->sso = dosomething_canada_get_sso();
-
-      if ($this->sso->authenticate($this->email, $this->password)) {
-        $this->remote_account = $this->sso->getRemoteUser();
-      }
-    }
-    catch (Exception $e) {
-
+    $remote_account = $this->sso->login($this->email, $this->password);
+    if (!$remote_account) {
+      // NOTE: By this point user already passed local authentication?
       // The only users that exist locally but not remotely should be admin
       // accounts that were created before SSO integration. These should be
       // created remotely as well.
@@ -82,21 +77,14 @@ class DosomethingCanadaLoginController implements ExternalAuthLoginController {
       );
       $this->sso->propagateLocalUser($local_account);
     }
+    $this->remote_account = $remote_account;
     return TRUE;
   }
 
   public function getRemoteUser() {
-    $this->sso = dosomething_canada_get_sso();
-    try {
-      if ($this->sso->authenticate($this->email, $this->password)) {
-        $this->remote_account = $this->sso->getRemoteUser();
-      }
-    } catch (Exception $e) {
-      // Login failed.
-      return FALSE;
-    }
+    $this->remote_account = $this->sso->login($this->email, $this->password);
     return $this->remote_account;
-  }
+   }
 
   /**
    * Create new local user based on remote SSO user during login.

--- a/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_impersonator.inc
+++ b/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_sso_impersonator.inc
@@ -54,7 +54,6 @@ class DosomethingUkSsoImpersonator {
    */
   private $last;
 
-
   // ---------------------------------------------------------------------
   // Constructor and factories
 
@@ -230,7 +229,7 @@ class DosomethingUkSsoImpersonator {
       $session = array(self::SESSION_NAME => $this->session);
       $defaults['headers']['Cookie'] = http_build_query($session);
     }
-    return  array_replace_recursive($options, $defaults);
+    return array_replace_recursive($options, $defaults);
   }
 
   private function apiPath($path) {


### PR DESCRIPTION
#### What's this PR do?
- Fixes remote users creation for local admins
- Uses `drupal_http_request` instead of curl
- Moves corresponding object variables to class constants
- Replaces Exceptions with silent logging
- Deprecates `CanadaSSOClient->getRemoteUser()`
#### Testing

Canada integration tests are consistent with the change:
![screen shot 2014-11-24 at 10 51 48 pm](https://cloud.githubusercontent.com/assets/672669/5172916/b46bd7d6-742c-11e4-8385-474dd00a35b2.png)
