### PR TITLE
Campaign Count totals

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -333,13 +333,19 @@ function dosomething_reportback_count_page() {
       // Loop through status values and set links for each.
       $i = 0;
       foreach ($status_values as $status) {
+        $count = (int) $vars['count_' . $status];
         $url = 'taxonomy/term/' . $term->tid . '/rb';
         $options = array();
         if ($i > 0) {
           $url = 'taxonomy/term/' . $term->tid . '/rb/reviewed';
           $options = array('query' => array('status' => $i));
         }
-        $row_values[] = l($vars['count_' . $status], $url, $options);
+        if ($count > 0) {
+          $row_values[] = l($count, $url, $options);
+        }
+        else {
+          $row_values[] = $count;
+        }
         $i++;
       }
       $rows[] = $row_values;

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -356,8 +356,12 @@ function dosomething_reportback_count_page() {
     'header' => $header,
     'rows' => $rows,
   ));
-  $reset_form = drupal_get_form('dosomething_reportback_reset_count_form');
-  $output .= render($reset_form);
+
+  if (user_access('administer modules')) {
+    $reset_form = drupal_get_form('dosomething_reportback_reset_count_form');
+    $output .= render($reset_form);
+  }
+
   return $output;
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -321,23 +321,59 @@ function dosomething_reportback_count_page() {
     $header[] = t($status);
   }
 
-  $rows = array();
-  $url = 'taxonomy/term/';
+  $tables = array();
+  $tables['node']['title'] = t("Campaigns");
+  $tables['node']['url'] = 'node/';
+  $tables['node']['results'] = array();
+  $query = new EntityFieldQuery();
+  $query->entityCondition('entity_type', 'node')
+    ->entityCondition('bundle', 'campaign')
+    ->propertyCondition('status', NODE_PUBLISHED)
+    ->fieldCondition('field_campaign_type', 'value', 'campaign', '=')
+    ->propertyOrderBy('title', 'ASC');
+  $result = $query->execute();
+
+  if (isset($result['node'])) {
+    $nids = array_keys($result['node']);
+    foreach ($nids as $nid) {
+      $node = node_load($nid);
+      $tables['node']['results'][] = array(
+        'id' => $nid,
+        'title' => $node->title,
+      );
+    }
+  }
+
+  $tables['taxonomy_term']['title'] = t("Cause");
+  $tables['taxonomy_term']['url'] = 'taxonomy/term/';
+  $tables['taxonomy_term']['results'] = array();
   $cause = taxonomy_vocabulary_machine_name_load('cause');
   if ($cause) {
     $terms = taxonomy_get_tree($cause->vid);
     foreach ($terms as $term) {
-      $vars = dosomething_helpers_get_variables('taxonomy_term', $term->tid);
+      $tables['taxonomy_term']['results'][] = array(
+        'id' => $term->tid,
+        'title' => $term->name,
+      );
+    }
+  }
+
+  foreach ($tables as $entity_type => $table) {
+    $rows = array();
+    foreach ($table['results'] as $record) {
+      $id = $record['id'];
+      $vars = dosomething_helpers_get_variables($entity_type, $id);
       ;
-      $row_values = array($term->name);
+      // First column is a link to the entity.
+      $row_values = array(l($record['title'], $table['url'] . $id));
       // Loop through status values and set links for each.
       $i = 0;
       foreach ($status_values as $status) {
         $count = (int) $vars['count_' . $status];
-        $url = 'taxonomy/term/' . $term->tid . '/rb';
+        $url = $table['url'] . $id . '/rb';
         $options = array();
         if ($i > 0) {
-          $url = 'taxonomy/term/' . $term->tid . '/rb/reviewed';
+          $url = $table['url'] . $id . '/rb/reviewed';
           $options = array('query' => array('status' => $i));
         }
         if ($count > 0) {
@@ -350,12 +386,12 @@ function dosomething_reportback_count_page() {
       }
       $rows[] = $row_values;
     }
+    $output .= '<h2>' . $table['title'] . '</h2>';
+    $output .= theme('table', array(
+      'header' => $header,
+      'rows' => $rows,
+    ));
   }
-  $output .= '<h2>' . t("Cause") . '</h2>';
-  $output .= theme('table', array(
-    'header' => $header,
-    'rows' => $rows,
-  ));
 
   if (user_access('administer modules')) {
     $reset_form = drupal_get_form('dosomething_reportback_reset_count_form');

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -104,23 +104,43 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
   // Display mode for rendering each Reportback File.
   $view_mode = 'full';
 
+  $entity_type = NULL;
+  $entity_id = NULL;
+
   // If we are viewing a reportback entity:
   if (isset($entity->rbid) && arg(0) === 'reportback') {
-    $params['rbid'] =$entity->rbid;
+    $params['rbid'] = $entity->rbid;
     // If viewing a Reportback, don't repeat the Reportback details in each file.
     $view_mode = 'teaser';
+    $entity_id = $entity->rbid;
+    $entity_type = 'reportback';
   }
   elseif (isset($entity->nid)) {
     $params['nid'] = $entity->nid;
+    $entity_id = $entity->nid;
+    $entity_type = 'node';
   }
   elseif (isset($entity->tid)) {
     $params['tid'] = $entity->tid;
+    $entity_id = $entity->tid;
+    $entity_type = 'taxonomy_term';
   }
 
   $form['view_mode'] = array(
     '#type' => 'hidden',
     '#value' => $view_mode,
   );
+
+  if (isset($entity_type)) {
+    $form['entity_type'] = array(
+      '#type' => 'hidden',
+      '#value' => $entity_type,
+    );
+    $form['entity_id'] = array(
+      '#type' => 'hidden',
+      '#value' => $entity_id,
+    );
+  }
 
   $page_size = 25;
   if (isset($_GET['pagesize'])) {
@@ -133,6 +153,10 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
   $result = dosomething_reportback_get_reportback_files_query_result($params, $page_size);
   // Get the total number of results.
   $total = dosomething_reportback_get_reportback_files_query_count($params);
+  // If it's zero, reset the count variables.
+  if (!$total) {
+    $total = dosomething_reportback_get_reportback_files_query_count($params, $reset = TRUE);
+  }
   $page_size_copy = '';
   if ($total > $page_size) {
     $page_size_copy = '<p>' . t("Displaying the most recent @num", array(
@@ -223,6 +247,9 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
     }
 
   }
+  if (isset($form_state['values']['entity_type'])) {
+    dosomething_reportback_reset_count($form_state['values']['entity_type'], $form_state['values']['entity_id']);
+  }
 
   drupal_set_message(t("Updated."));
 }
@@ -287,29 +314,35 @@ function theme_dosomething_reportback_files_form($variables) {
  * Page callback which displays all Reportback Count variables.
  */
 function dosomething_reportback_count_page() {
-  // Reset all Reportback Totals for terms in the Cause vocabulary.
-  $header = array(
-    t('Title'),
-    t('Pending'),
-    t('Approved'),
-    t('Promoted'),
-    t('Excluded'),
-    t('Flagged'),
-  );
+  $status_values = dosomething_reportback_get_file_status_values();
+
+  $header = array(t('Title'));
+  foreach ($status_values as $status) {
+    $header[] = t($status);
+  }
+
   $rows = array();
+  $url = 'taxonomy/term/';
   $cause = taxonomy_vocabulary_machine_name_load('cause');
   if ($cause) {
     $terms = taxonomy_get_tree($cause->vid);
     foreach ($terms as $term) {
       $vars = dosomething_helpers_get_variables('taxonomy_term', $term->tid);
-      $rows[] = array(
-        $term->name,
-        $vars['count_pending'],
-        $vars['count_approved'],
-        $vars['count_promoted'],
-        $vars['count_excluded'],
-        $vars['count_flagged'],
-      );
+      ;
+      $row_values = array($term->name);
+      // Loop through status values and set links for each.
+      $i = 0;
+      foreach ($status_values as $status) {
+        $url = 'taxonomy/term/' . $term->tid . '/rb';
+        $options = array();
+        if ($i > 0) {
+          $url = 'taxonomy/term/' . $term->tid . '/rb/reviewed';
+          $options = array('query' => array('status' => $i));
+        }
+        $row_values[] = l($vars['count_' . $status], $url, $options);
+        $i++;
+      }
+      $rows[] = $row_values;
     }
   }
   $output .= '<h2>' . t("Cause") . '</h2>';

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -201,10 +201,6 @@ function dosomething_reportback_menu() {
     'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('view', 1),
   );
-
-  // Add Reportback menu items for admin/users.
-  // $users_rb = dosomething_reportback_get_review_menu_items('admin/users', NULL);
-  // $items = array_merge($items, $users_rb);
   $items['admin/users/rb'] = array(
     'title' => 'Reportbacks',
     'page callback' => 'dosomething_reportback_count_page',


### PR DESCRIPTION
Refs #3846
- Displays Reportback totals for campaigns
- Updates totals per entity upon Review Form submission
- Renders count as link to the relevant view if non-zero

TODO:
- [x] Function to reset all campaign totals
- [x] Create `dosomething_campaign_get_campaigns` function to avoid `node_load` to get Campaign title

![totals-2](https://cloud.githubusercontent.com/assets/1236811/6032553/7e8b8b64-abd8-11e4-866e-911ea8dd865c.png)
