### PR TITLE
Fix typo in dosomething_mbp uninstall function name.

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -40,7 +40,7 @@ function dosomething_mbp_install() {
 /**
  * Implements hook_uninstall().
  */
-function dosomething_canada_uninstall() {
+function dosomething_mbp_uninstall() {
   $vars = array(
     'message_broker_producer_rabbitmq_host',
     'message_broker_producer_rabbitmq_port',


### PR DESCRIPTION
Fixes PHP Fatal error: `Cannot redeclare dosomething_canada_uninstall()`.
http://admin.dosomething.org/jenkins/job/Beta-Deploy/749/console
