### PR TITLE
Provides additional settings and debug messages to DS MBP installation.

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -9,10 +9,13 @@
  */
 function dosomething_mbp_install() {
 
+  drupal_set_message(t('Setting up DoSomething Message Broker.'));
+
   // Default Message Broker RabbitMQ connection settings
   variable_set('message_broker_producer_rabbitmq_host', getenv('DS_MB_RABBITMQ_HOST'));
   variable_set('message_broker_producer_rabbitmq_port', getenv('DS_MB_RABBITMQ_PORT'));
   variable_set('message_broker_producer_rabbitmq_username', getenv('DS_MB_RABBITMQ_USERNAME'));
+  variable_set('message_broker_producer_rabbitmq_password', getenv('DS_MB_RABBITMQ_PASSWORD'));
   variable_set('message_broker_producer_rabbitmq_vhost', getenv('DS_MB_RABBITMQ_VHOST'));
 
   // Define the Message Broker application_id as the affiliate country code

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -41,6 +41,7 @@ dependencies[] = libraries
 dependencies[] = l10n_update
 dependencies[] = link
 dependencies[] = markdown
+dependencies[] = message_broker_producer
 dependencies[] = module_filter
 dependencies[] = new_relic_rpm
 dependencies[] = pathauto


### PR DESCRIPTION
#### What's this PR do?
- Sets additional Drupal message during `dosomething_mbp` install stage to ensure its execution
- Specifies explicit `message_broker_producer` dependency
- Automatically sets rabbitmq password from env variable
