### PR TITLE
Terms API endpoint

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -6,4 +6,4 @@ dependencies[] = services
 features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
-mtime = 1420500855
+mtime = 1420573413

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -42,3 +42,42 @@ function dosomething_api_services_resources() {
   $resources = array_merge_recursive($resources, _reportback_resource_defintion());
   return $resources;
 }
+
+/**
+ * Returns the Reportback Gallery of a specified node.
+ *
+ * @param array $params
+ *   Parameters to pass to the Reportback Files query.
+ *   @see dosomething_reportback_get_reportback_files_query_result().
+ * @param int $count
+ *   Number of Reporback Files to return.
+ * @param int $start
+ *   Which RB File to start with. If present, $start and $count are used together
+ *   to create a LIMIT clause to select RB Files. This could be used to do paging.
+ *
+ * @return
+ *   An array of Reportback File objects.
+ */
+function dosomething_api_get_reportback_files($params, $count = 25, $start = 0) {
+  // Load Services module to use its index_query functions.
+  module_load_include('inc', 'services', 'services.module');
+  $int_properties = array('rbid', 'fid', 'fid_processed');
+  $results = dosomething_reportback_get_reportback_files_query_result($params, $count, $start);
+  $result = services_resource_build_index_list($results, 'reportback_files', 'fid');
+
+  foreach ($result as &$record) {
+    // Convert string output to integers were appropriate.
+    foreach ($int_properties as $property) {
+      $record->{$property} = (int) $record->{$property};
+    }
+    // We'll eventually want to use the fid_processed here.
+    // And also probably won't need to apply an image style, since it
+    // will already be cropped.
+    $record->src = dosomething_image_get_themed_image_url_by_fid($record->fid, '300x300');
+  }
+  // @see http://php.net/manual/en/control-structures.foreach.php:
+  // Reference of a $value and the last array element remain even after
+  // the foreach loop. It is recommended to destroy it by unset().
+  unset($record);
+  return $result;
+}

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -8,6 +8,7 @@ include_once 'dosomething_api.features.inc';
 include_once 'resources/campaign_resource.inc';
 include_once 'resources/member_resource.inc';
 include_once 'resources/reportback_resource.inc';
+include_once 'resources/term_resource.inc';
 
 /**
  * Implements hook_services_request_postprocess_alter().
@@ -40,6 +41,8 @@ function dosomething_api_services_resources() {
   $resources = array_merge_recursive($resources, _member_resource_defintion());
   // Add Reportback resource.
   $resources = array_merge_recursive($resources, _reportback_resource_defintion());
+  // Add Term resource.
+  $resources = array_merge_recursive($resources, _term_resource_defintion());
   return $resources;
 }
 

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -98,6 +98,18 @@ function dosomething_api_default_services_endpoint() {
         ),
       ),
     ),
+    'terms' => array(
+      'operations' => array(
+        'index' => array(
+          'enabled' => '1',
+        ),
+      ),
+      'relationships' => array(
+        'inbox' => array(
+          'enabled' => '1',
+        ),
+      ),
+    ),
     'users' => array(
       'operations' => array(
         'create' => array(

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -268,31 +268,9 @@ function _campaign_resource_reportback($nid, $values) {
  *   An array of Reportback File objects.
  */
 function _campaign_resource_load_gallery($nid, $count = 25, $start = 0) {
-  // Load Services module to use its index_query functions.
-  module_load_include('inc', 'services', 'services.module');
-  $int_properties = array('rbid', 'fid', 'fid_processed');
   $params = array(
     'nid' => $nid,
     'status' => 'approved',
-    'count' => $count,
-    'start' => $start,
   );
-  $results = dosomething_reportback_get_reportback_files_query_result($params, $count, $start);
-  $result = services_resource_build_index_list($results, 'reportback_files', 'fid');
-
-  foreach ($result as &$record) {
-    // Convert string output to integers were appropriate.
-    foreach ($int_properties as $property) {
-      $record->{$property} = (int) $record->{$property};
-    }
-    // We'll eventually want to use the fid_processed here.
-    // And also probably won't need to apply an image style, since it
-    // will already be cropped.
-    $record->src = dosomething_image_get_themed_image_url_by_fid($record->fid, '300x300');
-  }
-  // @see http://php.net/manual/en/control-structures.foreach.php:
-  // Reference of a $value and the last array element remain even after
-  // the foreach loop. It is recommended to destroy it by unset().
-  unset($record);
-  return $result;
+  return dosomething_api_get_reportback_files($params, $count, $start);
 }

--- a/lib/modules/dosomething/dosomething_api/resources/term_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/term_resource.inc
@@ -74,8 +74,8 @@ function _term_resource_index($parameters) {
 /**
  * Returns the Reportback Inbox of a specified term.
  *
- * @param int $nid
- *   Unique identifier for the node.
+ * @param int $tid
+ *   Unique identifier for the taxonomy term.
  * @param int $count
  *   Number of Reporback Files to return.
  * @param int $start

--- a/lib/modules/dosomething/dosomething_api/resources/term_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/term_resource.inc
@@ -22,11 +22,11 @@ function _term_resource_defintion() {
       ),
     ),
     'relationships' => array(
-      'pending' => array(
+      'inbox' => array(
         'file' => array('type' => 'inc', 'module' => 'dosomething_api', 'name' => 'resources/term_resource'),
-        'help'   => 'Returns Reportback Inbox for a term. GET from terms/123/pending',
+        'help'   => 'Returns Reportback Inbox for a term. GET from terms/123/inbox',
         'access arguments' => array('view any reportback'),
-        'callback' => '_term_resource_load_pending',
+        'callback' => '_term_resource_load_inbox',
         'args'     => array(
           array(
             'name' => 'tid',
@@ -85,7 +85,7 @@ function _term_resource_index($parameters) {
  * @return
  *   An array of Reportback File objects.
  */
-function _term_resource_load_pending($tid, $count = 25, $start = 0) {
+function _term_resource_load_inbox($tid, $count = 25, $start = 0) {
   $params = array(
     'tid' => $tid,
     'status' => 'pending',

--- a/lib/modules/dosomething/dosomething_api/resources/term_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/term_resource.inc
@@ -58,11 +58,16 @@ function _term_resource_defintion() {
 
 /**
  * Callback for Terms index.
+ *
+ * For now, only return Cause terms (only needed vocabulary for this endpoint).
  */
 function _term_resource_index($parameters) {
-  // @todo: Write real code.
-  $index = array();
-  return $index;
+  $terms = array();
+  $cause = taxonomy_vocabulary_machine_name_load('cause');
+  if ($cause) {
+    $terms = taxonomy_get_tree($cause->vid);
+  }
+  return $terms;
 }
 
 

--- a/lib/modules/dosomething/dosomething_api/resources/term_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/term_resource.inc
@@ -1,0 +1,89 @@
+<?php
+
+function _term_resource_defintion() {
+  $resource = array();
+  $resource['terms'] = array(
+    'operations' => array(
+      'index' => array(
+        'help' => 'List relevant taxonomy terms.',
+        'file' => array('type' => 'inc', 'module' => 'dosomething_api', 'name' => 'resources/term_resource'),
+        'callback' => '_term_resource_index',
+        'access arguments' => array('access content'),
+        'args' => array(
+          array(
+            'name' => 'parameters',
+            'optional' => TRUE,
+            'type' => 'array',
+            'description' => 'Parameters',
+            'default value' => array(),
+            'source' => array('param' => 'parameters'),
+          ),
+        ),
+      ),
+    ),
+    'relationships' => array(
+      'pending' => array(
+        'file' => array('type' => 'inc', 'module' => 'dosomething_api', 'name' => 'resources/term_resource'),
+        'help'   => 'Returns Reportback Inbox for a term. GET from terms/123/pending',
+        'access arguments' => array('view any reportback'),
+        'callback' => '_term_resource_load_pending',
+        'args'     => array(
+          array(
+            'name' => 'tid',
+            'optional' => FALSE,
+            'source' => array('path' => 0),
+            'type' => 'int',
+            'description' => 'The tid of the term whose gallery we are getting',
+          ),
+          array(
+            'name' => 'count',
+            'type' => 'int',
+            'description' => t('Number of Reportback Files to load.'),
+            'source' => array('param' => 'count'),
+            'optional' => TRUE,
+          ),
+          array(
+            'name' => 'offset',
+            'type' => 'int',
+            'description' => t('If count is set to non-zero value, you can pass also non-zero value for start. For example to get Reportback Files from 5 to 15, pass count=10 and start=5.'),
+            'source' => array('param' => 'offset'),
+            'optional' => TRUE,
+          ),
+        ),
+      ),
+    ),
+  );
+  return $resource;
+}
+
+/**
+ * Callback for Terms index.
+ */
+function _term_resource_index($parameters) {
+  // @todo: Write real code.
+  $index = array();
+  return $index;
+}
+
+
+/**
+ * Returns the Reportback Inbox of a specified term.
+ *
+ * @param int $nid
+ *   Unique identifier for the node.
+ * @param int $count
+ *   Number of Reporback Files to return.
+ * @param int $start
+ *   Which RB File to start with. If present, $start and $count are used together
+ *   to create a LIMIT clause to select RB Files. This could be used to do paging.
+ *
+ * @return
+ *   An array of Reportback File objects.
+ */
+function _term_resource_load_pending($tid, $count = 25, $start = 0) {
+  $params = array(
+    'tid' => $tid,
+    'status' => 'pending',
+  );
+  return dosomething_api_get_reportback_files($params, $count, $start);
+}

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -953,7 +953,12 @@ function dosomething_reportback_get_reportback_files_query($params = array()) {
     $query->condition('rb.rbid', $params['rbid']);
   }
   $query->fields('rbf', array('fid', 'caption', 'rbid'));
-  $query->fields('rb', array('quantity', 'uid'));
+  $rb_fields = array('quantity');
+  if (user_access('view any reportback')) {
+    $rb_fields[] = 'uid';
+    $rb_fields[] = 'why_participated';
+  }
+  $query->fields('rb', $rb_fields);
   $query->fields('n', array('nid', 'title'));
   $query->fields('f', array('timestamp'));
   if (isset($params['random'])) {


### PR DESCRIPTION
New endpoints needed for the [iOS Reviewer app](https://github.com/dosomething/ios-RBReviewer):
- **GET** `/api/v1/terms`: Currently returns all Cause terms (only vocabulary needed for the endpoint at this time)
- **GET** `/api/v1/terms/[tid]/inbox`: Returns Reportback Files with status `pending` for a given taxonomy term.  Only accessible for users with permission to `view any reportback`

Also:
- Adds `dosomething_api_get_reportback_files` function to DRY loading data for the `campaigns/[nid]/gallery` and `terms/[tid]/inbox` endpoints
- Returns `why_participated` and `uid` properties in the response if the user has access to `view any reportback`
