### PR TITLE
Upgrade Google Analytics contrib module

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -80,7 +80,7 @@ projects[flag][version] = "3.5"
 projects[flag][subdir] = "contrib"
 
 ; Google Analytics
-projects[google_analytics][version] = "1.4"
+projects[google_analytics][version] = "2.1"
 projects[google_analytics][subdir] = "contrib"
 
 ; Http Client


### PR DESCRIPTION
This upgrades the Google Analytics contrib module in light of https://www.drupal.org/node/2390689

> The module leaks the site specific hash salt to authenticated users when user-id tracking is turned on.
> 
> This vulnerability is mitigated by the fact that user-id tracking must be turned on and the attacker needs to have an account on the site.

Unfortunately it looks like we do this, so we need to regenerate hash salts per the instructions in the link above:

![screen shot 2014-12-11 at 8 35 03 am](https://cloud.githubusercontent.com/assets/1236811/5394886/b6479734-8110-11e4-930d-1372c1a56622.png)

Ran this locally and all seems ok. Checked prod and we do not seem to be using any custom variables... @DFurnes @sergii-tkachenko -- can you confirm?

```
Updating database...
 Googleanalytics  7200  Delete custom ga.js code snipptes to prevent           
                        malfunctions in new Universal Analytics tracker. A     
                        backup of your snippets will be created.               
 Googleanalytics  7201  Delete obsolete custom variables. Custom variables are 
                        now custom dimensions and metrics.                     
 Googleanalytics  7202  Delete obsolete JavaScript scope variable.             
 Googleanalytics  7203  Flatten the metrics and dimensions arrays.             
 Googleanalytics  7204  Remove obsolete backup variables.                      
 Googleanalytics  7205  Update list of default file extensions.
Do you wish to run all pending updates? (y/n): y
No custom code snipped found. Nothing to do.                         [ok]
Performed update: googleanalytics_update_7200                        [ok]
Deleted obsolete custom variables. Custom variables are now custom   [ok]
dimensions and metrics and you need to manually configure them!
Performed update: googleanalytics_update_7201                        [ok]
Removed obsolete JavaScript scope variable.                          [ok]
Performed update: googleanalytics_update_7202                        [ok]
Saved custom dimensions and metrics.                                 [ok]
Performed update: googleanalytics_update_7203                        [ok]
Removed obsolete backup variables.                                   [ok]
Performed update: googleanalytics_update_7204                        [ok]
The default extensions for download tracking have been updated.      [ok]
Performed update: googleanalytics_update_7205                        [ok]
'all' cache was cleared.        
```
