### PR TITLE
Aligns prove it buttons on User profile

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_user.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_user.scss
@@ -8,11 +8,7 @@
     .__tagline { display: none; }
   }
   
-  .figure__title {
-    height: 2em;
-  }
-  
-  .figure__description {
+  .figure__title,  .figure__description{
     height: 2em;
   }
   

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_user.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_user.scss
@@ -9,7 +9,7 @@
   }
   
   .figure__title,  .figure__description{
-    height: 2em;
+    min-height: 2em;
   }
   
   .figure {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_user.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_user.scss
@@ -3,9 +3,25 @@
 // ----------------
 
 .profile {
+  
   .tile {
     .__tagline { display: none; }
   }
+  
+  .figure__title {
+    height: 2em;
+  }
+  
+  .figure__description {
+    height: 2em;
+  }
+  
+  .figure {
+    .button {
+      margin-top: 1em;
+    }
+  }
+
 }
 
 // Profile Settings


### PR DESCRIPTION
Fixes #3662

Adds 2em height to the figure title and description, adds 1em margin to the button (otherwise it sticks to the description)

![screen shot 2015-01-14 at 2 27 13 pm](https://cloud.githubusercontent.com/assets/897368/5745835/7c14f2d8-9bf9-11e4-9e6d-9617171feb15.png)

@DFurnes 
