### PR TITLE
Restores and fixes `cancel-us-users` drush task

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.drush.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.drush.inc
@@ -51,8 +51,13 @@ function drush_dosomething_user_cancel_us_users() {
   $where = db_or()
   ->condition('r.rid', $staff_roles, 'not IN')
   // …or don't have any role assigned…
-  ->isNull('r.uid', NULL);
+  ->isNull('r.uid');
   $query->condition($where);
+
+  // …and has no content created…
+  $query->leftJoin('node', 'n', 'n.uid = u.uid');
+  $query->condition(db_and()->isNull('n.uid'));
+
   // …and not the anonymous.
   $query->condition('u.uid', 0, '<>');
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.drush.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.drush.inc
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ *  Implements hook_drush_command
+ */
+function dosomething_user_drush_command() {
+  $items = array(
+    'cancel-us-users' => array(
+      'description' => 'Removes US users from DS affiliates.',
+    ),
+  );
+  return $items;
+}
+
+/**
+ * Callback for cancel-us-users command.
+ *
+ * Removes US users from DS affiliates.
+ */
+function drush_dosomething_user_cancel_us_users() {
+  if (!dosomething_settings_is_affiliate()) {
+    return t("Available only on affiliates.");
+  }
+  $lock = variable_get('dosomething_user_cancel_us_users_lock', FALSE);
+  if ($lock) {
+    return t("Waiting for previous operation to complete.");
+  }
+  variable_set('dosomething_user_cancel_us_users_lock', TRUE);
+
+  $sandbox = variable_get('dosomething_user_cancel_us_users_sandbox');
+
+  // Find users…
+  $query = db_select('users', 'u')->fields('u', array('uid'));
+
+  // …registered before the international release (2014-09-03 23:00:00 UTC)…
+  $date = new DateTime('2014-09-03T23:00:00Z');
+  $where = db_or()
+  ->condition(
+    'u.created',
+    $date->getTimestamp(),
+    '<'
+  );
+  $query->condition($where);
+
+  // …and not staff…
+  $staff_roles = array(
+    user_role_load_by_name('administrator')->rid,
+    user_role_load_by_name('editor')->rid,
+  );
+  $query->leftJoin('users_roles', 'r', 'r.uid = u.uid');
+  $where = db_or()
+  ->condition('r.rid', $staff_roles, 'not IN')
+  // …or don't have any role assigned…
+  ->isNull('r.uid', NULL);
+  $query->condition($where);
+  // …and not the anonymous.
+  $query->condition('u.uid', 0, '<>');
+
+  // Load sandbox data.
+  $sandbox = variable_get('dosomething_user_cancel_us_users_sandbox');
+  if (!isset($sandbox['total'])) {
+    $sandbox['current'] = 0;
+    $sandbox['total'] = $query->countQuery()->execute()->fetchField();
+  }
+
+  if (!$sandbox['total']) {
+    variable_del('dosomething_user_cancel_us_users_lock');
+    return t("User cleansing has finished.");
+  }
+
+  // There are more than on and a half million users, we better keep it easy.
+  $batch_size = 1000;
+  $users = $query->range(0, $batch_size)->execute()->fetchAllKeyed(0, 0);
+  $count = count($users);
+
+  // Delete a batch of users.
+  if ($count > 0) {
+    user_delete_multiple(array_keys($users));
+  }
+
+  // Track progress.
+  $sandbox['current'] += $count;
+
+  // Sandbox #finished must be 1 when batch is finished.
+  $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+
+  // Set status message on success.
+  if ($sandbox['#finished'] === 1) {
+    variable_del('dosomething_user_cancel_us_users_lock');
+    variable_del('dosomething_user_cancel_us_users_sandbox');
+    return t('Canceled !total user accounts.',
+             array('!total' => $sandbox['total']));
+  }
+
+  // Save the sandbox.
+  variable_set('dosomething_user_cancel_us_users_lock', FALSE);
+  variable_set('dosomething_user_cancel_us_users_sandbox', $sandbox);
+  return t('Canceled !current of !total user accounts.',
+           array('!current' => $sandbox['current'],
+                 '!total'   => $sandbox['total']));
+}


### PR DESCRIPTION
#### What's this PR do?
- Restores `cancel-us-users` from 6954a14
- Adds a condition to skip users with any node content create: 1fdc063
#### Testing

Node count in `2014-11-20-185511.uk.sql.gz`:
 ![screen shot 2014-11-25 at 8 56 12 pm](https://cloud.githubusercontent.com/assets/672669/5189991/c65f52d8-74ea-11e4-8614-3644119cf888.png)

After running the original script on only **10** users it removed `886` nodes out of `1138`:
![screen shot 2014-11-25 at 9 10 06 pm copy](https://cloud.githubusercontent.com/assets/672669/5190002/dac230ce-74ea-11e4-8553-6f5d063a6cce.png)

After running the modified script run **1000** users it's still `1138` nodes:
![screen shot 2014-11-25 at 9 29 48 pm](https://cloud.githubusercontent.com/assets/672669/5190029/014b0dc4-74eb-11e4-9375-600e632ba698.png)
12 users were not deleted compared to the original script.
#### What are the relevant tickets?

A part of #3552
