### PR TITLE
Enables Reportback endpoint

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -6,4 +6,4 @@ dependencies[] = services
 features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
-mtime = 1415889493
+mtime = 1416603771

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -59,6 +59,11 @@ function dosomething_api_default_services_endpoint() {
           'enabled' => '1',
         ),
       ),
+      'targeted_actions' => array(
+        'reportback' => array(
+          'enabled' => '1',
+        ),
+      ),
     ),
     'node' => array(
       'alias' => 'content',

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -53,6 +53,8 @@ function _campaign_resource_defintion() {
         'file' => array('type' => 'inc', 'module' => 'dosomething_api', 'name' => 'resources/campaign_resource'),
         'callback' => '_campaign_resource_reportback',
         'access callback' => '_campaign_resource_access',
+        'access arguments' => array('reportback'),
+        'access arguments append' => TRUE,
         'args' => array(
           array(
             'name' => 'nid',
@@ -87,11 +89,18 @@ function _campaign_resource_defintion() {
  * @see node_access()
  */
 function _campaign_resource_access($op = 'view', $args = array()) {
+  if (DOSOMETHING_REPORTBACK_LOG) {
+    watchdog('dosomething_api', '_campaign_resource_access args:' . json_encode($args));
+  }
+
   if ($op == 'index') {
     return TRUE;
   }
 
   $node = node_load($args[0]);
+  if (!$node) {
+    return services_error(t('No node found for @nid', array('@nid' => $args[0])), 403);
+  }
 
   if ($op == 'view') {
     return node_access($op, $node);
@@ -185,6 +194,8 @@ function _campaign_resource_reportback($nid, $values) {
     $rbid = 0;
   }
   $values['rbid'] = $rbid;
-
+  if (DOSOMETHING_REPORTBACK_LOG) {
+    watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
+  }
   return dosomething_reportback_save($values);
 }

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -106,6 +106,10 @@ function _campaign_resource_access($op = 'view', $args = array()) {
     return node_access($op, $node);
   }
 
+  if (!user_is_logged_in()) {
+    return services_error(t('Must be logged in!'), 403);
+  }
+
   if (dosomething_campaign_is_active($node)) {
     return TRUE;
     //@todo: If op==reportback and SMS Game, return 403 error.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -16,6 +16,13 @@ function dosomething_reportback_admin_config_form($form, &$form_state) {
     '#default_value' => variable_get('dosomething_reportback_is_crop_enabled', FALSE),
     '#description' => t("Allows users to crop their own Reportback images."),
   );
+
+  $form['dosomething_reportback_log'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Log Reportbacks.'),
+    '#default_value' => variable_get('dosomething_reportback_log', FALSE),
+    '#description' => t("Logs Reportback activity. This should be disabled on production."),
+  );
   return system_settings_form($form);
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -7,6 +7,8 @@
 include_once 'dosomething_reportback.features.inc';
 include_once 'dosomething_reportback.forms.inc';
 
+DEFINE('DOSOMETHING_REPORTBACK_LOG', variable_get('dosomething_reportback_log') ? TRUE : FALSE);
+
 /**
  * Implements hook_entity_info().
  */
@@ -514,8 +516,14 @@ function dosomething_reportback_set_field_values(&$entity, $values) {
  *   A file object if save is successful, FALSE if not.
  */
 function dosomething_reportback_save_file_from_url($nid, $uid, $url) {
+  if (DOSOMETHING_REPORTBACK_LOG) {
+    watchdog('dosomething_reportback', 'Save file from url: '. $url);
+  }
   // Get the location for where file should be saved to.
   $dest = dosomething_reportback_get_file_dest(basename($url), $nid, $uid);
+  if (DOSOMETHING_REPORTBACK_LOG) {
+    watchdog('dosomething_reportback', 'Write to dest: '. $dest);
+  }
   // Download and save file to that location.
   $file_contents = file_get_contents($url);
   $file = file_save_data($file_contents, $dest);
@@ -523,6 +531,9 @@ function dosomething_reportback_save_file_from_url($nid, $uid, $url) {
   $file->uid = $uid;
   $file->status = FILE_STATUS_PERMANENT;
   file_save($file);
+  if (DOSOMETHING_REPORTBACK_LOG) {
+    watchdog('dosomething_reportback', json_encode($file));
+  }
   return $file;
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -472,17 +472,19 @@ function dosomething_reportback_set_properties(&$entity, $values) {
 }
 
 /**
- * Sets a reportback entity's files.
+ * Sets a reportback entity's file and caption.
  *
  * @param object $entity
  *   The reportback entity to set properties for.
  * @param array $values
- *   An array of file fid's to set.
+ *   An array of Reportback File data to set.
  */
 function dosomething_reportback_set_files(&$entity, $values) {
   if (isset($values['fid']) && !empty($values['fid'])) {
     $entity->fid = $values['fid'];
-    $entity->caption = $values['caption'];
+    if (!empty($values['caption'])) {
+      $entity->caption = $values['caption'];
+    }
   }
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -3,11 +3,10 @@
  * @file
  * Code for the DoSomething Reportback feature.
  */
+define('DOSOMETHING_REPORTBACK_LOG', variable_get('dosomething_reportback_log') ? TRUE : FALSE);
 
 include_once 'dosomething_reportback.features.inc';
 include_once 'dosomething_reportback.forms.inc';
-
-DEFINE('DOSOMETHING_REPORTBACK_LOG', variable_get('dosomething_reportback_log') ? TRUE : FALSE);
 
 /**
  * Implements hook_entity_info().

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -433,8 +433,6 @@ function dosomething_reportback_save($values) {
     dosomething_reportback_set_properties($entity, $values);
     // Set entity files.
     dosomething_reportback_set_files($entity, $values);
-    // Set reportback field values.
-    dosomething_reportback_set_field_values($entity, $values);
     // Save the entity.
     $entity->save();
     // Return reportback rbid.
@@ -485,20 +483,6 @@ function dosomething_reportback_set_files(&$entity, $values) {
   if (isset($values['fid']) && !empty($values['fid'])) {
     $entity->fid = $values['fid'];
     $entity->caption = $values['caption'];
-  }
-}
-
-/**
- * Sets a reportback entity's reportback field values.
- */
-function dosomething_reportback_set_field_values(&$entity, $values) {
-  $entity->field_values = NULL;
-  // If this entity has an active custom field:
-  if (isset($entity->field) && $entity->field['status'] == 1) {
-    $field_name = $entity->field['name'];
-    $entity->field_values = array(
-      $field_name => $values[$field_name],
-    );
   }
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -348,6 +348,9 @@ class ReportbackEntityController extends EntityAPIController {
       $op = 'insert';
     }
     $entity->updated = $now;
+    if (DOSOMETHING_REPORTBACK_LOG) {
+      watchdog('dosomething_reportback', 'save:' . json_encode($entity));
+    }
     parent::save($entity, $transaction);
     // If a file fid exists:
     if (isset($entity->fid)) {

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -141,6 +141,9 @@ class ReportbackEntity extends Entity {
    *   Values to write to a dosomething_reportback_file record.
    */
   public function createReportbackFile($values) {
+    if (!isset($values->caption)) {
+      $values->caption = NULL;
+    }
     return db_insert($this->files_table)
       ->fields(array(
           'rbid' => $this->rbid,


### PR DESCRIPTION
Closes #3528

Enables `campaigns/[nid]/reportback` endpoint, and fixes a bug in the resource definition to get it working correctly (adding `'access arguments'` and `'access arguments append'` ).

Will work with or without Reportback Image caption.

Also adds logging (based on a `dosomething_reportback_log` variable).

**POST** dev.dosomething.org:8888/api/v1/campaigns/1273/reportback

Sample post data:

```
{
  "quantity": 30,
  "file_url": "http://data1.whicdn.com/images/50522843/large.jpg",
  "why_participated": "Hello world",
  "caption": "Whats up yo"
}
```

The reportback rbid (created or updated) will be returned upon success:

```
[
    "305"
]
```
