### PR TITLE
Gallery File fid's variable

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -19,6 +19,18 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#collapsed' => TRUE,
   );
 
+  // Comma separated list of default Gallery File fid's.
+  $var_name = 'dosomething_campaign_default_gallery_fids';
+  $form['campaign'][$var_name] = array(
+    '#type' => 'textfield',
+    '#title' => t('Placeholder Gallery Files'),
+    '#description' => t("A comma separated list of !link to use for the Gallery if not enough Reportbacks exist.  Do not use spaces.<p>e.g. 3123,234,8929,100112", array(
+      '!link' => l("File fid's", 'admin/content/files'),
+    )),
+    '#required' => TRUE,
+    '#default_value' => variable_get($var_name),
+  );
+
   // Reportback variables.
   $form['campaign']['reportback'] = array(
     '#type' => 'fieldset',

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -815,3 +815,27 @@ function dosomething_campaign_form_campaign_node_form_after_build($form, &$form_
   drupal_add_js ($path . "/js/campaign_node_form.js");
   return $form;
 }
+
+/**
+ * Returns array of Image URL's for the default placeholder images in a Campaign Gallery.
+ *
+ * @param string $size
+ *   The preset to theme the image with.
+ *
+ * @return array
+ */
+function dosomething_campaign_get_default_gallery_image_urls($size = '300x300') {
+  $urls = array();
+  // Variable name which holds a comma separated list of default File fid's.
+  $var_name = 'dosomething_campaign_default_gallery_fids';
+  // Extract the fid's.
+  $fids = explode(',', variable_get($var_name, array()));
+  // Loop through each one:
+  foreach ($fids as $fid) {
+    // Make sure an image exists:
+    if ($url = dosomething_image_get_themed_image_url_by_fid((int) $fid, $size)) {
+      $urls[] = $url;
+    }
+  }
+  return $urls;
+}

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -829,7 +829,7 @@ function dosomething_campaign_get_default_gallery_image_urls($size = '300x300') 
   // Variable name which holds a comma separated list of default File fid's.
   $var_name = 'dosomething_campaign_default_gallery_fids';
   // Extract the fid's.
-  $fids = explode(',', variable_get($var_name, array()));
+  $fids = explode(',', variable_get($var_name, ''));
   // Loop through each one:
   foreach ($fids as $fid) {
     // Make sure an image exists:


### PR DESCRIPTION
Creates an admin variable to set the default placeholder images when a Campaign does not have enough Reportback Images to display.

![screen shot 2015-01-12 at 10 26 05 am](https://cloud.githubusercontent.com/assets/1236811/5705402/0cf80d08-9a47-11e4-85d6-e8bc6405e8ab.png)

For the sake of simplicity, the variable stores a comma separated list of File fid's.  To theme these images, use the new `dosomething_campaign_get_default_gallery_image_urls` function, which [explodes](http://php.net/manual/en/function.explode.php) the variable and returns an array of image URLs to each file (if it exists).
