### PR TITLE
Reportback File status

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -19,6 +19,90 @@ function dosomething_reportback_admin_config_form($form, &$form_state) {
   return system_settings_form($form);
 }
 
+function dosomething_reportback_get_file_status_options() {
+  return array(
+    'approved' => 'Approve',
+    'promoted' => 'Promote',
+    'ignored' => 'Ignore',
+    'flagged' => 'Flag',
+  );
+}
+
+/**
+ * Form to review Reportback Files.
+ */
+function dosomething_reportback_files_form() {
+  // Identify that the elements in 'gallery_items' are a collection, to
+  // prevent Form API from flattening the array when submitted.
+  $form['rb_files']['#tree'] = TRUE;
+  $options = dosomething_reportback_get_file_status_options();
+
+  $result = dosomething_reportback_get_gallery_results();
+  foreach ($result as $record) {
+    $preview = dosomething_reportback_file_preview($record);
+    $form['rb_files'][$record->fid] = array(
+      'preview' => array(
+        '#markup' => $preview,
+      ),
+      'date' => array(
+        '#markup' => format_date($record->updated, 'short'),
+      ),
+      'quantity' => array(
+        '#markup' => $record->quantity,
+      ),
+      'node' => array(
+        '#markup' => $record->title,
+      ),
+      'status' => array(
+        '#type' => 'radios',
+        '#required' => TRUE,
+        '#options' => $options,
+      ),
+    );
+  }
+  $form['actions'] = array('#type' => 'actions');
+  $form['actions']['submit'] = array(
+    '#type' => 'submit', 
+    '#value' => t('Save')
+  );
+  return $form;
+}
+
+function theme_dosomething_reportback_files_form($variables) {
+  $form = $variables['form'];
+  $rb_files = element_children($form['rb_files']);
+
+  // If no results, just return form.
+  if (empty($rb_files)) {
+    return t("No results found.");
+  }
+
+  // Initialize the variable which will store our table rows.
+  $rows = array();
+  foreach ($rb_files as $id) {
+    $rows[] = array(
+      'data' => array(
+        // Add the columns defined in the form.
+        drupal_render($form['rb_files'][$id]['date']),
+        drupal_render($form['rb_files'][$id]['preview']),
+        drupal_render($form['rb_files'][$id]['quantity']),
+        drupal_render($form['rb_files'][$id]['status']),
+        drupal_render($form['rb_files'][$id]['node']),
+      ),
+    );
+  }
+  $header = array(t('Submitted'), NULL, t('Quantity'), t('Op'), t('Campaign'));
+  // We can render our tabledrag table for output.
+  $output = theme('table', array(
+    'header' => $header,
+    'rows' => $rows,
+  ));
+  // And then render any remaining form elements (such as our submit button).
+  $output .= drupal_render_children($form);
+  return $output;
+}
+
+
 /**
  * Page callback for Admin Gallery table.
  */
@@ -56,6 +140,9 @@ function dosomething_reportback_admin_gallery_page() {
   ));
 }
 
-function dosomething_reportback_admin_gallery_row_form() {
-
+function dosomething_reportback_file_preview($record) {
+  $img = dosomething_image_get_themed_image_by_fid($record->fid, '300x300');
+  $info = $img . '<p><strong>' . $record->caption . '</strong></p>';
+  $info .= '<hr />' . $record->why_participated;
+  return $info;
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -19,15 +19,6 @@ function dosomething_reportback_admin_config_form($form, &$form_state) {
   return system_settings_form($form);
 }
 
-function dosomething_reportback_get_file_status_options() {
-  return array(
-    'approved' => 'Approved',
-    'promoted' => 'Promoted',
-    'excluded' => 'Excluded',
-    'flagged' => 'Flagged',
-  );
-}
-
 /**
  * Form to review Reportback Files.
  */
@@ -63,6 +54,7 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL) 
         '#title' => t('Status'),
         '#required' => TRUE,
         '#options' => $options,
+        '#default_value' => $record->status,
       ),
     );
   }
@@ -107,7 +99,13 @@ function theme_dosomething_reportback_files_form($variables) {
       ),
     );
   }
-  $header = array(t('Submitted'), NULL, t('Quantity'), t('Op'), t('Campaign'));
+  $header = array(
+    t('Submitted'),
+    NULL,
+    t('Quantity'),
+    t('Campaign'),
+    t('Op'),
+  );
   // We can render our tabledrag table for output.
   $output = theme('table', array(
     'header' => $header,
@@ -116,44 +114,6 @@ function theme_dosomething_reportback_files_form($variables) {
   // And then render any remaining form elements (such as our submit button).
   $output .= drupal_render_children($form);
   return $output;
-}
-
-
-/**
- * Page callback for Admin Gallery table.
- */
-function dosomething_reportback_admin_gallery_page() {
-  $header = array(
-    t('Submitted'),
-    NULL,
-    t('Quantity'),
-    t('Email'),
-    t('Campaign'),
-  );
-
-  $result = dosomething_reportback_get_gallery_results();
-  $rows = array();
-
-  foreach ($result as $record) {
-    $img = dosomething_image_get_themed_image_by_fid($record->fid, '300x300');
-    $info = $img . '<p><strong>' . $record->caption . '</strong></p>';
-    $info .= '<hr />' . $record->why_participated;
-    $date = format_date($record->updated, 'short');
-
-    $rows[] = array(
-      l($date, 'reportback/' . $record->rbid),
-      $info,
-      $record->quantity,
-      l($record->mail, 'user/'. $record->uid),
-      l($record->title, 'node/'. $record->nid),
-    );
-
-  }
-
-  return theme('table', array(
-    'header' => $header,
-    'rows' => $rows,
-  ));
 }
 
 function dosomething_reportback_file_preview($record) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -21,10 +21,10 @@ function dosomething_reportback_admin_config_form($form, &$form_state) {
 
 function dosomething_reportback_get_file_status_options() {
   return array(
-    'approved' => 'Approve',
-    'promoted' => 'Promote',
-    'ignored' => 'Ignore',
-    'flagged' => 'Flag',
+    'approved' => 'Approved',
+    'promoted' => 'Promoted',
+    'excluded' => 'Excluded',
+    'flagged' => 'Flagged',
   );
 }
 
@@ -55,6 +55,7 @@ function dosomething_reportback_files_form() {
       ),
       'status' => array(
         '#type' => 'radios',
+        '#title' => t('Status'),
         '#required' => TRUE,
         '#options' => $options,
       ),
@@ -86,8 +87,8 @@ function theme_dosomething_reportback_files_form($variables) {
         drupal_render($form['rb_files'][$id]['date']),
         drupal_render($form['rb_files'][$id]['preview']),
         drupal_render($form['rb_files'][$id]['quantity']),
-        drupal_render($form['rb_files'][$id]['status']),
         drupal_render($form['rb_files'][$id]['node']),
+        drupal_render($form['rb_files'][$id]['status']),
       ),
     );
   }
@@ -143,6 +144,7 @@ function dosomething_reportback_admin_gallery_page() {
 function dosomething_reportback_file_preview($record) {
   $img = dosomething_image_get_themed_image_by_fid($record->fid, '300x300');
   $info = $img . '<p><strong>' . $record->caption . '</strong></p>';
+  $info .= l($record->mail, 'user/' . $record->uid);
   $info .= '<hr />' . $record->why_participated;
   return $info;
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -18,3 +18,44 @@ function dosomething_reportback_admin_config_form($form, &$form_state) {
   );
   return system_settings_form($form);
 }
+
+/**
+ * Page callback for Admin Gallery table.
+ */
+function dosomething_reportback_admin_gallery_page() {
+  $header = array(
+    t('Submitted'),
+    NULL,
+    t('Quantity'),
+    t('Email'),
+    t('Campaign'),
+  );
+
+  $result = dosomething_reportback_get_gallery_results();
+  $rows = array();
+
+  foreach ($result as $record) {
+    $img = dosomething_image_get_themed_image_by_fid($record->fid, '300x300');
+    $info = $img . '<p><strong>' . $record->caption . '</strong></p>';
+    $info .= '<hr />' . $record->why_participated;
+    $date = format_date($record->updated, 'short');
+
+    $rows[] = array(
+      l($date, 'reportback/' . $record->rbid),
+      $info,
+      $record->quantity,
+      l($record->mail, 'user/'. $record->uid),
+      l($record->title, 'node/'. $record->nid),
+    );
+
+  }
+
+  return theme('table', array(
+    'header' => $header,
+    'rows' => $rows,
+  ));
+}
+
+function dosomething_reportback_admin_gallery_row_form() {
+
+}

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -31,27 +31,32 @@ function dosomething_reportback_get_file_status_options() {
 /**
  * Form to review Reportback Files.
  */
-function dosomething_reportback_files_form() {
+function dosomething_reportback_files_form($form, &$form_state, $status = NULL) {
   // Identify that the elements in 'gallery_items' are a collection, to
   // prevent Form API from flattening the array when submitted.
   $form['rb_files']['#tree'] = TRUE;
   $options = dosomething_reportback_get_file_status_options();
 
-  $result = dosomething_reportback_get_gallery_results();
+  $result = dosomething_reportback_get_gallery_results($status);
   foreach ($result as $record) {
     $preview = dosomething_reportback_file_preview($record);
+    $rb_path = 'reportback/' . $record->rbid;
     $form['rb_files'][$record->fid] = array(
       'preview' => array(
         '#markup' => $preview,
       ),
       'date' => array(
-        '#markup' => format_date($record->updated, 'short'),
+        '#markup' => l(format_date($record->updated, 'short'), $rb_path),
       ),
       'quantity' => array(
         '#markup' => $record->quantity,
       ),
       'node' => array(
         '#markup' => $record->title,
+      ),
+      'fid' => array(
+        '#type' => 'hidden',
+        '#value' => $record->fid,
       ),
       'status' => array(
         '#type' => 'radios',
@@ -67,6 +72,16 @@ function dosomething_reportback_files_form() {
     '#value' => t('Save')
   );
   return $form;
+}
+
+function dosomething_reportback_files_form_submit($form, &$form_state) {
+  foreach ($form_state['values']['rb_files'] as $id => $item) {
+    $status = dosomething_reportback_update_reportback_file_status($item['fid'], $item['status']);
+    if (!$status) {
+      form_set_error(t("An error has occurred."));
+    }
+  }
+  drupal_set_message(t("Updated."));
 }
 
 function theme_dosomething_reportback_files_form($variables) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -20,7 +20,10 @@ function dosomething_reportback_admin_config_form($form, &$form_state) {
 }
 
 /**
- * Form to review Reportback Files.
+ * Form to set the status of Reportback Files.
+ *
+ * @param string $status
+ *   (optional) The Reportback File status to filter by.
  */
 function dosomething_reportback_files_form($form, &$form_state, $status = NULL) {
   // Identify that the elements in 'gallery_items' are a collection, to
@@ -66,6 +69,9 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL) 
   return $form;
 }
 
+/**
+ * Form submit callback for dosomething_reportback_files_form_submit.
+ */
 function dosomething_reportback_files_form_submit($form, &$form_state) {
   foreach ($form_state['values']['rb_files'] as $id => $item) {
     $status = dosomething_reportback_update_reportback_file_status($item['fid'], $item['status']);
@@ -76,6 +82,9 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
   drupal_set_message(t("Updated."));
 }
 
+/**
+ * Themes the dosomething_reportback_files_form constructor.
+ */
 function theme_dosomething_reportback_files_form($variables) {
   $form = $variables['form'];
   $rb_files = element_children($form['rb_files']);
@@ -116,6 +125,11 @@ function theme_dosomething_reportback_files_form($variables) {
   return $output;
 }
 
+/**
+ * Returns markup for a Reportback File preview.
+ *
+ * @todo Move this into a tpl file.
+ */
 function dosomething_reportback_file_preview($record) {
   $img = dosomething_image_get_themed_image_by_fid($record->fid, '300x300');
   $info = $img . '<p><strong>' . $record->caption . '</strong></p>';

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -26,7 +26,7 @@ function dosomething_reportback_admin_config_form($form, &$form_state) {
  *   (optional) The Reportback File status to filter by.
  */
 function dosomething_reportback_files_form($form, &$form_state, $status = NULL) {
-  // Identify that the elements in 'gallery_items' are a collection, to
+  // Identify that the elements in 'rb_files' are a collection, to
   // prevent Form API from flattening the array when submitted.
   $form['rb_files']['#tree'] = TRUE;
   $options = dosomething_reportback_get_file_status_options();
@@ -73,7 +73,11 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL) 
  * Form submit callback for dosomething_reportback_files_form_submit.
  */
 function dosomething_reportback_files_form_submit($form, &$form_state) {
-  foreach ($form_state['values']['rb_files'] as $id => $item) {
+  $rb_files = $form_state['values']['rb_files'];
+  if (empty($rb_files) || !is_array($rb_files)) {
+    return;
+  }
+  foreach ($rb_files as $id => $item) {
     $status = dosomething_reportback_update_reportback_file_status($item['fid'], $item['status']);
     if (!$status) {
       form_set_error(t("An error has occurred."));
@@ -132,8 +136,8 @@ function theme_dosomething_reportback_files_form($variables) {
  */
 function dosomething_reportback_file_preview($record) {
   $img = dosomething_image_get_themed_image_by_fid($record->fid, '300x300');
-  $info = $img . '<p><strong>' . $record->caption . '</strong></p>';
+  $info = $img . '<p><strong>' . check_plain($record->caption) . '</strong></p>';
   $info .= l($record->mail, 'user/' . $record->uid);
-  $info .= '<hr />' . $record->why_participated;
+  $info .= '<hr />' . check_plain($record->why_participated);
   return $info;
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -362,4 +362,9 @@ function dosomething_reportback_update_7014(&$sandbox) {
   if (!db_index_exists($tbl_name, $fld_name)) {
     db_add_index($tbl_name, $fld_name, array($fld_name));
   }
+  // Add index for fid column.
+  $fld_name = 'fid';
+  if (!db_index_exists($tbl_name, $fld_name)) {
+    db_add_index($tbl_name, $fld_name, array($fld_name));
+  }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -179,6 +179,13 @@ function dosomething_reportback_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'status' => array(
+        'description' => 'The reportback file status.',
+        'type' => 'varchar',
+        'length' => 16,
+        'not null' => FALSE,
+        'default' => 'pending',
+      ),
     ),
     'primary key' => array('rbid', 'fid'),
   );
@@ -338,5 +345,21 @@ function dosomething_reportback_update_7013(&$sandbox) {
       // Add it per the schema field definition.
       db_add_field($tbl_name, $fld_name, $schema[$tbl_name]['fields'][$fld_name]);
     }
+  }
+}
+
+/**
+ * Adds new status column to the dosomething_reportback_file table.
+ */
+function dosomething_reportback_update_7014(&$sandbox) {
+  $tbl_name = 'dosomething_reportback_file';
+  $fld_name = 'status';
+  $schema = dosomething_reportback_schema();
+  if (!db_field_exists($tbl_name, $fld_name)) {
+    // Add it per the schema field definition.
+    db_add_field($tbl_name, $fld_name, $schema[$tbl_name]['fields'][$fld_name]);
+  }
+  if (!db_index_exists($tbl_name, $fld_name)) {
+    db_add_index($tbl_name, $fld_name, array($fld_name));
   }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -918,6 +918,13 @@ function dosomething_reportback_flush_caches() {
  * Returns Reportback Gallery data.
  */
 function dosomething_reportback_get_gallery_results($status = NULL) {
+  $limit = 25;
+  if (isset($_GET['pagesize'])) {
+    $limit = $_GET['pagesize'];
+    if (!is_numeric($limit) || $limit > 100) {
+      $limit = 25;
+    }
+  }
   $query = db_select('dosomething_reportback_file', 'rbf');
   $query->join('dosomething_reportback', 'rb', 'rb.rbid = rbf.rbid');
   $query->join('users', 'u', 'rb.uid = u.uid');
@@ -930,7 +937,7 @@ function dosomething_reportback_get_gallery_results($status = NULL) {
   $query->fields('u', array('uid', 'mail'));
   $query->fields('n', array('nid', 'title'));
   $query->orderBy('rb.updated', 'DESC');
-  $query->range(0,25);
+  $query->range(0,$limit);
   $result = $query->execute()->fetchAll();
   return $result;
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -937,7 +937,7 @@ function dosomething_reportback_get_gallery_results($status = NULL) {
   $query->fields('u', array('uid', 'mail'));
   $query->fields('n', array('nid', 'title'));
   $query->orderBy('rb.updated', 'DESC');
-  $query->range(0,$limit);
+  $query->range(0, $limit);
   $result = $query->execute()->fetchAll();
   return $result;
 }
@@ -946,12 +946,17 @@ function dosomething_reportback_get_gallery_results($status = NULL) {
  * Returns list of valid options a Reportback File can be set to.
  */
 function dosomething_reportback_get_file_status_options() {
-  return array(
-    'approved' => 'Approved',
-    'promoted' => 'Promoted',
-    'excluded' => 'Excluded',
-    'flagged' => 'Flagged',
+  $keys = array(
+    'approved',
+    'promoted',
+    'excluded',
+    'flagged',
   );
+  $options = array();
+  foreach ($keys as $name) {
+    $options[$name] = t(ucfirst($name));
+  }
+  return $options;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -116,13 +116,20 @@ function dosomething_reportback_menu() {
     'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('view', 1),
   );
-
-  $items['admin/users/reportbacks/inbox'] = array(
+  $items['admin/users/rb'] = array(
+    'title' => 'Reportbacks',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_reportback_files_form', 'pending'),
+    'access callback' => 'user_access',
+    'access arguments' => array('administer modules'),
+    'file' => 'dosomething_reportback.admin.inc',
+  );
+  $items['admin/users/rb/inbox'] = array(
     'title' => 'Inbox',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_reportback_files_form', 'pending'),
-    'access callback' => 'dosomething_reportback_access',
-    'access arguments' => array('edit', 1),
+    'access callback' => 'user_access',
+    'access arguments' => array('administer modules'),
     'file' => 'dosomething_reportback.admin.inc',
     'type' => MENU_DEFAULT_LOCAL_TASK,
     'weight' => 10,
@@ -131,12 +138,12 @@ function dosomething_reportback_menu() {
   $status_options = dosomething_reportback_get_file_status_options();
   $weight = 20;
   foreach ($status_options as $status => $title) {
-    $items['admin/users/reportbacks/' . $status] = array(
+    $items['admin/users/rb/' . $status] = array(
       'title' => $title,
       'page callback' => 'drupal_get_form',
       'page arguments' => array('dosomething_reportback_files_form', $status),
-      'access callback' => 'dosomething_reportback_access',
-      'access arguments' => array('edit', 1),
+      'access callback' => 'user_access',
+      'access arguments' => array('administer modules'),
       'file' => 'dosomething_reportback.admin.inc',
       'type' => MENU_LOCAL_TASK,
       'weight' => $weight,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -116,6 +116,7 @@ function dosomething_reportback_menu() {
     'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('view', 1),
   );
+
   $items['admin/users/reportbacks/inbox'] = array(
     'title' => 'Inbox',
     'page callback' => 'drupal_get_form',
@@ -123,15 +124,33 @@ function dosomething_reportback_menu() {
     'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('edit', 1),
     'file' => 'dosomething_reportback.admin.inc',
+    'type' => MENU_DEFAULT_LOCAL_TASK,
+    'weight' => 10,
   );
+  // Loop through status options.
+  $status_options = dosomething_reportback_get_file_status_options();
+  $weight = 20;
+  foreach ($status_options as $status => $title) {
+    $items['admin/users/reportbacks/' . $status] = array(
+      'title' => $title,
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('dosomething_reportback_files_form', $status),
+      'access callback' => 'dosomething_reportback_access',
+      'access arguments' => array('edit', 1),
+      'file' => 'dosomething_reportback.admin.inc',
+      'type' => MENU_LOCAL_TASK,
+      'weight' => $weight,
+    );
+    $weight++;
+  }
   $items['admin/users/reportbacks/add'] = array(
     'title' => 'Add reportback',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_reportback_form'),
-    'access callback' => 'dosomething_reportback_access',
-    'access arguments' => array('edit', 1),
+    'access callback' => 'user_access',
+    'access arguments' => array('administer modules'),
     'type' => MENU_LOCAL_TASK,
-    'weight' => 20,
+    'weight' => 100,
   );
   $items['reportback/%reportback/edit'] = array(
     'title' => 'Edit',
@@ -904,9 +923,18 @@ function dosomething_reportback_get_gallery_results($status = NULL) {
   $query->fields('u', array('uid', 'mail'));
   $query->fields('n', array('nid', 'title'));
   $query->orderBy('rb.updated', 'DESC');
-  $query->range(0,5);
+  $query->range(0,25);
   $result = $query->execute()->fetchAll();
   return $result;
+}
+
+function dosomething_reportback_get_file_status_options() {
+  return array(
+    'approved' => 'Approved',
+    'promoted' => 'Promoted',
+    'excluded' => 'Excluded',
+    'flagged' => 'Flagged',
+  );
 }
 
 function dosomething_reportback_update_reportback_file_status($fid, $status) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -942,6 +942,9 @@ function dosomething_reportback_get_gallery_results($status = NULL) {
   return $result;
 }
 
+/**
+ * Returns list of valid options a Reportback File can be set to.
+ */
 function dosomething_reportback_get_file_status_options() {
   return array(
     'approved' => 'Approved',
@@ -951,6 +954,9 @@ function dosomething_reportback_get_file_status_options() {
   );
 }
 
+/**
+ * Updates a given Reportback File $fid's Reportback File status.
+ */
 function dosomething_reportback_update_reportback_file_status($fid, $status) {
   return db_update('dosomething_reportback_file')
     ->fields(array('status' => $status))

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -119,7 +119,7 @@ function dosomething_reportback_menu() {
   $items['admin/users/reportbacks/inbox'] = array(
     'title' => 'Inbox',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('dosomething_reportback_files_form'),
+    'page arguments' => array('dosomething_reportback_files_form', 'pending'),
     'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('edit', 1),
     'file' => 'dosomething_reportback.admin.inc',
@@ -891,17 +891,27 @@ function dosomething_reportback_flush_caches() {
 /**
  * Returns Reportback Gallery data.
  */
-function dosomething_reportback_get_gallery_results() {
+function dosomething_reportback_get_gallery_results($status = NULL) {
   $query = db_select('dosomething_reportback_file', 'rbf');
   $query->join('dosomething_reportback', 'rb', 'rb.rbid = rbf.rbid');
   $query->join('users', 'u', 'rb.uid = u.uid');
   $query->join('node', 'n', 'rb.nid = n.nid');
+  if ($status) {
+    $query->condition('rbf.status', $status);
+  }
   $query->fields('rbf');
   $query->fields('rb');
   $query->fields('u', array('uid', 'mail'));
   $query->fields('n', array('nid', 'title'));
   $query->orderBy('rb.updated', 'DESC');
-  $query->range(0,10);
+  $query->range(0,5);
   $result = $query->execute()->fetchAll();
   return $result;
+}
+
+function dosomething_reportback_update_reportback_file_status($fid, $status) {
+  return db_update('dosomething_reportback_file')
+    ->fields(array('status' => $status))
+    ->condition('fid', $fid)
+    ->execute();
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -118,7 +118,8 @@ function dosomething_reportback_menu() {
   );
   $items['admin/users/reportbacks/inbox'] = array(
     'title' => 'Inbox',
-    'page callback' => 'dosomething_reportback_admin_gallery_page',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_reportback_files_form'),
     'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('edit', 1),
     'file' => 'dosomething_reportback.admin.inc',
@@ -225,6 +226,10 @@ function dosomething_reportback_theme($existing, $type, $theme, $path) {
     'dosomething_reportback_gallery_form' => array(
       'render element' => 'form',
       'file' => 'dosomething_reportback.forms.inc',
+    ),
+    'dosomething_reportback_files_form' => array(
+      'render element' => 'form',
+      'file' => 'dosomething_reportback.admin.inc',
     ),
   );
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -116,6 +116,13 @@ function dosomething_reportback_menu() {
     'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('view', 1),
   );
+  $items['admin/users/reportbacks/inbox'] = array(
+    'title' => 'Inbox',
+    'page callback' => 'dosomething_reportback_admin_gallery_page',
+    'access callback' => 'dosomething_reportback_access',
+    'access arguments' => array('edit', 1),
+    'file' => 'dosomething_reportback.admin.inc',
+  );
   $items['admin/users/reportbacks/add'] = array(
     'title' => 'Add reportback',
     'page callback' => 'drupal_get_form',
@@ -874,4 +881,22 @@ function dosomething_reportback_cache_clear_all() {
  */
 function dosomething_reportback_flush_caches() {
   return array('cache_dosomething_reportback');
+}
+
+/**
+ * Returns Reportback Gallery data.
+ */
+function dosomething_reportback_get_gallery_results() {
+  $query = db_select('dosomething_reportback_file', 'rbf');
+  $query->join('dosomething_reportback', 'rb', 'rb.rbid = rbf.rbid');
+  $query->join('users', 'u', 'rb.uid = u.uid');
+  $query->join('node', 'n', 'rb.nid = n.nid');
+  $query->fields('rbf');
+  $query->fields('rb');
+  $query->fields('u', array('uid', 'mail'));
+  $query->fields('n', array('nid', 'title'));
+  $query->orderBy('rb.updated', 'DESC');
+  $query->range(0,10);
+  $result = $query->execute()->fetchAll();
+  return $result;
 }


### PR DESCRIPTION
Begins work on #3389.

Adds a `status` column to the `dosomething_reportback_file` table, with default value of `pending`.

Adds a Reportback Review form which allows administrators (for now -- editors soon) to each the Reportback File status.

This is still a work in progress, but opening the PR up now as it's a big one.  Will be adding to this functionality to eventually replace Promote / Flagged Flag module functionality.

![rb-review](https://cloud.githubusercontent.com/assets/1236811/5208603/bd52ab88-7583-11e4-8c43-cc8fe2397cb3.png)
