### PR TITLE
Grants org friend access to the active page callback

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -279,11 +279,7 @@ function _dosomething_campaign_closed_page_access($node) {
  * Determines whether a user has access to the active page callback.
  */
 function _dosomething_campaign_active_page_access($node) {
-  global $user;
-  // Grant access if you're  staff OR you're an org friend:
-  $has_access = dosomething_user_is_staff() || in_array('org friend', $user->roles);
-  if (!$has_access) {
-    // No active page for you.
+  if (!user_access('view any unpublished content')) {
     return FALSE;
   }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -279,9 +279,15 @@ function _dosomething_campaign_closed_page_access($node) {
  * Determines whether a user has access to the active page callback.
  */
 function _dosomething_campaign_active_page_access($node) {
-  // Staff only.
-  if (!dosomething_user_is_staff()) { return FALSE; }
+  global $user;
+  // Grant access if you're  staff OR you're an org friend:
+  $has_access = dosomething_user_is_staff() || in_array('org friend', $user->roles);
+  if (!$has_access) {
+    // No active page for you.
+    return FALSE;
+  }
 
+  // Active tab should only be displayed if the campaign has been closed.
   return dosomething_campaign_is_closed($node);
 }
 


### PR DESCRIPTION
Fixes #3822

@mikefantini - Note: The Org friend will not see the tabs, but will be able to access the active page directly via URL (http://staging.beta.dosomething.org/node/362/active)
