### PR TITLE
Archive Activity form

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -318,20 +318,15 @@ function dosomething_campaign_reportback_config_form_submit(&$form, &$form_state
  * @ingroup forms
  */
 function dosomething_campaign_archive_activity_form($form, &$form_state, $node) {
-  $query = new EntityFieldQuery();
-  $query->entityCondition('entity_type', 'node')
-    ->entityCondition('bundle', 'campaign_run')
-    ->fieldCondition('field_campaigns', 'target_id', $node->nid, '=');
-  $result = $query->execute();
+  $campaign_runs = dosomething_campaign_get_campaign_runs($node);
+  // Should't happen, but just in case:
+  if (empty($campaign_runs)) {
+    $form['markup'] = array(
+      '#markup' => t("There are no Campaign Run nodes associated with this campaign."),
+    );
+    return $form;
+  }
 
-  if (isset($result['node'])) {
-    $campaign_run_nids = array_keys($result['node']);
-    $campaign_run_nodes = entity_load('node', $campaign_run_nids);
-  }
-  $options = array();
-  foreach ($campaign_run_nodes as $run) {
-    $options[$run->nid] = $run->title;
-  }
   $form['source_nid'] = array(
     '#type' => 'hidden',
     '#default_value' => $node->nid,
@@ -340,7 +335,7 @@ function dosomething_campaign_archive_activity_form($form, &$form_state, $node) 
     '#type' => 'radios',
     '#required' => TRUE,
     '#title' => t("Archive all current Signups and Reportbacks to:"),
-    '#options' => $options,
+    '#options' => $campaign_runs,
     '#description' => t("Warning! This cannot be undone.  Do not do this unless you really, really mean it."),
   );
   $form['actions'] = array(
@@ -359,6 +354,9 @@ function dosomething_campaign_archive_activity_form($form, &$form_state, $node) 
 function dosomething_campaign_archive_activity_form_submit(&$form, &$form_state) {
   $source_nid = $form_state['values']['source_nid'];
   $target_nid = $form_state['values']['target_nid'];
+
+  //@todo Add batch processing for cases where there are large numbers of signups.
+
   // Update signups.
   $num_signups = db_update('dosomething_signup')
     ->fields(array(
@@ -373,6 +371,7 @@ function dosomething_campaign_archive_activity_form_submit(&$form, &$form_state)
     ))
     ->condition('nid', $source_nid)
     ->execute();
+
   drupal_set_message(t("Archived @signups Signups and @reportbacks Reportbacks from @source to @target.", array(
     '@signups' => $num_signups,
     '@reportbacks' => $num_reportbacks,

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -308,3 +308,54 @@ function dosomething_campaign_reportback_config_form_submit(&$form, &$form_state
   dosomething_helpers_set_variable($node, $var_name, $values[$var_name]);
   drupal_set_message("Updated.");
 }
+
+/**
+ * Form constructor for archiving Campaign activity to a Campaign Run.
+ *
+ * @param object $node
+ *   A loaded campaign node.
+ *
+ * @ingroup forms
+ */
+function dosomething_campaign_archive_activity_form($form, &$form_state, $node) {
+  $query = new EntityFieldQuery();
+  $query->entityCondition('entity_type', 'node')
+    ->entityCondition('bundle', 'campaign_run')
+    ->fieldCondition('field_campaigns', 'target_id', $node->nid, '=');
+  $result = $query->execute();
+
+  if (isset($result['node'])) {
+    $campaign_run_nids = array_keys($result['node']);
+    $campaign_run_nodes = entity_load('node', $campaign_run_nids);
+  }
+  $options = array();
+  foreach ($campaign_run_nodes as $run) {
+    $options[$run->nid] = $run->title;
+  }
+  $form['source_nid'] = array(
+    '#type' => 'hidden',
+    '#default_value' => $node->nid,
+  );
+  $form['target_nid'] = array(
+    '#type' => 'radios',
+    '#required' => TRUE,
+    '#title' => t("Archive all current Signups and Reportbacks to:"),
+    '#options' => $options,
+    '#description' => t("Warning! This cannot be undone.  Do not do this unless you really, really mean it."),
+  );
+  $form['actions'] = array(
+    '#type' => 'actions',
+    'submit' => array(
+      '#type' => 'submit',
+      '#value' => t("Archive"),
+    ),
+  );
+  return $form;
+}
+
+/**
+ * Submit callback for dosomething_campaign_reportback_config_form().
+ */
+function dosomething_campaign_archive_activity_form_submit(&$form, &$form_state) {
+  // @todo Update all signups and reportbacks to nid = target_nid where nid = source_nid
+}

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -357,5 +357,26 @@ function dosomething_campaign_archive_activity_form($form, &$form_state, $node) 
  * Submit callback for dosomething_campaign_reportback_config_form().
  */
 function dosomething_campaign_archive_activity_form_submit(&$form, &$form_state) {
-  // @todo Update all signups and reportbacks to nid = target_nid where nid = source_nid
+  $source_nid = $form_state['values']['source_nid'];
+  $target_nid = $form_state['values']['target_nid'];
+  // Update signups.
+  $num_signups = db_update('dosomething_signup')
+    ->fields(array(
+      'nid' => $target_nid,
+    ))
+    ->condition('nid', $source_nid)
+    ->execute();
+  // Update reportbacks.
+  $num_reportbacks = db_update('dosomething_reportback')
+    ->fields(array(
+      'nid' => $target_nid,
+    ))
+    ->condition('nid', $source_nid)
+    ->execute();
+  drupal_set_message(t("Archived @signups Signups and @reportbacks Reportbacks from @source to @target.", array(
+    '@signups' => $num_signups,
+    '@reportbacks' => $num_reportbacks,
+    '@source' => $source_nid,
+    '@target' => $target_nid,
+  )));
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -98,6 +98,17 @@ function dosomething_campaign_menu() {
     'access arguments' => array(1),
     'file' => 'dosomething_campaign.pages.inc',
   );
+  // Archive Activity form.
+  $items['node/%node/archive'] = array(
+    'title' => 'Archive Activity',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_campaign_archive_activity_form', 1),
+    'access callback' => 'dosomething_campaign_archive_activity_form_access',
+    'access arguments' => array(1),
+    'file' => 'dosomething_campaign.admin.inc',
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 900,
+  );
   return $items;
 }
 
@@ -214,6 +225,7 @@ function dosomething_campaign_get_scholarships() {
  */
 function dosomething_campaign_admin_paths() {
   $paths = array(
+    'node/*/archive' => TRUE,
     'node/*/custom-settings' => TRUE,
   );
   return $paths;
@@ -838,4 +850,8 @@ function dosomething_campaign_get_default_gallery_image_urls($size = '300x300') 
     }
   }
   return $urls;
+}
+
+function dosomething_campaign_archive_activity_form_access($node) {
+  return ($node->type == 'campaign');
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -852,6 +852,48 @@ function dosomething_campaign_get_default_gallery_image_urls($size = '300x300') 
   return $urls;
 }
 
+/**
+ * Access callback for the Archive Activity page callback.
+ *
+ * @param object $node
+ *   Loaded campaign node to check if access to Archive Activity.
+ *
+ * @return bool
+ */
 function dosomething_campaign_archive_activity_form_access($node) {
-  return ($node->type == 'campaign');
+  if (!user_access('administer modules')) {
+    return FALSE;
+  }
+  if ($node->type === 'campaign') {
+    $runs = dosomething_campaign_get_campaign_runs($node);
+    return (!empty($runs));
+  }
+  return FALSE;
+}
+
+/**
+ * Returns array of Campaign Run nodes for a given $node.
+ *
+ * @param object $node
+ *   Loaded campaign node to check if access to Archive Activity.
+ *
+ * @return array
+ */
+function dosomething_campaign_get_campaign_runs($node) {
+  $campaign_runs = array();
+  $query = new EntityFieldQuery();
+  $query->entityCondition('entity_type', 'node')
+    ->entityCondition('bundle', 'campaign_run')
+    ->fieldCondition('field_campaigns', 'target_id', $node->nid, '=');
+  $result = $query->execute();
+
+  if (isset($result['node'])) {
+    $campaign_run_nids = array_keys($result['node']);
+    $campaign_run_nodes = entity_load('node', $campaign_run_nids);
+    foreach ($campaign_run_nodes as $run) {
+      $campaign_runs[$run->nid] = $run->title;
+    }
+  }
+
+  return $campaign_runs;
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -301,6 +301,9 @@ function dosomething_reportback_review_page_access($entity) {
   }
   // Is this a node?
   if (isset($entity->nid)) {
+    if ($entity->type == 'campaign_run') {
+      return TRUE;
+    }
     if ($entity->type == 'campaign') {
       return dosomething_campaign_get_campaign_type($entity) == 'campaign';
     }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.info
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.info
@@ -14,4 +14,4 @@ features[user_permission][] = view any signup
 features[views_view][] = node_signups
 files[] = dosomething_signup.test
 files[] = includes/dosomething_signup.inc
-mtime = 1416603772
+mtime = 1417616743

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.views_default.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.views_default.inc
@@ -125,6 +125,7 @@ function dosomething_signup_views_default_views() {
   $handler->display->display_options['arguments']['nid']['validate_options']['types'] = array(
     'campaign' => 'campaign',
     'campaign_group' => 'campaign_group',
+    'campaign_run' => 'campaign_run',
   );
   $handler->display->display_options['arguments']['nid']['validate_options']['access_op'] = 'update';
   /* Filter criterion: Signups: Uid */


### PR DESCRIPTION
Refs #3707

Creates a page callback and form to bulk migrate a Campaign's Activity (Signups + reportback) to a Campaign Run associated with it, thus opening the Campaign up for a second run.

The Archive page will only display for Campaign nodes for which Campaign Runs exist.

This form won't be submitted any time too soon.  last TODO left is to add batch processing into the form submit, to avoid timeouts for campaigns with large activity numbers.

![screen shot 2015-01-13 at 3 18 38 pm](https://cloud.githubusercontent.com/assets/1236811/5728391/d246039e-9b37-11e4-9e3d-9b3265eaea84.png)
