### PR TITLE
Image sizes

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -185,7 +185,7 @@ function dosomething_campaign_run_preprocess_klout_gallery(&$vars, $nid) {
         $klout_gallery[$i]['items'][$a]['image'] = dosomething_image_get_themed_image($image_nid, 'thumb', 'wmax-300-hmax-75');
       }
       else if ($klout_gallery[$i]['type'] == 'mention') {
-        $klout_gallery[$i]['items'][$a]['image'] = dosomething_image_get_themed_image($image_nid, 'thumb', '100x100');
+        $klout_gallery[$i]['items'][$a]['image'] = dosomething_image_get_themed_image($image_nid, 'thumb', '300x300');
       }
       // @TODO: link this link?
       if (!empty($gallery_items[$gallery_item_entity_id]->field_image_title)) {
@@ -198,6 +198,7 @@ function dosomething_campaign_run_preprocess_klout_gallery(&$vars, $nid) {
       $klout_gallery[$i]['items'][$a]['desc'] = $gallery_items[$gallery_item_entity_id]->field_image_description[LANGUAGE_NONE][0]['value'];
     }
   }
+
   $vars['klout_gallery'] = $klout_gallery;
 }
 

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
@@ -96,7 +96,7 @@ function dosomething_static_content_preprocess_gallery_vars(&$vars) {
     $style = 'default';
     // Defaults to use the Image node square field.
     $image_ratio = 'square';
-    $image_style = '300x300';
+    $image_style = '400x400';
 
     $vars['galleries'][$i] = array();
     $collection_item = reset($content['field_gallery'][$i]['entity']['field_collection_item']);

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -142,7 +142,7 @@ function paraneue_dosomething_get_search_vars($results) {
         $image = $result_node->field_image_campaign_cover;
         // Make it available as a variable, if it exists. Otherwise, leave it empty.
         if (!empty($image)) {
-          $value['display_image'] = dosomething_image_get_themed_image($image['und'][0]['target_id'], 'square', '100x100');
+          $value['display_image'] = dosomething_image_get_themed_image($image['und'][0]['target_id'], 'square', '300x300');
         }
         else {
           $value['display_image'] = '';
@@ -294,7 +294,7 @@ function paraneue_dosomething_get_recommended_campaign_gallery($tid = NULL, $uid
   if (isset($rec_vars)) {
     $gallery_items = array();
     foreach ($rec_vars as $delta => $value) {
-      $image = dosomething_image_get_themed_image($value['nid_image'], 'landscape', '300x300');
+      $image = dosomething_image_get_themed_image($value['nid_image'], 'landscape', '400x400');
       $item = array(
         'title' => $value['link'],
         'image' => $image,

--- a/lib/themes/dosomething/paraneue_dosomething/includes/patterns.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/patterns.inc
@@ -23,22 +23,18 @@
  *
  * @return string
  */
-function paraneue_dosomething_get_gallery_item($content, $type = 'figure', $use_default = TRUE, $classes_array = array()) {
+function paraneue_dosomething_get_gallery_item($content, $type = 'figure', $use_default = TRUE, $classes_array = array('-medium')) {
   // If no image is provided and we want to use a default, then set the default image here.
   if (empty($content['image']) && $use_default) {
     $content['image'] = theme('image', array(
-      'path' => path_to_theme() . '/bower_components/neue/dist/assets/images/apple-touch-icon-precomposed.png',
-      'width' => 100,
-      'height' => 100
+      'path' => path_to_theme() . '/bower_components/neue/dist/assets/images/apple-touch-icon-precomposed.png'
     ));
   }
 
   $variables = array(
     'content' => $content,
+    'classes' => implode(' ', $classes_array)
   );
-  if (isset($classes_array)) {
-    $variables['classes'] = implode(' ', $classes_array);
-  }
 
   $tpl = 'paraneue_' . $type;
   return theme($tpl, $variables);

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -406,7 +406,7 @@ function paraneue_dosomething_preprocess_reportback_files(&$vars) {
   $params['random'] = TRUE;
   $promoted_results = dosomething_reportback_get_reportback_files_query_result($params, $initial_count);
   foreach ($promoted_results as $rb_file) {
-    $rb_file->image = dosomething_image_get_themed_image_url_by_fid($rb_file->fid, '300x300');
+    $rb_file->image = dosomething_image_get_themed_image_url_by_fid($rb_file->fid, '400x400');
     $reportbacks_gallery['items'][] = paraneue_dosomething_get_gallery_item((array) $rb_file, 'photo');
   }
 
@@ -561,7 +561,7 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
   global $base_url;
   if ($doing = $vars['doing']) {
     foreach ($doing as $delta => $value) {
-      $image = dosomething_image_get_themed_image($value['nid_image'], 'landscape', '300x300');
+      $image = dosomething_image_get_themed_image($value['nid_image'], 'landscape', '400x400');
       $item = array(
         'title' => $value['link'],
         'image' => $image,
@@ -584,7 +584,7 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
         // Link to the full reportback entity view.
         $impact = l($impact, 'reportback/' . $rbid);
       }
-      $img = dosomething_image_get_themed_image_by_fid($reportback->fids[0], '100x100');
+      $img = dosomething_image_get_themed_image_by_fid($reportback->fids[0], '300x300');
       // Media gallery template expects a full URL.
       $url = $base_url . '/' . drupal_get_path_alias('node/' . $reportback->nid);
       $content = array(

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -28,6 +28,7 @@ $asset-path: "";
 @import "patterns/disclaimer";
 @import "patterns/info-bar"; // @TODO: Move to Neue!
 @import "patterns/list-compacted";
+@import "patterns/media"; // @TODO: Move to Neue!
 @import "patterns/promotion"; // @TODO: Move to Neue!
 @import "patterns/sources"; // @TODO: Move to Neue!
 @import "patterns/statistic"; // @TODO: Move to Neue!

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_media.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_media.scss
@@ -1,0 +1,8 @@
+// @TODO: Move to Neue!
+.media {
+  &.-medium {
+    .media__image {
+      width: 150px;
+    }
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
@@ -165,7 +165,7 @@
 
               <?php if ($klout_gallery_item['type'] === 'mention') : ?>
                 <li class="<?php print $gallery_item['order_class']; ?>">
-                  <div class="media">
+                  <div class="media -medium">
                     <?php if (isset($gallery_item['image'])): ?>
                     <div class="media__image">
                       <?php if (isset($gallery_item['url']) && !empty($gallery_item['url'])): ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/media.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/media.tpl.php
@@ -14,7 +14,7 @@
  * @see paraneue_dosomething_get_gallery_item()
  */
 ?>
-<article class="media">
+<article class="media <?php print $classes; ?>">
   <div class="media__image">
     <?php if (!empty($content['image'])): ?>
       <?php print $content['image']; ?>


### PR DESCRIPTION
# Changes
- Adds `.-medium` modifier to media pattern, which sets image container to 150px.
- Increase image sizes so they fit properly in new Neue galleries (figure now uses 400px image, media uses 300px image, both scaled to fit on the client).

Fixes #3758.

For review: @DoSomething/front-end 
