### PR TITLE
Updates view_unpublished contrib module

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -192,9 +192,8 @@ projects[varnish][version] = "1.0-beta2"
 projects[varnish][subdir] = "contrib"
 
 ; View Unpublished
-projects[view_unpublished][version] = "1.1"
+projects[view_unpublished][version] = "1.2"
 projects[view_unpublished][subdir] = "contrib"
-projects[view_unpublished][patch][] = "https://drupal.org/files/view_unpublished_content_admin-1192074-60.patch"
 
 ; Views
 projects[views][version] = "3.8"


### PR DESCRIPTION
I've ran a build locally and verified that we no longer need the patch per latest update of the View Unpublished module.
