### PR TITLE
Use latest Neue 6.0 beta, and restores mosaic gallery views.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/bower.json
+++ b/lib/themes/dosomething/paraneue_dosomething/bower.json
@@ -20,7 +20,7 @@
     "tests"
   ],
   "dependencies": {
-    "neue": "DoSomething/neue#~6.0.1",
+    "neue": "DoSomething/neue#6.0.0-beta1",
     "jquery": "1.8.3",
     "mailcheck": "~1.0.3",
     "html5shiv": "~3.7.0",

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -272,9 +272,10 @@ function paraneue_dosomething_get_campaign_gallery($nids, $source = NULL, $show_
     $item = paraneue_dosomething_get_node_gallery_item($nid, $source);
     $items[] = paraneue_dosomething_get_gallery_item($item['content'], 'tile', TRUE);
   }
+  $gallery_classes = array('-mosaic');
   // If 5 items or more, the tiles should appear with a featured tile.
   if (count($items) > 4) {
-    $gallery_classes = array('-featured');
+    $gallery_classes = array('-featured -mosaic');
   }
   return paraneue_dosomething_get_gallery($items, 'quartet', $gallery_classes, $show_more);
 }

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
@@ -15,7 +15,7 @@ define(function(require) {
     $container: null,
 
     // The gallery located in the container
-    $gallery: $("<ul class='gallery -quartet'></ul>"),
+    $gallery: $("<ul class='gallery -quartet -mosaic'></ul>"),
 
     // The div that is shown if no filters are selected
     $blankSlateDiv: null,

--- a/lib/themes/dosomething/paraneue_dosomething/templates/home/node--home.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/home/node--home.tpl.php
@@ -88,11 +88,9 @@
 </div>
 
 <section class="container finder--results -blankslate js-campaign-blankslate">
-  <div class="container__body">
-    <ul class="gallery -quartet -featured">
-      <?php foreach($thumbnails as $thumbnail) { print '<li>' . $thumbnail . '</li>'; } ?>
-    </ul>
-  </div>
+  <ul class="gallery -quartet -featured -mosaic">
+    <?php foreach($thumbnails as $thumbnail) { print '<li>' . $thumbnail . '</li>'; } ?>
+  </ul>
 </section>
 
 <?php if( $show_campaign_finder ): ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/taxonomy/taxonomy-term.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/taxonomy/taxonomy-term.tpl.php
@@ -43,9 +43,7 @@
 
   <?php if (!empty($campaign_gallery)): ?>
     <section id="gallery" class="container">
-      <div class="container__body">
-        <?php print $campaign_gallery; ?>
-      </div>
+      <?php print $campaign_gallery; ?>
     </section>
   <?php endif; ?>
 


### PR DESCRIPTION
# Changes
- Pulls in the latest beta of Neue 6.0, and restores mosaic gallery views to the homepage and campaign taxonomy page. :art: 
