### PR TITLE
Reportback cropping fixes

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageCrop.js
@@ -131,8 +131,6 @@ define(function(require) {
     // Calculate the initial dimensions of the cropbox. Add the cropbox to the page.
     $cropBox.width(previewImageHeight / 2);
     $cropBox.height(previewImageHeight / 2);
-    // $(".banner").append("<p>" + previewImageHeight + "</p>" );
-    // $(".banner").append("<p>" + (previewImageHeight / 2) + "</p>" );
     minThreshold = previewImageHeight / 2;
     $cropBox.insertBefore($previewImage);
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageCrop.js
@@ -131,6 +131,8 @@ define(function(require) {
     // Calculate the initial dimensions of the cropbox. Add the cropbox to the page.
     $cropBox.width(previewImageHeight / 2);
     $cropBox.height(previewImageHeight / 2);
+    // $(".banner").append("<p>" + previewImageHeight + "</p>" );
+    // $(".banner").append("<p>" + (previewImageHeight / 2) + "</p>" );
     minThreshold = previewImageHeight / 2;
     $cropBox.insertBefore($previewImage);
 
@@ -139,7 +141,7 @@ define(function(require) {
     resizeCropBoxInit();
 
     // Bind move events to the document.
-    $cropContainer.on("touchmove mousemove", function(event) {
+    $cropBox.on("touchmove mousemove", function(event) {
       event.preventDefault();
       var coords = getCoords(event);
 
@@ -196,7 +198,7 @@ define(function(require) {
      *  When the user stops moving the mouse or touching the screen, turn of the drag and resizing events.
      *  Get the final position and size of the crop and populate hidden form elements with them.
      */
-    $cropContainer.on("touchend mouseup", function() {
+    $cropBox.on("touchend mouseup", function() {
       dragState = false;
       resizeState = false;
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploadBeta.js
@@ -52,11 +52,6 @@ define(function(require) {
 
       // Add the preview image to the modal
       _this.previewImage(files, _this.$imagePreview);
-
-      // Check if cropping is enabled, and then intiate.
-      if (_this.cropEnabled) {
-        _this.cropInit(files);
-      }
     });
 
     /**
@@ -80,14 +75,21 @@ define(function(require) {
    */
   ImageUploadBeta.prototype.previewImage = function(files, $imageContainer) {
     var $preview = $("<img class='preview' src=''>");
-    $imageContainer.html( $preview );
+    $imageContainer.html($preview);
 
     if (/^image/.test( files[0].type)) {
       var reader = new FileReader();
       reader.readAsDataURL(files[0]);
+      var _this = this;
 
       reader.onloadend = function() {
-        $preview.attr("src", this.result);
+        var result = this.result;
+        $preview.attr("src", result).load(function() {
+          // Initiate cropping if it is enabled.
+          if (_this.cropEnabled) {
+            _this.cropInit(result);
+          }
+        });
       };
     }
   };
@@ -95,24 +97,17 @@ define(function(require) {
   /**
    * Initiates cropping on a file.
    *
-   * @param {jQuery} files  An object representing a file.
+   * @param {jQuery} result  The result property of a file reader object.
    */
-  ImageUploadBeta.prototype.cropInit = function(files) {
+  ImageUploadBeta.prototype.cropInit = function(result) {
     var ImageCrop = require("campaign/ImageCrop");
-    var _this = this;
+    var origImage = new Image();
+    origImage.src = result;
 
-    if (/^image/.test( files[0].type)) {
-      var reader = new FileReader();
-      reader.readAsDataURL(files[0]);
-
-      reader.onloadend = function() {
-        var origImage = new Image();
-        origImage.src = this.result;
-        // Remove any cropping already on the page before initiating.
-        ImageCrop.dsCropperDestroy();
-        ImageCrop.dsCropperInit(origImage, _this.$reportbackForm);
-      };
-    }
+    // Remove any cropping already on the page before initiating.
+    // @TODO - remove this check. the crop init js should be smart enough to reset itself it is already initiate.
+    ImageCrop.dsCropperDestroy();
+    ImageCrop.dsCropperInit(origImage, this.$reportbackForm);
   };
 
   /**

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-crop.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-crop.scss
@@ -10,17 +10,16 @@
     .__buttons {
       text-align: right;
 
+      * {
+        display: inline-block;
+      }
+
       .btn {
         padding: 0;
       }
 
-      .-rotate {
-        display: inline-block;
-      }
-
       .-change {
         position: relative;
-        display: inline-block;
         margin-left: 10px;
 
         input[type="file"] {
@@ -36,11 +35,8 @@
   }
 
   .btn {
-    &.secondary {
-      background: $blue;
-      display: table;
-      margin: 0 auto;
-    }
+    display: table;
+    margin: 0 auto;
   }
 
   .image-preview {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-crop.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-crop.scss
@@ -10,15 +10,16 @@
     .__buttons {
       text-align: right;
 
-      * {
-        display: inline-block;
-      }
-
       .btn {
         padding: 0;
       }
 
+      .-rotate {
+        display: inline-block;
+      }
+
       .-change {
+        display: inline-block;
         position: relative;
         margin-left: 10px;
 
@@ -32,11 +33,11 @@
         }
       }
     }
-  }
 
-  .btn {
-    display: table;
-    margin: 0 auto;
+    .-done {
+      display: table;
+      margin: 0 auto;
+    }
   }
 
   .image-preview {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-crop.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-crop.scss
@@ -7,17 +7,15 @@
   .image-editor {
     padding-top: 10px;
 
-    a {
-      color: $off-black;
-      text-decoration: underline;
-    }
-
     .__buttons {
       text-align: right;
 
+      .btn {
+        padding: 0;
+      }
+
       .-rotate {
         display: inline-block;
-        color: $blue;
       }
 
       .-change {
@@ -31,6 +29,7 @@
           right: 0;
           opacity: 0;
           cursor: pointer;
+          width: 100%;
         }
       }
     }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -356,10 +356,9 @@
                 <div class="image-preview"><!-- Preview image inserted with js --></div>
                 <div class="image-editor">
                   <div class="__buttons">
-                    <!-- @TODO update these to be tertiary neue buttons with modifiers -->
-                    <a href="#" class="-rotate">rotate photo</a>
+                    <a href="#" class="btn tertiary -rotate">rotate photo</a>
                     <div class="-change">
-                      <a href="#">change photo</a>
+                      <a href="#" class="btn tertiary">change photo</a>
                       <input type="file" class="js-image-upload-beta" />
                     </div>
                   </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -367,7 +367,7 @@
                   <form action="#" method="post" id="dosomething-reportback-image-form" accept-charset="UTF-8">
                     <label for="caption">Caption</label>
                     <input placeholder="Write something..." type="text" id="caption" name="caption" value="" size="60" maxlength="128">
-                    <input type="submit" value="done" class="btn secondary" />
+                    <input type="submit" value="done" class="btn" />
                   </form>
                 </div>
               </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -367,7 +367,7 @@
                   <form action="#" method="post" id="dosomething-reportback-image-form" accept-charset="UTF-8">
                     <label for="caption">Caption</label>
                     <input placeholder="Write something..." type="text" id="caption" name="caption" value="" size="60" maxlength="128">
-                    <input type="submit" value="done" class="btn" />
+                    <input type="submit" value="done" class="btn -done" />
                   </form>
                 </div>
               </div>


### PR DESCRIPTION
This branch fixes a few bugs I found when testing cropping and fixes some of the styling. 
- Switches the rotate and change photo buttons to be tertiary neue buttons with an override for spacing.
- Changes the done button in the modal to be the neue primary button. 
- Initiates crop after the preview image src has been added to the page to make sure it has an image to initiate on.

@DFurnes @weerd /cc @barryclark  
