### PR TITLE
Update SMS form for Neue 6.0.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -41,6 +41,7 @@ $asset-path: "";
 @import "content/affiliate";
 @import "content/auth";
 @import "content/campaign";
+@import "content/campaign-sms";
 @import "content/campaign-closed";
 @import "content/donate";
 @import "content/explore-campaigns";

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-sms.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-sms.scss
@@ -1,0 +1,66 @@
+// Campaign SMS Game Page
+.campaign--sms {
+  .container--do {
+    form {
+      position: relative;
+      clear: both;
+      overflow: hidden;
+
+      .message-callout {
+        margin: 0 auto;
+        text-align: center;
+        width: 215px;
+
+        @include media($tablet) {
+          position: absolute;
+          top: 0;
+          right: 20px;
+          margin: 0;
+        }
+
+        .__copy {
+          &:before {
+            right: -10px;
+          }
+        }
+      }
+    }
+
+    .form-item-alpha-first-name {
+      @include span(100%);
+
+      @include media($medium) {
+        @include span(50%);
+      }
+    }
+
+    .form-wrapper.-columned {
+      @include span(100%);
+
+      @include media($medium) {
+        @include span(50%);
+      }
+
+      &:first-of-type {
+        clear: both;
+      }
+    }
+
+    .form-actions {
+      @include span(100%);
+      clear: both;
+      text-align: left;
+    }
+
+    .message-callout.-right {
+      position: absolute;
+      left: 144px;
+      bottom: -15px;
+
+      @include media($tablet) {
+        bottom: 0;
+      }
+    }
+  }
+}
+

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -136,43 +136,4 @@
   }
 }
 
-// Campaign SMS Game Page
-.campaign--sms {
-  .form-actions {
-    text-align: left;
-  }
-
-  .container--do {
-    form {
-      .message-callout {
-        margin: 0 auto;
-        text-align: center;
-        width: 215px;
-
-        @include media($tablet) {
-          position: absolute;
-          top: 0;
-          right: 20px;
-          margin: 0;
-        }
-
-        .__copy {
-          &:before {
-            right: -10px;
-          }
-        }
-      }
-    }
-
-    .message-callout.-right {
-      position: absolute;
-      left: 144px;
-      bottom: -15px;
-
-      @include media($tablet) {
-        bottom: 0;
-      }
-    }
-  }
-}
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -92,20 +92,20 @@
           <?php if (isset($starter)) : ?>
             <div><?php print $starter['safe_value']; ?></div>
           <?php endif; ?>
+        </div>
 
-          <?php if (isset($signup_form)) : ?>
-            <?php print render($signup_form); ?>
-          <?php endif; ?>
+        <?php if (isset($signup_form)) : ?>
+          <?php print render($signup_form); ?>
+        <?php endif; ?>
 
-          <?php print $campaign_scholarship; ?>
+        <?php print $campaign_scholarship; ?>
 
-          <div class="disclaimer legal">
-            <p>
-              <?php
-              print t("Taking part in this experience means you agree to our !terms_link &amp; to receive our weekly update. Message &amp; data rates may apply. Text STOP to opt-out, HELP for help.",
-                array("!terms_link" => l(t('Terms of Service'), 'about/terms-service'))); ?>
-            </p>
-          </div>
+        <div class="container__body -narrow">
+          <p class="legal">
+            <?php
+            print t("Taking part in this experience means you agree to our !terms_link &amp; to receive our weekly update. Message &amp; data rates may apply. Text STOP to opt-out, HELP for help.",
+              array("!terms_link" => l(t('Terms of Service'), 'about/terms-service'))); ?>
+          </p>
         </div>
 
       </div>


### PR DESCRIPTION
# Changes
- Move SMS campaign styles into their own partial.
- Updates the SMS form for Neue 6.0. Restores pretty two-column view. Fixes #3768.
# Screenshots
#### Desktop

![screen shot 2015-01-21 at 2 55 28 pm](https://cloud.githubusercontent.com/assets/583202/5843914/1097eec2-a17e-11e4-9197-2492660dbe2b.png)
#### Mobile

![screen shot 2015-01-21 at 2 55 41 pm](https://cloud.githubusercontent.com/assets/583202/5843916/16b445c6-a17e-11e4-818a-d74b02032f7d.png)
