### PR TITLE
Generate Reportback form

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -16,7 +16,12 @@ function dosomething_reportback_admin_config_form($form, &$form_state) {
     '#default_value' => variable_get('dosomething_reportback_is_crop_enabled', FALSE),
     '#description' => t("Allows users to crop their own Reportback images."),
   );
-
+  $form['dosomething_reportback_is_generate_enabled'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable Dummy Reportback Generation.'),
+    '#default_value' => variable_get('dosomething_reportback_is_generate_enabled', FALSE),
+    '#description' => t("Allows admins to generate Lorem ipsum Reportbacks."),
+  );
   $form['dosomething_reportback_log'] = array(
     '#type' => 'checkbox',
     '#title' => t('Log Reportbacks.'),
@@ -24,6 +29,55 @@ function dosomething_reportback_admin_config_form($form, &$form_state) {
     '#description' => t("Logs Reportback activity. This should be disabled on production."),
   );
   return system_settings_form($form);
+}
+
+/**
+ * Form constructor for generating dummy Reportbacks.
+ *
+ * @see dosomething_reportback_menu()
+ */
+function dosomething_reportback_admin_generate_form($form, &$form_state) {
+  $form['help'] = array(
+    '#markup' => t("Submitting this form will generate Lorem ipsum Reportbacks for your account."),
+  );
+  $form['nid'] = array(
+    '#type' => 'entity_autocomplete',
+    '#title' => t('Campaign'),
+    '#description' => t("Select the campaign to generate reportbacks for."),
+    '#entity_type' => 'node',
+    '#bundles' => array('campaign'),
+    '#required' => TRUE,
+  );
+   $form['num'] = array(
+     '#type' => 'select',
+     '#title' => t('Number of reportbacks'),
+     '#required' => TRUE,
+     '#options' => array(
+        5 => t('5'),
+        10 => t('10'),
+        15 => t('15'),
+        20 => t('20'),
+        25 => t('25'),
+     ),
+     '#default_value' => 15,
+   );
+  $form['actions'] = array(
+    '#type' => 'actions',
+    'submit' => array(
+      '#type' => 'submit',
+      '#value' => t("Submit"),
+    ),
+  );
+  return $form;
+}
+
+/**
+ * Form submit callback for dosomething_reportback_admin_generate_form.
+ */
+function dosomething_reportback_admin_generate_form_submit($form, &$form_state) {
+  $values = $form_state['values'];
+  dosomething_reportback_generate($values['nid'], $values['num']);
+  drupal_set_message(t("Generated %num dummy reportbacks.", array('%num' => $values['num'])));
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -114,7 +114,7 @@ function dosomething_reportback_entity_property_info() {
  */
 function dosomething_reportback_menu() {
   $items = array();
-  // Admin campaign configuration page.
+  // Admin Reportback configuration page.
   $items['admin/config/dosomething/dosomething_reportback'] = array(
     'title' => 'DoSomething Reportback',
     'description' => 'Admin form to set Reportback variables.',
@@ -124,6 +124,17 @@ function dosomething_reportback_menu() {
     'access arguments' => array('administer modules'),
     'file' => 'dosomething_reportback.admin.inc',
   );
+  if (variable_get('dosomething_reportback_is_generate_enabled', FALSE)) {
+    $items['admin/config/dosomething/dosomething_reportback/generate'] = array(
+      'title' => 'Generate Reportbacks',
+      'description' => 'Admin form to generate Lorem ipsum Reportbacks.',
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('dosomething_reportback_admin_generate_form'),
+      'access callback' => 'user_access',
+      'access arguments' => array('administer modules'),
+      'file' => 'dosomething_reportback.admin.inc',
+    );
+  }
   $items['reportback/%reportback'] = array(
     'title' => 'Reportback',
     'page callback' => 'dosomething_reportback_view_entity',
@@ -1088,6 +1099,7 @@ function dosomething_reportback_get_file_status_options() {
  * Generates a new Reportback with Placekitten and Lorem ipsum.
  */
 function dosomething_reportback_generate($nid = NULL, $num_reportbacks = 5) {
+  global $user;
   // Load devel_generate module to get random Lorem ipsum's.
   module_load_include('inc', 'devel_generate', 'devel_generate');
   if ($num_reportbacks > 50) {
@@ -1110,15 +1122,9 @@ function dosomething_reportback_generate($nid = NULL, $num_reportbacks = 5) {
     'place-hoff',
   );
   for ($i = 0; $i < $num_reportbacks; $i++) {
-    $uid = db_select("users", "u")
-      ->fields("u", array("uid"))
-      ->orderRandom()
-      ->range(0,1)
-      ->execute()
-      ->fetchField();
     $values = array(
       'nid' => $nid,
-      'uid' => $uid,
+      'uid' => $user->uid,
       'rbid' => 0,
       'caption' => devel_create_greeking(rand(1, 3)),
       'why_participated' => devel_create_greeking(rand(2, 20)),

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -634,8 +634,11 @@ function dosomething_reportback_get_file_dest($name, $nid, $uid = NULL) {
   }
   // Parse original filename.
   $pathinfo = pathinfo($name);
+  $ext = 'jpg';
   // Save its extension.
-  $ext = $pathinfo['extension'];
+  if (isset($pathinfo['extension'])) {
+    $ext = $pathinfo['extension'];
+  }
   // Define reportback nid file directory.
   $dir = 'public://reportbacks/' . $nid;
   // If directory doesn't exist / can't be created:
@@ -1079,4 +1082,56 @@ function dosomething_reportback_get_file_status_options() {
     $options[$name] = t(ucfirst($name));
   }
   return $options;
+}
+
+/**
+ * Generates a new Reportback with Placekitten and Lorem ipsum.
+ */
+function dosomething_reportback_generate($nid = NULL, $num_reportbacks = 5) {
+  // Load devel_generate module to get random Lorem ipsum's.
+  module_load_include('inc', 'devel_generate', 'devel_generate');
+  if ($num_reportbacks > 50) {
+    return FALSE;
+  }
+  if (!$nid) {
+    $nid = db_select("node", "n")
+      ->fields("n", array("nid"))
+      ->condition("type", "campaign")
+      ->orderRandom()
+      ->range(0,1)
+      ->execute()
+      ->fetchField();
+  }
+  // List of sites to grab images from.
+  $generators = array(
+    'placebear',
+    'placecreature',
+    'placekitten',
+    'place-hoff',
+  );
+  for ($i = 0; $i < $num_reportbacks; $i++) {
+    $uid = db_select("users", "u")
+      ->fields("u", array("uid"))
+      ->orderRandom()
+      ->range(0,1)
+      ->execute()
+      ->fetchField();
+    $values = array(
+      'nid' => $nid,
+      'uid' => $uid,
+      'rbid' => 0,
+      'caption' => devel_create_greeking(rand(1, 3)),
+      'why_participated' => devel_create_greeking(rand(2, 20)),
+      'quantity' => rand(2,800),
+    );
+    // Pick a site, any site.
+    $site = $generators[rand(0, count($generators)-1)];
+    // Pick an image, any image.
+    $file_url = "http://" . $site . ".com/" . rand(300, 1000) . "/" . rand(300, 1000);
+    // Save it.
+    $file = dosomething_reportback_save_file_from_url($nid, $uid, $file_url);
+    $values['fid'] = $file->fid;
+    watchdog('dosomething_reportback', "Generated RB:" . json_encode($values));
+    dosomething_reportback_save($values);
+  }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1131,7 +1131,9 @@ function dosomething_reportback_generate($nid = NULL, $num_reportbacks = 5) {
       'quantity' => rand(2,800),
     );
     // Pick a site, any site.
-    $site = $generators[rand(0, count($generators)-1)];
+    $random_key = array_rand($generators);
+    $site = $generators[$random_key];
+
     // Pick an image, any image.
     $file_url = "http://" . $site . ".com/" . rand(300, 1000) . "/" . rand(300, 1000);
     // Save it.


### PR DESCRIPTION
Admin-only form to allow easier development of Reportback Gallery and Review functionality. Closes #3634

Hardcodes the Reportback uid to the logged in user, because as is, once dployed to staging, this will send live Reportback Transactional emails.

![screen shot 2014-12-16 at 10 57 33 am](https://cloud.githubusercontent.com/assets/1236811/5456557/68b0b400-8512-11e4-8ebf-2cdfd5362c93.png)

A nice to have TODO: Allow setting the Review status automatically, e.g. `approved`, `promoted`.
