### PR TITLE
Remove username from password_reset MBP payload

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -124,7 +124,6 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
 
     case 'user_password':
       $payload['merge_vars']['FNAME'] = $params['first_name'];
-      $payload['merge_vars']['USERNAME'] = $params['username'];
       $payload['merge_vars']['RESET_LINK'] = $params['reset_link'];
       $payload['email_tags'][] = 'drupal_user_password';
       break;

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -408,7 +408,6 @@ function dosomething_user_user_pass_submit($form, &$form_state) {
         'email' => $account->mail,
         'uid' => $account->uid,
         'first_name' => dosomething_user_get_field('field_first_name', $account),
-        'username' => $account->name,
         'reset_link' => user_pass_reset_url($account),
       );
       if (module_exists('dosomething_mbp')) {


### PR DESCRIPTION
Fixes #3921 

Remove `username` from mbp password_reset payload as it's not used by the Mandrill template.
