### PR TITLE
Delete Reportback Images

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -95,7 +95,6 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
     'irrelevant' => t('Irrelevant'),
     'inappropriate' => t('Inappropriate'),
     'unrealistic' => t('Unrealistic quantity'),
-    'delete' => t('Delete this image'),
   );
 
   $params = array(
@@ -146,6 +145,10 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
       'flagged_reason' => array(
         '#type' => 'checkboxes',
         '#options' => $flagged_options,
+      ),
+      'delete' => array(
+        '#type' => 'checkbox',
+        '#title' => t("Delete this image"),
       ),
     );
   }
@@ -208,6 +211,8 @@ function theme_dosomething_reportback_files_form($variables) {
   // Initialize the variable which will store our table rows.
   $rows = array();
   foreach ($rb_files as $fid) {
+    $flag_form = drupal_render($form['rb_files'][$fid]['flagged_reason']);
+    $flag_form .= drupal_render($form['rb_files'][$fid]['delete']);
     $rows[] = array(
       'data' => array(
         // Add the columns defined in the form.
@@ -215,7 +220,7 @@ function theme_dosomething_reportback_files_form($variables) {
         drupal_render($form['rb_files'][$fid]['preview']),
         drupal_render($form['rb_files'][$fid]['quantity']),
         drupal_render($form['rb_files'][$fid]['node']),
-        drupal_render($form['rb_files'][$fid]['status']) . '<div class="flag-form"><hr />' . drupal_render($form['rb_files'][$fid]['flagged_reason']) . '</div>',
+        drupal_render($form['rb_files'][$fid]['status']) . '<div class="flag-form"><hr />' . $flag_form . '</div>',
       ),
     );
   }

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -218,13 +218,9 @@ class ReportbackEntity extends Entity {
   public function deleteFiles() {
     // Loop through the reportback files:
     foreach ($this->getFids() as $fid) {
-      $file = file_load($fid);
-      file_delete($file);
+      $rbf = reportback_file_load($fid);
+      $rbf->delete();
     }
-    // Delete the files table rows.
-    db_delete($this->files_table)
-      ->condition('rbid', $this->rbid)
-      ->execute();
   }
 
   /**
@@ -413,9 +409,10 @@ class ReportbackEntityController extends EntityAPIController {
    */
   public function delete($ids, DatabaseTransaction $transaction = NULL) {
     // Log deletions.
-    foreach ($ids as $id) {
-      $rb = reportback_load($id);
+    foreach ($ids as $rbid) {
+      $rb = reportback_load($rbid);
       $rb->insertLog('delete');
+      $rb->deleteFiles();
     }
     parent::delete($ids, $transaction);
   }

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
@@ -58,7 +58,7 @@ class ReportbackFileEntity extends Entity {
     if ($this->status === 'flagged') {
       $reportback = reportback_load($this->rbid);
       $reportback->flag($values['flagged_reason']);
-      if ($values['delete'] == 1) {
+      if ($values['delete']) {
         $this->deleteFile();
       }
     }

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
@@ -71,7 +71,9 @@ class ReportbackFileEntity extends Entity {
    */
   public function deleteFile() {
     $file = file_load($this->fid);
-    return file_delete($file);
+    if ($file) {
+      return file_delete($file);
+    }
   }
 }
 
@@ -124,4 +126,15 @@ class ReportbackFileEntityController extends EntityAPIController {
     return $build;
   }
 
+  /**
+   * Overrides delete() method.
+   */
+  public function delete($ids, DatabaseTransaction $transaction = NULL) {
+    // Delete the related Files.
+    foreach ($ids as $fid) {
+      $rbf = reportback_file_load($fid);
+      $rbf->deleteFile();
+    }
+    parent::delete($ids, $transaction);
+  }
 }

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
@@ -30,7 +30,15 @@ class ReportbackFileEntity extends Entity {
   }
 
   /**
-   * Sets the Reportback File status column and Reviewer details.
+   * Sets the Reportback File status and Reviewer details.
+   *
+   * @param array $values
+   *   An associative array containing:
+   *   - status (string).  Required.
+   *   - source (string). The page or device the Review has been submitted from.
+   *   - flagged_reason (string).
+   *   - delete (integer).  If set to 1, delete the corresponding File entity.
+   *
    */
   public function review($values) {
     global $user;
@@ -50,9 +58,20 @@ class ReportbackFileEntity extends Entity {
     if ($this->status === 'flagged') {
       $reportback = reportback_load($this->rbid);
       $reportback->flag($values['flagged_reason']);
+      if ($values['delete'] == 1) {
+        $this->deleteFile();
+      }
     }
     // Save the reviewed properties.
     return entity_save('reportback_file', $this);
+  }
+
+  /**
+   * Deletes the File associated with this Reportback File.
+   */
+  public function deleteFile() {
+    $file = file_load($this->fid);
+    return file_delete($file);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/js/reportback_review_form.js
+++ b/lib/modules/dosomething/dosomething_reportback/js/reportback_review_form.js
@@ -4,7 +4,7 @@
     // Hide all flag forms to start.
     $('.flag-form').hide();
 
-    // Listen for changes to Status checkboxes.
+    // Listen for changes to Status radios.
     $('.form-radio:input[name*="status"]').click(function() {
       // Find the flagForm that corresponds to this checkbox.
       var flagForm = $(this).parents('.form-type-radios').next('.flag-form');
@@ -17,5 +17,15 @@
         flagForm.hide();
       }
     });
+
+    // Listen for changes to Delete checkboxes.
+    $(':input[name*="delete"]').click(function() {
+
+      // If "flagged" was checked:
+      if ($(this).is(':checked')) {
+        alert(Drupal.t("Deleting this image cannot be undone.\n\nOnly do this if you really, really mean it!"));
+      }
+    });
+
   });
 }(jQuery));


### PR DESCRIPTION
Refs #3564 - allows staff to delete a Reportback image from the new review form.  This is necessary for when users upload things we don't want hosted on our server.

Also cleans up the Reportback Files and related `file_managed` Files upon deleting a Reportback.
