### PR TITLE
Update Campaign RB Totals upon Reportback File Save 

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -104,9 +104,6 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
   // Display mode for rendering each Reportback File.
   $view_mode = 'full';
 
-  $entity_type = NULL;
-  $entity_id = NULL;
-
   // If we are viewing a reportback entity:
   if (isset($entity->rbid) && arg(0) === 'reportback') {
     $params['rbid'] = $entity->rbid;
@@ -115,30 +112,15 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
   }
   elseif (isset($entity->nid)) {
     $params['nid'] = $entity->nid;
-    $entity_id = $entity->nid;
-    $entity_type = 'node';
   }
   elseif (isset($entity->tid)) {
     $params['tid'] = $entity->tid;
-    $entity_id = $entity->tid;
-    $entity_type = 'taxonomy_term';
   }
 
   $form['view_mode'] = array(
     '#type' => 'hidden',
     '#value' => $view_mode,
   );
-
-  if (isset($entity_type)) {
-    $form['entity_type'] = array(
-      '#type' => 'hidden',
-      '#value' => $entity_type,
-    );
-    $form['entity_id'] = array(
-      '#type' => 'hidden',
-      '#value' => $entity_id,
-    );
-  }
 
   $page_size = 25;
   if (isset($_GET['pagesize'])) {
@@ -244,9 +226,6 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
       form_set_error(t("An error has occurred."));
     }
 
-  }
-  if (isset($form_state['values']['entity_type'])) {
-    dosomething_reportback_reset_count($form_state['values']['entity_type'], $form_state['values']['entity_id']);
   }
 
   drupal_set_message(t("Updated."));

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -973,7 +973,7 @@ function dosomething_reportback_get_reportback_files_query_count($params, $reset
 /**
  * Resets Reportback Count variables for given entity type and entity_id.
  */
-function dosomething_reportback_reset_count($entity_type, $entity_id) {
+function dosomething_reportback_reset_count($entity_type, $entity_id, $status = NULL) {
   $params = array();
   if ($entity_type == 'node') {
     $params['nid'] = $entity_id;
@@ -981,6 +981,14 @@ function dosomething_reportback_reset_count($entity_type, $entity_id) {
   elseif ($entity_type == 'taxonomy_term') {
     $params['tid'] = $entity_id;
   }
+
+  // If a status is provided, reset its count.
+  if (isset($status)) {
+    $params['status'] = $status;
+    return dosomething_reportback_get_reportback_files_query_count($params, TRUE);
+  }
+
+  // Otherwise reset for all status counts.
   $status_values = dosomething_reportback_get_file_status_values();
   foreach ($status_values as $status) {
     $params['status'] = $status;

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -108,15 +108,14 @@ class ReportbackEntity extends Entity {
     if ($this->flagged) {
       $status = 'flagged';
     }
-    return db_insert($this->files_table)
-      ->fields(array(
-          'rbid' => $this->rbid,
-          'fid' => $values->fid,
-          'caption' => $values->caption,
-          'remote_addr' => dosomething_helpers_ip_address(),
-          'status' => $status,
-        ))
-      ->execute();
+    $reportback_file = entity_create('reportback_file', array(
+      'rbid' => $this->rbid,
+      'fid' => $values->fid,
+      'caption' => $values->caption,
+      'remote_addr' => dosomething_helpers_ip_address(),
+      'status' => $status,
+    ));
+    return $reportback_file->save();
   }
 
   /**

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback_file.inc
@@ -169,6 +169,26 @@ class ReportbackFileEntityController extends EntityAPIController {
   }
 
   /**
+   * Overrides save() method.
+   *
+   * Updates count variables for corresponding nodes and taxonomy terms.
+   */
+  public function save($entity, DatabaseTransaction $transaction = NULL) {
+    if (DOSOMETHING_REPORTBACK_LOG) {
+      watchdog('dosomething_reportback_file', 'save:' . json_encode($entity));
+    }
+    $status = NULL;
+    if (isset($entity->is_new)) {
+      $op = 'insert';
+      $status = 'pending';
+    }
+    parent::save($entity, $transaction);
+    // Update the pending count for the node reportback was saved for.
+    $reportback = reportback_load($entity->rbid);
+    dosomething_reportback_reset_count('node', $reportback->nid, $status);
+  }
+
+  /**
    * Overrides delete() method.
    */
   public function delete($ids, DatabaseTransaction $transaction = NULL) {


### PR DESCRIPTION
Per convo with @sergii-tkachenko today re: #3874

Instead of relying on the Review Form to calculate Entity Reportback totals, calculate the relevant total per saving a Reportback File.

This PR calculates the total for the node reported back on. Following PR will update the node's Cause term totals.
