### PR TITLE
Fixes #3617.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
@@ -150,8 +150,7 @@ define(function(require) {
         $notAffiliatedConfirmationMessage.hide();
       }
 
-      $stateField.trigger("focus").trigger("change").trigger("blur");
-      $schoolSignupForm.find("input[type='submit']").trigger("focus");
+      $stateField.trigger("change");
     });
 
     $schoolSignupForm.find(".js-schoolfinder-help").on("click", function() {


### PR DESCRIPTION
# Changes
- Fixes #3617. Submit button was un-tappable when focus was triggered on Mobile Safari. By not programmatically focusing the submit button, we avoid that issue.

For review: @DoSomething/front-end 
