### PR TITLE
Switching class placed on upload field based on theme setting

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -81,11 +81,12 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
       '#access' => FALSE,
     );
   }
+  $reportback_file_class = (theme_get_setting('show_new_reportback')) ? 'js-image-upload-beta' : 'js-image-upload';
   $form['reportback_file'] = array(
     '#type' => 'file',
     '#title' => t('Upload a pic'),
     '#attributes' => array(
-      'class' => array('js-image-upload-beta'),
+      'class' => array($reportback_file_class),
     ),
   );
   // Hidden fields to collect cropping information.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -81,6 +81,7 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
       '#access' => FALSE,
     );
   }
+  // @TODO - Remove this switch once we get rid of the old experience.
   $reportback_file_class = (theme_get_setting('show_new_reportback')) ? 'js-image-upload-beta' : 'js-image-upload';
   $form['reportback_file'] = array(
     '#type' => 'file',


### PR DESCRIPTION
We are supporting both reportback experiences for the time being, so this puts the correct class on the image upload field to support the different js scripts. 

@DFurnes @aaronschachter 
