### PR TITLE
Reportback form: Query by Primary Cause

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -860,8 +860,9 @@ function dosomething_reportback_get_reportback_files_query($params = array()) {
   $query->join('node', 'n', 'rb.nid = n.nid');
   $query->join('file_managed', 'f', 'rbf.fid = f.fid');
   if (isset($params['tid'])) {
-    $query->join('taxonomy_index', 't', 't.nid = n.nid');
-    $query->condition('t.tid', $params['tid']);
+    $query->join('field_data_field_primary_cause', 't', 't.entity_id = n.nid');
+    $query->condition('t.field_primary_cause_tid', $params['tid']);
+    $query->condition('t.entity_type', 'node');
   }
   if (isset($params['status'])) {
     $query->condition('rbf.status', $params['status']);


### PR DESCRIPTION
Alters the `dosomething_reportback_get_reportback_files_query` function to query the `field_data_field_primary_cause` table instead of `taxonomy_index`, to avoid situations where Reviewers may be reviewing the same reportbacks - as a campaign can only have 1 taxonomy term tid assigned to its Primary Cause.
