### PR TITLE
Don't encode Reportback / RB File user input on entity load

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -86,6 +86,8 @@ function dosomething_api_get_reportback_files($params, $count = 25, $start = 0) 
     foreach ($user_input as $property) {
       $record->{$property} = check_plain($record->{$property});
     }
+    $reportback = reportback_load($record->rbid);
+    $record->quantity_label = $reportback->quantity_label;
     // We'll eventually want to use the fid_processed here.
     // And also probably won't need to apply an image style, since it
     // will already be cropped.

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -72,6 +72,8 @@ function dosomething_api_get_reportback_files($params, $count = 25, $start = 0) 
     'timestamp',
     'uid',
   );
+  $user_input = array('caption', 'why_participated');
+
   $results = dosomething_reportback_get_reportback_files_query_result($params, $count, $start);
   $result = services_resource_build_index_list($results, 'reportback_files', 'fid');
 
@@ -80,8 +82,10 @@ function dosomething_api_get_reportback_files($params, $count = 25, $start = 0) 
     foreach ($int_properties as $property) {
       $record->{$property} = (int) $record->{$property};
     }
-    $reportback = reportback_load($record->rbid);
-    $record->quantity_label = $reportback->quantity_label;
+    // Encode user inputted properties.
+    foreach ($user_input as $property) {
+      $record->{$property} = check_plain($record->{$property});
+    }
     // We'll eventually want to use the fid_processed here.
     // And also probably won't need to apply an image style, since it
     // will already be cropped.

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -29,7 +29,6 @@ class ReportbackEntity extends Entity {
     if (isset($this->rbid)) {
       $this->fids = $this->getFids();
     }
-    $this->why_participated = check_plain($this->why_participated);
     // If a reportback nid exists:
     if (isset($this->nid)) {
       // Set properties found on the reportback's node nid.

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
@@ -17,14 +17,6 @@ class ReportbackFileEntity extends Entity {
     return array('path' => 'rb/' . $this->identifier());
   }
 
-  /**
-   * Overrides construct to set calculated properties.
-   */
-  public function __construct(array $values = array(), $entityType = NULL) {
-    parent::__construct($values, $entityType);
-    $this->caption = check_plain($this->caption);
-  }
-
   public function getImage() {
     $image = dosomething_image_get_themed_image_by_fid($this->fid, '300x300');
     if (!$image) {
@@ -105,7 +97,7 @@ class ReportbackFileEntityController extends EntityAPIController {
 
     $build['caption'] = array(
       '#prefix' => '<p><strong>',
-      '#markup' => $entity->caption,
+      '#markup' => check_plain($entity->caption),
       '#suffix' => '</strong></p>',
     );
 
@@ -144,7 +136,7 @@ class ReportbackFileEntityController extends EntityAPIController {
 
       $build['why'] = array(
         '#prefix' => '<p>',
-        '#markup' => $reportback->why_participated,
+        '#markup' => check_plain($reportback->why_participated),
         '#suffix' => '</p>',
       );
     }


### PR DESCRIPTION
Fixes #3704 - which was occurring when a User updates a Reportback that contains special characters in the Caption or Why Participated.  The form was being loaded with encoded input, thus the user would save the encoded values if they didn't go back in and fix the weird looking characters.
