### PR TITLE
Use compacted lists on fact index page.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/fact_page/fact-page-list.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/fact_page/fact-page-list.tpl.php
@@ -13,7 +13,7 @@
 		<div class="container__body">
 			<?php foreach ($links as $cause => $fact_pages): ?>
 			  <h3 class="inline--alt-color"><?php print $cause; ?></h3>
-			  <ul>
+			  <ul class="list-compacted">
 			    <?php foreach ($fact_pages as $link): ?>
 			    <li><?php print $link; ?></li>
 			    <?php endforeach ; ?>


### PR DESCRIPTION
# Changes
- Use compacted lists on fact index page. Fixes #3772.

For review: @DoSomething/front-end 
