### PR TITLE
Enables application/x-www-form-urlencoded request parsing

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -6,4 +6,4 @@ dependencies[] = services
 features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
-mtime = 1420573413
+mtime = 1420822034

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -30,9 +30,9 @@ function dosomething_api_default_services_endpoint() {
     ),
     'parsers' => array(
       'application/json' => TRUE,
+      'application/x-www-form-urlencoded' => TRUE,
       'application/xml' => TRUE,
       'application/vnd.php.serialized' => FALSE,
-      'application/x-www-form-urlencoded' => FALSE,
       'application/x-yaml' => FALSE,
       'multipart/form-data' => FALSE,
       'text/xml' => FALSE,


### PR DESCRIPTION
Fixes the logout POST in the Reviewer iOS app, which was resulting in a 406.  See http://drupal.stackexchange.com/questions/62349/post-request-trying-to-make-a-session-authentication-in-the-rest-server-return-a
