### PR TITLE
user_name should be username in MBP params

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -408,7 +408,7 @@ function dosomething_user_user_pass_submit($form, &$form_state) {
         'email' => $account->mail,
         'uid' => $account->uid,
         'first_name' => dosomething_user_get_field('field_first_name', $account),
-        'user_name' => $account->name,
+        'username' => $account->name,
         'reset_link' => user_pass_reset_url($account),
       );
       if (module_exists('dosomething_mbp')) {


### PR DESCRIPTION
Fixes #3921 

`dosomething_mbp_get_transactional_payload()` is looking for `username` rather that `user_name`.

**See**:
- https://github.com/DoSomething/dosomething/blob/dev/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module#L127
- https://github.com/DoSomething/dosomething/blob/dev/lib/modules/dosomething/dosomething_user/dosomething_user.module#L411
