### PR TITLE
Reportback ie behavior

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadFallback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadFallback.js
@@ -4,26 +4,37 @@
 define(function(require) {
   "use strict";
 
-  var $ = require("jquery");
+  var $                    = require("jquery");
+  var _                    = require("lodash");
+  var fallbackUploadTplSrc = require("text!images/templates/fallback-upload-interface.tpl.html");
 
   var ImageUploadFallback = {
+    /**
+     * Initialize the fallback file input script.
+     * @param  jQuery Object $input    Button input from form.
+     * @param  String        container Class name for container that should house fallback content.
+     * @return void
+     */
+    init: function ($input, container) {
+      _this = this;
+      
+      console.log($input);
 
-    init: function ($button, $context) {
-      this.$container      = $context;
-      this.$uploadButton   = $button
+      // this.$fileInput = $input;
+      
+      // this.button.$original = this.$fileInput.parent();
+      // this.button.id = this.$fileInput.attr('id');
+      // this.button.name = this.$fileInput.attr('name');
+      // this.$container = this.$fileInput.closest(container);
 
-      this.$uploadButton.on('change', function(event) {
-        var file = event.target.value;
-        var start = file.indexOf("fakepath\\");
+      // console.log(this.button);
 
-        console.log(file);
+      // this.$fileInput.on('change', function (event) {
+      //   var fileName = _this.getFileName(event.target.value);
 
-        if (start >= 0) {
-          file = file.substring(start + 9, file.length);
-        }
-
-      });
-    }
+      //   _this.buildReplacementInterface(fileName);
+      // });
+    },
   };
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadFallback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadFallback.js
@@ -1,0 +1,31 @@
+/**
+ * Provides a fallback for customized file input if the File API is not supported.
+ */
+define(function(require) {
+  "use strict";
+
+  var $ = require("jquery");
+
+  var ImageUploadFallback = {
+
+    init: function ($button, $context) {
+      this.$container      = $context;
+      this.$uploadButton   = $button
+
+      this.$uploadButton.on('change', function(event) {
+        var file = event.target.value;
+        var start = file.indexOf("fakepath\\");
+
+        console.log(file);
+
+        if (start >= 0) {
+          file = file.substring(start + 9, file.length);
+        }
+
+      });
+    }
+  };
+
+
+  return ImageUploadFallback;
+});

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadFallback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadFallback.js
@@ -12,10 +12,12 @@ define(function(require) {
   var ImageUploadFallback = {
 
     component: {
-      $origButton: null,
-      $newButton: null,
+      $container: null,
+      $fileInterface: null,
+      $indicator: null,
+      $input: null,
+      fileName: null,
       id: null,
-      name: null,
       classes: [
         'button',
         'button--file',
@@ -26,32 +28,106 @@ define(function(require) {
 
     /**
      * Initialize the fallback file input script.
-     * @param  jQuery Object $input    Button input from form.
-     * @param  String        container Class name for container that should house fallback content.
+     * @param  jQuery  $input     Button input from form.
+     * @param  string  container  Container Class name for container that should house fallback components.
      * @return void
      */
     init: function ($input, container) {
-      _this = this;
+      $input.attr('class', '');
 
-      console.log($input);
-      console.log(this.component);
+      this.component.$input = $input;
+      this.component.id = $input.attr('id');
+      this.component.$container = $(container);
 
-      this.$fileInput = $input;
+      this.activateInput(this.component.$input);
+    },
 
-      this.component.$origButton = this.$fileInput.parent();
-      // this.button.id = this.$fileInput.attr('id');
-      // this.button.name = this.$fileInput.attr('name');
-      // this.$container = this.$fileInput.closest(container);
 
-      // console.log(this.button);
+    /**
+     * Activate the input to watch for file input change event.
+     * @param  jQuery  $input Specific file input.
+     * @return void
+     */
+    activateInput: function ($input) {
+      var _this = this;
 
-      this.$fileInput.on('change', function (event) {
-        console.log(_this.component);
-      //   var fileName = _this.getFileName(event.target.value);
+      $input.on('change', function (event) {
+        _this.component.fileName = _this.getFileName(event.target.value);
 
-      //   _this.buildReplacementInterface(fileName);
+        if (_this.component.$fileInterface) {
+          _this.updateFileSelection();
+        }
+        else {
+          _this.buildUpatedComponent();
+        }
       });
     },
+
+
+    /**
+     * Remove markup from the specified container.
+     * Clear it out to insert new interface.
+     * @return void
+     */
+    emptyContainer: function () {
+      this.component.$container.html('');
+    },
+
+
+    /**
+     * Get the file name for the uploaded file.
+     * @param  string  path  Full path string for uploaded image.
+     * @return string        Extracted file name from the full path.
+     */
+    getFileName: function (path) {
+      var start = path.indexOf("fakepath\\");
+
+      if (start >= 0) {
+        return path.substring(start + 9, path.length); // 9 is length of "fakepath\"
+      }
+
+      return path;
+    },
+
+
+    /**
+     * Construct the new interface component for the file api fallback.
+     * @return void
+     */
+    buildUpatedComponent: function () {
+      var data = {
+        "id": this.component.id,
+        "classes": this.component.classes.join(' '),
+        "file": this.component.fileName
+      };
+      var $markup = $(_.template(fallbackUploadTplSrc, data));
+
+      this.component.$input.detach();
+      $markup.find('.button--file').append(this.component.$input);
+
+      this.emptyContainer();
+      this.component.$indicator = $markup.find('.file-selection__name');
+      this.component.$fileInterface = $markup;
+      this.insertUpdatedComponent();
+    },
+
+
+    /**
+     * Insert the new interface into the specified container.
+     * @return void
+     */
+    insertUpdatedComponent: function () {
+      this.component.$container.prepend(this.component.$fileInterface);
+    },
+
+
+    /**
+     * Update just the file name displayed in the new file api interface.
+     * @return void
+     */
+    updateFileSelection: function () {
+      this.component.$indicator.text(this.component.fileName);
+    }
   };
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadFallback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadFallback.js
@@ -8,7 +8,22 @@ define(function(require) {
   var _                    = require("lodash");
   var fallbackUploadTplSrc = require("text!images/templates/fallback-upload-interface.tpl.html");
 
+
   var ImageUploadFallback = {
+
+    component: {
+      $origButton: null,
+      $newButton: null,
+      id: null,
+      name: null,
+      classes: [
+        'button',
+        'button--file',
+        '-tertiary'
+      ]
+    },
+
+
     /**
      * Initialize the fallback file input script.
      * @param  jQuery Object $input    Button input from form.
@@ -17,23 +32,25 @@ define(function(require) {
      */
     init: function ($input, container) {
       _this = this;
-      
-      console.log($input);
 
-      // this.$fileInput = $input;
-      
-      // this.button.$original = this.$fileInput.parent();
+      console.log($input);
+      console.log(this.component);
+
+      this.$fileInput = $input;
+
+      this.component.$origButton = this.$fileInput.parent();
       // this.button.id = this.$fileInput.attr('id');
       // this.button.name = this.$fileInput.attr('name');
       // this.$container = this.$fileInput.closest(container);
 
       // console.log(this.button);
 
-      // this.$fileInput.on('change', function (event) {
+      this.$fileInput.on('change', function (event) {
+        console.log(_this.component);
       //   var fileName = _this.getFileName(event.target.value);
 
       //   _this.buildReplacementInterface(fileName);
-      // });
+      });
     },
   };
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/templates/fallback-upload-interface.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/templates/fallback-upload-interface.tpl.html
@@ -1,0 +1,5 @@
+<p class="field-file-name"><strong>Selected Photo:</strong> <span><%= file %></span></p>
+<label class="<%= classes %>" id="<%= id %>">
+  <span>Change photo</span>
+  <input type="file" aria-label="file" id="<%= id %>" name="<%= name %>" />
+</label>

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/templates/fallback-upload-interface.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/templates/fallback-upload-interface.tpl.html
@@ -1,5 +1,8 @@
-<p class="field-file-name"><strong>Selected Photo:</strong> <span><%= file %></span></p>
-<label class="<%= classes %>" id="<%= id %>">
-  <span>Change photo</span>
-  <input type="file" aria-label="file" id="<%= id %>" name="<%= name %>" />
-</label>
+<div class="file-selection">
+  <p class="file-selection__indicator">
+    <strong>Selected Photo:</strong> <span class="file-selection__name"><%= file %></span>
+  </p>
+  <label class="<%= classes %>" for="<%= id %>">
+    <span>Change photo</span>
+  </label>
+</div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -62,7 +62,12 @@ define(function(require) {
         this.enableResponsive();
       }
 
-      Modernizr.filereader ? this.imageUploadInit() : ImageUploadFallback.init(this.$uploadButton, '.reportback__submissions');
+      if (Modernizr.filereader) {
+        this.imageUploadInit()
+      }
+      else {
+         ImageUploadFallback.init(this.$uploadButton, '.reportback__submissions');
+      }
     },
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -1,11 +1,12 @@
 define(function(require) {
   "use strict";
 
-  var $                = require("jquery");
-  var _                = require("lodash");
-  var Modal            = require("modal");
-  var ImageUploadBeta  = require("../images/ImageUploadBeta");
-  var reportbackTplSrc = require("text!reportback/templates/reportback.tpl.html");
+  var $                   = require("jquery");
+  var _                   = require("lodash");
+  var Modal               = require("modal");
+  var ImageUploadBeta     = require("../images/ImageUploadBeta");
+  var ImageUploadFallback = require("../images/ImageUploadFallback");
+  var reportbackTplSrc    = require("text!reportback/templates/reportback.tpl.html");
 
 
   var Reportback = {
@@ -61,13 +62,11 @@ define(function(require) {
         this.enableResponsive();
       }
 
-      if (Modernizr.filereader) {
-        this.imageUploadInit();
-      }
+      !Modernizr.filereader ? this.imageUploadInit() : ImageUploadFallback.init(this.$uploadButton, this.$reportbackForm);
     },
 
 
-    imageUploadInit: function() {
+    imageUploadInit: function () {
       var _this = this;
       var imageUpload = new ImageUploadBeta(this.$uploadButton);
       var submittedImage = this.$reportbackForm.find(".submitted-image").length > 0;
@@ -82,6 +81,7 @@ define(function(require) {
         _this.$captionField.show();
       });
     },
+
 
     /**
      * Add the reportback entries to the DOM.

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -62,7 +62,7 @@ define(function(require) {
         this.enableResponsive();
       }
 
-      !Modernizr.filereader ? this.imageUploadInit() : ImageUploadFallback.init(this.$uploadButton, '.reportback__submissions');
+      Modernizr.filereader ? this.imageUploadInit() : ImageUploadFallback.init(this.$uploadButton, '.reportback__submissions');
     },
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -62,7 +62,7 @@ define(function(require) {
         this.enableResponsive();
       }
 
-      !Modernizr.filereader ? this.imageUploadInit() : ImageUploadFallback.init(this.$uploadButton, this.$reportbackForm);
+      !Modernizr.filereader ? this.imageUploadInit() : ImageUploadFallback.init(this.$uploadButton, '.reportback__submissions');
     },
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -63,7 +63,7 @@ define(function(require) {
       }
 
       if (Modernizr.filereader) {
-        this.imageUploadInit()
+        this.imageUploadInit();
       }
       else {
          ImageUploadFallback.init(this.$uploadButton, '.reportback__submissions');

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
@@ -189,6 +189,16 @@
     text-transform: lowercase;
     width: auto;
   }
+
+  .field-file-name {
+    background-color: $light-gray;
+    font-size: $font-smaller;
+    padding: ($base-spacing / 2);
+
+    span {
+      font-style: italic;
+    }
+  }
 }
 
 .reportback__submissions-latest {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
@@ -1,5 +1,5 @@
 // @TODO: Patternize and move/merge into Neue!
-// Potentially rework into being part of the 
+// Potentially rework into being part of the
 // .media pattern.
 .photo {
 
@@ -46,7 +46,7 @@
     background-color: transparent;
     display: none;
     width: ($base-spacing / 2);
-  
+
     @include media($medium) {
       display: table-cell;
     }
@@ -122,7 +122,7 @@
     &:first-child { margin-top: 0; }
     &:nth-child(2) { margin-top: 0; }
     &.-second { margin-top: 0; }  // IE8fix
-    
+
     @include media($medium) {
       @include span(100%);
       float: none;
@@ -137,7 +137,7 @@
       &:nth-child(2) { margin-top: 0; }
       &.-second { margin-top: 0; }  // IE8fix
     }
-    
+
     &:nth-child(n+5) {
       display: none;
 
@@ -172,7 +172,7 @@
 // Temporary additions to work through fix for upload button issues.
 .reportback__submissions {
   margin-bottom: ($base-spacing / 2);
-  
+
   figure {
     img { width: 100%; }
   }
@@ -190,14 +190,18 @@
     width: auto;
   }
 
-  .field-file-name {
+  .file-selection {
+    padding-bottom: $base-spacing;
+  }
+
+  .file-selection__indicator {
     background-color: $light-gray;
     font-size: $font-smaller;
     padding: ($base-spacing / 2);
+  }
 
-    span {
-      font-style: italic;
-    }
+  .file-selection__name {
+    font-style: italic;
   }
 }
 
@@ -219,9 +223,9 @@
   @include list_reset();
   margin: 0 (-($base-spacing / 2));
 
-  > li { 
+  > li {
     float: left;
-    width: span(25%); 
+    width: span(25%);
   }
 }
 
@@ -233,7 +237,7 @@
   height: 270px;
   margin: 0;
   position: relative;
-  
+
   @include media($medium) {
     height: 0;
     padding-bottom: 100%;
@@ -261,7 +265,7 @@
   &:hover:before {
     background-color: lighten($blue, $color-tint);
   }
-  
+
   > .message-callout {
     bottom: 0;
     left: 50%;

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/requirejs.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/requirejs.js
@@ -12,7 +12,7 @@ module.exports = {
         compress: {
           dead_code: true,
           drop_debugger: true,
-          drop_console: true,
+          drop_console: false,
           global_defs: {
             DEBUG: false
           }

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/requirejs.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/requirejs.js
@@ -12,7 +12,7 @@ module.exports = {
         compress: {
           dead_code: true,
           drop_debugger: true,
-          drop_console: false,
+          drop_console: true,
           global_defs: {
             DEBUG: false
           }


### PR DESCRIPTION
## Fixes #3699

This script provides a fallback interface for the file upload on the Reportback 2.0 when a browser does not support the File API.

The fallback interface will show a more streamlined interface (AFTER activating the input to add a photo) with the file name selected along with a link to _change photo_ if the user would like to select a different image before submitting.

![image](https://cloud.githubusercontent.com/assets/105849/6134016/2904556e-b12c-11e4-9e4d-dc06cdfb8508.png)
