### PR TITLE
Gets rid of the last PHP short tag.

### DIFF
--- a/lib/modules/dosomething/dosomething_static_content/node--static_content.tpl.php
+++ b/lib/modules/dosomething/dosomething_static_content/node--static_content.tpl.php
@@ -35,7 +35,7 @@
         <p><?php print $gallery['image_description']; ?></p>
       <?php endif; ?>
     <?php endforeach; ?>
-  <? endif; ?>
+  <?php endif; ?>
   
   <?php if (isset($additional_text_title)): ?>
     <h2><?php print $additional_text_title; ?></h2>


### PR DESCRIPTION
As per #3865 and #3868.
