### PR TITLE
Automatically flag Images for flagged Reportbacks

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -64,7 +64,7 @@ function dosomething_api_services_resources() {
 function dosomething_api_get_reportback_files($params, $count = 25, $start = 0) {
   // Load Services module to use its index_query functions.
   module_load_include('inc', 'services', 'services.module');
-  $int_properties = array('rbid', 'fid', 'fid_processed');
+  $int_properties = array('rbid', 'fid');
   $results = dosomething_reportback_get_reportback_files_query_result($params, $count, $start);
   $result = services_resource_build_index_list($results, 'reportback_files', 'fid');
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -124,12 +124,19 @@ class ReportbackEntity extends Entity {
     if (!isset($values->caption)) {
       $values->caption = NULL;
     }
+    // Default status should be pending:
+    $status = 'pending';
+    // If this reportback has been flagged already:
+    if ($this->flagged) {
+      $status = 'flagged';
+    }
     return db_insert($this->files_table)
       ->fields(array(
           'rbid' => $this->rbid,
           'fid' => $values->fid,
           'caption' => $values->caption,
           'remote_addr' => dosomething_helpers_ip_address(),
+          'status' => $status,
         ))
       ->execute();
   }


### PR DESCRIPTION
If a reportback is flagged, a user can still upload more images.  This PR sets each subsequent image status to `flagged` when the user uploads a new image to a flagged Reportback.
