### PR TITLE
Bind move event to the document.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
@@ -128,9 +128,7 @@ define(function(require) {
     $cropBox.off("touchend mouseup");
 
     // Bind move events to the document.
-    $cropBox.on("touchmove mousemove", function(event) {
-      event.preventDefault();
-
+    $(document).on("touchmove mousemove", function(event) {
       var coords = getCoords(event);
 
       var cropBoxHeight = parseInt($cropBox.css("height"),10);


### PR DESCRIPTION
## The problem

One issue causing a rough animation when resizing the cropbox, was that I was binding the move event to the cropbox. That meant if the user's mouse left the cropbox while they were dragging the mouse to resize it, the animation would stop. The user was having to move the mouse really slowly to stay on the cropbox as they resized it.

Addresses #3790 . I will have another PR moving all the animations to use `requestAnimationFrame()`, but this should serve as a quick win. 
## Changes

Binds the mouse move event to the `$(document)` so the users mouse can be anywhere as the move.

@DoSomething/front-end 
