### PR TITLE
Reportback cropbox size

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
@@ -53,13 +53,44 @@ define(function(require) {
   };
 
   /**
-   * Calculates what the initial size of the cropbox should be.
+   * Calculates the initial size of the cropbox. The initial
+   * size of the cropbox should be 50% of the size of the image,
+   * but have a minimum equal to the minimum allowed crop size.
    *
-   * @param {number} minimum     minimum size of the cropbox
+   * @param {number} width      width of the image.
+   * @param {number} height     height of the image.
+   * @param {number} minimum    minimum size of the cropbox
    */
-  // var getMinimumSize = function(minimum) {
-  //   return minThreshold / scale;
-  // };
+  var getCropBoxSize = function(width, height, minimum) {
+    var cropBoxSize;
+    var orientation = (width > height) ? "landscape" : "portrait";
+
+    // Make the cropbox half the size of the largest dimension.
+    // But, make sure the cropbox will fit in the image by
+    // checking that it isn't ever greater than smallest dimension.
+    if (orientation === "landscape") {
+      var halfWidth = width / 2;
+
+      if (halfWidth > height) {
+        cropBoxSize = height;
+      }
+      else {
+        cropBoxSize = halfWidth;
+      }
+    }
+    else {
+      var halfHeight = height / 2;
+
+      if (halfHeight > width) {
+        cropBoxSize = width;
+      }
+      else {
+        cropBoxSize = halfHeight;
+      }
+    }
+
+    return (cropBoxSize > minimum) ? cropBoxSize : minimum;
+  };
 
   /**
    * This returns the amount to translate an image after it has been rotated so
@@ -139,8 +170,8 @@ define(function(require) {
   var croppingReset = function (width, height) {
     // Turn off any previously bound events so
     // we can rebind them later using new settings.
-    $cropBox.off("touchmove mousemove");
-    $cropBox.off("touchend mouseup");
+    $(document).off("touchmove mousemove");
+    $(document).off("touchend mouseup");
 
     // Bind move events to the document.
     $(document).on("touchmove mousemove", function(event) {
@@ -217,6 +248,7 @@ define(function(require) {
     }
 
     var $cropContainer = $previewImage.parent();
+    var cropBoxSize = getCropBoxSize(width, height, minThreshold);
 
     // Expicitly set the dimensions of the crop area.
     $cropContainer.width(width);
@@ -225,10 +257,10 @@ define(function(require) {
     // Set the initial position of the cropbox in the center of the image
     // and with a minimum value of 480px.
     $cropBox.insertBefore($previewImage).css({
-      "left"   : Math.floor((width / 2) - (minThreshold / 2)),
-      "top"    : Math.floor((height / 2) - (minThreshold / 2)),
-      "width"  : minThreshold,
-      "height" : minThreshold,
+      "left"   : Math.floor((width / 2) - (cropBoxSize / 2)),
+      "top"    : Math.floor((height / 2) - (cropBoxSize / 2)),
+      "width"  : cropBoxSize,
+      "height" : cropBoxSize,
     });
 
     // Initiate dragging and resizing.

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
@@ -4,8 +4,6 @@ define(function(require) {
   var $ = require("jquery");
 
   // Initialize variables.
-  var resizeState = false;
-  var dragState = false;
   var xInitPos;
   var yInitPos;
   var offsetLeft;
@@ -14,14 +12,16 @@ define(function(require) {
   var initialCropBoxWidth;
   var previewImageWidth;
   var previewImageHeight;
-  var resizeClickPositionX = 0;
-  var resizeClickPositionY = 0;
-  var $cropBox = $("<div class='cropbox'><div class='resize-handle'><div class='square'></div></div></div>");
   var $previewImage;
   var origImage;
-  var scale = 1;
-  var degrees = 0;
-  var minThreshold = 480;
+  var resizeState          = false;
+  var dragState            = false;
+  var $cropBox             = $("<div class='cropbox'><div class='resize-handle'><div class='square'></div></div></div>");
+  var resizeClickPositionX = 0;
+  var resizeClickPositionY = 0;
+  var scale                = 1;
+  var degrees              = 0;
+  var minThreshold         = 480;
 
   /**
    * Returns the coordinates of a touch or mouse event.
@@ -53,12 +53,21 @@ define(function(require) {
   };
 
   /**
+   * Calculates what the initial size of the cropbox should be.
+   *
+   * @param {number} minimum     minimum size of the cropbox
+   */
+  // var getMinimumSize = function(minimum) {
+  //   return minThreshold / scale;
+  // };
+
+  /**
    * This returns the amount to translate an image after it has been rotated so
    * so that it stays center in it's container.
    *
-   * @param {jQuery} width      Width of the image.
-   * @param {jQuery} height     height of the image.
-   * @param {jQuery} degrees    How many degrees the image has been rotated.
+   * @param {number} width      Width of the image.
+   * @param {number} height     height of the image.
+   * @param {number} degrees    How many degrees the image has been rotated.
    */
   var getTranslateDifference = function(width, height, degrees) {
     var translateDiff = (width / 2) - (height / 2);
@@ -88,7 +97,7 @@ define(function(require) {
       // Sets the initial positioning of the crop box.
       if ($cropBox.length) {
         offsetLeft = parseInt($cropBox.css("left"), 10);
-        offsetTop = parseInt($cropBox.css("top"), 10);
+        offsetTop  = parseInt($cropBox.css("top"), 10);
       }
 
       // Turns on dragging.
@@ -109,7 +118,7 @@ define(function(require) {
       // Set the initial size of the crop box.
       if ($cropBox.length) {
         initialCropBoxHeight = parseInt($cropBox.css("height"), 10);
-        initialCropBoxWidth = parseInt($cropBox.css("width"), 10);
+        initialCropBoxWidth  = parseInt($cropBox.css("width"), 10);
       }
 
       // Set the position of the mouse.
@@ -121,6 +130,12 @@ define(function(require) {
     });
   };
 
+  /**
+   * Sets up the mouse events on the cropping interface using a give width and height.
+   *
+   * @param {number} width     Width of the crop area.
+   * @param {number} height    Height of the crop area.
+   */
   var croppingReset = function (width, height) {
     // Turn off any previously bound events so
     // we can rebind them later using new settings.
@@ -129,21 +144,20 @@ define(function(require) {
 
     // Bind move events to the document.
     $(document).on("touchmove mousemove", function(event) {
-      var coords = getCoords(event);
-
+      var coords        = getCoords(event);
       var cropBoxHeight = parseInt($cropBox.css("height"),10);
-      var cropBoxWidth = parseInt($cropBox.css("width"),10);
-      var cropBoxTop = parseInt($cropBox.css("top"), 10);
-      var cropBoxLeft = parseInt($cropBox.css("left"), 10);
+      var cropBoxWidth  = parseInt($cropBox.css("width"),10);
+      var cropBoxTop    = parseInt($cropBox.css("top"), 10);
+      var cropBoxLeft   = parseInt($cropBox.css("left"), 10);
 
       // If dragging, drag the crop box along.
       if (dragState) {
         // Calculate how far to move the box down and right based on the mouse position.
         var moveRight = offsetLeft + (coords.pageX - xInitPos);
-        var moveDown = offsetTop + (coords.pageY - yInitPos);
+        var moveDown  = offsetTop + (coords.pageY - yInitPos);
 
         // Boundary threshold tests.
-        var withinTopBounds = (height - cropBoxHeight) > moveDown ? true : false;
+        var withinTopBounds  = (height - cropBoxHeight) > moveDown ? true : false;
         var withinLeftBounds = (width - cropBoxWidth) > moveRight ? true : false;
 
         // Make sure we are still within the bounds of the image and then actully move the box.
@@ -160,14 +174,14 @@ define(function(require) {
         dragState = false;
         // Calculate how much to resize the cropbox.
         var resizeHorizontal = initialCropBoxWidth + (coords.pageX - resizeClickPositionX);
-        var resizeVertical = initialCropBoxHeight + (coords.pageX - resizeClickPositionX);
+        var resizeVertical   = initialCropBoxHeight + (coords.pageX - resizeClickPositionX);
 
         // Boundary threshold tests.
         var withinHeightBounds = (cropBoxHeight + cropBoxTop) < height ? true : false;
-        var withinWidthBounds = (cropBoxWidth + cropBoxLeft) < width ? true : false;
+        var withinWidthBounds  = (cropBoxWidth + cropBoxLeft) < width ? true : false;
         var cropBoxSizeAllowed = (cropBoxWidth > minThreshold) ? true : false;
-        var increasingSize = (coords.pageX - resizeClickPositionX) > 0 ? true : false;
-        var decreasingSize = (coords.pageX - resizeClickPositionX) < 0 ? true : false;
+        var increasingSize     = (coords.pageX - resizeClickPositionX) > 0 ? true : false;
+        var decreasingSize     = (coords.pageX - resizeClickPositionX) < 0 ? true : false;
 
         // Make sure we are still in the boundaries of the image, and then resize the box.
         if (withinHeightBounds && withinWidthBounds && (cropBoxSizeAllowed || increasingSize)) {
@@ -185,8 +199,8 @@ define(function(require) {
      *  When the user stops moving the mouse or touching the screen, turn of the drag and resizing events.
      *  Get the final position and size of the crop and populate hidden form elements with them.
      */
-    $cropBox.on("touchend mouseup", function() {
-      dragState = false;
+    $(document).on("touchend mouseup", function() {
+      dragState   = false;
       resizeState = false;
     });
   };
@@ -194,9 +208,8 @@ define(function(require) {
   /**
    * This sets up the cropping interface with a given height and width.
    *
-   * @param {jQuery} $image     Image to be rotated.
-   * @param {jQuery} $container Container the image will be rotated in.
-   * @param {jQuery} degrees    How many degrees to rotate the image.
+   * @param {number} width     Width of the crop area.
+   * @param {number} height    Height of the crop area.
    */
   var setupCrop = function(width, height) {
     if (!$previewImage.length) {
@@ -209,8 +222,9 @@ define(function(require) {
     $cropContainer.width(width);
     $cropContainer.height(height);
 
+    // Set the initial position of the cropbox in the center of the image
+    // and with a minimum value of 480px.
     $cropBox.insertBefore($previewImage).css({
-      // Center the crop box on the image initially.
       "left"   : Math.floor((width / 2) - (minThreshold / 2)),
       "top"    : Math.floor((height / 2) - (minThreshold / 2)),
       "width"  : minThreshold,
@@ -230,12 +244,11 @@ define(function(require) {
    * the new height of the container.
    *
    * @param {jQuery} $image     Image to be rotated.
-   * @param {jQuery} $container Container the image will be rotated in.
-   * @param {jQuery} degrees    How many degrees to rotate the image.
+   * @param {number} degrees    How many degrees to rotate the image.
    */
   var rotateImage = function($image, degrees) {
-    var width = $image.width();
-    var height = $image.height();
+    var width          = $image.width();
+    var height         = $image.height();
     var $cropContainer = $previewImage.parent();
 
     // Calculate how much to translate the image by.
@@ -267,27 +280,26 @@ define(function(require) {
    * Populates fields in the main reportback form with values to use for cropping
    * and rotating on the backend.
    *
-   * @param {jQuery} cropValues Object containing x, y, width and height of the crop.
-   * @param {jQuery} degrees    (optional) How many degrees to rotate the image.
+   * @param {jQuery} form       The form to populate.
    */
   var populateFields = function($form) {
     // Get the hidden form elements.
-    var $cropX = $form.find("input[name='crop_x']");
-    var $cropY = $form.find("input[name='crop_y']");
-    var $cropWidth = $form.find("input[name='crop_width']");
-    var $cropHeight = $form.find("input[name='crop_height']");
+    var $cropX        = $form.find("input[name='crop_x']");
+    var $cropY        = $form.find("input[name='crop_y']");
+    var $cropWidth    = $form.find("input[name='crop_width']");
+    var $cropHeight   = $form.find("input[name='crop_height']");
     var $cropRotation = $form.find("input[name='crop_rotate']");
     var $captionField = $form.find("input[name='caption']");
-    var caption = $("#dosomething-reportback-image-form").find("#caption").val();
+    var caption       = $("#dosomething-reportback-image-form").find("#caption").val();
 
 
     // Calculate cropping information.
     var cropValues = {
-      top    :  Math.round(($cropBox.offset().top - $previewImage.offset().top) * scale),
-      left   :  Math.round(($cropBox.offset().left - $previewImage.offset().left) * scale),
-      width  :  Math.round($cropBox.outerWidth() * scale),
-      height :  Math.round($cropBox.outerHeight() * scale),
-      degrees:  degrees,
+      top     :  Math.round(($cropBox.offset().top - $previewImage.offset().top) * scale),
+      left    :  Math.round(($cropBox.offset().left - $previewImage.offset().left) * scale),
+      width   :  Math.round($cropBox.outerWidth() * scale),
+      height  :  Math.round($cropBox.outerHeight() * scale),
+      degrees :  degrees,
     };
 
     // Populate fields.
@@ -302,7 +314,7 @@ define(function(require) {
   /**
    * Initiates cropping js.
    *
-   * @param {jQuery} origImage  Image object to crop
+   * @param {Image} origImage  Image object to crop
    */
   var dsCropperInit = function(image) {
     // Store the image;
@@ -316,10 +328,10 @@ define(function(require) {
     }
 
     // Set global valuea.
-    previewImageWidth = $previewImage.width();
+    previewImageWidth  = $previewImage.width();
     previewImageHeight = $previewImage.height();
-    scale = origImage.width / $previewImage.width();
-    minThreshold = getMinimumSize();
+    scale              = origImage.width / $previewImage.width();
+    minThreshold       = getMinimumSize();
 
     // Create the crop area.
     $previewImage.wrap($("<div class='crop-bounding-box'></div>"));


### PR DESCRIPTION
## Fixes #3864

The cropbox was being set to start at 480x480. But if an image was really big, then as 480x480 box was too small to start with. 
## Changes

This PR makes some code style and comment updates, but mostly it adds a function `getCropBoxSize()` that calculates a larger starting size for the cropbox. 

@DoSomething/front-end 
