### PR TITLE
Reportback File Reviewer

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -6,4 +6,4 @@ dependencies[] = services
 features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
-mtime = 1417530124
+mtime = 1418230975

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -82,6 +82,11 @@ function dosomething_api_default_services_endpoint() {
           'enabled' => '1',
         ),
       ),
+      'targeted_actions' => array(
+        'review' => array(
+          'enabled' => '1',
+        ),
+      ),
     ),
     'system' => array(
       'actions' => array(

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
@@ -41,6 +41,34 @@ function _reportback_resource_defintion() {
         'access arguments' => array('access content'),
       ),
     ),
+    'targeted_actions' => array(
+      'review' => array(
+        'help' => 'Review a reportback file. POST to reportback_files/123/review',
+        'file' => array(
+          'type' => 'inc',
+          'module' => 'dosomething_api',
+          'name' => 'resources/reportback_resource',
+        ),
+        'callback' => '_reportback_resource_review',
+        'access arguments' => array('view any reportback'),
+        'args' => array(
+          array(
+            'name' => 'fid',
+            'optional' => FALSE,
+            'source' => array('path' => 0),
+            'type' => 'int',
+            'description' => 'The fid of the Reportback File to review.',
+          ),
+          array(
+            'name' => 'values',
+            'optional' => FALSE,
+            'source' => 'data',
+            'description' => 'Array including Reviewer status and source',
+            'type' => 'array',
+          ),
+        ),
+      ),
+    ),
   );
   return $resources;
 }
@@ -82,4 +110,23 @@ function _reportback_file_resource_index($page, $parameters, $page_size) {
   // the foreach loop. It is recommended to destroy it by unset().
   unset($record);
   return $result;
+}
+
+/**
+ * Callback for Reportback Files review targeted action.
+ *
+ * @param int $fid
+ *   The Reportback File fid to post the review to.
+ * @param array $values
+ *   The review data to post. Expected keys:
+ *   - status: (string).
+ *   - source (string). e.g. 'ios', 'android'.
+ */
+function _reportback_resource_review($fid, $values) {
+  $rbf = reportback_file_load($fid);
+  if (!$rbf) {
+    return NULL;
+  }
+  $rbf->review($values['status'], $values['source']);
+  return $rbf;
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -111,9 +111,10 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
   if (empty($rb_files) || !is_array($rb_files)) {
     return;
   }
-  foreach ($rb_files as $id => $item) {
-    $status = dosomething_reportback_update_reportback_file_status($item['fid'], $item['status']);
-    if (!$status) {
+  foreach ($rb_files as $fid => $item) {
+    $rbf = reportback_file_load($fid);
+    $save = $rbf->review($item['status']);
+    if (!$save) {
       form_set_error(t("An error has occurred."));
     }
   }
@@ -135,15 +136,15 @@ function theme_dosomething_reportback_files_form($variables) {
 
   // Initialize the variable which will store our table rows.
   $rows = array();
-  foreach ($rb_files as $id) {
+  foreach ($rb_files as $fid) {
     $rows[] = array(
       'data' => array(
         // Add the columns defined in the form.
-        drupal_render($form['rb_files'][$id]['date']),
-        drupal_render($form['rb_files'][$id]['preview']),
-        drupal_render($form['rb_files'][$id]['quantity']),
-        drupal_render($form['rb_files'][$id]['node']),
-        drupal_render($form['rb_files'][$id]['status']) . '<div class="flag-form"><hr />' . drupal_render($form['rb_files'][$id]['flagged_reason']) . '</div>',
+        drupal_render($form['rb_files'][$fid]['date']),
+        drupal_render($form['rb_files'][$fid]['preview']),
+        drupal_render($form['rb_files'][$fid]['quantity']),
+        drupal_render($form['rb_files'][$fid]['node']),
+        drupal_render($form['rb_files'][$fid]['status']) . '<div class="flag-form"><hr />' . drupal_render($form['rb_files'][$fid]['flagged_reason']) . '</div>',
       ),
     );
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -186,6 +186,24 @@ function dosomething_reportback_schema() {
         'not null' => FALSE,
         'default' => 'pending',
       ),
+      'reviewed' => array(
+        'description' => 'Reviewed timestamp',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'default' => NULL,
+      ),
+      'reviewer' => array(
+        'description' => 'Reviewer uid',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'default' => NULL,
+      ),
+      'review_source' => array(
+        'description' => 'Source URL which review was submitted from.',
+        'type' => 'varchar',
+        'length' => 128,
+        'default' => NULL,
+      ),
     ),
     'primary key' => array('rbid', 'fid'),
   );
@@ -366,5 +384,20 @@ function dosomething_reportback_update_7014(&$sandbox) {
   $fld_name = 'fid';
   if (!db_index_exists($tbl_name, $fld_name)) {
     db_add_index($tbl_name, $fld_name, array($fld_name));
+  }
+}
+
+/**
+ * Adds review columns to the dosomething_reportback_file table.
+ */
+function dosomething_reportback_update_7015(&$sandbox) {
+  $tbl_name = 'dosomething_reportback_file';
+  $fields = array('reviewed', 'reviewer', 'review_source');
+  $schema = dosomething_reportback_schema();
+  foreach ($fields as $fld_name) {
+    if (!db_field_exists($tbl_name, $fld_name)) {
+      // Add it per the schema field definition.
+      db_add_field($tbl_name, $fld_name, $schema[$tbl_name]['fields'][$fld_name]);
+    }
   }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -421,8 +421,8 @@ function reportback_load($id) {
 /**
  * Menu autoloader for /reportback.
  */
-function reportback_file_load($id) {
-  $reportback_file = entity_load('reportback_file', array($id));
+function reportback_file_load($fid) {
+  $reportback_file = entity_load('reportback_file', array($fid));
   return array_pop($reportback_file);
 }
 
@@ -1079,14 +1079,4 @@ function dosomething_reportback_get_file_status_options() {
     $options[$name] = t(ucfirst($name));
   }
   return $options;
-}
-
-/**
- * Updates a given Reportback File $fid's Reportback File status.
- */
-function dosomething_reportback_update_reportback_file_status($fid, $status) {
-  return db_update('dosomething_reportback_file')
-    ->fields(array('status' => $status))
-    ->condition('fid', $fid)
-    ->execute();
 }

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
@@ -17,6 +17,24 @@ class ReportbackFileEntity extends Entity {
     return array('path' => 'rbf/' . $this->identifier());
   }
 
+  /**
+   * Sets the Reportback File status column and Reviewer details.
+   */
+  public function review($status, $source = NULL) {
+    global $user;
+    $this->status = $status;
+    $this->reviewer = $user->uid;
+    $this->reviewed = REQUEST_TIME;
+    // Default source as the current URL path of page being viewed.
+    $this->review_source = current_path();
+    // If source was passed:
+    if ($source) {
+      // Store that instead.
+      $this->review_source = check_plain($source);
+    }
+    // Save the reviewed properties.
+    return entity_save('reportback_file', $this);
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #3597
- Adds columns to store the user who reviewed each Reportback File, time reviewed, and the review source (what URL they were reviewing from, or could be set to `ios` for the upcoming Reviewer iOS app)
- Adds `$reportback_file->review($status, $source)` method to the ReportbackFileEntity to set all of said properties
- Adds new API endpoint `reportback_files/[fid]/review` to POST review status and source via DS API
