### PR TITLE
Binding touch events to image not document

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageCrop.js
@@ -115,7 +115,7 @@ define(function(require) {
     resizeCropBoxInit();
 
     // Bind move events to the document.
-    $(document).on("touchmove mousemove", function(event) {
+    $cropContainer.on("touchmove mousemove", function(event) {
       event.preventDefault();
       var coords = getCoords(event);
 
@@ -178,7 +178,7 @@ define(function(require) {
      *  When the user stops moving the mouse or touching the screen, turn of the drag and resizing events.
      *  Get the final position and size of the crop and populate hidden form elements with them.
      */
-    $(document).on("touchend mouseup", function(){
+    $cropContainer.on("touchend mouseup", function(){
       // Calulate how much the image has been resized.
       var resizeAmount = origImageWidth / $previewImage.width();
       // Get the hidden form elements.


### PR DESCRIPTION
Of course, if you bind events to the whole document and then preventDefault() you will turn on scrolling completely. Updated the code so that the touch events controlling dragging and resizing are binded to the image crop container only. Fixes #3571 

@DFurnes 
