### PR TITLE
Style updates to the resize handle

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
@@ -16,7 +16,7 @@ define(function(require) {
   var previewImageHeight;
   var resizeClickPositionX = 0;
   var resizeClickPositionY = 0;
-  var $cropBox = $("<div class='cropbox'><div class='resize-handle'><div class='square'></div></div></div>");
+  var $cropBox = $("<div class='cropbox'><div class='resize-handle'></div></div>");
   var $previewImage;
   var origImage;
   var scale = 1;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-crop.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-crop.scss
@@ -82,20 +82,22 @@
       position: absolute;
       right: 0;
       bottom: 0;
-      width: 40px;
-      height: 40px;
+      width: 35px;
+      height: 35px;
+      background-color: $blue;
 
       &:hover {
         cursor: se-resize;
       }
 
-      .square {
-        top: 35px;
-        left: 35px;
+      &:after {
+        display: block;
+        content: "\2198";
+        font-size: 39px;
         position: absolute;
-        background: $blue;
-        width: 10px;
-        height: 10px;
+        top: 19px;
+        left: 2px;
+        color: white;
       }
     }
   }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-crop.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-crop.scss
@@ -93,7 +93,7 @@
       &:after {
         display: block;
         content: "\2198";
-        font-size: 39px;
+        font-size: 30px;
         position: absolute;
         top: 19px;
         left: 2px;


### PR DESCRIPTION
## Fixes Issue #3884

Moves the resize handle in to the bottom right corner with a blue background and an south east arrow icon to indicate to the user that is where they need to grab to resize the box.

@DoSomething/front-end 
