### PR TITLE
Show preview image of correct image file

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -56,6 +56,7 @@ define(function(require) {
           image.src = result;
 
           image.onload = function() {
+            var image = this;
             var isValid = _this.validImage(this);
             var $errorMsg = _this.$uploadButton.parent().siblings(".error");
 
@@ -73,11 +74,16 @@ define(function(require) {
               );
 
               // Add the preview image to the modal
-              _this.previewImage(this, _this.$imagePreview);
+              _this.previewImage(image, _this.$imagePreview);
 
               // Make sure submit button is enabled when the modal opens.
               _this.enableSubmit();
 
+              // When the user is done with the modal, send crop values to the form.
+              Events.subscribe("Modal:Close", function() {
+                ImageCrop.populateFields(_this.$reportbackForm);
+                ImageCropPreview.cropPreview(image,_this.getCropValues());
+              });
             }
             // Show user an error if they upload an image that is too small.
             else {
@@ -86,12 +92,6 @@ define(function(require) {
                 $error.insertAfter(_this.$uploadButton.parent());
               }
             }
-
-            // When the user is done with the modal, send crop values to the form.
-            Events.subscribe("Modal:Close", function() {
-              ImageCrop.populateFields(_this.$reportbackForm);
-              ImageCropPreview.cropPreview(image,_this.getCropValues());
-            });
           };
         };
       }


### PR DESCRIPTION
## Problem

The crop preview logic was tied to a Modal close event that was being subscribed to whether the image was valid or not. So, if a user first uploaded an image that was too small, that image was stored and bound to the modal close event which called the crop preview logic and this image didn't get updated when the user submitted another image that actually passed validation. 
## Changes - Fixes #3892

Only subscribes to the Modal close event, and calls the crop preview code if the image passes validation.

@DoSomething/front-end 
