### PR TITLE
Issue3523 mbp international settings v2

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.info
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.info
@@ -5,6 +5,7 @@ package = DoSomething
 version = 7.x-1.1
 dependencies[] = features
 dependencies[] = message_broker_producer
+dependencies[] = dosomething_settings
 configure = admin/config/dosomething/dosomething_mbp
 features[features_api][] = api:2
 features[user_permission][] = administer message_broker_producer

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -13,7 +13,6 @@ function dosomething_mbp_install() {
   variable_set('message_broker_producer_rabbitmq_host', getenv('DS_MB_RABBITMQ_HOST'));
   variable_set('message_broker_producer_rabbitmq_port', getenv('DS_MB_RABBITMQ_PORT'));
   variable_set('message_broker_producer_rabbitmq_username', getenv('DS_MB_RABBITMQ_USERNAME'));
-  variable_set('message_broker_producer_rabbitmq_password', getenv('DS_MB_RABBITMQ_PASSWORD'));
   variable_set('message_broker_producer_rabbitmq_vhost', getenv('DS_MB_RABBITMQ_VHOST'));
 
   // Define the Message Broker application_id as the affiliate country code

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -5,6 +5,36 @@
  */
  
 /**
+ * Implements hook_install().
+ */
+function dosomething_mbp_install() {
+
+   // Default Message Broker RabbitMQ connection settings
+   variable_set('message_broker_producer_rabbitmq_host', getenv('DS_MB_RABBITMQ_HOST'));
+   variable_set('message_broker_producer_rabbitmq_port', getenv('DS_MB_RABBITMQ_PORT'));
+   variable_set('message_broker_producer_rabbitmq_username', getenv('DS_MB_RABBITMQ_USERNAME'));
+   variable_set('message_broker_producer_rabbitmq_password', getenv('DS_MB_RABBITMQ_PASSWORD'));
+   variable_set('message_broker_producer_rabbitmq_vhost', getenv('DS_MB_RABBITMQ_VHOST'));
+
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function dosomething_canada_uninstall() {
+  $vars = array(
+    'message_broker_producer_rabbitmq_host',
+    'message_broker_producer_rabbitmq_port',
+    'message_broker_producer_rabbitmq_username',
+    'message_broker_producer_rabbitmq_password',
+    'message_broker_producer_rabbitmq_vhost',
+  );
+  foreach ($vars as $var) {
+    variable_del($var);
+  }
+}
+
+/**
  * Deletes dosomething_mbp_send_campaign_api system variable
  */
 function dosomething_mbp_update_7001(&$sandbox) {
@@ -108,16 +138,3 @@ function dosomething_mbp_update_7003(&$sandbox) {
   }
 
 }
-
-/**
- * Switch affiliate sites to use Message Broker for transactional email messages.
- */
- function dosomething_mbp_update_7004(&$sandbox) {
-
-   // Default Message Broker RabbitMQ connection settings
-   variable_set('message_broker_producer_rabbitmq_host', '10.241.0.14');
-   variable_set('message_broker_producer_rabbitmq_port', '5672');
-   variable_set('message_broker_producer_rabbitmq_username', 'dosomething');
-   variable_set('message_broker_producer_rabbitmq_vhost', 'dosomething');
-
- }

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -114,24 +114,10 @@ function dosomething_mbp_update_7003(&$sandbox) {
  */
  function dosomething_mbp_update_7004(&$sandbox) {
 
-   $modules = array(
-     'message_broker_producer',
-     'dosomething_mbp'
-   );
-   module_enable($modules);
-
    // Default Message Broker RabbitMQ connection settings
    variable_set('message_broker_producer_rabbitmq_host', '10.241.0.14');
    variable_set('message_broker_producer_rabbitmq_port', '5672');
    variable_set('message_broker_producer_rabbitmq_username', 'dosomething');
    variable_set('message_broker_producer_rabbitmq_vhost', 'dosomething');
-
-   $affiliate = dosomething_settings_get_affiliate_country_code();
-
-   variable_set("dosomething_mbp_user_register_template", 'mb-user-register-' . $affiliate);
-   variable_set("dosomething_mbp_user_password_template", 'mb-user-password-' . $affiliate);
-   variable_set("dosomething_mbp_campaign_signup_template", 'mb-campaign-signup-' . $affiliate);
-   variable_set("dosomething_mbp_campaign_reportback_template", 'mb-campaign-reportback-' . $affiliate);
-   variable_set("dosomething_mbp_campaign_group_signup_template", 'mb-campaign-group-signup-' . $affiliate);
 
  }

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -4,14 +4,14 @@
  * Installation and schema hooks for dosomething_mbp.module.
  */
  
- /**
+/**
  * Deletes dosomething_mbp_send_campaign_api system variable
  */
 function dosomething_mbp_update_7001(&$sandbox) {
   variable_del('dosomething_mbp_send_campaign_api');
 }
 
- /**
+/**
  * Creates default production entries in message_broker_producer
  */
 function dosomething_mbp_update_7002(&$sandbox) {
@@ -86,7 +86,7 @@ function dosomething_mbp_update_7002(&$sandbox) {
 
 }
 
- /**
+/**
  * Creates production entry in message_broker_producer for user profile updates
  */
 function dosomething_mbp_update_7003(&$sandbox) {
@@ -108,3 +108,30 @@ function dosomething_mbp_update_7003(&$sandbox) {
   }
 
 }
+
+/**
+ * Switch affiliate sites to use Message Broker for transactional email messages.
+ */
+ function dosomething_mbp_update_7004(&$sandbox) {
+
+   $modules = array(
+     'message_broker_producer',
+     'dosomething_mbp'
+   );
+   module_enable($modules);
+
+   // Default Message Broker RabbitMQ connection settings
+   variable_set('message_broker_producer_rabbitmq_host', '10.241.0.14');
+   variable_set('message_broker_producer_rabbitmq_port', '5672');
+   variable_set('message_broker_producer_rabbitmq_username', 'dosomething');
+   variable_set('message_broker_producer_rabbitmq_vhost', 'dosomething');
+
+   $affiliate = dosomething_settings_get_affiliate_country_code();
+
+   variable_set("dosomething_mbp_user_register_template", 'mb-user-register-' . $affiliate);
+   variable_set("dosomething_mbp_user_password_template", 'mb-user-password-' . $affiliate);
+   variable_set("dosomething_mbp_campaign_signup_template", 'mb-campaign-signup-' . $affiliate);
+   variable_set("dosomething_mbp_campaign_reportback_template", 'mb-campaign-reportback-' . $affiliate);
+   variable_set("dosomething_mbp_campaign_group_signup_template", 'mb-campaign-group-signup-' . $affiliate);
+
+ }

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -19,6 +19,22 @@ function dosomething_mbp_install() {
   $affiliate = strtoupper(dosomething_settings_get_affiliate_country_code());
   variable_set('message_broker_producer_application_id', $affiliate);
 
+  // Install the DoSomething production settings in message_broker_producer
+  // 7002
+  dosomething_mbp_install_productions();
+
+  // 7003
+  $productions[0]['machine_name'] = 'transactional_user_profile_update';
+  $productions[0]['exchange'] = 'transactionalExchange';
+  $productions[0]['queues'][] = 'userAPIProfileQueue';
+  $productions[0]['queues'][] = 'userProfileMailchimpQueue';
+  $productions[0]['routing_key'] = 'user.profile.update';
+  $productions[0]['status'] = 1;
+
+  foreach($productions as $production) {
+    message_broker_producer_production_create($production);
+  }
+
 }
 
 /**
@@ -48,8 +64,41 @@ function dosomething_mbp_update_7001(&$sandbox) {
  * Creates default production entries in message_broker_producer
  */
 function dosomething_mbp_update_7002(&$sandbox) {
+
+  dosomething_mbp_install_productions();
+
+}
+
+/**
+ * Creates production entry in message_broker_producer for user profile updates
+ */
+function dosomething_mbp_update_7003(&$sandbox) {
   // Only run this if Message Broker Producer is enabled.
   if (!module_exists('message_broker_producer')) {
+    return;
+  }
+
+  $productions[0]['machine_name'] = 'transactional_user_profile_update';
+  $productions[0]['exchange'] = 'transactionalExchange';
+  $productions[0]['queues'][] = 'userAPIProfileQueue';
+  $productions[0]['queues'][] = 'userProfileMailchimpQueue';
+  $productions[0]['routing_key'] = 'user.profile.update';
+  $productions[0]['status'] = 1;
+
+  foreach($productions as $production) {
+    message_broker_producer_production_create($production);
+  }
+
+}
+
+/**
+ * Common function for install and update of related DoSomething specific
+ * message_broker_producer produciton settings.
+ */
+function dosomething_mbp_install_productions() {
+
+  if (!module_exists('message_broker_producer')) {
+    drupal_set_message('message_broker_producer() module not enabled, skip installing DoSomething production settings.', 'error');
     return;
   }
 
@@ -112,29 +161,6 @@ function dosomething_mbp_update_7002(&$sandbox) {
   $productions[4]['queues'][] = 'userAPICampaignActivityQueue';
   $productions[4]['routing_key'] = 'campaign.report_back.transactional';
   $productions[4]['status'] = 1;
-
-  foreach($productions as $production) {
-    message_broker_producer_production_create($production);
-  }
-
-}
-
-/**
- * Creates production entry in message_broker_producer for user profile updates
- */
-function dosomething_mbp_update_7003(&$sandbox) {
-  // Only run this if Message Broker Producer is enabled.
-  if (!module_exists('message_broker_producer')) {
-    return;
-  }
-
-  $productions[0]['machine_name'] = 'transactional_user_profile_update';
-  $productions[0]['exchange'] = 'transactionalExchange';
-  $productions[0]['queues'][] = 'userAPIProfileQueue';
-  $productions[0]['queues'][] = 'userProfileMailchimpQueue';
-  $productions[0]['routing_key'] = 'user.profile.update';
-  $productions[0]['status'] = 1;
-
 
   foreach($productions as $production) {
     message_broker_producer_production_create($production);

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -9,12 +9,16 @@
  */
 function dosomething_mbp_install() {
 
-   // Default Message Broker RabbitMQ connection settings
-   variable_set('message_broker_producer_rabbitmq_host', getenv('DS_MB_RABBITMQ_HOST'));
-   variable_set('message_broker_producer_rabbitmq_port', getenv('DS_MB_RABBITMQ_PORT'));
-   variable_set('message_broker_producer_rabbitmq_username', getenv('DS_MB_RABBITMQ_USERNAME'));
-   variable_set('message_broker_producer_rabbitmq_password', getenv('DS_MB_RABBITMQ_PASSWORD'));
-   variable_set('message_broker_producer_rabbitmq_vhost', getenv('DS_MB_RABBITMQ_VHOST'));
+  // Default Message Broker RabbitMQ connection settings
+  variable_set('message_broker_producer_rabbitmq_host', getenv('DS_MB_RABBITMQ_HOST'));
+  variable_set('message_broker_producer_rabbitmq_port', getenv('DS_MB_RABBITMQ_PORT'));
+  variable_set('message_broker_producer_rabbitmq_username', getenv('DS_MB_RABBITMQ_USERNAME'));
+  variable_set('message_broker_producer_rabbitmq_password', getenv('DS_MB_RABBITMQ_PASSWORD'));
+  variable_set('message_broker_producer_rabbitmq_vhost', getenv('DS_MB_RABBITMQ_VHOST'));
+
+  // Define the Message Broker application_id as the affiliate country code
+  $affiliate = strtoupper(dosomething_settings_get_affiliate_country_code());
+  variable_set('message_broker_producer_application_id', $affiliate);
 
 }
 

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -57,6 +57,9 @@ function dosomething_mbp_request($origin, $params = NULL) {
       $production = 'transactional_campaign_reportback';
       break;
 
+    default:
+      watchdog('dosomething_mbp', 'Undefined origin: %origin sent to dosomething_mbp_request()', array('%origin' => $origin), WATCHDOG_ERROR);
+
   }
   $payload = dosomething_mbp_get_transactional_payload($origin, $params);
   if (variable_get('dosomething_mbp_log')) {
@@ -148,9 +151,6 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
       $payload['email_tags'][] = 'drupal_campaign_reportback';
       break;
 
-    default:
-      watchdog('dosomething_mbp', 'Invslid dosomething_mbp_get_transactional_payload() $origin value: ' . $origin, WATCHDOG_ERROR);
-
   }
 
   return $payload;
@@ -189,7 +189,7 @@ function dosomething_mbp_get_common_campaign_payload(&$payload, $params) {
  * affiliate code.
  *
  * @param string $event_name
- *   NamExample: "campaign_signup", "password_reset", etc
+ *   Example: "campaign_signup", "password_reset", etc
  *
  * @return string
  *   Name of Mandrill template to use for transactional message.

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -184,3 +184,20 @@ function dosomething_mbp_get_common_campaign_payload(&$payload, $params) {
   $payload['merge_vars']['CAMPAIGN_TITLE'] = $params['campaign_title'];
   $payload['merge_vars']['CAMPAIGN_LINK'] = $params['campaign_link'];
 }
+
+/**
+ * Define template name to use for transaction based on the event and the
+ * affiliate code.
+ *
+ * @param string $event_name
+ *   NamExample: "campaign_signup", "password_reset", etc
+ *
+ * @return string
+ *   Name of Mandrill template to use for transactional message.
+ */
+function dosomething_mbp_get_template_name($event_name) {
+  $country_code = dosomething_settings_get_affiliate_country_code();
+  // Convert from "_" to "-" for template name
+  $event_name = str_replace('_', '-', $event_name);
+  return 'mb-' . $event_name . '-' . $country_code;
+}

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -193,7 +193,7 @@ function dosomething_mbp_get_common_campaign_payload(&$payload, $params) {
  */
 function dosomething_mbp_get_template_name($event_name) {
   $country_code = dosomething_settings_get_affiliate_country_code();
-  // Convert from "_" to "-" for template name
+  // Convert from $origin use of "_" to "-" for template name
   $event_name = str_replace('_', '-', $event_name);
   return 'mb-' . $event_name . '-' . $country_code;
 }

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -148,6 +148,9 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
       $payload['email_tags'][] = 'drupal_campaign_reportback';
       break;
 
+    default:
+      watchdog('dosomething_mbp', 'Invslid dosomething_mbp_get_transactional_payload() $origin value: ' . $origin, WATCHDOG_ERROR);
+
   }
 
   return $payload;

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -97,6 +97,7 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
     'activity' => $origin,
     'email' => $params['email'],
     'uid' => $params['uid'],
+    'email_template' => dosomething_mbp_get_template_name($origin),
     'merge_vars' => array(
       'MEMBER_COUNT' => dosomething_user_get_member_count(TRUE),
     ),
@@ -111,7 +112,6 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
         $payload['mobile'] = $params['mobile'];
       }
       $payload['merge_vars']['FNAME'] = $params['first_name'];
-      $payload['email_template'] = 'mb-general-signup';
       $payload['email_tags'][] = 'drupal_user_register';
       break;
 
@@ -119,7 +119,6 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
       $payload['merge_vars']['FNAME'] = $params['first_name'];
       $payload['merge_vars']['USERNAME'] = $params['username'];
       $payload['merge_vars']['RESET_LINK'] = $params['reset_link'];
-      $payload['email_template'] = 'mb-password-reset';
       $payload['email_tags'][] = 'drupal_user_password';
       break;
 
@@ -129,14 +128,12 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
       $payload['merge_vars']['STEP_ONE'] = $params['step_one'];
       $payload['merge_vars']['STEP_TWO'] = $params['step_two'];
       $payload['merge_vars']['STEP_THREE'] = $params['step_three'];
-      $payload['email_template'] = 'mb-campaign-signup';
       $payload['email_tags'][] = 'drupal_campaign_signup';
       break;
 
     case 'campaign_group_signup':
       dosomething_mbp_get_common_campaign_payload($payload, $params);
       $payload['merge_vars']['CAMPAIGN_COPY'] = $params['transactional_email_copy'];
-      $payload['email_template'] = 'mb-group-campaign-signup';
       $payload['email_tags'][] = 'drupal_campaign_group_signup';
       break;
 
@@ -148,7 +145,6 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
       $payload['merge_vars']['IMPACT_NUMBER'] = $params['impact_number'];
       $payload['merge_vars']['IMPACT_NOUN'] = $params['impact_noun'];
       $payload['merge_vars']['REPORTBACK_IMAGE_MARKUP'] = $params['image_markup'];
-      $payload['email_template'] = 'mb-campaign-report-back';
       $payload['email_tags'][] = 'drupal_campaign_reportback';
       break;
 


### PR DESCRIPTION
Fixes #3523 

Replaces:
https://github.com/DoSomething/dosomething/pull/3640
- Assigns Mandrill template name based on the `$origin` of the request:
  - `user_register`
  - `user_password`
  - `campaign_signup`
  - `campaign_group_signup`
  - `campaign_reportback`
- and the `dosomething_settings_get_affiliate_country_code()`.

All templates have been created and named in MailChimp based on this naming pattern. The MailChimp templates have been exported to Mandrill.
