### PR TITLE
Wrapping up image swapping script for high res feature tile images.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/bower.json
+++ b/lib/themes/dosomething/paraneue_dosomething/bower.json
@@ -20,7 +20,7 @@
     "tests"
   ],
   "dependencies": {
-    "neue": "DoSomething/neue#~5.3.3",
+    "neue": "DoSomething/neue#~5.3.4",
     "jquery": "1.8.3",
     "mailcheck": "~1.0.3",
     "html5shiv": "~3.7.0",

--- a/lib/themes/dosomething/paraneue_dosomething/js/app.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/app.js
@@ -1,7 +1,7 @@
 /**
  * This is where we load and initialize components of our app.
  */
-define("app", function(require) {
+define("app", function (require) {
   "use strict";
 
   var $ = require("jquery");
@@ -10,6 +10,7 @@ define("app", function(require) {
   var Finder   = require("finder/Finder");
   var Donate   = require("donate/Donate");
   var Revealer = require("revealer/Revealer");
+  var Swapper  = require("swapper/Swapper");
 
   // Initialize modules on load
   require("neue/main");
@@ -27,7 +28,7 @@ define("app", function(require) {
   require("tiles");
 
 
-  $(document).ready(function() {
+  $(document).ready(function () {
     var $body = $("body");
 
     var $campaignFinderForm = $(".js-finder-form");
@@ -44,16 +45,16 @@ define("app", function(require) {
     }
 
 
+    var $mosaicGalleries = $body.find(".gallery.-mosaic");
+
     /**
      * Show hide large galleries.
      * Only applies to taxonomy pages for the time being.
      */
-    var $galleries = $body.find(".gallery.-mosaic");
-
-    if ($body.hasClass("page-taxonomy") && $galleries.length > 0) {
+    if ($body.hasClass("page-taxonomy") && $mosaicGalleries.length > 0) {
       var galleryList = [];
 
-      $galleries.each(function (index, gallery) {
+      $mosaicGalleries.each(function (index, gallery) {
         var $gallery = $(gallery);
         var $tiles = $gallery.find("li");
 
@@ -63,9 +64,29 @@ define("app", function(require) {
       });
     }
 
-    
+
+    /**
+     * Swap low resolution images for feature tiles in mosaic gallery
+     * with higher resolution version from tablet size up.
+     */
+    if ($mosaicGalleries.length && $mosaicGalleries.hasClass("-featured")) {
+      var swappedImagesList = [];
+
+      $(window).on("resize", _.debounce(function () {
+
+        if (window.matchMedia("(min-width: 768px)").matches && !swappedImagesList.length) {
+          $mosaicGalleries.each(function (index, gallery) {
+            var $featureTile = $(this).find("li").first();
+            swappedImagesList[index] = new Swapper($featureTile);
+          });
+        }
+      }, 500));
+
+    }
+
+
     $("html").addClass("js-ready");
-    
+
   });
 
 });

--- a/lib/themes/dosomething/paraneue_dosomething/js/swapper/Swapper.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/swapper/Swapper.js
@@ -1,0 +1,27 @@
+define(function() {
+  "use strict";
+
+  var Swapper = function ($content) {
+    this.$image   = $content.find("img");
+
+    this.init();
+  };
+
+
+  Swapper.prototype.init = function () {
+    var srcLarge = this.$image.data("src-large") || null;
+
+    this.exchange(srcLarge);
+  };
+
+
+  Swapper.prototype.exchange = function (url) {
+    if (url) {
+      this.$image.attr("src", url);
+    }
+  };
+
+
+  return Swapper;
+
+});


### PR DESCRIPTION
Resolves #3267

@DFurnes @sbsmith86 @tjrosario 

Dave, took a slightly different approach than needing to remove the data role after image swap. Instead, saving all feature tiles to an array; if array empty, then images swapped, otherwise they've already been swapped and added to the "completed" array and thus no action required :)

All changed `$galleries` var to `$mosaicGalleries` so it's more descriptive of the actual jQuery collection obtained.

CC: @aaronschachter @barryclark 
