### PR TITLE
Enables dosomething message broker globally.

### DIFF
--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -77,6 +77,7 @@ dependencies[] = dosomething_campaign_run
 dependencies[] = dosomething_fact
 dependencies[] = dosomething_fact_page
 dependencies[] = dosomething_image
+dependencies[] = dosomething_mbp
 dependencies[] = dosomething_helpers
 dependencies[] = dosomething_home
 dependencies[] = dosomething_reportback

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -234,8 +234,8 @@ projects[conductor_sms][subdir] = "contrib"
 projects[message_broker_producer][type] = "module"
 projects[message_broker_producer][download][type] = "git"
 projects[message_broker_producer][download][url] = "https://github.com/DoSomething/message_broker_producer.git"
+projects[message_broker_producer][download][tag] = "0.2.4"
 projects[message_broker_producer][subdir] = "contrib"
-
 
 ; DEVELOPMENT
 


### PR DESCRIPTION
Enables `dosomething_mbp` on US and international.
This enables `message_broker_producer` by the dependency.
