### PR TITLE
Fix display issue where carousel was breaking out of grid.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -24,6 +24,7 @@ $asset-path: "";
 @import "overrides/drupal";
 
 // Local patterns
+@import "patterns/carousel";
 @import "patterns/container";
 @import "patterns/disclaimer";
 @import "patterns/list-compacted";

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_carousel.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_carousel.scss
@@ -1,0 +1,3 @@
+.carousel {
+  max-width: 100%;
+}


### PR DESCRIPTION
# Changes
- Fixes a display issue where carousel in "Prove It" section was breaking out of the grid in Firefox.

References #3834. For review: @DoSomething/front-end 
