### PR TITLE
waiting for image to load for mobile. fixes #3803

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/ImageUploadBeta.js
@@ -1,5 +1,3 @@
-// @TODO - Move to new folder.
-
 define(function(require) {
   "use strict";
 
@@ -51,39 +49,41 @@ define(function(require) {
         reader.onloadend = function() {
           var result = this.result;
 
-          var isValid = _this.validImage(result);
-          var $errorMsg = _this.$uploadButton.parent().siblings(".error");
+          var image = new Image();
+          image.src = result;
 
-          if(isValid) {
-            // Remove any previously added error message.
-            if ($errorMsg.length) {
-              $errorMsg.remove();
-            }
+          image.onload = function() {
+            var isValid = _this.validImage(this);
+            var $errorMsg = _this.$uploadButton.parent().siblings(".error");
 
-            // Open the modal.
-            Modal.open(_this.$cropModal,
-              {
-                animated: false,
+            if(isValid) {
+              // Remove any previously added error message.
+              if ($errorMsg.length) {
+                $errorMsg.remove();
               }
-            );
 
-            // Add the preview image to the modal
-            _this.previewImage(result, _this.$imagePreview);
+              // Open the modal.
+              Modal.open(_this.$cropModal,
+                {
+                  animated: false,
+                }
+              );
 
-            // Make sure submit button is enabled when the modal opens.
-            var $submitButton = _this.$cropModal.find(".-done");
+              // Add the preview image to the modal
+              _this.previewImage(this, _this.$imagePreview);
 
-            if ($submitButton.prop("disabled")) {
-              $submitButton.prop("disabled", false);
+              // Make sure submit button is enabled when the modal opens.
+              _this.enableSubmit();
+
             }
-          }
-          // Show user an error if they upload an image that is too small.
-          else {
-            if (!$errorMsg.length) {
-              var $error = $("<div class='messages error'>Please upload a larger photo. Min. size is 480px by 480px.</div>");
-              $error.insertAfter(_this.$uploadButton.parent());
+            // Show user an error if they upload an image that is too small.
+            else {
+              if (!$errorMsg.length) {
+                var $error = $("<div class='messages error'>Please upload a larger photo. Min. size is 480px by 480px.</div>");
+                $error.insertAfter(_this.$uploadButton.parent());
+              }
             }
-          }
+          };
         };
       }
     });
@@ -100,12 +100,20 @@ define(function(require) {
   };
 
   /**
+   * Enables submit button in modal when it opens.
+   */
+  ImageUploadBeta.prototype.enableSubmit = function() {
+    var $submitButton = _this.$cropModal.find(".-done");
+
+    if ($submitButton.prop("disabled")) {
+      $submitButton.prop("disabled", false);
+    }
+  }
+
+  /**
    * Validates image size.
    */
-  ImageUploadBeta.prototype.validImage = function(fileReaderResult) {
-    var image = new Image();
-    image.src = fileReaderResult;
-
+  ImageUploadBeta.prototype.validImage = function(image) {
     return (image.width > 480 && image.height > 480);
   };
 
@@ -142,20 +150,20 @@ define(function(require) {
    * @param {jQuery} fileReaderResult   The result property of a file reader object.
    * @param {jQuery} $imageContainer    The DOM element to put the preview image in.
    */
-  ImageUploadBeta.prototype.previewImage = function(fileReaderResult, $imageContainer) {
+  ImageUploadBeta.prototype.previewImage = function(image, $imageContainer) {
     var _this = this;
 
     var $preview = $("<img class='preview' src=''>");
     $imageContainer.html($preview);
 
-    $preview.attr("src", fileReaderResult).load(function() {
+    $preview.attr("src", image.src).load(function() {
       var $this = $(this);
 
       _this.resizeImage($this, $imageContainer);
 
       // Initiate cropping if it is enabled.
       if (_this.cropEnabled) {
-        _this.cropInit(fileReaderResult);
+        _this.cropInit(image);
       }
     });
   };
@@ -165,11 +173,8 @@ define(function(require) {
    *
    * @param {jQuery} fileReaderResult  The result property of a file reader object.
    */
-  ImageUploadBeta.prototype.cropInit = function(fileReaderResult) {
-    var originalImage = new Image();
-    originalImage.src = fileReaderResult;
-
-    ImageCrop.dsCropperInit(originalImage);
+  ImageUploadBeta.prototype.cropInit = function(image) {
+    ImageCrop.dsCropperInit(image);
   };
 
   /**


### PR DESCRIPTION
### The problem

On mobile, when the validation ran the image had not yet been loaded and so the function thought that the dimension of the image was 0x0, causing an error to be thrown that the image was not large enough.
### Changes

This PR creates an image object from the file reader result and then waits for it to load using `image.onload = function() {}` . It then refactors the code a bit so that we pass the image created to various functions instead of the file reader result object. 

@DoSomething/front-end 
