### PR TITLE
Reportback Review page filters

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
@@ -62,31 +62,11 @@ function _reportback_resource_defintion() {
 function _reportback_file_resource_index($page, $parameters, $page_size) {
   // Load Services module to use its index_query functions.
   module_load_include('inc', 'services', 'services.module');
-  module_load_include('inc', 'services', 'includes/services.runtime');
-
-  // Needs to be aliased as t for services_resource_build_index_query to work.
-  $query = db_select('dosomething_reportback_file', 't');
-  $query->join('dosomething_reportback', 'rb', 'rb.rbid = t.rbid');
-  //$query->join('node', 'n', 'rb.nid = n.nid');
-  if (isset($parameters['nid'])) {
-    $query->condition('nid', $parameters['nid']);
-  }
-  // @todo Add condition to only display approved Reportback Files.
-  // Show most recent first.
-  $query->orderBy('fid', 'DESC');
-
-  // The fields on t alias to return.
-  $rb_file_fields = "'rbid', 'fid', fid_processed', 'caption', 'status'";
-  services_resource_build_index_query($query, $page, $rb_file_fields, $parameters, $page_size, 'reportbacks');
-
-  // Add fields from other tables.
-  $query->fields('rb', array('nid', 'quantity'));
-
-  $results = services_resource_execute_index_query($query);
 
   $int_properties = array('rbid', 'fid', 'fid_processed', 'nid', 'quantity');
+  $results = dosomething_reportback_get_reportback_files_query($page, $parameters, $page_size);
+  $result = services_resource_build_index_list($results, 'reportback_files', 'fid');
 
-  $result = services_resource_build_index_list($results, 'reportbacks', 'rbid');
   foreach ($result as &$record) {
     // Convert string output to integers were appropriate.
     foreach ($int_properties as $property) {

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
@@ -62,24 +62,36 @@ function _reportback_resource_defintion() {
 function _reportback_file_resource_index($page, $parameters, $page_size) {
   // Load Services module to use its index_query functions.
   module_load_include('inc', 'services', 'services.module');
+  module_load_include('inc', 'services', 'includes/services.runtime');
 
   // Needs to be aliased as t for services_resource_build_index_query to work.
   $query = db_select('dosomething_reportback_file', 't');
+  $query->join('dosomething_reportback', 'rb', 'rb.rbid = t.rbid');
+  //$query->join('node', 'n', 'rb.nid = n.nid');
   if (isset($parameters['nid'])) {
-    $query->join('dosomething_reportback', 'rb', 'rb.rbid = t.rbid');
     $query->condition('nid', $parameters['nid']);
   }
   // @todo Add condition to only display approved Reportback Files.
   // Show most recent first.
   $query->orderBy('fid', 'DESC');
-  // Fields to return.
-  $fields = "'rbid', 'fid', 'fid_processed', 'caption'";
-  services_resource_build_index_query($query, $page, $fields, $parameters, $page_size, 'reportbacks');
+
+  // The fields on t alias to return.
+  $rb_file_fields = "'rbid', 'fid', fid_processed', 'caption', 'status'";
+  services_resource_build_index_query($query, $page, $rb_file_fields, $parameters, $page_size, 'reportbacks');
+
+  // Add fields from other tables.
+  $query->fields('rb', array('nid', 'quantity'));
 
   $results = services_resource_execute_index_query($query);
 
+  $int_properties = array('rbid', 'fid', 'fid_processed', 'nid', 'quantity');
+
   $result = services_resource_build_index_list($results, 'reportbacks', 'rbid');
   foreach ($result as &$record) {
+    // Convert string output to integers were appropriate.
+    foreach ($int_properties as $property) {
+      $record->{$property} = (int) $record->{$property};
+    }
     // We'll eventually want to use the fid_processed here.
     // And also probably won't need to apply an image style, since it
     // will already be cropped.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -47,8 +47,14 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
   elseif (isset($entity->tid)) {
     $params['tid'] = $entity->tid;
   }
-  watchdog('dosomething_reportback', json_encode($params));
-  $result = dosomething_reportback_get_reportback_files_query(0, $params, 25);
+  $page_size = 25;
+  if (isset($_GET['pagesize'])) {
+    $limit = $_GET['pagesize'];
+    if (is_numeric($limit) || $limit < 100) {
+      $page_size = $limit;
+    }
+  }
+  $result = dosomething_reportback_get_reportback_files_query(0, $params, $page_size);
 
   foreach ($result as $record) {
     $preview = dosomething_reportback_file_preview($record);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -38,7 +38,11 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL) 
   $form['rb_files']['#tree'] = TRUE;
   $options = dosomething_reportback_get_file_status_options();
 
-  $result = dosomething_reportback_get_gallery_results($status);
+  $params = array(
+    'status' => $status,
+  );
+  $result = dosomething_reportback_get_reportback_files_query(0, $params, 25);
+
   foreach ($result as $record) {
     $preview = dosomething_reportback_file_preview($record);
     $rb_path = 'reportback/' . $record->rbid;
@@ -47,7 +51,7 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL) 
         '#markup' => $preview,
       ),
       'date' => array(
-        '#markup' => l(format_date($record->updated, 'short'), $rb_path),
+        '#markup' => l(format_date($record->timestamp, 'short'), $rb_path),
       ),
       'quantity' => array(
         '#markup' => $record->quantity,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -32,7 +32,7 @@ function dosomething_reportback_admin_config_form($form, &$form_state) {
  * @param string $status
  *   (optional) The Reportback File status to filter by.
  */
-function dosomething_reportback_files_form($form, &$form_state, $status = NULL) {
+function dosomething_reportback_files_form($form, &$form_state, $status = NULL, $entity = NULL) {
   // Identify that the elements in 'rb_files' are a collection, to
   // prevent Form API from flattening the array when submitted.
   $form['rb_files']['#tree'] = TRUE;
@@ -41,6 +41,13 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL) 
   $params = array(
     'status' => $status,
   );
+  if (isset($entity->nid)) {
+    $params['nid'] = $entity->nid;
+  }
+  elseif (isset($entity->tid)) {
+    $params['tid'] = $entity->tid;
+  }
+  watchdog('dosomething_reportback', json_encode($params));
   $result = dosomething_reportback_get_reportback_files_query(0, $params, 25);
 
   foreach ($result as $record) {
@@ -57,7 +64,7 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL) 
         '#markup' => $record->quantity,
       ),
       'node' => array(
-        '#markup' => $record->title,
+        '#markup' => l($record->title, 'node/'. $record->nid),
       ),
       'fid' => array(
         '#type' => 'hidden',

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -929,28 +929,29 @@ function dosomething_reportback_preprocess_page(&$vars) {
 /**
  * Returns Reportback Gallery data.
  */
-function dosomething_reportback_get_gallery_results($status = NULL) {
-  $limit = 25;
+function dosomething_reportback_get_reportback_files_query($page = 0, $params = array(), $page_size = 25) {
   if (isset($_GET['pagesize'])) {
-    $limit = $_GET['pagesize'];
-    if (!is_numeric($limit) || $limit > 100) {
-      $limit = 25;
-    }
+    $page_size = $_GET['pagesize'];
   }
   $query = db_select('dosomething_reportback_file', 'rbf');
   $query->join('dosomething_reportback', 'rb', 'rb.rbid = rbf.rbid');
   $query->join('users', 'u', 'rb.uid = u.uid');
   $query->join('node', 'n', 'rb.nid = n.nid');
-  if ($status) {
-    $query->condition('rbf.status', $status);
+  $query->join('file_managed', 'f', 'rbf.fid = f.fid');
+  if (isset($params['status'])) {
+    $query->condition('rbf.status', $params['status']);
+  }
+  if (isset($params['nid'])) {
+    $query->condition('rb.nid', $params['nid']);
   }
   $query->fields('rbf');
-  $query->fields('rb');
+  $query->fields('rb', array('quantity', 'why_participated'));
   $query->fields('u', array('uid', 'mail'));
   $query->fields('n', array('nid', 'title'));
+  $query->fields('f', array('timestamp'));
   $query->orderBy('rb.updated', 'DESC');
-  $query->range(0, $limit);
-  $result = $query->execute()->fetchAll();
+  $query->range($page * $page_size, $page_size);
+  $result = $query->execute();
   return $result;
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -174,6 +174,13 @@ function dosomething_reportback_menu() {
 
 /**
  * Returns array of menu items for given $prefix.
+ *
+ * @param string $prefix
+ *   The URL prefix to use for this set of Review menu items.
+ * @param int $arg_index
+ *   The index of the argument of the loaded entity.
+ *
+ * @return array
  */
 function dosomething_reportback_get_review_menu_items($prefix, $arg_index) {
   // Append /rb path to the given $prefix.
@@ -220,6 +227,11 @@ function dosomething_reportback_get_review_menu_items($prefix, $arg_index) {
 
 /**
  * Access callback for entity reportback review page.
+ *
+ * @param object $entity
+ *   Loaded entity to inspect whether or not to display the RB Review page for.
+ *
+ * @return bool
  */
 function dosomething_reportback_review_page_access($entity) {
   if (!user_access('view any reportback')) {
@@ -234,6 +246,7 @@ function dosomething_reportback_review_page_access($entity) {
   elseif (isset($entity->tid)) {
     return TRUE;
   }
+  return FALSE;
 }
 
 /**
@@ -974,12 +987,22 @@ function dosomething_reportback_preprocess_page(&$vars) {
 }
 
 /**
- * Returns Reportback Gallery data.
+ * Returns Reportback Files query to loop through.
+ *
+ * @param int $page
+ *   The results page to start from.
+ * @param array $params
+ *   An associative array of conditions to filter by. Possible keys:
+ *   - nid: A node nid to filter by.
+ *   - tid: A taxonomy term tid, filters RB Files for all nodes tagged tid.
+ *   - status: The RB File status.
+ * @param int $page_size
+ *   Number of results to display on a page.
+ *
+ * @return
+ *   An executed database query object to iterate through.
  */
 function dosomething_reportback_get_reportback_files_query($page = 0, $params = array(), $page_size = 25) {
-  if (isset($_GET['pagesize'])) {
-    $page_size = $_GET['pagesize'];
-  }
   $query = db_select('dosomething_reportback_file', 'rbf');
   $query->join('dosomething_reportback', 'rb', 'rb.rbid = rbf.rbid');
   $query->join('users', 'u', 'rb.uid = u.uid');

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -183,8 +183,8 @@ function dosomething_reportback_get_review_menu_items($prefix, $arg_index) {
     'title' => 'Reportbacks',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_reportback_files_form', 'pending', $arg_index),
-    'access callback' => 'user_access',
-    'access arguments' => array('administer modules'),
+    'access callback' => 'dosomething_reportback_review_page_access',
+    'access arguments' => array($arg_index),
     'file' => 'dosomething_reportback.admin.inc',
     'type' => MENU_LOCAL_TASK,
     'weight' => 900,
@@ -193,8 +193,8 @@ function dosomething_reportback_get_review_menu_items($prefix, $arg_index) {
     'title' => 'Inbox',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_reportback_files_form', 'pending', $arg_index),
-    'access callback' => 'user_access',
-    'access arguments' => array('administer modules'),
+    'access callback' => 'dosomething_reportback_review_page_access',
+    'access arguments' => array($arg_index),
     'file' => 'dosomething_reportback.admin.inc',
     'type' => MENU_DEFAULT_LOCAL_TASK,
     'weight' => 10,
@@ -207,8 +207,8 @@ function dosomething_reportback_get_review_menu_items($prefix, $arg_index) {
       'title' => $title,
       'page callback' => 'drupal_get_form',
       'page arguments' => array('dosomething_reportback_files_form', $status, $arg_index),
-      'access callback' => 'user_access',
-      'access arguments' => array('administer modules'),
+      'access callback' => 'dosomething_reportback_review_page_access',
+      'access arguments' => array($arg_index),
       'file' => 'dosomething_reportback.admin.inc',
       'type' => MENU_LOCAL_TASK,
       'weight' => $weight,
@@ -216,6 +216,24 @@ function dosomething_reportback_get_review_menu_items($prefix, $arg_index) {
     $weight++;
   }
   return $items;
+}
+
+/**
+ * Access callback for entity reportback review page.
+ */
+function dosomething_reportback_review_page_access($entity) {
+  if (!user_access('view any reportback')) {
+    return FALSE;
+  }
+  if (isset($entity->nid)) {
+    if ($entity->type == 'campaign') {
+      return dosomething_campaign_get_campaign_type($entity) == 'campaign';
+    }
+    return FALSE;
+  }
+  elseif (isset($entity->tid)) {
+    return TRUE;
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -117,40 +117,21 @@ function dosomething_reportback_menu() {
     'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('view', 1),
   );
-  $items['admin/users/rb'] = array(
-    'title' => 'Reportbacks',
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('dosomething_reportback_files_form', 'pending'),
-    'access callback' => 'user_access',
-    'access arguments' => array('administer modules'),
-    'file' => 'dosomething_reportback.admin.inc',
+
+  // Add Reportback menu items for admin/users.
+  $users_rb = dosomething_reportback_get_review_menu_items('admin/users', NULL);
+  $items = array_merge($items, $users_rb);
+
+  // Add Reportback menu items for taxonomy_term and node entities:
+  $rb_paths = array(
+    'taxonomy/term/%taxonomy_term' => 2,
+    'node/%node' => 1,
   );
-  $items['admin/users/rb/inbox'] = array(
-    'title' => 'Inbox',
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('dosomething_reportback_files_form', 'pending'),
-    'access callback' => 'user_access',
-    'access arguments' => array('administer modules'),
-    'file' => 'dosomething_reportback.admin.inc',
-    'type' => MENU_DEFAULT_LOCAL_TASK,
-    'weight' => 10,
-  );
-  // Loop through status options.
-  $status_options = dosomething_reportback_get_file_status_options();
-  $weight = 20;
-  foreach ($status_options as $status => $title) {
-    $items['admin/users/rb/' . $status] = array(
-      'title' => $title,
-      'page callback' => 'drupal_get_form',
-      'page arguments' => array('dosomething_reportback_files_form', $status),
-      'access callback' => 'user_access',
-      'access arguments' => array('administer modules'),
-      'file' => 'dosomething_reportback.admin.inc',
-      'type' => MENU_LOCAL_TASK,
-      'weight' => $weight,
-    );
-    $weight++;
+  foreach ($rb_paths as $rb_path => $arg_index) {
+    $rb_items = dosomething_reportback_get_review_menu_items($rb_path, $arg_index);
+    $items = array_merge($items, $rb_items);
   }
+
   $items['admin/users/reportbacks/add'] = array(
     'title' => 'Add reportback',
     'page callback' => 'drupal_get_form',
@@ -188,6 +169,52 @@ function dosomething_reportback_menu() {
     'weight' => 200,
     'file' => 'dosomething_reportback.forms.inc',
   );
+  return $items;
+}
+
+/**
+ * Returns array of menu items for given $prefix.
+ */
+function dosomething_reportback_get_review_menu_items($prefix, $arg_index) {
+  // Append /rb path to the given $prefix.
+  $prefix .= '/rb';
+  // Creates the parent tab.
+  $items[$prefix] = array(
+    'title' => 'Reportbacks',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_reportback_files_form', 'pending', $arg_index),
+    'access callback' => 'user_access',
+    'access arguments' => array('administer modules'),
+    'file' => 'dosomething_reportback.admin.inc',
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 900,
+  );
+  $items[$prefix . '/inbox'] = array(
+    'title' => 'Inbox',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_reportback_files_form', 'pending', $arg_index),
+    'access callback' => 'user_access',
+    'access arguments' => array('administer modules'),
+    'file' => 'dosomething_reportback.admin.inc',
+    'type' => MENU_DEFAULT_LOCAL_TASK,
+    'weight' => 10,
+  );
+  // Loop through status options.
+  $status_options = dosomething_reportback_get_file_status_options();
+  $weight = 20;
+  foreach ($status_options as $status => $title) {
+    $items[$prefix . '/' . $status] = array(
+      'title' => $title,
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('dosomething_reportback_files_form', $status, $arg_index),
+      'access callback' => 'user_access',
+      'access arguments' => array('administer modules'),
+      'file' => 'dosomething_reportback.admin.inc',
+      'type' => MENU_LOCAL_TASK,
+      'weight' => $weight,
+    );
+    $weight++;
+  }
   return $items;
 }
 
@@ -267,9 +294,11 @@ function dosomething_reportback_theme($existing, $type, $theme, $path) {
 function dosomething_reportback_admin_paths() {
   $paths = array(
     'node/*/reportbacks' => TRUE,
+    'node/*/rb*' => TRUE,
     'node/*/gallery' => TRUE,
     'flag/confirm/*/*/*' => TRUE,
     'reportback/*' => TRUE,
+    'taxonomy/term/*/rb*' => TRUE,
   );
   return $paths;
 }
@@ -938,6 +967,10 @@ function dosomething_reportback_get_reportback_files_query($page = 0, $params = 
   $query->join('users', 'u', 'rb.uid = u.uid');
   $query->join('node', 'n', 'rb.nid = n.nid');
   $query->join('file_managed', 'f', 'rbf.fid = f.fid');
+  if (isset($params['tid'])) {
+    $query->join('taxonomy_index', 't', 't.nid = n.nid');
+    $query->condition('t.tid', $params['tid']);
+  }
   if (isset($params['status'])) {
     $query->condition('rbf.status', $params['status']);
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -996,6 +996,7 @@ function dosomething_reportback_preprocess_page(&$vars) {
  *   - nid: A node nid to filter by.
  *   - tid: A taxonomy term tid, filters RB Files for all nodes tagged tid.
  *   - status: The RB File status.
+ *   - random: If set, randomly sort the results.
  * @param int $page_size
  *   Number of results to display on a page.
  *
@@ -1023,7 +1024,12 @@ function dosomething_reportback_get_reportback_files_query($page = 0, $params = 
   $query->fields('u', array('uid', 'mail'));
   $query->fields('n', array('nid', 'title'));
   $query->fields('f', array('timestamp'));
-  $query->orderBy('rb.updated', 'DESC');
+  if (isset($params['random'])) {
+    $query->orderRandom();
+  }
+  else {
+    $query->orderBy('rb.updated', 'DESC');
+  }
   $query->range($page * $page_size, $page_size);
   $result = $query->execute();
   return $result;


### PR DESCRIPTION
Closes #3389

Adds filtering to the Reportback Review admin pages: 
- Adds new Reportback Review forms to all Taxonomy terms
- Adds new Reportback Review forms to all Campaign nodes (excluding SMS Games)

Also replaces the use of Services index query functions like `services_resource_build_index_query`  in the `reportback_files` resource with the `dosomething_reportback_get_reportback_files_query` function, to DRY.
## Notes

The original `node/*/reportbacks` view will be removed once all functionality has been ported over to these new views.  This is enabling the forms for now so staff can begin to test them.
## Screenshots

![cause-rb](https://cloud.githubusercontent.com/assets/1236811/5348214/e2e00eb4-7efb-11e4-9eb4-b50bb6e73fc6.png)
