### PR TITLE
No source mappy

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
+++ b/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
@@ -27,7 +27,7 @@ module.exports = function(grunt) {
       file: __dirname + '/scss/app.scss',
       outFile: __dirname + '/dist/app.min.css',
       outputStyle: 'compressed',
-      sourceMap: true
+      sourceMap: false
     });
 
     writeFile(__dirname + '/dist/app.min.css', result.css);

--- a/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
+++ b/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
@@ -12,6 +12,14 @@ module.exports = function(grunt) {
   // Load tasks from `/tasks`
   grunt.loadTasks('tasks');
 
+  function writeFile(path, contents) {
+    if(grunt.file.exists(path)) {
+      grunt.file.delete(path);
+    }
+
+    grunt.file.write(path, contents);
+  }
+
   grunt.registerTask('nodesass', function() {
     console.log(sass.info());
 
@@ -22,7 +30,7 @@ module.exports = function(grunt) {
       sourceMap: true
     });
 
-    grunt.file.write(__dirname + '/dist/app.min.css', result.css);
+    writeFile(__dirname + '/dist/app.min.css', result.css);
   });
 
   // Load plugin configuration from `tasks/options`.

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/options/postcss.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/options/postcss.js
@@ -2,7 +2,7 @@ module.exports = {
   process: {
     src: "dist/app.min.css",
     options: {
-      map: true,
+      map: false,
       processors: [
         require('autoprefixer-core')({
           browsers: ['last 4 versions', 'Firefox ESR', 'Opera 12.1']


### PR DESCRIPTION
# Changes
- Disables source maps (having trouble rendering properly with node-sass beta).
- Fixes issue where CSS would not be overwritten if file already existed (which caused issues on watch task).

For review: @DoSomething/front-end 
