### PR TITLE
Adds Markdown support to Transactional Email copy for Campaign Group

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
@@ -1365,7 +1365,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Transactional Email Copy',
     'required' => 0,
     'settings' => array(
-      'text_processing' => 0,
+      'text_processing' => 1,
       'user_register_form' => FALSE,
     ),
     'widget' => array(

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.info
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.info
@@ -83,3 +83,4 @@ features[variable][] = node_options_campaign_group
 features[variable][] = node_preview_campaign_group
 features[variable][] = node_submitted_campaign_group
 features[variable][] = pathauto_node_campaign_group_pattern
+mtime = 1416603771

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -60,7 +60,8 @@ function dosomething_mbp_request($origin, $params = NULL) {
   }
   $payload = dosomething_mbp_get_transactional_payload($origin, $params);
   if (variable_get('dosomething_mbp_log')) {
-    watchdog('dosomething_mbp', json_encode($payload));
+    watchdog('dosomething_mbp', $production . " params: " . json_encode($params));
+    watchdog('dosomething_mbp', "Payload: " . json_encode($payload));
   }
 
   try {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -527,8 +527,8 @@ function dosomething_signup_get_mbp_params_campaign(&$params, $node) {
 function dosomething_signup_get_mbp_params_campaign_group(&$params, $node) {
   if ($node->type == 'campaign_group') {
     $copy = '';
-    if (isset($node->field_transactional_email_copy [LANGUAGE_NONE][0]['safe_value'])) {
-      $copy = $node->field_transactional_email_copy [LANGUAGE_NONE][0]['safe_value'];
+    if (isset($node->field_transactional_email_copy[LANGUAGE_NONE][0]['safe_value'])) {
+      $copy = $node->field_transactional_email_copy[LANGUAGE_NONE][0]['safe_value'];
     }
     $params['transactional_email_copy'] = $copy;
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -526,8 +526,11 @@ function dosomething_signup_get_mbp_params_campaign(&$params, $node) {
  */
 function dosomething_signup_get_mbp_params_campaign_group(&$params, $node) {
   if ($node->type == 'campaign_group') {
-    $wrapper = entity_metadata_wrapper('node', $node);
-    $params['transactional_email_copy'] = nl2br($wrapper->field_transactional_email_copy->value());
+    $copy = '';
+    if (isset($node->field_transactional_email_copy [LANGUAGE_NONE][0]['safe_value'])) {
+      $copy = $node->field_transactional_email_copy [LANGUAGE_NONE][0]['safe_value'];
+    }
+    $params['transactional_email_copy'] = $copy;
   }
 }
 


### PR DESCRIPTION
Sample input:

```
Hi I am just a robot

- hello world
- right back at ya

OK me neither [Hi there](http://www.dosomething.org/campaigns)
```

Resulting email:
![screen shot 2014-11-25 at 4 32 56 pm](https://cloud.githubusercontent.com/assets/1236811/5191967/07280186-74c1-11e4-85e0-27d8fae3d7ff.png)
