### PR TITLE
Implements ExternalAuthUserPassController on UK and Canada.

### DIFF
--- a/lib/modules/dosomething/dosomething_canada/dosomething_canada.info
+++ b/lib/modules/dosomething/dosomething_canada/dosomething_canada.info
@@ -23,3 +23,4 @@ files[] = includes/dosomething_canada_sso_user.inc
 files[] = includes/dosomething_canada_login_controller.inc
 files[] = includes/dosomething_canada_profile_sync_controller.inc
 files[] = includes/dosomething_canada_register_controller.inc
+files[] = includes/dosomething_canada_user_pass_controller.inc

--- a/lib/modules/dosomething/dosomething_canada/dosomething_canada.module
+++ b/lib/modules/dosomething/dosomething_canada/dosomething_canada.module
@@ -27,6 +27,7 @@ function dosomething_canada_external_auth_method() {
     'login controller'        => 'DosomethingCanadaLoginController',
     'register controller'     => 'DosomethingCanadaRegisterController',
     'profile sync controller' => 'DosomethingCanadaProfileSyncController',
+    'user pass controller'    => 'DosomethingCanadaUserPassController',
    );
   return $items;
 }

--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_sso_client.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_sso_client.inc
@@ -91,13 +91,13 @@ class CanadaSSOClient {
   // Public: remote API calls
 
   /**
-   * Submit to login endpoint. If successful, loads user data
-   * into CanadaSSOClient::user.
+   * Submit to login endpoint.
    *
    * @param string $email
    * @param string $password
    *
-   * @return DosomethingCanadaSsoUser
+   * @return DosomethingCanadaSsoUser|FALSE
+   *   User object if login successful, otherwise FALSE.
    */
   public function login($email, $password)
   {
@@ -113,6 +113,20 @@ class CanadaSSOClient {
     }
     $account->setPassword($password);
     return $account;
+  }
+
+  /**
+   * Seeks remote user by its email.
+   *
+   * @param string $email
+   *
+   * @return DosomethingCanadaSsoUser|FALSE
+   *   User object if found, otherwise FALSE.
+   */
+  public function getUserByEmail($email)
+  {
+    $this->get(self::ENDPOINT_USERS . '/' . $email);
+    return $this->getUser();
   }
 
   /**
@@ -217,7 +231,7 @@ class CanadaSSOClient {
  * @param array $data
  * @return bool
  */
-  private function get($uri, $data)
+  private function get($uri, $data = array())
   {
     return $this->execute($uri, 'GET', $data);
   }
@@ -229,7 +243,7 @@ class CanadaSSOClient {
    * @param array $data
    * @return bool
    */
-  private function post($uri, $data)
+  private function post($uri, $data = array())
   {
     return $this->execute($uri, 'POST', $data);
   }

--- a/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_user_pass_controller.inc
+++ b/lib/modules/dosomething/dosomething_canada/includes/dosomething_canada_user_pass_controller.inc
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Canada User Pass Controller.
+ */
+class DosomethingCanadaUserPassController implements ExternalAuthUserPassController {
+
+  // ---------------------------------------------------------------------
+  // Public: interface implementation
+
+  public function ensure_local_user_exists(Array $form, Array &$form_state) {
+    if (empty($form_state['values']['name'])) {
+      return FALSE;
+    }
+    $this->sso = dosomething_canada_get_sso();
+    $remote_account = $this->sso->getUserByEmail($form_state['values']['name']);
+
+    if (!$remote_account) {
+      return FALSE;
+    }
+
+    // Sent random password.
+    $remote_account->setPassword(user_password());
+    $remote_account->saveAsLocal();
+    return TRUE;
+  }
+
+  // ---------------------------------------------------------------------
+
+}

--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.info
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.info
@@ -27,3 +27,4 @@ files[] = includes/dosomething_uk_sso_user.inc
 files[] = includes/dosomething_uk_login_controller.inc
 files[] = includes/dosomething_uk_profile_sync_controller.inc
 files[] = includes/dosomething_uk_register_controller.inc
+files[] = includes/dosomething_uk_user_pass_controller.inc

--- a/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
+++ b/lib/modules/dosomething/dosomething_uk/dosomething_uk.module
@@ -45,6 +45,7 @@ function dosomething_uk_external_auth_method() {
     'login controller'        => 'DosomethingUkLoginController',
     'register controller'     => 'DosomethingUkRegisterController',
     'profile sync controller' => 'DosomethingUkProfileSyncController',
+    'user pass controller'    => 'DosomethingUkUserPassController',
    );
   return $items;
 }

--- a/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_user_pass_controller.inc
+++ b/lib/modules/dosomething/dosomething_uk/includes/dosomething_uk_user_pass_controller.inc
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * UK User Pass Controller.
+ */
+class DosomethingUkUserPassController implements ExternalAuthUserPassController {
+
+  // ---------------------------------------------------------------------
+  // Public: interface implementation
+
+  public function ensure_local_user_exists(Array $form, Array &$form_state) {
+    return TRUE;
+  }
+
+  // ---------------------------------------------------------------------
+
+}

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -215,7 +215,7 @@ projects[xmlsitemap][subdir] = "contrib"
 projects[external_auth][type] = "module"
 projects[external_auth][download][type] = "git"
 projects[external_auth][download][url] = "https://github.com/DoSomething/drupal-external-auth.git"
-projects[external_auth][download][revision] = "5230277"
+projects[external_auth][download][revision] = "c6bda54"
 projects[external_auth][subdir] = "contrib"
 
 ; Conductor


### PR DESCRIPTION
#### What's this PR do?
- Automatically creates user from remote source when forgot password requested and the user has no local account
#### Test results

UK:
![screen shot 2015-01-27 at 3 04 25 pm](https://cloud.githubusercontent.com/assets/672669/5926123/b3a51a6a-a636-11e4-90b1-c22f468fa9d5.png)

Canada:
![screen shot 2015-01-27 at 3 06 40 pm](https://cloud.githubusercontent.com/assets/672669/5926124/b8d4065e-a636-11e4-8a70-8cdbc34f0160.png)
#### What are the relevant tickets?

Fixes #3749
