### PR TITLE
Rescoping header CSS on not found pages

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_notfound.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_notfound.scss
@@ -1,8 +1,8 @@
-.page-notfound {
-  header.notfound p {
-    color: #fff;
-  }
+header.notfound p {
+  color: #fff;
+}
 
+.page-notfound {
   .search-form {
     @include media($tablet) {
       width: 75%;


### PR DESCRIPTION
If you hit a node url directly it does not use the .page-notfound class so we can't scope all the css to these pages. This fixes #3536 

@DFurnes @weerd 
