### PR TITLE
Reportback Count variables

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -270,7 +270,7 @@ function dosomething_campaign_admin_status_call_to_action_query($char_count = 65
  */
 function dosomething_campaign_reportback_config_form($form, &$form_state, $node) {
   // Load the node's helpers variables.
-  $vars = dosomething_helpers_get_variables($node->nid);
+  $vars = dosomething_helpers_get_variables('node', $node->nid);
   $form['nid'] = array(
     '#type' => 'hidden',
     '#value' => $node->nid,

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -197,7 +197,7 @@ function dosomething_campaign_load($node, $public = FALSE) {
   }
 
   // Store any dosomething_helpers variables.
-  $campaign->variables = dosomething_helpers_get_variables($campaign->nid);
+  $campaign->variables = dosomething_helpers_get_variables('node', $campaign->nid);
 
   // Set image_cover property.
   $campaign->image_cover = NULL;

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -565,7 +565,7 @@ function dosomething_campaign_add_signup_data_form_vars(&$node) {
  * Preprocesses a Shipment Form for the $node, if configured.
  */
 function dosomething_campaign_add_shipment_form_vars($node) {
-  $config = dosomething_helpers_get_variables($node->nid);
+  $config = dosomething_helpers_get_variables('node', $node->nid);
   if (!empty($config['shipment_item'])) {
     // Pass the user signup path as the entity to store on the Shipment.
     $config['entity_type'] = 'signup';

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
@@ -112,7 +112,7 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
         $label = NULL;
         if (module_exists('dosomething_helpers')) {
           // Check if a Signup Form Submit Label has been set.
-          $label = dosomething_helpers_get_variable($node->nid, 'signup_form_submit_label');
+          $label = dosomething_helpers_get_variable('node', $node->nid, 'signup_form_submit_label');
         }
         // Adds signup_button_primary and signup_button_secondary vars.
         $ids = array('primary', 'secondary');

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -187,7 +187,7 @@ function dosomething_helpers_preprocess_custom_vars(&$vars) {
     }
   }
   elseif (isset($vars['nid'])) {
-    $custom_vars = dosomething_helpers_get_variables($vars['nid']);
+    $custom_vars = dosomething_helpers_get_variables('node', $vars['nid']);
      if ($custom_vars['alt_color']) {
       $alt_color = $custom_vars['alt_color'];
     }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -225,6 +225,7 @@ function dosomething_helpers_set_variable($entity, $var_name, $value) {
   elseif (isset($entity->tid)) {
     $entity_type = 'taxonomy_term';
     $entity_id = $entity->tid;
+    $entity->type = $entity->vocabulary_machine_name;
   }
   // If a value is present:
   if (!empty($value) || $value === 0) {

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -6,7 +6,7 @@
  */
 
 function dosomething_helpers_variable_form($form, &$form_state, $node) {
-  $vars = dosomething_helpers_get_variables($node->nid);
+  $vars = dosomething_helpers_get_variables('node', $node->nid);
   $form['nid'] = array(
     '#type' => 'hidden',
     '#value' => $node->nid,

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -204,12 +204,12 @@ function dosomething_helpers_get_variables($nid) {
  * @return string
  *   All variable values are stored as strings.
  */
-function dosomething_helpers_get_variable($nid, $name) {
+function dosomething_helpers_get_variable($entity_type, $entity_id, $var_name) {
   return db_select('dosomething_helpers_variable', 'v')
     ->fields('v', array('value'))
-    ->condition('entity_id', $nid)
-    ->condition('entity_type', 'node')
-    ->condition('name', $name)
+    ->condition('entity_id', $entity_id)
+    ->condition('entity_type', $entity_type)
+    ->condition('name', $var_name)
     ->execute()
     ->fetchField(0);
 }
@@ -267,14 +267,14 @@ function dosomething_helpers_third_party_variable_form($form, &$form_state, $nod
   );
   // SMS Games have different variables.
   if (dosomething_campaign_get_campaign_type($node) == 'sms_game') {
-    $value = dosomething_helpers_get_variable($nid, 'mobilecommons_opt_in_path');
+    $value = dosomething_helpers_get_variable('node', $nid, 'mobilecommons_opt_in_path');
     $form['optins']['mobilecommons'] = array(
       '#type' => 'textfield',
       '#title' => t('Mobilecommons Alpha Opt-in Path'),
       '#default_value' => $value,
       '#disabled' => TRUE,
     );
-    $value = dosomething_helpers_get_variable($nid, 'mobilecommons_friends_opt_in_path');
+    $value = dosomething_helpers_get_variable('node', $nid, 'mobilecommons_friends_opt_in_path');
     $form['optins']['mobilecommons_friends'] = array(
       '#type' => 'textfield',
       '#title' => t('Mobilecommons Beta Opt-in Path'),
@@ -283,21 +283,21 @@ function dosomething_helpers_third_party_variable_form($form, &$form_state, $nod
     );
   }
   else {
-    $value = dosomething_helpers_get_variable($nid, 'mailchimp_grouping_id');
+    $value = dosomething_helpers_get_variable('node', $nid, 'mailchimp_grouping_id');
     $form['optins']['mailchimp_grouping_id'] = array(
       '#type' => 'textfield',
       '#title' => t('MailChimp Grouping ID'),
       '#default_value' => $value,
       '#disabled' => TRUE,
     );
-    $value = dosomething_helpers_get_variable($nid, 'mailchimp_group_name');
+    $value = dosomething_helpers_get_variable('node', $nid, 'mailchimp_group_name');
     $form['optins']['mailchimp_group_name'] = array(
       '#type' => 'textfield',
       '#title' => t('MailChimp Group Name'),
       '#default_value' => $value,
       '#disabled' => TRUE,
     );
-    $value = dosomething_helpers_get_variable($nid, 'mobilecommons_opt_in_path');
+    $value = dosomething_helpers_get_variable('node', $nid, 'mobilecommons_opt_in_path');
     $form['optins']['mobilecommons'] = array(
       '#type' => 'textfield',
       '#title' => t('MobileCommons Opt-in Path'),

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -201,8 +201,8 @@ function dosomething_helpers_get_variables($nid) {
 /**
  * Returns value of given $nid's $name variable.
  *
- * @return string
- *   All variable values are stored as strings.
+ * @return
+ *   String if variable exists, FALSE if not.
  */
 function dosomething_helpers_get_variable($entity_type, $entity_id, $var_name) {
   return db_select('dosomething_helpers_variable', 'v')

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -152,6 +152,11 @@ function dosomething_helpers_get_variable_names() {
     'alt_color',
     'alt_image_campaign_cover_nid',
     'collect_num_participants',
+    'count_approved',
+    'count_excluded',
+    'count_flagged',
+    'count_pending',
+    'count_promoted',
     'mobilecommons_opt_in_path',
     'mobilecommons_friends_opt_in_path',
     'shipment_form_confirm_msg',
@@ -214,7 +219,7 @@ function dosomething_helpers_get_variable($nid, $name) {
  */
 function dosomething_helpers_set_variable($node, $name, $value) {
   // If a value is present:
-  if (!empty($value)) {
+  if (!empty($value) || $value === 0) {
     db_merge('dosomething_helpers_variable')
         ->key(array('entity_type' => 'node', 'entity_id' => $node->nid, 'name' => $name))
         ->fields(array(

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -180,7 +180,7 @@ function dosomething_helpers_get_variable_names() {
  * @return array
  *   Keyed by the variable name.
  */
-function dosomething_helpers_get_variables($nid) {
+function dosomething_helpers_get_variables($entity_type, $entity_id) {
   // Initialize array with NULL defaults.
   foreach (dosomething_helpers_get_variable_names() as $name) {
     $vars[$name] = NULL;
@@ -188,8 +188,8 @@ function dosomething_helpers_get_variables($nid) {
   // Query for variable records for given $node.
   $result = db_select('dosomething_helpers_variable', 'v')
     ->fields('v')
-    ->condition('entity_id', $nid)
-    ->condition('entity_type', 'node')
+    ->condition('entity_id', $entity_id)
+    ->condition('entity_type', $entity_type)
     ->execute()
     ->fetchAll();
   foreach ($result as $record) {

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -217,26 +217,38 @@ function dosomething_helpers_get_variable($nid, $name) {
 /**
  * Sets a given dosomething_helper variable $name to $value for given $node.
  */
-function dosomething_helpers_set_variable($node, $name, $value) {
+function dosomething_helpers_set_variable($entity, $var_name, $value) {
+  if (isset($entity->nid)) {
+    $entity_type = 'node';
+    $entity_id = $entity->nid;
+  }
+  elseif (isset($entity->tid)) {
+    $entity_type = 'taxonomy_term';
+    $entity_id = $entity->tid;
+  }
   // If a value is present:
   if (!empty($value) || $value === 0) {
     db_merge('dosomething_helpers_variable')
-        ->key(array('entity_type' => 'node', 'entity_id' => $node->nid, 'name' => $name))
+        ->key(array(
+            'entity_type' => $entity_type,
+            'entity_id' => $entity_id,
+            'name' => $var_name,
+          ))
         ->fields(array(
-            'entity_type' => 'node',
-            'bundle' => $node->type,
-            'entity_id' => $node->nid,
-            'name' => $name,
+            'entity_type' => $entity_type,
+            'bundle' => $entity->type,
+            'entity_id' => $entity_id,
+            'name' => $var_name,
             'value' => $value,
-        ))
+           ))
         ->execute();
   }
   // Else delete the value, to prevent storing an empty value.
   else {
     db_delete('dosomething_helpers_variable')
-      ->condition('entity_id', $node->nid)
-      ->condition('entity_type', 'node')
-      ->condition('name', $name)
+      ->condition('entity_id', $entity_id)
+      ->condition('entity_type', $entity_type)
+      ->condition('name', $var_name)
       ->execute();
   }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -132,7 +132,7 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
   // Get the DatabaseQuery to loop through.
   $result = dosomething_reportback_get_reportback_files_query_result($params, $page_size);
   // Get the total number of results.
-  // $total = dosomething_reportback_get_reportback_files_query_count($params);
+  $total = dosomething_reportback_get_reportback_files_query_count($params);
   $page_size_copy = '';
   if ($total > $page_size) {
     $page_size_copy = '<p>' . t("Displaying the most recent @num", array(

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -282,3 +282,35 @@ function theme_dosomething_reportback_files_form($variables) {
   $output .= drupal_render_children($form);
   return $output;
 }
+
+function dosomething_reportback_count_page() {
+  // Reset all Reportback Totals for terms in the Cause vocabulary.
+  $header = array(
+    t('Title'),
+    t('Pending'),
+    t('Approved'),
+    t('Promoted'),
+    t('Excluded'),
+    t('Flagged'),
+  );
+  $rows = array();
+  $cause = taxonomy_vocabulary_machine_name_load('cause');
+  if ($cause) {
+    $terms = taxonomy_get_tree($cause->vid);
+    foreach ($terms as $term) {
+      $vars = dosomething_helpers_get_variables($term->tid, 'taxonomy_term');
+      $rows[] = array(
+        $term->name,
+        $vars['count_pending'],
+        $vars['count_approved'],
+        $vars['count_promoted'],
+        $vars['count_excluded'],
+        $vars['count_flagged'],
+      );
+    }
+  }
+  return theme('table', array(
+    'header' => $header,
+    'rows' => $rows,
+  ));;
+}

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -298,7 +298,7 @@ function dosomething_reportback_count_page() {
   if ($cause) {
     $terms = taxonomy_get_tree($cause->vid);
     foreach ($terms as $term) {
-      $vars = dosomething_helpers_get_variables($term->tid, 'taxonomy_term');
+      $vars = dosomething_helpers_get_variables('taxonomy_term', $term->tid);
       $rows[] = array(
         $term->name,
         $vars['count_pending'],

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -132,7 +132,7 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
   // Get the DatabaseQuery to loop through.
   $result = dosomething_reportback_get_reportback_files_query_result($params, $page_size);
   // Get the total number of results.
-  $total = dosomething_reportback_get_reportback_files_query_count($params);
+  // $total = dosomething_reportback_get_reportback_files_query_count($params);
   $page_size_copy = '';
   if ($total > $page_size) {
     $page_size_copy = '<p>' . t("Displaying the most recent @num", array(

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -283,6 +283,9 @@ function theme_dosomething_reportback_files_form($variables) {
   return $output;
 }
 
+/**
+ * Page callback which displays all Reportback Count variables.
+ */
 function dosomething_reportback_count_page() {
   // Reset all Reportback Totals for terms in the Cause vocabulary.
   $header = array(
@@ -309,8 +312,32 @@ function dosomething_reportback_count_page() {
       );
     }
   }
-  return theme('table', array(
+  $output .= '<h2>' . t("Cause") . '</h2>';
+  $output .= theme('table', array(
     'header' => $header,
     'rows' => $rows,
-  ));;
+  ));
+  $reset_form = drupal_get_form('dosomething_reportback_reset_count_form');
+  $output .= render($reset_form);
+  return $output;
+}
+
+/**
+ * Form to reset all Reportback Count variables.
+ */
+function dosomething_reportback_reset_count_form() {
+  $form['actions'] = array('#type' => 'actions');
+  $form['actions']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Refresh Totals'),
+  );
+  return $form;
+}
+
+/**
+ * Submit handler for dosomething_reportback_reset_count_form().
+ */
+function dosomething_reportback_reset_count_form_submit($form, &$form_state) {
+  dosomething_reportback_reset_all('taxonomy_term');
+  drupal_set_message(t("Totals have been refreshed."));
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -245,7 +245,7 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
   );
 
   // Load helpers variables for the nid this reportback is for.
-  $config = dosomething_helpers_get_variables($entity->nid);
+  $config = dosomething_helpers_get_variables('node', $entity->nid);
   // If we are collecting num_participants for this node:
   if ($config['collect_num_participants']) {
     // Set default label for num_participants form element.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -205,7 +205,13 @@ function dosomething_reportback_menu() {
   // Add Reportback menu items for admin/users.
   // $users_rb = dosomething_reportback_get_review_menu_items('admin/users', NULL);
   // $items = array_merge($items, $users_rb);
-
+  $items['admin/users/rb'] = array(
+    'title' => 'Reportbacks',
+    'page callback' => 'dosomething_reportback_count_page',
+    'access arguments' => array('view any reportback'),
+    'file' => 'dosomething_reportback.admin.inc',
+    'weight' => 900,
+  );
   // Add Reportback menu items for taxonomy_term and node entities:
   $rb_paths = array(
     'taxonomy/term/%taxonomy_term' => 2,
@@ -982,6 +988,22 @@ function dosomething_reportback_reset_count($entity_type, $entity_id) {
   foreach ($status_values as $status) {
     $params['status'] = $status;
     dosomething_reportback_get_reportback_files_query_count($params, TRUE);
+  }
+}
+
+function dosomething_reportback_reset_all($entity_type) {
+  if ($entity_type == 'node') {
+    // @todo: Loop through campaigns.
+  }
+  elseif ($entity_type == 'taxonomy_term') {
+    // Reset all Reportback Totals for terms in the Cause vocabulary.
+    $cause = taxonomy_vocabulary_machine_name_load('cause');
+    if ($cause) {
+      $terms = taxonomy_get_tree($cause->vid);
+      foreach ($terms as $term) {
+        dosomething_reportback_reset_count($entity_type, $term->tid);
+      }
+    }
   }
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -930,6 +930,9 @@ function dosomething_reportback_get_reportback_files_query_result($params = arra
  *
  * @param array $params
  *   Associative array of query parameters.
+ * @param bool $reset
+ *   If TRUE, run SQL count query.
+ *   If FALSE, use the Helper count variable if exists.
  *
  * @see dosomething_reportback_get_reportback_files_query().
  *
@@ -976,6 +979,9 @@ function dosomething_reportback_get_reportback_files_query_count($params, $reset
   return $count;
 }
 
+/**
+ * Resets Reportback Count variables for given entity type and entity_id.
+ */
 function dosomething_reportback_reset_count($entity_type, $entity_id) {
   $params = array();
   if ($entity_type == 'node') {
@@ -991,6 +997,9 @@ function dosomething_reportback_reset_count($entity_type, $entity_id) {
   }
 }
 
+/**
+ * Resets all Reportback Count variables for given entity type $entity_type.
+ */
 function dosomething_reportback_reset_all($entity_type) {
   if ($entity_type == 'node') {
     // @todo: Loop through campaigns.
@@ -1007,7 +1016,9 @@ function dosomething_reportback_reset_all($entity_type) {
   }
 }
 
-
+/**
+ * Returns array of all valid values for a Reportback File's status.
+ */
 function dosomething_reportback_get_file_status_values() {
   return array(
     'pending',
@@ -1019,7 +1030,7 @@ function dosomething_reportback_get_file_status_values() {
 }
 
 /**
- * Returns list of valid options a Reportback File can be set to.
+ * Returns list of valid form options a Reportback File can be set to.
  */
 function dosomething_reportback_get_file_status_options() {
   $keys = dosomething_reportback_get_file_status_values();

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -931,12 +931,16 @@ function dosomething_reportback_get_reportback_files_query_result($params = arra
  */
 function dosomething_reportback_get_reportback_files_query_count($params, $reset = FALSE) {
 
-  if ( isset($params['nid']) && isset($params['status']) ) {
+  // Name of helper variable which stores count for this status.
+  $var_name = 'count_' . $params['status'];
+
+  if ( !$reset && isset($params['nid']) ) {
     // Check if we have the count stored already.
     $var_name = 'count_' . $params['status'];
     if ($count = dosomething_helpers_get_variable($params['nid'], $var_name)) {
       return $count;
     }
+    // We don't have a count, so set one.
     $reset = TRUE;
   }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -945,11 +945,12 @@ function dosomething_reportback_get_reportback_files_query_count($params, $reset
   if (!$reset) {
     // Check if we have the count stored already.
     $count = dosomething_helpers_get_variable($entity_type, $entity_id, $var_name);
-    if (isset($count)) {
+    if ($count === FALSE) {
+      $reset = TRUE;
+    }
+    else {
       return $count;
     }
-    // We don't have a count, so set one.
-    $reset = TRUE;
   }
 
   $query = dosomething_reportback_get_reportback_files_query($params);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -929,10 +929,45 @@ function dosomething_reportback_get_reportback_files_query_result($params = arra
  *
  * @return int
  */
-function dosomething_reportback_get_reportback_files_query_count($params) {
+function dosomething_reportback_get_reportback_files_query_count($params, $reset = FALSE) {
+
+  if ( isset($params['nid']) && isset($params['status']) ) {
+    // Check if we have the count stored already.
+    $var_name = 'count_' . $params['status'];
+    if ($count = dosomething_helpers_get_variable($params['nid'], $var_name)) {
+      return $count;
+    }
+    $reset = TRUE;
+  }
+
   $query = dosomething_reportback_get_reportback_files_query($params);
   $result = $query->execute();
-  return $result->rowCount();
+  $count = $result->rowCount();
+
+  if ($reset) {
+    $node = node_load($params['nid']);
+    dosomething_helpers_set_variable($node, $var_name, $count);
+  }
+
+}
+
+function dosomething_reportback_reset_count($nid) {
+  $params['nid'] = $nid;
+  $status_values = dosomething_reportback_get_file_status_values();
+  foreach ($status_values as $status) {
+    $params['status'] = $status;
+    dosomething_reportback_get_reportback_files_query_count($params, TRUE);
+  }
+}
+
+function dosomething_reportback_get_file_status_values() {
+  return  array(
+    'pending',
+    'approved',
+    'promoted',
+    'excluded',
+    'flagged',
+  );
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -934,10 +934,17 @@ function dosomething_reportback_get_reportback_files_query_count($params, $reset
   // Name of helper variable which stores count for this status.
   $var_name = 'count_' . $params['status'];
 
-  if ( !$reset && isset($params['nid']) ) {
+  if (!$reset) {
+    if (isset($params['nid'])) {
+      $entity_type = 'node';
+      $entity_id = $params['nid'];
+    }
+    elseif (isset($params['tid'])) {
+      $entity_type = 'taxonomy_term';
+      $entity_id = $params['tid'];
+    }
     // Check if we have the count stored already.
-    $var_name = 'count_' . $params['status'];
-    if ($count = dosomething_helpers_get_variable($params['nid'], $var_name)) {
+    if ($count = dosomething_helpers_get_variable('node', $entity_type, $entity_id, $var_name)) {
       return $count;
     }
     // We don't have a count, so set one.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -203,8 +203,8 @@ function dosomething_reportback_menu() {
   );
 
   // Add Reportback menu items for admin/users.
-  $users_rb = dosomething_reportback_get_review_menu_items('admin/users', NULL);
-  $items = array_merge($items, $users_rb);
+  // $users_rb = dosomething_reportback_get_review_menu_items('admin/users', NULL);
+  // $items = array_merge($items, $users_rb);
 
   // Add Reportback menu items for taxonomy_term and node entities:
   $rb_paths = array(
@@ -933,18 +933,19 @@ function dosomething_reportback_get_reportback_files_query_count($params, $reset
 
   // Name of helper variable which stores count for this status.
   $var_name = 'count_' . $params['status'];
+  if (isset($params['nid'])) {
+    $entity_type = 'node';
+    $entity_id = $params['nid'];
+  }
+  elseif (isset($params['tid'])) {
+    $entity_type = 'taxonomy_term';
+    $entity_id = $params['tid'];
+  }
 
   if (!$reset) {
-    if (isset($params['nid'])) {
-      $entity_type = 'node';
-      $entity_id = $params['nid'];
-    }
-    elseif (isset($params['tid'])) {
-      $entity_type = 'taxonomy_term';
-      $entity_id = $params['tid'];
-    }
     // Check if we have the count stored already.
-    if ($count = dosomething_helpers_get_variable('node', $entity_type, $entity_id, $var_name)) {
+    $count = dosomething_helpers_get_variable($entity_type, $entity_id, $var_name);
+    if (isset($count)) {
       return $count;
     }
     // We don't have a count, so set one.
@@ -956,14 +957,26 @@ function dosomething_reportback_get_reportback_files_query_count($params, $reset
   $count = $result->rowCount();
 
   if ($reset) {
-    $node = node_load($params['nid']);
-    dosomething_helpers_set_variable($node, $var_name, $count);
+    if ($entity_type == 'node') {
+      $entity = node_load($entity_id);
+    }
+    elseif ($entity_type == 'taxonomy_term') {
+      $entity = taxonomy_term_load($entity_id);
+    }
+    dosomething_helpers_set_variable($entity, $var_name, $count);
   }
 
+  return $count;
 }
 
-function dosomething_reportback_reset_count($nid) {
-  $params['nid'] = $nid;
+function dosomething_reportback_reset_count($entity_type, $entity_id) {
+  $params = array();
+  if ($entity_type == 'node') {
+    $params['nid'] = $entity_id;
+  }
+  elseif ($entity_type == 'taxonomy_term') {
+    $params['tid'] = $entity_id;
+  }
   $status_values = dosomething_reportback_get_file_status_values();
   foreach ($status_values as $status) {
     $params['status'] = $status;

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -985,8 +985,9 @@ function dosomething_reportback_reset_count($entity_type, $entity_id) {
   }
 }
 
+
 function dosomething_reportback_get_file_status_values() {
-  return  array(
+  return array(
     'pending',
     'approved',
     'promoted',
@@ -999,16 +1000,17 @@ function dosomething_reportback_get_file_status_values() {
  * Returns list of valid options a Reportback File can be set to.
  */
 function dosomething_reportback_get_file_status_options() {
-  $keys = array(
-    'approved',
-    'promoted',
-    'excluded',
-    'flagged',
-  );
+  $keys = dosomething_reportback_get_file_status_values();
   $options = array();
   foreach ($keys as $name) {
     $options[$name] = t(ucfirst($name));
   }
+
+  // Don't allow Pending as a form value.
+  if (isset($options['pending'])) {
+    unset($options['pending']);
+  }
+
   return $options;
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -126,7 +126,7 @@ function dosomething_signup_opt_in_config_form_add_elements(&$form, $node_vars, 
     $form[$nid][$nid . '_' . $name] = array(
       '#type' => 'textfield',
       '#title' => $name,
-      '#default_value' => dosomething_helpers_get_variable($nid, $name),
+      '#default_value' => dosomething_helpers_get_variable('node', $nid, $name),
       '#description' => $description,
     );
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -228,7 +228,7 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
  *   The node $nid to check configuration values for.
  */
 function dosomething_signup_sms_game_form_config(&$form, $nid) {
-  $vars = dosomething_helpers_get_variables($nid);
+  $vars = dosomething_helpers_get_variables('node', $nid);
 
   $sms_game_type = NULL;
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -397,7 +397,7 @@ function dosomething_signup_entity_insert($entity, $type) {
 function dosomething_signup_third_party_subscribe($account, $node) {
   $var_name  = 'mobilecommons_opt_in_path';
   // Is there an override set on this campaign?
-  $opt_in = dosomething_helpers_get_variable($node->nid, $var_name);
+  $opt_in = dosomething_helpers_get_variable('node', $node->nid, $var_name);
   // If not:
   if (!$opt_in) {
     // Use general opt_in_path.
@@ -550,8 +550,8 @@ function dosomething_signup_get_mbp_params_campaign_group(&$params, $node) {
  */
 function dosomething_signup_get_mbp_params_mailchimp(&$params, $node) {
   $nid = $node->nid;
-  $grouping_id = dosomething_helpers_get_variable($nid, 'mailchimp_grouping_id');
-  $group_name = dosomething_helpers_get_variable($nid, 'mailchimp_group_name');
+  $grouping_id = dosomething_helpers_get_variable('node', $nid, 'mailchimp_grouping_id');
+  $group_name = dosomething_helpers_get_variable('node', $nid, 'mailchimp_group_name');
   // If a value is present for Mailchimp groups:
   if (isset($grouping_id) && isset($group_name)) {
     // Add it into the mbp_request params.


### PR DESCRIPTION
Begins work on #3846: Creates `dosomething_helper_variable` records to store the count per status of the Reportbacks per entity.

Refactors the `dosomething_helper_variable_get` and `dosomething_helper_variable_set` functions to work with Taxonomy Term as well as Node entities.

TODO: 
- Store totals for individual campaign nodes
- Display campaign totals in the page
- Refresh campaign totals upon form submit

Screenshot:
![totals](https://cloud.githubusercontent.com/assets/1236811/6029730/8e340d10-abc0-11e4-80c2-47b021fdc13a.png)
