### PR TITLE
Gallery api

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -6,4 +6,4 @@ dependencies[] = services
 features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
-mtime = 1420500775
+mtime = 1420500855

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -6,4 +6,4 @@ dependencies[] = services
 features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
-mtime = 1418230975
+mtime = 1420500775

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -59,6 +59,11 @@ function dosomething_api_default_services_endpoint() {
           'enabled' => '1',
         ),
       ),
+      'relationships' => array(
+        'gallery' => array(
+          'enabled' => '1',
+        ),
+      ),
       'targeted_actions' => array(
         'signup' => array(
           'enabled' => '1',

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -82,11 +82,6 @@ function dosomething_api_default_services_endpoint() {
       ),
     ),
     'reportback_files' => array(
-      'operations' => array(
-        'index' => array(
-          'enabled' => '1',
-        ),
-      ),
       'targeted_actions' => array(
         'review' => array(
           'enabled' => '1',

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -22,6 +22,33 @@ function _campaign_resource_defintion() {
         ),
       ),
     ),
+    'relationships' => array(
+      'gallery' => array(
+        'file' => array('type' => 'inc', 'module' => 'dosomething_api', 'name' => 'resources/campaign_resource'),
+        'help'   => 'Returns Reportback Gallery. GET from campaigns/123/gallery',
+        'access callback' => '_node_resource_access',
+        'access arguments' => array('view'),
+        'access arguments append' => TRUE,
+        'callback' => '_campaign_resource_load_gallery',
+        'args'     => array(
+          array(
+            'name' => 'nid',
+            'optional' => FALSE,
+            'source' => array('path' => 0),
+            'type' => 'int',
+            'description' => 'The nid of the node whose gallery we are getting',
+          ),
+          array(
+            'name' => 'is_promoted',
+            'type' => 'int',
+            'description'  => t('To return promoted or not.'),
+            'source' => array('path' => 2),
+            'optional' => TRUE,
+            'default value' => TRUE,
+          ),
+        ),
+      ),
+    ),
     'targeted_actions' => array(
       'signup' => array(
         'help' => 'Signup a user for a campaign. POST to campaigns/123/signup',
@@ -218,4 +245,29 @@ function _campaign_resource_reportback($nid, $values) {
     watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
   }
   return dosomething_reportback_save($values);
+}
+
+function _campaign_resource_load_gallery($nid) {
+  // Load Services module to use its index_query functions.
+  module_load_include('inc', 'services', 'services.module');
+  $int_properties = array('rbid', 'fid', 'fid_processed');
+  $params = array('nid' => $nid);
+  $results = dosomething_reportback_get_reportback_files_query(0, $params);
+  $result = services_resource_build_index_list($results, 'reportback_files', 'fid');
+
+  foreach ($result as &$record) {
+    // Convert string output to integers were appropriate.
+    foreach ($int_properties as $property) {
+      $record->{$property} = (int) $record->{$property};
+    }
+    // We'll eventually want to use the fid_processed here.
+    // And also probably won't need to apply an image style, since it
+    // will already be cropped.
+    $record->src = dosomething_image_get_themed_image_url_by_fid($record->fid, '300x300');
+  }
+  // @see http://php.net/manual/en/control-structures.foreach.php:
+  // Reference of a $value and the last array element remain even after
+  // the foreach loop. It is recommended to destroy it by unset().
+  unset($record);
+  return $result;
 }

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -39,12 +39,18 @@ function _campaign_resource_defintion() {
             'description' => 'The nid of the node whose gallery we are getting',
           ),
           array(
-            'name' => 'is_promoted',
-            'type' => 'int',
-            'description'  => t('To return promoted or not.'),
-            'source' => array('path' => 2),
-            'optional' => TRUE,
-            'default value' => TRUE,
+            'name'         => 'count',
+            'type'         => 'int',
+            'description'  => t('Number of Reportback Files to load.'),
+            'source'       => array('param' => 'count'),
+            'optional'     => TRUE,
+          ),
+          array(
+            'name'         => 'offset',
+            'type'         => 'int',
+            'description'  => t('If count is set to non-zero value, you can pass also non-zero value for start. For example to get Reportback Files from 5 to 15, pass count=10 and start=5.'),
+            'source'       => array('param' => 'offset'),
+            'optional'     => TRUE,
           ),
         ),
       ),
@@ -247,13 +253,29 @@ function _campaign_resource_reportback($nid, $values) {
   return dosomething_reportback_save($values);
 }
 
-function _campaign_resource_load_gallery($nid) {
+/**
+ * Returns the Reportback Gallery of a specified node.
+ *
+ * @param $nid
+ *   Unique identifier for the node.
+ * @param $count
+ *   Number of Reporback Files to return.
+ * @param $start
+ *   Which RB File to start with. If present, $start and $count are used together
+ *   to create a LIMIT clause to select RB Files. This could be used to do paging.
+ *
+ * @return
+ *   An array of Reportback File objects.
+ */
+function _campaign_resource_load_gallery($nid, $count = 25, $start = 0) {
   // Load Services module to use its index_query functions.
   module_load_include('inc', 'services', 'services.module');
   $int_properties = array('rbid', 'fid', 'fid_processed');
   $params = array(
     'nid' => $nid,
     'status' => 'approved',
+    'count' => $count,
+    'start' => $start,
   );
   $results = dosomething_reportback_get_reportback_files_query(0, $params);
   $result = services_resource_build_index_list($results, 'reportback_files', 'fid');

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -39,18 +39,18 @@ function _campaign_resource_defintion() {
             'description' => 'The nid of the node whose gallery we are getting',
           ),
           array(
-            'name'         => 'count',
-            'type'         => 'int',
-            'description'  => t('Number of Reportback Files to load.'),
-            'source'       => array('param' => 'count'),
-            'optional'     => TRUE,
+            'name' => 'count',
+            'type' => 'int',
+            'description' => t('Number of Reportback Files to load.'),
+            'source' => array('param' => 'count'),
+            'optional' => TRUE,
           ),
           array(
-            'name'         => 'offset',
-            'type'         => 'int',
-            'description'  => t('If count is set to non-zero value, you can pass also non-zero value for start. For example to get Reportback Files from 5 to 15, pass count=10 and start=5.'),
-            'source'       => array('param' => 'offset'),
-            'optional'     => TRUE,
+            'name' => 'offset',
+            'type' => 'int',
+            'description' => t('If count is set to non-zero value, you can pass also non-zero value for start. For example to get Reportback Files from 5 to 15, pass count=10 and start=5.'),
+            'source' => array('param' => 'offset'),
+            'optional' => TRUE,
           ),
         ),
       ),
@@ -277,7 +277,7 @@ function _campaign_resource_load_gallery($nid, $count = 25, $start = 0) {
     'count' => $count,
     'start' => $start,
   );
-  $results = dosomething_reportback_get_reportback_files_query(0, $params);
+  $results = dosomething_reportback_get_reportback_files_query_result($params, $count, $start);
   $result = services_resource_build_index_list($results, 'reportback_files', 'fid');
 
   foreach ($result as &$record) {

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -251,7 +251,10 @@ function _campaign_resource_load_gallery($nid) {
   // Load Services module to use its index_query functions.
   module_load_include('inc', 'services', 'services.module');
   $int_properties = array('rbid', 'fid', 'fid_processed');
-  $params = array('nid' => $nid);
+  $params = array(
+    'nid' => $nid,
+    'status' => 'approved',
+  );
   $results = dosomething_reportback_get_reportback_files_query(0, $params);
   $result = services_resource_build_index_list($results, 'reportback_files', 'fid');
 

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -256,11 +256,11 @@ function _campaign_resource_reportback($nid, $values) {
 /**
  * Returns the Reportback Gallery of a specified node.
  *
- * @param $nid
+ * @param int $nid
  *   Unique identifier for the node.
- * @param $count
+ * @param int $count
  *   Number of Reporback Files to return.
- * @param $start
+ * @param int $start
  *   Which RB File to start with. If present, $start and $count are used together
  *   to create a LIMIT clause to select RB Files. This could be used to do paging.
  *

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
@@ -3,44 +3,6 @@
 function _reportback_resource_defintion() {
   $resources = array();
   $resources['reportback_files'] = array(
-    'operations' => array(
-      'index' => array(
-        'help' => 'List all reportback files',
-        'file' => array(
-          'type' => 'inc',
-          'module' => 'dosomething_api',
-          'name' => 'resources/reportback_resource',
-        ),
-        'callback' => '_reportback_file_resource_index',
-        'args' => array(
-          array(
-            'name' => 'page',
-            'optional' => TRUE,
-            'type' => 'int',
-            'description' => 'The zero-based index of the page to get, defaults to 0.',
-            'default value' => 0,
-            'source' => array('param' => 'page'),
-          ),
-          array(
-            'name' => 'parameters',
-            'optional' => TRUE,
-            'type' => 'array',
-            'description' => 'Parameters array',
-            'default value' => array(),
-            'source' => array('param' => 'parameters'),
-          ),
-          array(
-            'name' => 'pagesize',
-            'optional' => TRUE,
-            'type' => 'int',
-            'description' => 'Number of records to get per page.',
-            'default value' => variable_get('services_node_index_page_size', 20),
-            'source' => array('param' => 'pagesize'),
-          ),
-        ),
-        'access arguments' => array('access content'),
-      ),
-    ),
     'targeted_actions' => array(
       'review' => array(
         'help' => 'Review a reportback file. POST to reportback_files/123/review',
@@ -71,45 +33,6 @@ function _reportback_resource_defintion() {
     ),
   );
   return $resources;
-}
-
-/**
- * Return an array of optionally paged reportback files based on a set of criteria.
- *
- * @param $page
- *   Page number of results to return (in pages of $pagesize, or 20).
- * @param $parameters
- *   An array containing fields and values used to build a sql WHERE clause
- *   indicating items to retrieve.
- * @param $page_size
- *   Integer number of items to be returned.
- *
- * @return
- *   An array of Reportback File objects.
- */
-function _reportback_file_resource_index($page, $parameters, $page_size) {
-  // Load Services module to use its index_query functions.
-  module_load_include('inc', 'services', 'services.module');
-
-  $int_properties = array('rbid', 'fid', 'fid_processed', 'nid', 'quantity');
-  $results = dosomething_reportback_get_reportback_files_query($page, $parameters, $page_size);
-  $result = services_resource_build_index_list($results, 'reportback_files', 'fid');
-
-  foreach ($result as &$record) {
-    // Convert string output to integers were appropriate.
-    foreach ($int_properties as $property) {
-      $record->{$property} = (int) $record->{$property};
-    }
-    // We'll eventually want to use the fid_processed here.
-    // And also probably won't need to apply an image style, since it
-    // will already be cropped.
-    $record->src = dosomething_image_get_themed_image_url_by_fid($record->fid, '300x300');
-  }
-  // @see http://php.net/manual/en/control-structures.foreach.php:
-  // Reference of a $value and the last array element remain even after
-  // the foreach loop. It is recommended to destroy it by unset().
-  unset($record);
-  return $result;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -386,7 +386,7 @@ function dosomething_campaign_preprocess_closed_reportback_gallery(&$vars, $styl
     'nid' => $vars['nid'],
     'status' => 'promoted',
   );
-  $result = dosomething_reportback_get_reportback_files_query($params, $num_items);
+  $result = dosomething_reportback_get_reportback_files_query_result($params, $num_items);
 
   // Loop through gallery_vars to only output what we need for theming:
   foreach ($result as $delta => $item) {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -386,7 +386,7 @@ function dosomething_campaign_preprocess_closed_reportback_gallery(&$vars, $styl
     'nid' => $vars['nid'],
     'status' => 'promoted',
   );
-  $result = dosomething_reportback_get_reportback_files_query(0, $params, $num_items);
+  $result = dosomething_reportback_get_reportback_files_query($params, $num_items);
 
   // Loop through gallery_vars to only output what we need for theming:
   foreach ($result as $delta => $item) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -130,7 +130,7 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
     }
   }
   // Get the DatabaseQuery to loop through.
-  $result = dosomething_reportback_get_reportback_files_query(0, $params, $page_size);
+  $result = dosomething_reportback_get_reportback_files_query($params, $page_size);
   // Get the total number of results.
   $total = dosomething_reportback_get_reportback_files_query_count($params);
   $page_size_copy = '';

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -130,7 +130,7 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
     }
   }
   // Get the DatabaseQuery to loop through.
-  $result = dosomething_reportback_get_reportback_files_query($params, $page_size);
+  $result = dosomething_reportback_get_reportback_files_query_result($params, $page_size);
   // Get the total number of results.
   $total = dosomething_reportback_get_reportback_files_query_count($params);
   $page_size_copy = '';

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -924,7 +924,7 @@ function dosomething_reportback_preprocess_page(&$vars) {
 }
 
 /**
- * Returns Reportback Files query to loop through.
+ * Returns a SelectQuery object of Reportback Files with given $params.
  *
  * @param array $params
  *   An associative array of conditions to filter by. Possible keys:
@@ -932,16 +932,8 @@ function dosomething_reportback_preprocess_page(&$vars) {
  *   - tid: A taxonomy term tid, filters RB Files for all nodes tagged tid.
  *   - status: The RB File status.
  *   - random: If set, randomly sort the results.
- * @param $count
- *   Number of Reportback Files to return.
- * @param $start
- *   Which RB File to start with. If present, $start and $count are used together
- *   to create a LIMIT clause for selecting RB Files. This could be used to do paging.
- *
- * @return
- *   An executed database query object to iterate through.
  */
-function dosomething_reportback_get_reportback_files_query($params = array(), $count = 25, $start = 0, $count_query = FALSE) {
+function dosomething_reportback_get_reportback_files_query($params = array()) {
   $query = db_select('dosomething_reportback_file', 'rbf');
   $query->join('dosomething_reportback', 'rb', 'rb.rbid = rbf.rbid');
   $query->join('users', 'u', 'rb.uid = u.uid');
@@ -970,11 +962,27 @@ function dosomething_reportback_get_reportback_files_query($params = array(), $c
   else {
     $query->orderBy('rb.updated', 'DESC');
   }
-  if ($count_query) {
-    $result = $query->execute();
-    return $result->rowCount();
-  }
-  elseif ($count) {
+  return $query;
+}
+
+/**
+ * Returns Reportback Files query result to loop through.
+ *
+ * @param array $params
+ *   An associative array of conditions to filter by.
+ *   @see dosomething_reportback_get_reportback_files_query()
+ * @param $count
+ *   Number of Reportback Files to return.
+ * @param $start
+ *   Which RB File to start with. If present, $start and $count are used together
+ *   to create a LIMIT clause for selecting RB Files. This could be used to do paging.
+ *
+ * @return
+ *   An executed database query object to iterate through.
+ */
+function dosomething_reportback_get_reportback_files_query_result($params = array(), $count = 25, $start = 0) {
+  $query = dosomething_reportback_get_reportback_files_query($params);
+  if ($count) {
     $query->range($start, $count);
   }
   $result = $query->execute();
@@ -992,7 +1000,9 @@ function dosomething_reportback_get_reportback_files_query($params = array(), $c
  * @return int
  */
 function dosomething_reportback_get_reportback_files_query_count($params) {
-  return dosomething_reportback_get_reportback_files_query($params, 0, NULL, TRUE);
+  $query = dosomething_reportback_get_reportback_files_query($params);
+  $result = $query->execute();
+  return $result->rowCount();
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -926,23 +926,22 @@ function dosomething_reportback_preprocess_page(&$vars) {
 /**
  * Returns Reportback Files query to loop through.
  *
- * @param int $page
- *   The results page to start from.
  * @param array $params
  *   An associative array of conditions to filter by. Possible keys:
  *   - nid: A node nid to filter by.
  *   - tid: A taxonomy term tid, filters RB Files for all nodes tagged tid.
  *   - status: The RB File status.
  *   - random: If set, randomly sort the results.
- * @param int $page_size
- *   Number of results to display on a page.
- * @param bool $count_query
- *   Whether to return the total count (instead of returning the records).
+ * @param $count
+ *   Number of Reportback Files to return.
+ * @param $start
+ *   Which RB File to start with. If present, $start and $count are used together
+ *   to create a LIMIT clause for selecting RB Files. This could be used to do paging.
  *
  * @return
  *   An executed database query object to iterate through.
  */
-function dosomething_reportback_get_reportback_files_query($page = 0, $params = array(), $page_size = 25, $count_query = FALSE) {
+function dosomething_reportback_get_reportback_files_query($params = array(), $count = 25, $start = 0, $count_query = FALSE) {
   $query = db_select('dosomething_reportback_file', 'rbf');
   $query->join('dosomething_reportback', 'rb', 'rb.rbid = rbf.rbid');
   $query->join('users', 'u', 'rb.uid = u.uid');
@@ -975,11 +974,8 @@ function dosomething_reportback_get_reportback_files_query($page = 0, $params = 
     $result = $query->execute();
     return $result->rowCount();
   }
-  if (!isset($params['count'])) {
-    $query->range($page * $page_size, $page_size);
-  }
-  else {
-    $query->range($params['start'], $params['count']);
+  elseif ($count) {
+    $query->range($start, $count);
   }
   $result = $query->execute();
   return $result;
@@ -996,7 +992,7 @@ function dosomething_reportback_get_reportback_files_query($page = 0, $params = 
  * @return int
  */
 function dosomething_reportback_get_reportback_files_query_count($params) {
-  return dosomething_reportback_get_reportback_files_query(0, $params, NULL, TRUE);
+  return dosomething_reportback_get_reportback_files_query($params, 0, NULL, TRUE);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -971,9 +971,9 @@ function dosomething_reportback_get_reportback_files_query($params = array()) {
  * @param array $params
  *   An associative array of conditions to filter by.
  *   @see dosomething_reportback_get_reportback_files_query()
- * @param $count
+ * @param int $count
  *   Number of Reportback Files to return.
- * @param $start
+ * @param int $start
  *   Which RB File to start with. If present, $start and $count are used together
  *   to create a LIMIT clause for selecting RB Files. This could be used to do paging.
  *

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -975,7 +975,12 @@ function dosomething_reportback_get_reportback_files_query($page = 0, $params = 
     $result = $query->execute();
     return $result->rowCount();
   }
-  $query->range($page * $page_size, $page_size);
+  if (!isset($params['count'])) {
+    $query->range($page * $page_size, $page_size);
+  }
+  else {
+    $query->range($params['start'], $params['count']);
+  }
   $result = $query->execute();
   return $result;
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -961,9 +961,8 @@ function dosomething_reportback_get_reportback_files_query($page = 0, $params = 
   elseif (isset($params['rbid'])) {
     $query->condition('rb.rbid', $params['rbid']);
   }
-  $query->fields('rbf');
+  $query->fields('rbf', array('fid', 'caption', 'rbid'));
   $query->fields('rb', array('quantity', 'why_participated'));
-  $query->fields('u', array('uid', 'mail'));
   $query->fields('n', array('nid', 'title'));
   $query->fields('f', array('timestamp'));
   if (isset($params['random'])) {

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -400,7 +400,7 @@ function paraneue_dosomething_preprocess_reportback_files(&$vars) {
   $params['nid'] = $vars['nid'];
   $params['status'] = 'promoted';
   $params['random'] = TRUE;
-  $promoted_results = dosomething_reportback_get_reportback_files_query(0, $params, $num_items);
+  $promoted_results = dosomething_reportback_get_reportback_files_query($params, $num_items);
   foreach ($promoted_results as $rb_file) {
     $rb_file->image = dosomething_image_get_themed_image_url_by_fid($rb_file->fid, '300x300');
     $vars['reportback_files'][] = paraneue_dosomething_get_gallery_item((array) $rb_file, 'photo');
@@ -413,7 +413,7 @@ function paraneue_dosomething_preprocess_reportback_files(&$vars) {
     // Set params to retrieve approved Reportback Files for this nid.
     $params['status'] = 'approved';
     unset($params['random']);
-    $approved_results  = dosomething_reportback_get_reportback_files_query(0, $params, $approved_count);
+    $approved_results  = dosomething_reportback_get_reportback_files_query($params, $approved_count);
     foreach ($approved_results as $rb_file) {
       // @todo: DRY. Potentially grab this data from the API endpoint to truly DRY?
       $rb_file->image = dosomething_image_get_themed_image_url_by_fid($rb_file->fid, '300x300');

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -400,7 +400,7 @@ function paraneue_dosomething_preprocess_reportback_files(&$vars) {
   $params['nid'] = $vars['nid'];
   $params['status'] = 'promoted';
   $params['random'] = TRUE;
-  $promoted_results = dosomething_reportback_get_reportback_files_query($params, $num_items);
+  $promoted_results = dosomething_reportback_get_reportback_files_query_result($params, $num_items);
   foreach ($promoted_results as $rb_file) {
     $rb_file->image = dosomething_image_get_themed_image_url_by_fid($rb_file->fid, '300x300');
     $vars['reportback_files'][] = paraneue_dosomething_get_gallery_item((array) $rb_file, 'photo');
@@ -413,7 +413,7 @@ function paraneue_dosomething_preprocess_reportback_files(&$vars) {
     // Set params to retrieve approved Reportback Files for this nid.
     $params['status'] = 'approved';
     unset($params['random']);
-    $approved_results  = dosomething_reportback_get_reportback_files_query($params, $approved_count);
+    $approved_results  = dosomething_reportback_get_reportback_files_query_result($params, $approved_count);
     foreach ($approved_results as $rb_file) {
       // @todo: DRY. Potentially grab this data from the API endpoint to truly DRY?
       $rb_file->image = dosomething_image_get_themed_image_url_by_fid($rb_file->fid, '300x300');


### PR DESCRIPTION
- Replaces the `reportback_files` GET endpoint with a `campaigns/[nid]/gallery` endpiont, with easier arguments:
  - e.g. `GET campaigns/362/gallery?offset=3&count=20`.  Heads up @weerd this breaks your ajax stuff!  Need to update the URL accordingly.
- Also refactors `dosomething_reportback_get_reportback_files_query` to simply return the SelectQuery, and adds `dosomething_reportback_get_reportback_files_query_result` function to be used along with `dosomething_reportback_get_reportback_files_query_count`, with easier parameters. 
- Also closes #3675 by hiding User information from the public gallery endpoint
