### PR TITLE
Quick fix for container collapsing issue with floated content.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_container.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_container.scss
@@ -1,6 +1,5 @@
-.container {
-  // Patterned background (such as the "Prove It" section on action page)
-  &.-patterned {
-    background: $purple asset-url("images/campaign-pattern-default.png") repeat center 63px;
-  }
+// Add clearfix to container body.
+// @TODO: Move to Neue.
+.container__body {
+  @include clearfix;
 }


### PR DESCRIPTION
# Changes
- Removes unused `-patterned` modifier. We are styling the "Prove It" container directly (since we toggle this style based on whether new report back is on/off).
- Add a clearfix to container body. This fixes issues where the container collapses with floated content and padding between sections is lost. This will be part of the next Neue release.

Fixes #3766. For review: @DoSomething/front-end 
