### PR TITLE
Fixes #3550

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
@@ -53,20 +53,7 @@ function dosomething_user_preprocess_user_profile(&$variables) {
   }
 
   // Collect User Reportbacks.
-  $variables['reportbacks'] = array();
-  $reportbacks = dosomething_reportback_get_reportbacks($uid);
-  if (!empty($reportbacks)) {
-    foreach ($reportbacks as $delta => $rbid) {
-      $reportback = reportback_load($rbid);
-      $variables['reportbacks'][$delta] = $reportback;
-      $impact = $reportback->quantity . ' ' . $reportback->noun . ' ' . $reportback->verb;
-      $variables['reportbacks'][$delta]->link = l($reportback->node_title, 'node/' . $reportback->nid);
-      $variables['reportbacks'][$delta]->impact = $impact;
-      // Use the first file uploaded for now.
-      $img = dosomething_image_get_themed_image_by_fid($reportback->fids[0], '300x300');
-      $variables['reportbacks'][$delta]->img = $img;
-    }
-  }
+  $variables['reportbacks'] = dosomething_reportback_get_reportbacks($uid);
 
   $variables['title'] = t("Hey, @name!", array("@name" => $variables['first_name'])); 
   $variables['subtitle'] = variable_get('dosomething_user_profile_subtitle', NULL);

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -512,16 +512,19 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
 
   // Get an array of reportbacks.
   $reportbacks = $vars['reportbacks'];
-
-  if ($reportbacks) {
+  if (!empty($reportbacks)) {
     // Theme each reportback and create an array.
-    foreach ($reportbacks as $delta => $value) {
-      $item = array(
-        'title' => $value->link,
-        'image' => $value->img,
-        'impact' => $value->impact,
+    foreach ($reportbacks as $delta => $rbid) {
+      $reportback = reportback_load((int) $rbid);
+      $impact = $reportback->quantity . ' ' . $reportback->noun . ' ' . $reportback->verb;
+      $img = dosomething_image_get_themed_image_by_fid($reportback->fids[0], '300x300');
+      $content = array(
+        'link' => 'node/' . $reportback->nid,
+        'title' => $reportback->node_title,
+        'image' => $img,
+        'impact' => $impact,
       );
-      $reportback_items[$delta] = paraneue_dosomething_get_gallery_item($item, 'media');
+      $reportback_items[$delta] = paraneue_dosomething_get_gallery_item($content, 'media');
     }
   }
   // Theme a gallery of reportbacks, and give the user profile template access to it.

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/media.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/media.tpl.php
@@ -28,6 +28,8 @@
           <a href="<?php print $content['link']; ?>">
             <?php print $content['title']; ?>
           </a>
+        <?php else: ?>
+          <?php print $content['title']; ?>
         <?php endif; ?>
       </h3>
     <?php endif; ?>


### PR DESCRIPTION
Fixes bug (missing `link` value in the content array) and moves all preprocess into theme template to keep logic in one place.

![screen shot 2014-11-26 at 4 32 44 pm](https://cloud.githubusercontent.com/assets/1236811/5209202/e0a9807e-7589-11e4-936e-244b3c2e1635.png)
