### PR TITLE
Fix official rules display issue.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -141,15 +141,20 @@
         text-align: left;
       }
     }
-    
+
     // @TODO: v2 Reportbacks temporary addition for classic version.
     &.reportback-classic {
-      h3 {
+      h3, p {
         color: #fff;
       }
 
-      p, a {
+      a {
         color: #fff;
+        text-decoration: underline;
+      }
+
+      .button {
+        text-decoration: none;
       }
     }
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -249,8 +249,8 @@
   <section id="prove" class="container container--prove inline--alt-bg <?php if($show_new_reportback): print 'reportback-beta'; else: print 'reportback-classic'; endif; ?>">
     <h2 class="heading -banner"><span><?php print t('Step 4: Prove It'); ?></span></h2>
 
-    <?php if( $show_new_reportback ): ?>
-      <div class="wrapper">
+    <div class="wrapper">
+      <?php if( $show_new_reportback ): ?>
         <div class="container__body">
           <h3 class="heading -beta"><?php print t('Pics or It Didn’t Happen'); ?></h3>
 
@@ -301,9 +301,7 @@
 
           </div>
         </div>
-      </div>
-    <?php else: ?>
-      <div class="wrapper">
+      <?php else: ?>
         <div class="container__body -half">
           <h3><?php print t('Pics or It Didn’t Happen'); ?></h3>
 
@@ -346,14 +344,16 @@
             <?php endif; ?>
           </aside>
         </div>
-      </div>
-    <?php endif; ?>
+      <?php endif; ?>
 
-    <?php if (isset($official_rules)): ?>
-      <div class="disclaimer">
-        <a class="official-rules" href="<?php print $official_rules_src; ?>"><?php print t('Official Rules'); ?></a>
-      </div>
-    <?php endif; ?>
+      <?php if (isset($official_rules)): ?>
+        <div class="container__body -narrow">
+          <div class="disclaimer">
+            <a class="official-rules" href="<?php print $official_rules_src; ?>"><?php print t('Official Rules'); ?></a>
+          </div>
+        </div>
+      <?php endif; ?>
+    </div>
 
     <?php if ($info_bar): ?>
       <?php print $info_bar; ?>


### PR DESCRIPTION
# Changes
- Fixes #3819. Moves `container`'s `wrapper` outside of the feature flag if-block, so that "Official Rules" can live inside it as well. Also adds a `container__body` around "official rules" section.

For review: @weerd 
# Screenshot

![screen shot 2015-01-28 at 1 53 50 pm](https://cloud.githubusercontent.com/assets/583202/5944459/1d08c52e-a6f5-11e4-9c08-19caadc756d8.png)
