### PR TITLE
Flagged Reason migrate fix

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -494,6 +494,9 @@ function dosomething_reportback_update_7018(&$sandbox) {
   while($record = $result->fetchAssoc()) {
     $rbid = $record['entity_id'];
     // Query the flagged_reason field to store the flagged reason on the entity.
+    // NOTE: This didn't work because we should have been querying for
+    // the flagging_id, not the reportback rbid.
+    // @see dosomething_reportback_update_7021()
     $reasons = array();
     $flagged_reason_result = db_select('field_data_field_flagged_reason', 'r')
       ->fields('r')

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -585,3 +585,56 @@ function dosomething_reportback_update_7020(&$sandbox) {
   $flag->disable();
   _flag_clear_cache($flag->entity_type, TRUE);
 }
+
+/**
+ * Fixes bug in flagged reason import from update 7018.
+ */
+function dosomething_reportback_update_7021(&$sandbox) {
+  if (!module_exists('flag')) {
+    return;
+  }
+  $flag = flag_get_flag('flagged_reportback');
+  if (!$flag) {
+    return;
+  }
+  $output = '';
+
+  // Query Flagging table for all Flagged Reportback flaggings.
+  $query = db_select('flagging', 'f');
+  $query->fields('f');
+  $query->condition('fid', $flag->fid)
+    ->condition('f.entity_type', 'reportback');
+  $result = $query->execute();
+
+  while($record = $result->fetchAssoc()) {
+    $rbid = $record['entity_id'];
+    $reasons = array();
+
+    // Query the flagged_reason field to store the flagging's flagged reasons.
+    $flagged_reason_result = db_select('field_data_field_flagged_reason', 'r')
+      ->fields('r')
+      ->condition('entity_id', $record['flagging_id'])
+      ->execute()
+      ->fetchAll();
+
+    // Loop through each flagged reason field value:
+    foreach ($flagged_reason_result as $record) {
+      $reasons[] = $record->field_flagged_reason_value;
+    }
+    // Implode reasons into a single string to set on the reportback entity.
+    $flagged_reason = implode(', ', $reasons);
+
+    // Update the Reportback.
+    $import = db_update('dosomething_reportback')
+      ->fields(array(
+        'flagged_reason' => $flagged_reason,
+        ))
+      ->condition('rbid', $rbid)
+      ->condition('flagged', 1)
+      ->execute();
+
+    $output .= "Imported Flag Reason for Reportback " . $rbid . ". ";
+  }
+
+  return $output;
+}

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
@@ -145,7 +145,19 @@ class ReportbackFileEntityController extends EntityAPIController {
       $reviewer = user_load($entity->reviewer);
       $build['reviewed'] = array(
         '#prefix' => '<p>',
-        '#markup' => '<strong>' . ucfirst($entity->status) . '</strong> ' . format_date($entity->reviewed, 'short') .' by ' . $reviewer->mail,
+        '#markup' => '<strong>' . ucfirst($entity->status) . '</strong> ' . format_date($entity->reviewed, 'short'),
+        '#suffix' => '</p>',
+      );
+      if ($reviewer->uid > 0) {
+        $build['reviewer'] = array(
+          '#prefix' => '<p>',
+          '#markup' => $reviewer->mail,
+          '#suffix' => '</p>',
+        );
+      }
+      $build['review_source'] = array(
+        '#prefix' => '<p>',
+        '#markup' => t("Source") . ': ' . $entity->review_source,
         '#suffix' => '</p>',
       );
     }


### PR DESCRIPTION
Closes #3652

Fixes error in `dosomething_reportback_update_7018`, which queried by the incorrect column when gathering the Flagged reasons.  This is a great example of why it makes more sense to simplify the build and store flaggings as a column on the reportback itself. 

Also exposes Review Source when viewing the Reportback File entity, to better spot check migrated Flagging records. 
