### PR TITLE
Flagged and flagged_reason columns

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -165,13 +165,30 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
   if (empty($rb_files) || !is_array($rb_files)) {
     return;
   }
-  foreach ($rb_files as $fid => $item) {
+
+  foreach ($rb_files as $fid => $values) {
+
     $rbf = reportback_file_load($fid);
-    $save = $rbf->review($item['status']);
+
+    // Loop through the flagged_reason values:
+    foreach ($values['flagged_reason'] as $reason_key => $reason_value) {
+      // Form sends unchecked as a 0.
+      if (!is_string($reason_value)) {
+        unset($values['flagged_reason'][$reason_key]);
+      }
+    }
+
+    // Overwrite flagged reason with the new concatenated string.
+    $values['flagged_reason'] = implode(', ', $values['flagged_reason']);
+
+    // Write the review data.
+    $save = $rbf->review($values);
     if (!$save) {
       form_set_error(t("An error has occurred."));
     }
+
   }
+
   drupal_set_message(t("Updated."));
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -58,6 +58,17 @@ function dosomething_reportback_schema() {
         'description' => 'The number of participants, if applicable.',
         'type' => 'int',
       ),
+      'flagged' => array(
+        'description' => 'Whether the Reportback has been flagged.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'flagged_reason' => array(
+        'description' => 'Reason why reportback was flagged.',
+        'type' => 'varchar',
+        'length' => '255',
+      ),
     ),
     'primary key' => array('rbid'),
     'indexes' => array(
@@ -393,6 +404,22 @@ function dosomething_reportback_update_7014(&$sandbox) {
 function dosomething_reportback_update_7015(&$sandbox) {
   $tbl_name = 'dosomething_reportback_file';
   $fields = array('reviewed', 'reviewer', 'review_source');
+  $schema = dosomething_reportback_schema();
+  foreach ($fields as $fld_name) {
+    if (!db_field_exists($tbl_name, $fld_name)) {
+      // Add it per the schema field definition.
+      db_add_field($tbl_name, $fld_name, $schema[$tbl_name]['fields'][$fld_name]);
+    }
+  }
+}
+
+
+/**
+ * Adds flagged columns to the dosomething_reportback table.
+ */
+function dosomething_reportback_update_7016(&$sandbox) {
+  $tbl_name = 'dosomething_reportback';
+  $fields = array('flagged', 'flagged_reason');
   $schema = dosomething_reportback_schema();
   foreach ($fields as $fld_name) {
     if (!db_field_exists($tbl_name, $fld_name)) {

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -226,6 +226,18 @@ class ReportbackEntity extends Entity {
       ->condition('rbid', $this->rbid)
       ->execute();
   }
+
+  /**
+   * Flags the reportback with the given $reason string.
+   *
+   * @param string $reason
+   *   Text to store in the flagged_reason property.
+   */
+  public function flag($reason) {
+    $this->flagged = 1;
+    $this->flagged_reason = $reason;
+    return entity_save('reportback_file', $this);
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
@@ -32,17 +32,24 @@ class ReportbackFileEntity extends Entity {
   /**
    * Sets the Reportback File status column and Reviewer details.
    */
-  public function review($status, $source = NULL) {
+  public function review($values) {
     global $user;
-    $this->status = $status;
+    if (!isset($values['status'])) {
+      return FALSE;
+    }
+    $this->status = $values['status'];
     $this->reviewer = $user->uid;
     $this->reviewed = REQUEST_TIME;
     // Default source as the current URL path of page being viewed.
     $this->review_source = current_path();
     // If source was passed:
-    if ($source) {
+    if (isset($values['source'])) {
       // Store that instead.
       $this->review_source = check_plain($source);
+    }
+    if ($this->status === 'flagged') {
+      $reportback = reportback_load($this->rbid);
+      $reportback->flag($values['flagged_reason']);
     }
     // Save the reviewed properties.
     return entity_save('reportback_file', $this);


### PR DESCRIPTION
Refs #3564

Adds `flagged` and `flagged_reason` columns to the `dosomething_reportback` table.  Writes the values upon setting a Reportback File to flagged.

This ditches the use of the Flag module for flagging Reportbacks, moving to a simpler custom implementation.
