### PR TITLE
Removed caption logic to reportback js

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -43,35 +43,44 @@ define(function(require) {
      * @param  {jQuery} $container  Reportback container object.
      */
     init: function ($container) {
-      var _this = this;
-      
       this.reportbackContainer = $container;
       this.$reportbackWrapper  = this.reportbackContainer.find(".wrapper");
       this.$reportbackForm     = this.reportbackContainer.find("#dosomething-reportback-form");
       this.$uploadButton       = this.reportbackContainer.find(".js-image-upload-beta");
+      this.$captionField       = this.$reportbackForm.find(".form-item-caption");
       this.$initialGallery     = $container.find(".gallery--reportback");
-      
+
       this.itemsPrefetched = $container.data("prefetched");
       this.itemsTotal      = $container.data("total") - this.itemsPrefetched;
       this.nid             = $container.data("nid");
       this.offset          = this.itemsPrefetched;
-      
+
       if (this.itemsPrefetched < this.itemsTotal) {
         this.apiUrl = this.buildApiUrl();
         this.enableViewMore();
         this.enableResponsive();
       }
-      
-      // Initializes image upload modal.
-      var imageUpload = new ImageUploadBeta(this.$uploadButton);
-      
-      // Grab the image caption from the modal only when the user is done with it.
-      Events.subscribe("Modal:Close", function() {
-        var $captionField = _this.$reportbackForm.find("input[name='caption']");
-        $captionField.val(imageUpload.getImageCaption());
-      });
+
+      this.imageUploadInit();
     },
 
+
+    imageUploadInit: function() {
+      var _this = this;
+      var imageUpload = new ImageUploadBeta(this.$uploadButton);
+      var submittedImage = this.$reportbackForm.find(".submitted-image").length === 0 ? false : true;
+
+      // If no prior submitted image is present, caption should be hidden.
+      if (!submittedImage)  {
+        this.$captionField.hide();
+      }
+
+      // Grab the image caption from the modal only when the user is done with it.
+      Events.subscribe("Modal:Close", function() {
+        _this.$captionField.find("input[name='caption']").val(imageUpload.getImageCaption());
+        _this.$captionField.show();
+      });
+    },
 
     /**
      * Add the reportback entries to the DOM.

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -68,7 +68,7 @@ define(function(require) {
     imageUploadInit: function() {
       var _this = this;
       var imageUpload = new ImageUploadBeta(this.$uploadButton);
-      var submittedImage = this.$reportbackForm.find(".submitted-image").length === 0 ? false : true;
+      var submittedImage = this.$reportbackForm.find(".submitted-image").length > 0;
 
       // If no prior submitted image is present, caption should be hidden.
       if (!submittedImage)  {


### PR DESCRIPTION
@weerd I moved the image caption show/hide logic into Reportback.js because the logic to show it after a user submits an image. It was in ImageUpload.js which we aren't using in the new reportback gallery. I needed to move it now, because the caption wasn't showing and a user won't be able to submit a form if they don't enter a caption. You had a TODO in there to do this. 

I haven't removed it from ImageUpload.js yet completely, since we are still supporting both experiences at the moment.
