### PR TITLE
DS Terms API: Inbox count

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/term_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/term_resource.inc
@@ -68,11 +68,20 @@ function _term_resource_index($parameters) {
   if ($cause) {
     $terms = taxonomy_get_tree($cause->vid);
   }
+  $display_totals = user_access('view any reportback');
   foreach ($terms as &$term) {
     // Convert string output to integers where appropriate.
     foreach ($int_properties as $property) {
       $term->{$property} = (int) $term->{$property};
     }
+    $params = array(
+      'tid' => $term->tid,
+      'status' => 'pending',
+    );
+    if ($display_totals) {
+      $term->inbox = dosomething_reportback_get_reportback_files_query_count($params);
+    }
+
   }
   unset($term);
   return $terms;


### PR DESCRIPTION
For use in the RB Reviewer app, adds an `inbox` property for each term's Inbox count if the user has access to `view any reportback`.
