### PR TITLE
Refactor dosomething_helpers_set_variable

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -305,7 +305,7 @@ function dosomething_campaign_reportback_config_form_submit(&$form, &$form_state
   $var_name = 'collect_num_participants';
   $values = $form_state['values'];
   $node = node_load($values['nid']);
-  dosomething_helpers_set_variable($node, $var_name, $values[$var_name]);
+  dosomething_helpers_set_variable('node', $node->nid, $var_name, $values[$var_name]);
   drupal_set_message("Updated.");
 }
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.install
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.install
@@ -84,7 +84,7 @@ function dosomething_helpers_update_7002() {
       $value = variable_get($name);
       // Save it to the dosomething_helpers_variable table for the node.
       $node = node_load($nid);
-      dosomething_helpers_set_variable($node, $variable, $value);
+      dosomething_helpers_set_variable('node', $node->nid, $variable, $value);
       // Delete the old variable.
       variable_del($name);
     }
@@ -121,7 +121,7 @@ function dosomething_helpers_update_7003() {
         $variable = 'mobilecommons_opt_in_path';
       }
       // Save it to the dosomething_helpers_variable table.
-      dosomething_helpers_set_variable($node, $variable, $value);
+      dosomething_helpers_set_variable('node', $node->nid, $variable, $value);
       // Delete the old variable.
       variable_del($name);
     }
@@ -138,5 +138,17 @@ function dosomething_helpers_update_7003() {
   foreach ($result as $record) {
     $name = $record->name;
     variable_del($name);
+  }
+}
+
+
+/**
+ * Deletes unused bundle column from Helpers Variable table.
+ */
+function dosomething_helpers_update_7004() {
+  $table = 'dosomething_helpers_variable';
+  $field = 'bundle';
+  if (db_field_exists($table, $field)) {
+    db_drop_field($table, $field);
   }
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -134,11 +134,11 @@ function dosomething_helpers_variable_form_submit(&$form, &$form_state) {
   $nid = $values['nid'];
   // Remove from values.
   unset($values['nid']);
-  $node = node_load($nid);
+
   // Loop through all remaining values:
   foreach ($values as $name => $value) {
     // Save to the variable table.
-    dosomething_helpers_set_variable($node, $name, $value);
+    dosomething_helpers_set_variable('node', $nid, $name, $value);
   }
   drupal_set_message("Updated.");
 }
@@ -216,17 +216,17 @@ function dosomething_helpers_get_variable($entity_type, $entity_id, $var_name) {
 
 /**
  * Sets a given dosomething_helper variable $name to $value for given $node.
+ *
+ * @param string $entity_type
+ *   The type of entity to store a value for, e.g. "node", "taxonomy_term"
+ * @param int $entity_id
+ *   The primary identifier of the entity.
+ * @param string $var_name
+ *   The name of the variable to store for the entity.
+ * @param mixed $value
+ *   The value to save for the variable. Will be stored as a string.
  */
-function dosomething_helpers_set_variable($entity, $var_name, $value) {
-  if (isset($entity->nid)) {
-    $entity_type = 'node';
-    $entity_id = $entity->nid;
-  }
-  elseif (isset($entity->tid)) {
-    $entity_type = 'taxonomy_term';
-    $entity_id = $entity->tid;
-    $entity->type = $entity->vocabulary_machine_name;
-  }
+function dosomething_helpers_set_variable($entity_type, $entity_id, $var_name, $value) {
   // If a value is present:
   if (!empty($value) || $value === 0) {
     db_merge('dosomething_helpers_variable')
@@ -237,7 +237,6 @@ function dosomething_helpers_set_variable($entity, $var_name, $value) {
           ))
         ->fields(array(
             'entity_type' => $entity_type,
-            'bundle' => $entity->type,
             'entity_id' => $entity_id,
             'name' => $var_name,
             'value' => $value,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -963,13 +963,7 @@ function dosomething_reportback_get_reportback_files_query_count($params, $reset
   $count = $result->rowCount();
 
   if ($reset) {
-    if ($entity_type == 'node') {
-      $entity = node_load($entity_id);
-    }
-    elseif ($entity_type == 'taxonomy_term') {
-      $entity = taxonomy_term_load($entity_id);
-    }
-    dosomething_helpers_set_variable($entity, $var_name, $count);
+    dosomething_helpers_set_variable($entity_type, $entity_id, $var_name, $count);
   }
 
   return $count;

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -90,7 +90,7 @@ function dosomething_signup_opt_in_config_form_submit($form, &$form_state) {
         // Get the form input value for this node helpers variable.
         $value = $values[$nid . '_' . $name];
         // Save it as a helpers variable.
-        dosomething_helpers_set_variable($node, $name, $value);
+        dosomething_helpers_set_variable('node', $node->nid, $name, $value);
       }
     }
   }


### PR DESCRIPTION
Refactors `dosomething_helpers_set_variable` so a loaded entity is no longer passed, but instead just the `entity_type` and `entity_id` are used as parameters.

This prevents unnecessary `node_load` calls when setting the Count totals for Campaign nodes and Taxonomy terms in `dosomething_reportback_get_reportback_files_query_count`.
