### PR TITLE
Updates to grab full reportback data, such as captions and limiting number of prior reportbacks to show

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -98,13 +98,23 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
       // Output reportback images with date last updated.
       $form['reportback_submissions']['reportback_file']['#attributes']['is_supersized'] = FALSE;
 
-      $reportback_prior_images = array_reverse($entity->getThemedImages('300x300'));
-      $reportback_latest_image = array_shift($reportback_prior_images);
+      $reportback_submissions_data = array();
+      // Specify number of prior reportbacks to retrieve, including the latest one to show prominently.
+      $reportback__submissions_count = 5;
+
+      foreach ($entity->fids as $index => $fid) {
+        $reportback_submissions_data[$index] = reportback_file_load($fid);
+        $reportback_submissions_data[$index]->image = dosomething_image_get_themed_image_by_fid($fid, '300x300'); 
+      }
+
+      $reportback_prior_submissions = array_reverse($reportback_submissions_data);
+      $reportback_prior_submissions = array_slice($reportback_prior_submissions, 0, $reportback__submissions_count);
+      $reportback_latest_submission = array_shift($reportback_prior_submissions);
 
       $form['reportback_submissions']['reportback_latest_submission'] = array(
         '#weight' => 0,
         '#markup' => theme('reportback_latest_submission', array(
-          'image' => $reportback_latest_image,
+          'reportback' => $reportback_latest_submission,
         )),
       );
 
@@ -112,7 +122,7 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
         '#weight' => 10,
         '#markup' => theme('reportback_prior_submissions', array(
           'updated' => format_date($entity->updated, 'short'),
-          'images' => $reportback_prior_images,
+          'reportbacks' => $reportback_prior_submissions,
         )),
       );
 

--- a/lib/modules/dosomething/dosomething_reportback/theme/reportback-latest-submission.tpl.php
+++ b/lib/modules/dosomething/dosomething_reportback/theme/reportback-latest-submission.tpl.php
@@ -1,1 +1,5 @@
-<?php print $image; ?>
+<?php print $reportback->image; ?>
+
+<?php if ($reportback->caption): ?>
+  <?php print $reportback->caption; ?>
+<?php endif; ?>

--- a/lib/modules/dosomething/dosomething_reportback/theme/reportback-prior-submissions.tpl.php
+++ b/lib/modules/dosomething/dosomething_reportback/theme/reportback-prior-submissions.tpl.php
@@ -1,4 +1,4 @@
 <p class="legal"><?php print t('Last updated:'); ?> <?php print $updated; ?></p>
-<?php foreach ($images as $image): ?>
-  <?php print $image; ?>
+<?php foreach ($reportbacks as $reportback): ?>
+  <?php print $reportback->image; ?>
 <?php endforeach; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-latest-submission.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-latest-submission.tpl.php
@@ -1,5 +1,7 @@
 <figure class="reportback__submission-latest">
-  <?php print $image; ?>
+  <?php print $reportback->image; ?>
 
-  <figcaption></figcaption>
+  <?php if ($reportback->caption): ?>
+    <figcaption><?php print $reportback->caption; ?></figcaption>
+  <?php endif; ?>
 </figure>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-prior-submissions.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-prior-submissions.tpl.php
@@ -1,5 +1,5 @@
 <ul class="reportback__submissions-list gallery">
-<?php foreach ($images as $image): ?>
-  <li><?php print $image; ?></li>
+<?php foreach ($reportbacks as $reportback): ?>
+  <li><?php print $reportback->image; ?></li>
 <?php endforeach; ?>
 </ul>


### PR DESCRIPTION
Now with captions!

This is now dynamically pulling in the captions added to each reportback, and showing it for the latest reportback submitted, as per the design mocks.

Also allows for specifying the number of prior reportbacks to show in new interface. Current setting is 5, which includes the latest submission (large image w/ caption), and 4 other reportbacks which are styled as tiny cubes in a row below the large entry.

@aaronschachter @sbsmith86 

CC: @barryclark @DFurnes 
