### PR TITLE
Stringoverrides

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -110,10 +110,6 @@ if (is_readable('sites/default/settings.'. $environment .'.php')) {
   include_once('sites/default/settings.'. $environment .'.php');
 }
 
-$conf['locale_custom_strings_en'][''] = array(
-   'Registration successful. You are now logged in.' => "You've created an account with DoSomething.org."
- );
-
 $conf['optimizely_id'] = '747623297';
 
 $conf['dosomething_is_affiliate'] = FALSE;

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -47,6 +47,7 @@ dependencies[] = redirect
 dependencies[] = redis
 dependencies[] = search
 dependencies[] = services
+dependencies[] = stringoverrides
 dependencies[] = strongarm
 dependencies[] = taxonomy_access_fix
 dependencies[] = uuid

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -151,6 +151,10 @@ projects[services][subdir] = "contrib"
 ; See https://www.drupal.org/node/2200269, https://github.com/DoSomething/dosomething/issues/3311
 projects[services][patch][] = "https://www.drupal.org/files/issues/services-2200269.patch"
 
+; String Overrides
+projects[stringoverrides][version] = "1.8"
+projects[stringoverrides][subdir] = "contrib"
+
 ; Strongarm
 projects[strongarm][version] = "2.0"
 projects[strongarm][subdir] = "contrib"


### PR DESCRIPTION
Makes everything in the world translatable via `admin/config/regional/stringoverrides`.

Here's the catch.  I can't save records here with the `$conf['locale_custom_strings_en']['']` setting in settings.php.  Removing it makes things work, but it means we have to manually add the string back in after deployment.  @sergii-tkachenko Anything I'm missing or does that seem right?

Also allows for easy Canadian translation to allow an admin use UI to fix #3545 and #3183.  

![screen shot 2014-11-25 at 5 37 32 pm](https://cloud.githubusercontent.com/assets/1236811/5193056/0dfc8b76-74cb-11e4-8f63-1ecf2ff2bdff.png)
