### PR TITLE
Refresh Campaign Count variables

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.install
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.install
@@ -141,7 +141,6 @@ function dosomething_helpers_update_7003() {
   }
 }
 
-
 /**
  * Deletes unused bundle column from Helpers Variable table.
  */
@@ -151,4 +150,13 @@ function dosomething_helpers_update_7004() {
   if (db_field_exists($table, $field)) {
     db_drop_field($table, $field);
   }
+}
+
+/**
+ * Creates index on dosomething_helpers_variable on entity_type and entity_id.
+ */
+function dosomething_helpers_update_7005() {
+  $table = 'dosomething_helpers_variable';
+  $fields = array('entity_type', 'entity_id');
+  db_add_index($table, 'entity_type_entity_id', $fields);
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -400,6 +400,7 @@ function dosomething_reportback_reset_count_form() {
  * Submit handler for dosomething_reportback_reset_count_form().
  */
 function dosomething_reportback_reset_count_form_submit($form, &$form_state) {
+  dosomething_reportback_reset_all('node');
   dosomething_reportback_reset_all('taxonomy_term');
   drupal_set_message(t("Totals have been refreshed."));
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -388,6 +388,12 @@ function dosomething_reportback_count_page() {
  * Form to reset all Reportback Count variables.
  */
 function dosomething_reportback_reset_count_form() {
+  $form['reset'] = array(
+    '#type' => 'checkboxes',
+    '#required' => TRUE,
+    '#title' => t('Select totals to refresh'),
+    '#options' => drupal_map_assoc(array(t('node'), t('taxonomy_term'))),
+  );
   $form['actions'] = array('#type' => 'actions');
   $form['actions']['submit'] = array(
     '#type' => 'submit',
@@ -400,7 +406,14 @@ function dosomething_reportback_reset_count_form() {
  * Submit handler for dosomething_reportback_reset_count_form().
  */
 function dosomething_reportback_reset_count_form_submit($form, &$form_state) {
-  dosomething_reportback_reset_all('node');
-  dosomething_reportback_reset_all('taxonomy_term');
-  drupal_set_message(t("Totals have been refreshed."));
+  $selected = array();
+  foreach ($form_state['values']['reset'] as $entity_type => $value) {
+    if ($value) {
+      dosomething_reportback_reset_all($entity_type);
+      $selected[] = $entity_type;
+    }
+  }
+  drupal_set_message(t("Totals have been refreshed for @entity.", array(
+    '@entity' => implode(', ', $selected),
+  )));
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -991,10 +991,13 @@ function dosomething_reportback_reset_count($entity_type, $entity_id) {
  * Resets all Reportback Count variables for given entity type $entity_type.
  */
 function dosomething_reportback_reset_all($entity_type) {
-  if ($entity_type == 'node') {
-    // @todo: Loop through campaigns.
+  if ($entity_type === 'node') {
+    $campaigns = dosomething_campaign_get_campaigns();
+    foreach ($campaigns as $campaign) {
+      dosomething_reportback_reset_count($entity_type, $campaign->nid);
+    }
   }
-  elseif ($entity_type == 'taxonomy_term') {
+  elseif ($entity_type === 'taxonomy_term') {
     // Reset all Reportback Totals for terms in the Cause vocabulary.
     $cause = taxonomy_vocabulary_machine_name_load('cause');
     if ($cause) {


### PR DESCRIPTION
Provides function and form for refreshing all Campaign Count helper variables.
- Closes #3846
- Last TODO left in #3876. 
- Also unblocks #3874
