### PR TITLE
Check Reportback uid and permissions upon save

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -156,7 +156,7 @@ function dosomething_reportback_menu() {
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_reportback_form'),
     'access callback' => 'user_access',
-    'access arguments' => array('administer modules'),
+    'access arguments' => array('edit any reportback'),
     'type' => MENU_LOCAL_TASK,
     'weight' => 100,
   );
@@ -434,8 +434,11 @@ function dosomething_reportback_save($values) {
     dosomething_reportback_set_files($entity, $values);
     // Save the entity.
     $entity->save();
-    // Return reportback rbid.
-    return $entity->rbid;
+    if (isset($entity->rbid)) {
+      // Return reportback rbid.
+      return $entity->rbid;
+    }
+    return FALSE;
   }
   catch (Exception $e) {
     watchdog('dosomething_reportback', $e, array(), WATCHDOG_ERROR);

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -341,6 +341,7 @@ class ReportbackEntityController extends EntityAPIController {
    * Populates created and uid automatically.
    */
   public function save($entity, DatabaseTransaction $transaction = NULL) {
+    global $user;
     $now = REQUEST_TIME;
     $op = 'update';
     if (isset($entity->is_new)) {
@@ -351,7 +352,26 @@ class ReportbackEntityController extends EntityAPIController {
     if (DOSOMETHING_REPORTBACK_LOG) {
       watchdog('dosomething_reportback', 'save:' . json_encode($entity));
     }
+
+    // Make sure a uid exists.
+    if (!isset($entity->uid)) {
+      return FALSE;
+    }
+    // If the entity uid doesnt belong to current user:
+    if ($entity->uid != $user->uid) {
+      // And current user can't edit any reportback:
+      if (!user_access('edit any reportback')) {
+        watchdog('dosomething_reportback', "Attempted uid override for @reportback by User @uid", 
+          array(
+            '@reportback' => json_encode($entity),
+            '@uid' => $user->uid,
+          ), WATCHDOG_WARNING);
+        return FALSE;
+      }
+    }
+
     parent::save($entity, $transaction);
+
     // If a file fid exists:
     if (isset($entity->fid)) {
       // Add it into the reportback files.


### PR DESCRIPTION
Checks for permission `edit any reportback` to allow creating a new role for Robot Users, which could potentially only have the `edit any reportback` permission and various other system permissions.
