### PR TITLE
Partners footer bug fix

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -83,6 +83,9 @@ function dosomething_helpers_preprocess_partners_vars(&$vars) {
     return;
   }
   // Returns partners, sponsors, and partner_info arrays.
+  if (empty($vars['field_partners'])) {
+    return;
+  }
   $partners_vars = dosomething_taxonomy_get_partners_vars($vars['field_partners']);
   // Gather any returned arrays.
   foreach ($partners_vars as $key => $values) {


### PR DESCRIPTION
Checks for existence of `$vars['field_partners']` before preprocessing it.

These errors were occurring viewing the page in question:

```
Warning: Invalid argument supplied for foreach() in dosomething_helpers_preprocess_partners_vars() (line 88 of /var/www/beta.dosomething.org/releases/20141209142557/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc).

Warning: Invalid argument supplied for foreach() in dosomething_helpers_format_partners_list() (line 127 of /var/www/beta.dosomething.org/releases/20141209142557/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc).
```
