### PR TITLE
Finder neue 6.0

### DIFF
--- a/lib/modules/dosomething/dosomething_home/dosomething_home.module
+++ b/lib/modules/dosomething/dosomething_home/dosomething_home.module
@@ -53,7 +53,7 @@ function dosomething_home_preprocess_node(&$vars) {
       }
 
       $tiles['status'] = TRUE;
-      $tiles['image'] = '<img src="' . $tiles['image_url'] . '">';
+      $tiles['image'] = '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=" data-src="' . $tiles['image_url'] . '">';
       $tiles['link'] = drupal_get_path_alias('node/' . $nid) . $source;
 
       $thumbnails[$nid] = paraneue_dosomething_get_gallery_item($tiles, 'tile');

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/Campaign.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/Campaign.js
@@ -12,8 +12,8 @@ define(function(require) {
   var Campaign = function (data) {
     // Default values for a newly created campaign
     var defaults = {
-      title: Drupal.t("New Campaign"),
-      description: Drupal.t("Take your dad to get his blood pressure checked"),
+      title: "",
+      description: "",
       url: "#",
       staffPick: false,
       featured: false

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
@@ -15,7 +15,7 @@ define(function(require) {
     $container: null,
 
     // The gallery located in the container
-    $gallery: $("<ul class='gallery -mosaic'></ul>"),
+    $gallery: $("<ul class='gallery -quartet'></ul>"),
 
     // The div that is shown if no filters are selected
     $blankSlateDiv: null,

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/templates/campaign.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/templates/campaign.tpl.html
@@ -1,10 +1,10 @@
 <li>
-<article class="tile tile--campaign campaign-result<% if(featured) { %> big<% } %>">
+<article class="tile">
   <a class="wrapper" href="<%= url %>">
     <% if(staffPick) {  %><div class="__flag -staff-pick"><%= Drupal.t("Staff Pick") %></div><% } %>
-    <div class="tile--meta">
-      <h1 class="__title"><%= title %></h1>
-      <p class="__tagline"><%= description %></p>
+    <div class="tile__meta">
+      <h1 class="tile__title"><%= title %></h1>
+      <p class="tile__tagline"><%= description %></p>
     </div>
     <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=" data-src="<%= image %>">
   </a>

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -25,6 +25,7 @@ $asset-path: "";
 
 // Local patterns
 @import "patterns/container";
+@import "patterns/tile";
 @import "patterns/disclaimer";
 @import "patterns/list-compacted";
 @import "patterns/message-callout"; // @TODO: Move to Neue!

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_tile.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_tile.scss
@@ -1,0 +1,7 @@
+// Tile pattern enhancements
+.tile {
+  img[data-src] {
+    opacity: 0;
+    transition: opacity 0.5s;
+  }
+}


### PR DESCRIPTION
# Changes
- Restores lazy-loading behavior on the homepage.
- Updates campaign finder to use Neue 6.0 gallery markup.

For review: @DoSomething/front-end 
