### PR TITLE
Reportback Permalink fix

### DIFF
--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
@@ -206,10 +206,11 @@ function dosomething_fact_page_get_fact_page_list_by_tid($tid) {
   $query->fields('n', array('nid', 'title'));
   $results = $query->execute();
 
-  foreach($results as $key => $result) {
+  $output = array();
+  foreach ($results as $key => $result) {
     $output[$key] = l($result->title, 'node/' . $result->nid);
   }
-  if ($output) {
+  if (!empty($output)) {
     return $output;
   }
   // If no results, return null.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -112,8 +112,6 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
     $params['rbid'] = $entity->rbid;
     // If viewing a Reportback, don't repeat the Reportback details in each file.
     $view_mode = 'teaser';
-    $entity_id = $entity->rbid;
-    $entity_type = 'reportback';
   }
   elseif (isset($entity->nid)) {
     $params['nid'] = $entity->nid;
@@ -165,7 +163,7 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
   }
 
   $form['count'] = array(
-    '#markup' => t("Inbox: @total Reportback Images", array(
+    '#markup' => t("Total: @total Reportback Images", array(
       '@num' => $page_size,
       '@total' => $total,
     )) . $page_size_copy,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -312,6 +312,7 @@ function theme_dosomething_reportback_files_form($variables) {
  * Page callback which displays all Reportback Count variables.
  */
 function dosomething_reportback_count_page() {
+  $output = '';
   $status_values = dosomething_reportback_get_file_status_values();
 
   $header = array(t('Title'));

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -935,6 +935,7 @@ function dosomething_reportback_get_reportback_files_query_result($params = arra
  * @return int
  */
 function dosomething_reportback_get_reportback_files_query_count($params, $reset = FALSE) {
+  $entity_type = NULL;
 
   // Name of helper variable which stores count for this status.
   $var_name = 'count_' . $params['status'];
@@ -947,7 +948,7 @@ function dosomething_reportback_get_reportback_files_query_count($params, $reset
     $entity_id = $params['tid'];
   }
 
-  if (!$reset) {
+  if ($entity_type && !$reset) {
     // Check if we have the count stored already.
     $count = dosomething_helpers_get_variable($entity_type, $entity_id, $var_name);
     if ($count === FALSE) {
@@ -962,7 +963,7 @@ function dosomething_reportback_get_reportback_files_query_count($params, $reset
   $result = $query->execute();
   $count = $result->rowCount();
 
-  if ($reset) {
+  if ($entity_type && $reset) {
     dosomething_helpers_set_variable($entity_type, $entity_id, $var_name, $count);
   }
 


### PR DESCRIPTION
The RB permalink page was broken, because it renders the `dosomething_reportback_files_form` for the Reportback entity.  The new changes to the form introduced in #3876 were attempting to set count variables for the Reportback entity.  We only need count variables per node and taxonomy term, so this adds checks to only set the count variables if an `$entity_type` has been defined.

Also fixes PHP notices in the Reportback Totals page, and Fact Page list block.
