### PR TITLE
Reportback updates part 1

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -118,13 +118,15 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
         )),
       );
 
-      $form['reportback_submissions']['reportback_prior_submissions'] = array(
-        '#weight' => 10,
-        '#markup' => theme('reportback_prior_submissions', array(
-          'updated' => format_date($entity->updated, 'short'),
-          'reportbacks' => $reportback_prior_submissions,
-        )),
-      );
+      if ($reportback_prior_submissions) {
+        $form['reportback_submissions']['reportback_prior_submissions'] = array(
+          '#weight' => 10,
+          '#markup' => theme('reportback_prior_submissions', array(
+            'updated' => format_date($entity->updated, 'short'),
+            'reportbacks' => $reportback_prior_submissions,
+          )),
+        );
+      }
 
       $submit_label = t("Update submission");
     }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -34,7 +34,8 @@ function paraneue_dosomething_file($variables) {
 
     // Need to include the <input> within <label> to universalize style for file input.
     if ($element['#attributes']['is_supersized']) {
-      return '<label class="gigantor" id="' . $id . '"><span>' . t('Upload a pic') . '</span><input' . drupal_attributes($element['#attributes']) . ' /></label>';
+      $message = '<div class="message-callout -below"><div class="message-callout__copy"><p>' . t('Join the cool kids!<br/> Add your photo here!') . '</p></div></div>';
+      return '<label class="gigantor" id="' . $id . '">' . $message . '<input' . drupal_attributes($element['#attributes']) . ' /></label>';
     }
     else {
       return '<label class="button button--file -tertiary" id="' . $id . '"><span>' . t('Add another photo') . '</span><input' . drupal_attributes($element['#attributes']) . ' /></label>';

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -338,9 +338,17 @@ function paraneue_dosomething_get_themed_approved_reportbacks($nid, $count = 6) 
 function paraneue_dosomething_get_themed_placeholder_reportbacks($count = 6) {
   $placeholder_urls = dosomething_campaign_get_default_gallery_image_urls();
   $placeholders = array();
+  $placeholder_captions = array(
+    'Integer posuere erat a ante venenatis dapibus posue aliquet.',
+    'Praesent commodo cursus magna, vel scelerisque et.',
+    'Donec id elit non mi porta gravida at eget.',
+    'Integer posuere erat a ante venenatis dapibus posuere.',
+    'Donec ullamcorper nulla non metus auctor fringilla.',
+    'Vivamus sagittis lacus vel augue.'
+  );
 
   for ($i = 0; $i < $count; $i++) {
-    $placeholders[] = paraneue_dosomething_get_gallery_item(array('image' => $placeholder_urls[$i]), 'placeholder');
+    $placeholders[] = paraneue_dosomething_get_gallery_item(array('image' => $placeholder_urls[$i], 'caption' => $placeholder_captions[$i]), 'photo');
   }
 
   return $placeholders;

--- a/lib/themes/dosomething/paraneue_dosomething/includes/theme.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/theme.inc
@@ -158,11 +158,6 @@ function paraneue_dosomething_theme() {
       'path' => PARANEUE_DS_PATH . '/templates/system/patterns',
     ),
 
-    'paraneue_placeholder' => array(
-      'template' => 'placeholder',
-      'path' => PARANEUE_DS_PATH . '/templates/system/patterns',
-    ),
-
     'paraneue_tile' => array(
       'template' => 'tile',
       'path' => PARANEUE_DS_PATH . '/templates/system/patterns',

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -134,13 +134,6 @@
   }
 
   .container--prove {
-    > .wrapper {
-      text-align: center;
-
-      @include media($tablet) {
-        text-align: left;
-      }
-    }
 
     // @TODO: v2 Reportbacks temporary addition for classic version.
     &.reportback-classic {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -17,10 +17,8 @@
 .campaign--pitch,
 .campaign--grouped,
 .campaign--action .container--prove {
-  .message-callout {
-    .message-callout__copy {
-      left: 12px;
-    }
+  .message-callout__copy {
+    left: 12px;
   }
 }
 
@@ -115,6 +113,9 @@
 }
 
 .campaign--action {
+  // @TODO: Need to create separate classes for SMS vs Regular Campaign
+  // .container--do elements, instead of wrapping within the .campaign--action
+  // parent class.
   .container--do {
     .polaroid {
       @include media($mobile) {
@@ -133,37 +134,36 @@
     margin-top: $base-spacing;
   }
 
-  .container--prove {
+}
 
-    // @TODO: v2 Reportbacks temporary addition for classic version.
-    &.reportback-classic {
-      h3, p {
-        color: #fff;
-      }
+.container--prove {
 
-      a {
-        color: #fff;
-        text-decoration: underline;
-      }
-
-      .button {
-        text-decoration: none;
-      }
+  // @TODO: v2 Reportbacks temporary addition for classic version.
+  &.reportback-classic {
+    h3, p {
+      color: #fff;
     }
 
-    .message-callout {
-      @include media($desktop) {
-        .message-callout__copy {
-          left: 75px;
-          top: -10px;
-        }
-      }
+    a {
+      color: #fff;
+      text-decoration: underline;
     }
 
-    .carousel {
-      @include media($tablet) {
-        float: right;
-      }
+    .button {
+      text-decoration: none;
+    }
+  }
+
+  .message-callout__copy {
+    @include media($larger) {
+      left: 75px;
+      top: -10px;
+    }
+  }
+
+  .carousel {
+    @include media($medium) {
+      float: right;
     }
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
@@ -8,7 +8,7 @@
     padding: ($base-spacing / 4);
 
     @include media($larger) {
-      padding: 10px;
+      padding: ($base-spacing / 2);
     }
 
     img {
@@ -17,7 +17,7 @@
 
     .__copy {
       font-size: $font-smaller;
-      height: 65px;
+      height: 75px;
       line-height: 1.1;
       padding-top: ($base-spacing / 2);
 
@@ -168,7 +168,6 @@
 }
 
 
-
 // @TODO: move to proper locations
 // Temporary additions to work through fix for upload button issues.
 .reportback__submissions {
@@ -181,7 +180,11 @@
   }
 
   .button--file {
+    font-weight: $weight-bold;
     height: auto;
+    margin: ($base-spacing / 2) 0 0;
+    padding: 0;
+    text-transform: lowercase;
     width: auto;
   }
 }
@@ -210,30 +213,63 @@
   }
 }
 
+
 .gigantor {
   background-color: #f2f2f2;
   cursor: pointer;
+  height: 270px;
+  margin: 0;
   position: relative;
-  text-align: center;
-  height: 300px;
+  
+  @include media($medium) {
+    height: 0;
+    padding-bottom: 100%;
+  }
+
 
   &:before {
-    background-color: #23b6fa;
-    content: "";
+    background-color: $blue;
+    border-radius: 100%;
+    color: $white;
+    content: "+";
     display: block;
+    font-size: 80px;
+    font-weight: $weight-normal;
     height: 70px;
     left: 50%;
+    line-height: 0.95;
     margin: -35px 0 0 -35px;
     position: absolute;
+    text-align: center;
     top: 50%;
     width: 70px;
   }
 
-  > span {
+  &:hover:before {
+    background-color: lighten($blue, $color-tint);
+  }
+  
+  > .message-callout {
     bottom: 0;
-    left: 0;
+    left: 50%;
+    margin-left: -130px;
     position: absolute;
-    width: 100%;
+    width: 240px;
+
+    @include media($medium) {
+      bottom: 30px;
+    }
+
+    @include media($larger) {
+      bottom: 40px;
+    }
+  }
+
+  .message-callout__copy {
+    @include media($larger) {
+      left: 0;
+      top: 0;
+    }
   }
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
@@ -5,7 +5,7 @@
 
   &.-framed {
     background-color: #fff;
-    padding: 5px;
+    padding: ($base-spacing / 4);
 
     @include media($larger) {
       padding: 10px;
@@ -16,9 +16,14 @@
     }
 
     .__copy {
-      font-size: $font-small;
-      height: 60px;
-      line-height: 1.2;
+      font-size: $font-smaller;
+      height: 65px;
+      line-height: 1.1;
+      padding-top: ($base-spacing / 2);
+
+      @include media($large) {
+        font-size: $font-small;
+      }
     }
   }
 
@@ -50,7 +55,7 @@
   form {
     background-color: #fff;
     height: 100%;
-    margin: 0 ($base-spacing / 2);
+    margin: $base-spacing ($base-spacing / 2) 0;
 
     > div {
       padding: gutters();
@@ -181,8 +186,23 @@
   }
 }
 
+.reportback__submissions-latest {
+  background-color: #fff;  // remove
+}
+
+.reportback__submission__copy {
+  font-size: $font-smaller;
+  line-height: 1.1;
+  padding-top: ($base-spacing / 2);
+
+  @include media($large) {
+    font-size: $font-small;
+  }
+}
+
 .reportback__submissions-list {
   @include list_reset();
+  margin: 0 (-($base-spacing / 2));
 
   > li { 
     float: left;

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-latest-submission.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-latest-submission.tpl.php
@@ -2,6 +2,6 @@
   <?php print $reportback->image; ?>
 
   <?php if ($reportback->caption): ?>
-    <figcaption><?php print $reportback->caption; ?></figcaption>
+    <figcaption class="reportback__submission__copy"><?php print $reportback->caption; ?></figcaption>
   <?php endif; ?>
 </figure>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-prior-submissions.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-prior-submissions.tpl.php
@@ -1,5 +1,5 @@
 <ul class="reportback__submissions-list gallery">
 <?php foreach ($reportbacks as $reportback): ?>
-  <li><?php print $reportback->image; ?></li>
+  <li class="reportback__submission"><?php print $reportback->image; ?></li>
 <?php endforeach; ?>
 </ul>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/placeholder.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/placeholder.tpl.php
@@ -1,3 +1,0 @@
-<div class="photo -stacked -framed -placeholder">
-  <img src="<?php print $content['image']; ?>" alt="placeholder reportback photo" />
-</div>


### PR DESCRIPTION
Removed the `placeholder.tpl.php` file now that the Reportback placeholders will have captions; best to template them using the same markup as other placeholders. Added the hardcoded placeholder captions with some temporary lorem ipsum which needs to be replaced.

Also adds styles for the **Gigantor** button and cleans up other styles within the reportback interface.

@DFurnes @sbsmith86 

CC: @aaronschachter 
