### PR TITLE
Member index

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -6,4 +6,4 @@ dependencies[] = services
 features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
-mtime = 1417467369
+mtime = 1417530124

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -98,6 +98,9 @@ function dosomething_api_default_services_endpoint() {
         'create' => array(
           'enabled' => '1',
         ),
+        'index' => array(
+          'enabled' => '1',
+        ),
       ),
       'actions' => array(
         'get_member_count' => array(

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -56,6 +56,7 @@ function _member_resource_defintion() {
         ),
         'callback' => '_member_resource_get_member_count',
         'access callback' => '_member_resource_access',
+        'access arguments' => array('get_member_count'),
       ),
     ),
   );
@@ -66,11 +67,11 @@ function _member_resource_defintion() {
  * Access callback for User resources.
  */
 function _member_resource_access($op) {
-  if ($op == 'create') {
+  if ($op == 'create' || $op == 'get_member_count') {
     return TRUE;
   }
   global $user;
-  // For now, only admins can access any reportback resources.
+  // For now, only admins can access any other User resources.
   return in_array('administrator', $user->roles);
 }
 

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -22,6 +22,28 @@ function _member_resource_defintion() {
             ),
           ),
         'access callback' => '_member_resource_access',
+        'access arguments' => array('create'),
+      ),
+      'index' => array(
+        'help' => 'List of all users.',
+        'file' => array(
+          'type' => 'inc',
+          'module' => 'dosomething_api',
+          'name' => 'resources/member_reource',
+        ),
+        'callback' => '_member_resource_index',
+        'access callback' => '_member_resource_access',
+        'access arguments' => array('index'),
+        'args' => array(
+          array(
+            'name' => 'parameters',
+            'optional' => FALSE,
+            'type' => 'array',
+            'description' => 'Parameters',
+            'default value' => array(),
+            'source' => array('param' => 'parameters'),
+          ),
+        ),
       ),
     ),
     'actions' => array(
@@ -43,16 +65,17 @@ function _member_resource_defintion() {
 /**
  * Access callback for User resources.
  */
-function _member_resource_access() {
-  // Return TRUE for development.
-  return TRUE;
+function _member_resource_access($op) {
+  if ($op == 'create') {
+    return TRUE;
+  }
   global $user;
   // For now, only admins can access any reportback resources.
   return in_array('administrator', $user->roles);
 }
 
 /**
- * Callback for Reportback resource create.
+ * Callback for User create.
  *
  * @param obj $account
  *   Array passed to the endpoint. Possible keys:
@@ -61,6 +84,7 @@ function _member_resource_access() {
  *   - birthdate (datestring).
  *   - first_name (string).
  *   - last_name (string).
+ *   - mobile (string).
  *   - user_registration_source (string).
  *
  * @return mixed
@@ -127,4 +151,34 @@ function _member_resource_get_member_count() {
     'formatted' => dosomething_user_get_member_count(),
     'readable' => dosomething_user_get_member_count($readable = TRUE),
   );
+}
+
+/**
+ * Callback for Users index.
+ *
+ * @param array $parameters
+ *   Array passed within query string. Possible keys:
+ *   - email (string)..
+ *   - mobile (string).
+ *
+ * @return mixed
+ *   Object of the newly created user if successful. String if errors.
+ */
+function _member_resource_index($parameters) {
+  // Initialize output.
+  $index = array();
+
+  $query = db_select('users', 'u');
+  // We only need uid for now, as we're just checking for user existence.
+  $query->fields('u', array('uid'));
+  if (isset($parameters['email'])) {
+    $query->condition('mail', $parameters['email']);
+  }
+  if (isset($parameters['mobile'])) {
+    $query->join('field_data_field_mobile', 'm', 'u.uid = m.entity_id');
+    $query->condition('field_mobile_value', $parameters['mobile']);
+  }
+  // Return max of ten records.
+  $query->range(0, 10);
+  return $query->execute()->fetchAll();
 }


### PR DESCRIPTION
Fixes #3603: Allows an logged in administrator to query by email or mobile via DS API.

Also adds an access argument to the `_member_resource_access` function, to restrict usage to admin's. 

Returns array of User objects that match the parameters, but only returns their uid.  The parameters query is required.

Usage:

**GET** `http://dev.dosomething.org:8888/api/v1/users.json?parameters[mobile]=2125551000`

Response:

```
[
    {
        "uid": "5"
    }
]
```

If there are no Users that match, an empty array is returned.
