### PR TITLE
Deletes Promoted flag for real

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -540,6 +540,8 @@ function dosomething_reportback_update_7019(&$sandbox) {
   field_delete_field('field_weight');
 
   // Delete the Image Descirption instance from the Promoted Flag.
+  // This is an error, it should have been flagging.
+  // This is what stopped the promoted flag from deleting.
   if ($instance = field_info_instance('flag', 'field_image_description', 'promoted')) {
     field_delete_instance($instance);
   }
@@ -553,3 +555,33 @@ function dosomething_reportback_update_7019(&$sandbox) {
   _flag_clear_cache($flag->entity_type, TRUE);
 }
 
+/**
+ * Deletes the promoted Flag for real this time. (without errors) 
+ */
+function dosomething_reportback_update_7020(&$sandbox) {
+  if (!module_exists('flag')) {
+    return;
+  }
+  // Load Flag module to use its cache clearing functions.
+  module_load_include('inc', 'flag', 'includes/flag.admin');
+  $flag = flag_get_flag('promoted');
+  if (!$flag) {
+    return;
+  }
+
+  // Delete the Weight field (only used by Promoted Flag).
+  field_delete_field('field_weight');
+
+  // Delete the Image Descirption instance from the Promoted Flag.
+  if ($instance = field_info_instance('flagging', 'field_image_description', 'promoted')) {
+    field_delete_instance($instance);
+  }
+
+  // Remove all flagging entities for this flag.
+  flag_reset_flag($flag);
+  // Delete the flag.
+  // @see flag_delete_confirm_submit()
+  $flag->delete();
+  $flag->disable();
+  _flag_clear_cache($flag->entity_type, TRUE);
+}


### PR DESCRIPTION
`dosomething_reportback_update_7019` never ended up deleting the Promoted flag, and I missed it. The issue seems to be because the Image Description field was never properly deleted from the Promoted flag.

This PR adds a new hook, `dosomething_reportback_update_7020`, which basically is identical to 7019 except it deletes the Image Description field correctly, allowing the Promoted flag to be deleted.  This is pretty gross but manually changing the schema in the DB doesn't feel like the right way to handle either...

What do you think @sergii-tkachenko ?
