### PR TITLE
restrict cropbox to never be smaller than 480px

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageCrop.js
@@ -46,7 +46,7 @@ define(function(require) {
   };
 
   /**
-   * Returns a values equal to the minimum allowed crop size scaled down to fit the image.
+   * Returns a value equal to the minimum allowed crop size scaled down to fit the image.
    */
   var getMinimumSize = function() {
     return minThreshold / scale;

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageCrop.js
@@ -18,9 +18,10 @@ define(function(require) {
   var $cropBox = $("<div class='cropbox'><div class='resize-handle'><div class='square'></div></div></div>");
   var $previewImage;
   var origImage;
-  var scale;
+  var scale = 1;
   var finalValues = {};
   var degrees = 0;
+  var minThreshold = 480;
 
   /**
    * Returns the coordinates of a touch or mouse event.
@@ -42,6 +43,13 @@ define(function(require) {
     }
 
     return coords;
+  };
+
+  /**
+   * Returns a values equal to the minimum allowed crop size scaled down to fit the image.
+   */
+  var getMinimumSize = function() {
+    return minThreshold / scale;
   };
 
   /**
@@ -99,9 +107,6 @@ define(function(require) {
     // we can rebind them later using new settings.
     $cropBox.off("touchmove mousemove");
     $cropBox.off("touchend mouseup");
-
-    // @TODO - set this to not allow any crop under 480x480.
-    var minThreshold = height / 2;
 
     // Bind move events to the document.
     $cropBox.on("touchmove mousemove", function(event) {
@@ -169,10 +174,10 @@ define(function(require) {
 
       // Calculate cropping information, taking into account how much the image has been scaled.
       finalValues = {
-        top:    Math.round($cropBox.offset().top - $previewImage.offset().top) * scale,
-        left:   Math.round($cropBox.offset().left - $previewImage.offset().left) * scale,
-        width:  $cropBox.width() * scale,
-        height: $cropBox.height() * scale,
+        top:    Math.round(($cropBox.offset().top - $previewImage.offset().top) * scale),
+        left:   Math.round(($cropBox.offset().left - $previewImage.offset().left) * scale),
+        width:  Math.round($cropBox.outerWidth() * scale),
+        height: Math.round($cropBox.outerHeight() * scale),
         degrees: degrees,
       };
 
@@ -201,9 +206,8 @@ define(function(require) {
     $cropBox.insertBefore($previewImage).css({
       "left"   : 0,
       "top"    : 0,
-      // @TODO - This should really be the minimum crop size (480x480) scaled to fit into the image.
-      "width"  : height / 2,
-      "height" : height / 2,
+      "width"  : minThreshold,
+      "height" : minThreshold,
     });
 
     // Initiate dragging and resizing.
@@ -306,6 +310,7 @@ define(function(require) {
     previewImageWidth = $previewImage.width();
     previewImageHeight = $previewImage.height();
     scale = origImage.width / $previewImage.width();
+    minThreshold = getMinimumSize();
 
     // Create the crop area.
     $previewImage.wrap($("<div class='crop-bounding-box'></div>"));


### PR DESCRIPTION
A user should not be able to crop an image under 480x480 so this just sets the minimum crop size to be that.

There will be another PR later to restrict user's from even uploading a file smaller than 480x480.

@DoSomething/front-end 
