### PR TITLE
User Profile - Reportback permalinks

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -564,6 +564,10 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
     foreach ($reportbacks as $delta => $rbid) {
       $reportback = reportback_load((int) $rbid);
       $impact = $reportback->quantity . ' ' . $reportback->noun . ' ' . $reportback->verb;
+      if (user_access('view any reportback')) {
+        // Link to the full reportback entity view.
+        $impact = l($impact, 'reportback/' . $rbid);
+      }
       $img = dosomething_image_get_themed_image_by_fid($reportback->fids[0], '300x300');
       // Media gallery template expects a full URL.
       $url = $base_url . '/' . drupal_get_path_alias('node/' . $reportback->nid);


### PR DESCRIPTION
Links the Impact description to the Reportback `reportback/[rbid]` if the logged in user has access to `view any reportback`. 
