### PR TITLE
Reportback caption validation

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -220,6 +220,7 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     '#type' => 'textfield',
     '#required' => TRUE,
     '#attributes' => array(
+      'data-validate' => 'caption',
       'data-validate-required' => '',
       'placeholder' => t("Write something..."),
     ),

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -222,7 +222,8 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     '#attributes' => array(
       'data-validate' => 'caption',
       'data-validate-required' => '',
-      'placeholder' => t("Write something..."),
+      'placeholder' => t("Write something in 60 characters or less"),
+      'maxlength' => '60',
     ),
     '#title' => t("Caption"),
     '#default_value' => $caption,

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -104,7 +104,12 @@ define(function(require) {
      */
     this.$imageForm.submit(function(event) {
       event.preventDefault();
-      Modal.close(false);
+
+      // @TODO: This is a temporary solution until Neue is updated with capacity
+      // to distinguish between a client side only form.
+      if (_this.$imageForm.data('validation-passed')) {
+        Modal.close(false);
+      }
     });
 
     // Close the modal when a user wants to change their photo.

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/reportback.js
@@ -2,6 +2,7 @@ define(function(require) {
   "use strict";
 
   var Validation = require("neue/validation");
+  var $          = require("jquery");
 
   // validate number of items
   Validation.registerValidationFunction("positiveInteger", function(string, done) {
@@ -30,6 +31,24 @@ define(function(require) {
       return done({
         success: false,
         message: Drupal.t("Tell us why you cared!")
+      });
+    }
+  });
+
+  // validate that string isn't blank and less than or equal to 60 characters
+  Validation.registerValidationFunction("caption", function(string, done) {
+    if( string !== "" && string.length <= 60 ) {
+      // @TODO: temporary solution until Neue validation script is updated to 
+      // handle client side only forms.
+      $("#dosomething-reportback-image-form").data("validation-passed", true);
+      return done({
+        success: true,
+        message: Drupal.t("Great!")
+      });
+    } else {
+      return done({
+        success: false,
+        message: Drupal.t("Tell us about your photo!")
       });
     }
   });

--- a/lib/themes/dosomething/paraneue_dosomething/js/validation/reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validation/reportback.js
@@ -37,15 +37,24 @@ define(function(require) {
 
   // validate that string isn't blank and less than or equal to 60 characters
   Validation.registerValidationFunction("caption", function(string, done) {
+    // @TODO: temporary solution until Neue validation script is 
+    // updated to handle client side only forms.
+    var $form = $("#dosomething-reportback-image-form");
+
     if( string !== "" && string.length <= 60 ) {
-      // @TODO: temporary solution until Neue validation script is updated to 
-      // handle client side only forms.
-      $("#dosomething-reportback-image-form").data("validation-passed", true);
+      if ($form.length) {
+        $form.data("validation-passed", true);
+      }
+
       return done({
         success: true,
-        message: Drupal.t("Great!")
+        message: Drupal.t("Sounds great!")
       });
     } else {
+      if ($form.length) {
+        $form.data("validation-passed", false);
+      }
+
       return done({
         success: false,
         message: Drupal.t("Tell us about your photo!")

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -301,7 +301,7 @@
                 <form action="#" method="post" id="dosomething-reportback-image-form" accept-charset="UTF-8" data-validation-passed="false">
                   <div class="form-item">
                     <label class="field-label" for="caption">Caption</label>
-                    <input class="text-field" placeholder="Write something..." type="text" id="caption" name="caption" data-validate="caption" data-validate-required maxlength="60" >
+                    <input class="text-field" placeholder="Write something in 60 characters or less" type="text" id="caption" name="caption" data-validate="caption" data-validate-required maxlength="60" >
                   </div>
                   <div class="form-actions">
                     <input type="submit" value="done" class="button -done" />

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -294,12 +294,14 @@
                     <a href="#" class="button -tertiary">change photo</a>
                   </div>
                 </div>
-                <!-- This is a purely frontend form that will grab crop options and a caption
-                And then when the user submits the form, it will populate the drupal form with these values. -->
-                <form action="#" method="post" id="dosomething-reportback-image-form" accept-charset="UTF-8">
+                <?php /*
+                This is a purely frontend form that will grab crop options and a caption
+                And then when the user submits the form, it will populate the drupal form with these values.
+                */?>
+                <form action="#" method="post" id="dosomething-reportback-image-form" accept-charset="UTF-8" data-validation-passed="false">
                   <div class="form-item">
                     <label class="field-label" for="caption">Caption</label>
-                    <input class="text-field" placeholder="Write something..." type="text" id="caption" name="caption" value="" size="60" maxlength="128">
+                    <input class="text-field" placeholder="Write something..." type="text" id="caption" name="caption" data-validate="caption" data-validate-required maxlength="60" >
                   </div>
                   <div class="form-actions">
                     <input type="submit" value="done" class="button -done" />


### PR DESCRIPTION
## Fixes #3527

Adds validation to the **caption** field in the Reportback form, as well as in the cropping modal.

However, part of the approach to address the form in the cropping modal involves a temporary fix until we update Neue with a capacity to discern between a regular form and a client-side only form (such as the caption field form in the cropping modal).

@DoSomething/front-end 
