### PR TITLE
Closed Gallery fix

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -405,6 +405,6 @@ function dosomething_campaign_preprocess_closed_reportback_gallery(&$vars, $styl
       $vars['reportback_gallery'][$delta]['caption'] = check_plain($item->caption);
     }
     $account = user_load($item->uid);
-    $vars['reportback_gallery'][$delta]['first_name'] = dosomething_user_get_field('field_first_name', $account);;
+    $vars['reportback_gallery'][$delta]['first_name'] = dosomething_user_get_field('field_first_name', $account);
   }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -876,11 +876,10 @@ function dosomething_reportback_get_reportback_files_query($params = array()) {
 
   // Public API properties to expose:
   $rbf_fields = array('fid', 'caption', 'rbid');
-  $rb_fields = array('quantity');
+  $rb_fields = array('quantity', 'uid');
   // Staff-only properties to add:
   if (user_access('view any reportback')) {
     $rbf_fields[] = 'status';
-    $rb_fields[] = 'uid';
     $rb_fields[] = 'why_participated';
   }
   $query->fields('rbf', $rbf_fields);


### PR DESCRIPTION
The closed gallery data is set via `dosomething_reportback_get_reportback_files_query`, which was only returning `uid` if the logged in user has access to `view any reportback`.

Instead, expose the uid regardless of permission.  Fixes bug. 
