### PR TITLE
Replaces PHP short-tag in Action Guide template which caused E_PARSE on PHP 5.9

### DIFF
--- a/lib/modules/dosomething/dosomething_action_guide/node--action_guide.tpl.php
+++ b/lib/modules/dosomething/dosomething_action_guide/node--action_guide.tpl.php
@@ -28,7 +28,7 @@
         <p><?php print $gallery['image_description']; ?></p>
       <?php endif; ?>
     <?php endforeach; ?>
-  <? endif; ?>
+  <?php endif; ?>
 
   <?php if (isset($additional_text_title)): ?>
     <h2><?php print $additional_text_title; ?></h2>


### PR DESCRIPTION
Fixes #3865.
