### PR TITLE
Updated reportback image flow.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCropPreview.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCropPreview.js
@@ -46,10 +46,9 @@ define(function(require) {
    *
    * @param {number} imageWidth      Width of the original image (not scaled).
    * @param {number} imageHeight     height of the original image (not scaled).
-   * @param {jQuery} $preview        The preview image scaled down to fit in the crop container.
    * @param {object} cropValues      An object containing x, y, width, and height values describing the crop.
    */
-  var getCropPreviewValues = function(imageWidth, imageHeight, $preview, cropValues) {
+  var getCropPreviewValues = function(imageWidth, imageHeight, cropValues) {
     var cropPreviewSize = $cropPreview.width();
     var horizontalScale = cropValues.width / cropPreviewSize;
     var verticalScale   = cropValues.height / cropPreviewSize;
@@ -102,7 +101,7 @@ define(function(require) {
     // Save the original image dimensions.
     var imageHeight   = image.height;
     var imageWidth    = image.width;
-    var $previewImage = $(image);
+    var $previewImage = "<img src='" + image.src + "'/>";
 
     // Add crop preview to the page.
     setUpCropPreview();
@@ -113,7 +112,7 @@ define(function(require) {
     $cropPreview.css("height", $cropPreview.width());
 
     // Create the crop preview.
-    var cropPreviewValues = getCropPreviewValues(imageWidth, imageHeight, $previewImage, cropValues);
+    var cropPreviewValues = getCropPreviewValues(imageWidth, imageHeight, cropValues);
     $cropPreview.find("img").css(cropPreviewValues);
   };
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -75,6 +75,10 @@ define(function(require) {
 
               // When the user submits the modal form, send crop values to the form.
               _this.$imageForm.submit(function(event) {
+
+                // @TODO: This is a temporary solution until Neue is updated with capacity
+                // to distinguish between a client side only form.
+                // if (_this.$imageForm.data('validation-passed')) {}
                 event.preventDefault();
 
                 // Send crop information to the main reportback form

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -79,11 +79,12 @@ define(function(require) {
               // Make sure submit button is enabled when the modal opens.
               _this.enableSubmit();
 
-              // When the user is done with the modal, send crop values to the form.
+              // When the user submits the modal form, send crop values to the form.
               _this.$imageForm.submit(function(event) {
                 event.preventDefault();
                 ImageCrop.populateFields(_this.$reportbackForm);
                 ImageCropPreview.cropPreview(image,_this.getCropValues());
+                _this.$uploadButton.siblings("span").html("edit photo");
                 Modal.close();
               });
             }
@@ -141,6 +142,10 @@ define(function(require) {
 
     if ($submitButton.prop("disabled")) {
       $submitButton.prop("disabled", false);
+    }
+
+    if ($submitButton.hasClass("is-loading")) {
+      $submitButton.removeClass("is-loading");
     }
   };
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -81,8 +81,10 @@ define(function(require) {
 
               // When the user is done with the modal, send crop values to the form.
               _this.$imageForm.submit(function(event) {
+                event.preventDefault();
                 ImageCrop.populateFields(_this.$reportbackForm);
                 ImageCropPreview.cropPreview(image,_this.getCropValues());
+                Modal.close();
               });
             }
             // Show user an error if they upload an image that is too small.
@@ -97,27 +99,18 @@ define(function(require) {
       }
     });
 
-    /**
-     * On submission of the form, close the modal.
-     * This publishes a close event that other scripts can subscribe to
-     * to use the information collected in the modal.
-     */
-    this.$imageForm.submit(function(event) {
-      event.preventDefault();
-
-      // @TODO: This is a temporary solution until Neue is updated with capacity
-      // to distinguish between a client side only form.
-      // if (_this.$imageForm.data('validation-passed')) {
-        Modal.close();
-      // }
+    Events.subscribe("Modal:Close", function() {
+      _this.resetFileField();
     });
+  };
 
-    // Close the modal when a user wants to change their photo.
-    this.$cropModal.find(".-change").click(function(event) {
-      event.preventDefault();
-      window.location.href = "#prove";
-      window.location.reload(true);
-    });
+  /**
+   *
+   */
+  ImageUploadBeta.prototype.resetFileField = function() {
+    var $input = this.$uploadButton;
+
+    $input.replaceWith($input.val("").clone(true));
   };
 
   /**

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -68,25 +68,30 @@ define(function(require) {
               }
 
               // Open the modal.
-              Modal.open(_this.$cropModal,
-                {
-                  animated: false,
-                }
-              );
+              _this.openModal();
 
               // Add the preview image to the modal
               _this.previewImage(image, _this.$imagePreview);
 
-              // Make sure submit button is enabled when the modal opens.
-              _this.enableSubmit();
-
               // When the user submits the modal form, send crop values to the form.
               _this.$imageForm.submit(function(event) {
                 event.preventDefault();
+
+                // Send crop information to the main reportback form
+                // so backend can use to crop.
                 ImageCrop.populateFields(_this.$reportbackForm);
+
+                // Create a crop preview on the client side.
                 ImageCropPreview.cropPreview(image,_this.getCropValues());
-                _this.$uploadButton.siblings("span").html("edit photo");
+
+                // Add a button to edit the image.
+                _this.createEditButton();
+
+                // The user clicked "done", so we can save this version of the crop
+                // and not reset the file field.
                 _this.readyToSave = true;
+
+                // Close the modal.
                 Modal.close();
               });
             }
@@ -114,14 +119,44 @@ define(function(require) {
   };
 
   /**
+   * Opens the modal making sure the done button is reset.
+   */
+  ImageUploadBeta.prototype.openModal = function() {
+    this.enableSubmit();
+    Modal.open(this.$cropModal,
+      {
+        animated: false,
+      }
+    );
+  };
+
+  /**
    * Clears the file field input and resets it globally,
-   * so that the user can re-upload an image and edit it.
+   * if the user accidentally closed out of the modal.
+   * Allows the user to re-upload an image and edit it.
    */
   ImageUploadBeta.prototype.resetFileField = function() {
     var $input = this.$uploadButton;
 
     if (!this.readyToSave) {
       $input.replaceWith(this.$uploadButton = $input.val("").clone(true));
+    }
+  };
+
+  /**
+   * Creates a button the user can click to re-open the modal
+   * and edit the crop they selected.
+   */
+  ImageUploadBeta.prototype.createEditButton = function() {
+    var _this = this;
+
+    if (!$(".reportback__submissions").find(".button--edit").length) {
+      var $editButton = $("<span class='button button--edit -tertiary'>edit photo</span>");
+      this.$uploadButton.parent().hide().before($editButton);
+
+      $editButton.click(function() {
+        _this.openModal();
+      });
     }
   };
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -80,7 +80,7 @@ define(function(require) {
               _this.enableSubmit();
 
               // When the user is done with the modal, send crop values to the form.
-              Events.subscribe("Modal:Close", function() {
+              _this.$imageForm.submit(function(event) {
                 ImageCrop.populateFields(_this.$reportbackForm);
                 ImageCropPreview.cropPreview(image,_this.getCropValues());
               });

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -24,6 +24,7 @@ define(function(require) {
     this.$imagePreview   = this.$cropModal.find(".image-preview");
     this.imageValues     = {};
     this.cropEnabled     = (typeof Drupal.settings.dsReportback.cropEnabled !== "undefined") ? Drupal.settings.dsReportback.cropEnabled : false;
+    this.readyToSave     = false;
 
     this.init();
   };
@@ -85,6 +86,7 @@ define(function(require) {
                 ImageCrop.populateFields(_this.$reportbackForm);
                 ImageCropPreview.cropPreview(image,_this.getCropValues());
                 _this.$uploadButton.siblings("span").html("edit photo");
+                _this.readyToSave = true;
                 Modal.close();
               });
             }
@@ -118,7 +120,9 @@ define(function(require) {
   ImageUploadBeta.prototype.resetFileField = function() {
     var $input = this.$uploadButton;
 
-    $input.replaceWith(this.$uploadButton = $input.val("").clone(true));
+    if (!this.readyToSave) {
+      $input.replaceWith(this.$uploadButton = $input.val("").clone(true));
+    }
   };
 
   /**

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -99,18 +99,25 @@ define(function(require) {
       }
     });
 
+    // Close the modal when a user wants to change their photo.
+    this.$cropModal.find(".-change").click(function(event) {
+      event.preventDefault();
+      Modal.close();
+    });
+
     Events.subscribe("Modal:Close", function() {
       _this.resetFileField();
     });
   };
 
   /**
-   *
+   * Clears the file field input and resets it globally,
+   * so that the user can re-upload an image and edit it.
    */
   ImageUploadBeta.prototype.resetFileField = function() {
     var $input = this.$uploadButton;
 
-    $input.replaceWith($input.val("").clone(true));
+    $input.replaceWith(this.$uploadButton = $input.val("").clone(true));
   };
 
   /**


### PR DESCRIPTION
## Problem

Needed to rework the reportback image flow to deal with various cases of the user not fully submitting the modal form and closing out of the modal.
## Changes
- Only creates the crop preview image if the user hits the "done" button in the modal.
- If the modal closes without the user clicking "done", we clone and reset the file field so that the user can reupload the image
- Creates an edit photo button if the user hits done that allows the user to open the modal again and reset their crop.
- Made some updates to the crop preview logic that was causing the preview to break if the modal was submitted more than once.

@DoSomething/front-end 
