### PR TITLE
Reportback placeholders

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -306,3 +306,42 @@ function paraneue_dosomething_get_recommended_campaign_gallery($tid = NULL, $uid
     return paraneue_dosomething_get_gallery($gallery_items, 'triad');
   }
 }
+
+/**
+ * Returns specified number of themed Approved Reportbacks.
+ *
+ * @param  integer $count  Number of reportbacks to prepare.
+ * @return array           Array of the specified number of Approved Reportbacks.
+ */
+function paraneue_dosomething_get_themed_approved_reportbacks($nid, $count = 6) {
+  // Set params to retrieve Approved Reportback for this nid.
+  $params['nid'] = $nid;
+  $params['status'] = 'approved';
+  $reportbacks = array();
+  $approved_reportbacks = dosomething_reportback_get_reportback_files_query_result($params, $count);
+
+  foreach ($approved_reportbacks as $reportback) {
+    // @Todo: DRY. Potentially grab this data from the API endpoint to truly DRY?
+    $reportback->image = dosomething_image_get_themed_image_url_by_fid($reportback->fid, '300x300');
+    $reportbacks[] = paraneue_dosomething_get_gallery_item((array) $reportback, 'photo');
+  }
+
+  return $reportbacks;
+}
+
+/**
+ * Returns specified number of themed Placeholder Reportbacks.
+ *
+ * @param  integer $count  Number of placeholders to prepare.
+ * @return array           Array of the specified number of Placeholders Reportback.
+ */
+function paraneue_dosomething_get_themed_placeholder_reportbacks($count = 6) {
+  $placeholder_urls = dosomething_campaign_get_default_gallery_image_urls();
+  $placeholders = array();
+
+  for ($i = 0; $i < $count; $i++) {
+    $placeholders[] = paraneue_dosomething_get_gallery_item(array('image' => $placeholder_urls[$i]), 'placeholder');
+  }
+
+  return $placeholders;
+}

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -400,8 +400,9 @@ function paraneue_dosomething_preprocess_reportback_files(&$vars) {
 
   $reportbacks_gallery['items'] = array();
 
+
   // Promoted Reportbacks:
-  // =====================
+  // ========================================================================
   // Set params to retrieve random Promoted Reportbacks for this nid.
   $params = array();
   $params['nid'] = $vars['nid'];
@@ -415,38 +416,30 @@ function paraneue_dosomething_preprocess_reportback_files(&$vars) {
   }
 
   // Total number of Promoted Reportbacks obtained.
-  // $reportbacks_gallery['items'] = array(); // Testing!
-  // $reportbacks_gallery['items'][] = '<figure>Sample</figure>';
-  // $reportbacks_gallery['items'][] = '<figure>Sample</figure>';
   $reportbacks_gallery['total_promoted'] = count($reportbacks_gallery['items']);
-  dpm($reportbacks_gallery['total_promoted'], 'Total Promoted');
 
 
   // Approved Reportbacks:
-  // =====================
+  // ========================================================================
   // Set params to get the total number of Approved Reportbacks for this nid.
   $params['status'] = 'approved';
   if (isset($params['random'])) {
     unset($params['random']);
   }
   $reportbacks_gallery['total_approved'] = dosomething_reportback_get_reportback_files_query_count($params);
-  // $reportbacks_gallery['total_approved'] = 0;
-  dpm($reportbacks_gallery['total_approved'], 'Total Approved');
 
 
-
+  // Build Reportback Gallery based on Promoted & Approved Reportback counts.
+  // ========================================================================
   // Total Promoted Reportbacks less than required initial count.
   if ($reportbacks_gallery['total_promoted'] < $initial_count) {
-    dpm('None or less than 6 Promoted Reportbacks.');
-
     $fill_count = $initial_count - $reportbacks_gallery['total_promoted'];
-    dpm($fill_count, 'Number of fill items required:');
 
     // Absolutely no Approved Reportbacks to fulfill the fill count needed.
     if ($reportbacks_gallery['total_approved'] === 0) {
-      dpm('No Approved Reportbacks, resort to Placeholders.');
       $placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks($fill_count);
       $reportbacks_gallery['items'] = array_merge($reportbacks_gallery['items'], $placeholders);
+      $reportbacks_gallery['prefetched'] = 0;
     }
 
     // Some but not enough Approved Reportbacks to fulfill the fill count needed.
@@ -454,48 +447,21 @@ function paraneue_dosomething_preprocess_reportback_files(&$vars) {
       $approved_reportbacks = paraneue_dosomething_get_themed_approved_reportbacks($vars['nid'], $reportbacks_gallery['total_approved']);
       $placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks($fill_count - $reportbacks_gallery['total_approved']);
       $reportbacks_gallery['items'] = array_merge($reportbacks_gallery['items'], $approved_reportbacks, $placeholders);
+      $reportbacks_gallery['prefetched'] = $reportbacks_gallery['total_approved'];
     }
 
     // There are enough Approved Reportbacks to fulfill the fill count needed.
     else {
-      dpm('We have enough Approved Reportbacks!');
       $approved_reportbacks = paraneue_dosomething_get_themed_approved_reportbacks($vars['nid'], $fill_count);
       $reportbacks_gallery['items'] = array_merge($reportbacks_gallery['items'], $approved_reportbacks);
       $reportbacks_gallery['prefetched'] = $fill_count;
     }
-
   }
+
   // Enough Total Promoted Reportbacks to fulfill the required initial count.
   else {
-    dpm('We have enough Promoted Reportbacks!');
     $reportbacks_gallery['prefetched'] = 0;
-    // $reportback_placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks(3);
-    // dpm($reportback_placeholders, 'Placeholder Reportbacks');
   }
-
-  // // Do we have enough promoted items?
-  // $current_count = count($reportbacks_gallery['items']);
-  // if ($current_count < $initial_count) {
-  //   // Find out how many additonal approved Reportback items to grab to fulfill the initial count.
-  //   $approved_count = $initial_count - $current_count;
-  //   // Set params to retrieve approved Reportback Files for this nid.
-  //   $params['status'] = 'approved';
-  //   unset($params['random']);
-  //   $approved_results = dosomething_reportback_get_reportback_files_query_result($params, $approved_count);
-
-  //   foreach ($approved_results as $rb_file) {
-  //     // @Todo: DRY. Potentially grab this data from the API endpoint to truly DRY?
-  //     $rb_file->image = dosomething_image_get_themed_image_url_by_fid($rb_file->fid, '300x300');
-  //     $reportbacks_gallery['items'][] = paraneue_dosomething_get_gallery_item((array) $rb_file, 'photo');
-  //   }
-  //   // Set how many images have been prefetched.
-  //   (count($reportbacks_gallery['items']) > 0) ? $reportbacks_gallery['prefetched'] = $approved_count : $reportbacks_gallery['prefetched'] = 0;
-  // } else {
-  //   $reportbacks_gallery['prefetched'] = 0;
-  // }
-
-  // Approved Reportbacks or Placeholders: why not both?
-  dpm($reportbacks_gallery, 'Gallery Data');
 }
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -399,44 +399,105 @@ function paraneue_dosomething_preprocess_reportback_files(&$vars) {
   $initial_count = $reportbacks_gallery['initial_count'];
 
   $reportbacks_gallery['items'] = array();
-   // Set params to retrieve random promoted Reportback Files for this nid.
+
+  // Promoted Reportbacks:
+  // =====================
+  // Set params to retrieve random Promoted Reportbacks for this nid.
   $params = array();
   $params['nid'] = $vars['nid'];
   $params['status'] = 'promoted';
   $params['random'] = TRUE;
   $promoted_results = dosomething_reportback_get_reportback_files_query_result($params, $initial_count);
+
   foreach ($promoted_results as $rb_file) {
     $rb_file->image = dosomething_image_get_themed_image_url_by_fid($rb_file->fid, '400x400');
     $reportbacks_gallery['items'][] = paraneue_dosomething_get_gallery_item((array) $rb_file, 'photo');
   }
 
-  // Do we have enough promoted items?
-  $current_count = count($reportbacks_gallery['items']);
-  if ($current_count < $initial_count) {
-    // Find out how many additonal approved Reportback items to grab to fulfill the initial count.
-    $approved_count = $initial_count - $current_count;
-    $reportbacks_gallery['prefetched'] = $approved_count;
-    // Set params to retrieve approved Reportback Files for this nid.
-    $params['status'] = 'approved';
-    unset($params['random']);
-    $approved_results  = dosomething_reportback_get_reportback_files_query_result($params, $approved_count);
-    foreach ($approved_results as $rb_file) {
-      // @todo: DRY. Potentially grab this data from the API endpoint to truly DRY?
-      $rb_file->image = dosomething_image_get_themed_image_url_by_fid($rb_file->fid, '300x300');
-      $reportbacks_gallery['items'][] = paraneue_dosomething_get_gallery_item((array) $rb_file, 'photo');
-    }
-  } else {
-    $reportbacks_gallery['prefetched'] = 0;
-  }
+  // Total number of Promoted Reportbacks obtained.
+  // $reportbacks_gallery['items'] = array(); // Testing!
+  // $reportbacks_gallery['items'][] = '<figure>Sample</figure>';
+  // $reportbacks_gallery['items'][] = '<figure>Sample</figure>';
+  $reportbacks_gallery['total_promoted'] = count($reportbacks_gallery['items']);
+  dpm($reportbacks_gallery['total_promoted'], 'Total Promoted');
 
-  // Get the total number of approved reportbacks.
+
+  // Approved Reportbacks:
+  // =====================
+  // Set params to get the total number of Approved Reportbacks for this nid.
   $params['status'] = 'approved';
   if (isset($params['random'])) {
     unset($params['random']);
   }
+  $reportbacks_gallery['total_approved'] = dosomething_reportback_get_reportback_files_query_count($params);
+  // $reportbacks_gallery['total_approved'] = 0;
+  dpm($reportbacks_gallery['total_approved'], 'Total Approved');
 
-  $reportbacks_gallery['total'] = dosomething_reportback_get_reportback_files_query_count($params);
+
+
+  // Total Promoted Reportbacks less than required initial count.
+  if ($reportbacks_gallery['total_promoted'] < $initial_count) {
+    dpm('None or less than 6 Promoted Reportbacks.');
+
+    $fill_count = $initial_count - $reportbacks_gallery['total_promoted'];
+    dpm($fill_count, 'Number of fill items required:');
+
+    // Absolutely no Approved Reportbacks to fulfill the fill count needed.
+    if ($reportbacks_gallery['total_approved'] === 0) {
+      dpm('No Approved Reportbacks, resort to Placeholders.');
+      $placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks($fill_count);
+      $reportbacks_gallery['items'] = array_merge($reportbacks_gallery['items'], $placeholders);
+    }
+
+    // Some but not enough Approved Reportbacks to fulfill the fill count needed.
+    elseif ($reportbacks_gallery['total_approved'] < $fill_count) {
+      $approved_reportbacks = paraneue_dosomething_get_themed_approved_reportbacks($vars['nid'], $reportbacks_gallery['total_approved']);
+      $placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks($fill_count - $reportbacks_gallery['total_approved']);
+      $reportbacks_gallery['items'] = array_merge($reportbacks_gallery['items'], $approved_reportbacks, $placeholders);
+    }
+
+    // There are enough Approved Reportbacks to fulfill the fill count needed.
+    else {
+      dpm('We have enough Approved Reportbacks!');
+      $approved_reportbacks = paraneue_dosomething_get_themed_approved_reportbacks($vars['nid'], $fill_count);
+      $reportbacks_gallery['items'] = array_merge($reportbacks_gallery['items'], $approved_reportbacks);
+      $reportbacks_gallery['prefetched'] = $fill_count;
+    }
+
+  }
+  // Enough Total Promoted Reportbacks to fulfill the required initial count.
+  else {
+    dpm('We have enough Promoted Reportbacks!');
+    $reportbacks_gallery['prefetched'] = 0;
+    // $reportback_placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks(3);
+    // dpm($reportback_placeholders, 'Placeholder Reportbacks');
+  }
+
+  // // Do we have enough promoted items?
+  // $current_count = count($reportbacks_gallery['items']);
+  // if ($current_count < $initial_count) {
+  //   // Find out how many additonal approved Reportback items to grab to fulfill the initial count.
+  //   $approved_count = $initial_count - $current_count;
+  //   // Set params to retrieve approved Reportback Files for this nid.
+  //   $params['status'] = 'approved';
+  //   unset($params['random']);
+  //   $approved_results = dosomething_reportback_get_reportback_files_query_result($params, $approved_count);
+
+  //   foreach ($approved_results as $rb_file) {
+  //     // @Todo: DRY. Potentially grab this data from the API endpoint to truly DRY?
+  //     $rb_file->image = dosomething_image_get_themed_image_url_by_fid($rb_file->fid, '300x300');
+  //     $reportbacks_gallery['items'][] = paraneue_dosomething_get_gallery_item((array) $rb_file, 'photo');
+  //   }
+  //   // Set how many images have been prefetched.
+  //   (count($reportbacks_gallery['items']) > 0) ? $reportbacks_gallery['prefetched'] = $approved_count : $reportbacks_gallery['prefetched'] = 0;
+  // } else {
+  //   $reportbacks_gallery['prefetched'] = 0;
+  // }
+
+  // Approved Reportbacks or Placeholders: why not both?
+  dpm($reportbacks_gallery, 'Gallery Data');
 }
+
 
 /**
  * Preprocesses a Campaign Group node.
@@ -448,6 +509,7 @@ function paraneue_dosomething_preprocess_node_campaign_group(&$vars) {
   $source = 'node/' . $vars['nid'];
   $vars['campaign_gallery'] = paraneue_dosomething_get_campaign_gallery($vars['campaigns'], $source);
 }
+
 
 /**
  * Sets a $campaign_scholarship variable based on $vars.

--- a/lib/themes/dosomething/paraneue_dosomething/includes/theme.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/theme.inc
@@ -158,6 +158,11 @@ function paraneue_dosomething_theme() {
       'path' => PARANEUE_DS_PATH . '/templates/system/patterns',
     ),
 
+    'paraneue_placeholder' => array(
+      'template' => 'placeholder',
+      'path' => PARANEUE_DS_PATH . '/templates/system/patterns',
+    ),
+
     'paraneue_tile' => array(
       'template' => 'tile',
       'path' => PARANEUE_DS_PATH . '/templates/system/patterns',

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -259,7 +259,7 @@
           <?php endif; ?>
         </div>
 
-        <div id="reportback" class="reportback" data-nid="<?php print $campaign->nid; ?>" data-prefetched="<?php print $reportbacks_gallery['prefetched']; ?>" data-total="<?php print $reportbacks_gallery['total']; ?>">
+        <div id="reportback" class="reportback" data-nid="<?php print $campaign->nid; ?>" data-prefetched="<?php print $reportbacks_gallery['prefetched']; ?>" data-total="<?php print $reportbacks_gallery['total_approved']; ?>">
           <div class="wrapper">
 
             <ul class="gallery gallery--reportback">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/placeholder.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/placeholder.tpl.php
@@ -1,0 +1,3 @@
+<div class="photo -stacked -framed -placeholder">
+  <img src="<?php print $content['image']; ?>" alt="placeholder reportback photo" />
+</div>


### PR DESCRIPTION
Resolves #3664

_Now With Placeholders!_

The Reportback Gallery now handles a variety of scenarios with what is available from Promoted and Approved  Reportbacks and when needed filling in with Placeholders. See below:

*Promoted RB Count and Approved RB Count indicate how many of each respective type are available for a campaign in the database.

| Promoted RB Count | Approved RB Count | Placeholders Used |
| :-: | :-: | :-: |
| 0 | 20 | 0 |
| 2 | 20 | 0 |
| 0 | 0 | 6 |
| 2 | 0 | 4 |
| 2 | 3 | 1 |
| 6 | 0 | 0 |

@aaronschachter @mikefantini 

CC @barryclark @sbsmith86 
