### PR TITLE
IE8 fix for reportback gallery extended gallery layout on desktop.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -241,11 +241,6 @@ define(function(require) {
      * @return {boolean}
      */
     isLargerMedia: function () {
-
-      if (window.matchMedia !== undefined) {
-        return window.matchMedia("(min-width: 760px)").matches;
-      }
-
       return ($(window).outerWidth() >= 760);
     },
 


### PR DESCRIPTION
@DFurnes regarding fix for weird issue with RespondJS mediaMatch working correctly in IE8 & IE9.
