### PR TITLE
Remove EXIF data from file

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -71,7 +71,6 @@ define(function(require) {
 
             // When the user submits the modal form, send crop values to the form.
             _this.$imageForm.submit(function(event) {
-              console.log("close");
               // @TODO: This is a temporary solution until Neue is updated with capacity
               // to distinguish between a client side only form.
               // if (_this.$imageForm.data('validation-passed')) {}

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -78,75 +78,138 @@ define(function(require) {
                 }, this);
                 newPieces.push(this.result.slice(recess));
                 var br = new Blob(newPieces, {type: 'image/jpeg'});
-                window.open(URL.createObjectURL(br), "_blank", "toolbar=yes, scrollbars=yes, resizable=yes, top=500, left=500, width=400, height=400");
+
+                var urlCreator = window.URL || window.webkitURL;
+                var imageUrl = urlCreator.createObjectURL( br );
+
+                var image = new Image();
+                image.src = imageUrl;
+
+                image.onload = function() {
+                  var image = this;
+                  var isValid = _this.validImage(this);
+                  var $errorMsg = _this.$uploadButton.parent().siblings(".error");
+
+                  if(isValid) {
+                    // Remove any previously added error message.
+                    if ($errorMsg.length) {
+                      $errorMsg.remove();
+                    }
+
+                    // Open the modal.
+                    _this.openModal();
+
+                    // Add the preview image to the modal
+                    _this.previewImage(image, _this.$imagePreview);
+
+                    // When the user submits the modal form, send crop values to the form.
+                    _this.$imageForm.submit(function(event) {
+                      console.log("close");
+                      // @TODO: This is a temporary solution until Neue is updated with capacity
+                      // to distinguish between a client side only form.
+                      // if (_this.$imageForm.data('validation-passed')) {}
+                      event.preventDefault();
+
+                      // Send crop information to the main reportback form
+                      // so backend can use to crop.
+                      ImageCrop.populateFields(_this.$reportbackForm);
+
+                      // Create a crop preview on the client side.
+                      ImageCropPreview.cropPreview(image,_this.getCropValues());
+
+                      // Add a button to edit the image.
+                      _this.createEditButton();
+
+                      // The user clicked "done", so we can save this version of the crop
+                      // and not reset the file field.
+                      _this.readyToSave = true;
+
+                      // Close the modal.
+                      Modal.close();
+                    });
+                  }
+                  // Show user an error if they upload an image that is too small.
+                  else {
+                    if (!$errorMsg.length) {
+                      var $error = $("<div class='messages error'>Please upload a larger photo. Min. size is 480px by 480px.</div>");
+                      $error.insertAfter(_this.$uploadButton.parent());
+                    }
+                  }
+
+                }
+
+                // window.open(URL.createObjectURL(br), "_blank", "toolbar=yes, scrollbars=yes, resizable=yes, top=500, left=500, width=400, height=400");
             }
         }
       }
 
 
-      if (/^image/.test( files[0].type)) {
-        var reader = new FileReader();
-        reader.readAsDataURL(files[0]);
+      // if (/^image/.test( files[0].type)) {
+      //   var reader = new FileReader();
+      //   reader.readAsDataURL(files[0]);
 
-        reader.onloadend = function() {
-          var result = this.result;
+      //   // var urlCreator = window.URL || window.webkitURL;
+      //   // var imageUrl = urlCreator.createObjectURL( _this.blob );
 
-          var image = new Image();
-          image.src = result;
+      //   reader.onloadend = function() {
+      //     var result = this.result;
 
-          image.onload = function() {
-            var image = this;
-            var isValid = _this.validImage(this);
-            var $errorMsg = _this.$uploadButton.parent().siblings(".error");
+      //     var image = new Image();
+      //     image.src = result;
 
-            if(isValid) {
-              // Remove any previously added error message.
-              if ($errorMsg.length) {
-                $errorMsg.remove();
-              }
+      //     image.onload = function() {
+      //       var image = this;
+      //       var isValid = _this.validImage(this);
+      //       var $errorMsg = _this.$uploadButton.parent().siblings(".error");
 
-              // Open the modal.
-              _this.openModal();
+      //       if(isValid) {
+      //         // Remove any previously added error message.
+      //         if ($errorMsg.length) {
+      //           $errorMsg.remove();
+      //         }
 
-              // Add the preview image to the modal
-              _this.previewImage(image, _this.$imagePreview);
+      //         // Open the modal.
+      //         _this.openModal();
 
-              // When the user submits the modal form, send crop values to the form.
-              _this.$imageForm.submit(function(event) {
+      //         // Add the preview image to the modal
+      //         _this.previewImage(image, _this.$imagePreview);
 
-                // @TODO: This is a temporary solution until Neue is updated with capacity
-                // to distinguish between a client side only form.
-                // if (_this.$imageForm.data('validation-passed')) {}
-                event.preventDefault();
+      //         // When the user submits the modal form, send crop values to the form.
+      //         _this.$imageForm.submit(function(event) {
 
-                // Send crop information to the main reportback form
-                // so backend can use to crop.
-                ImageCrop.populateFields(_this.$reportbackForm);
+      //           // @TODO: This is a temporary solution until Neue is updated with capacity
+      //           // to distinguish between a client side only form.
+      //           // if (_this.$imageForm.data('validation-passed')) {}
+      //           event.preventDefault();
 
-                // Create a crop preview on the client side.
-                ImageCropPreview.cropPreview(image,_this.getCropValues());
+      //           // Send crop information to the main reportback form
+      //           // so backend can use to crop.
+      //           ImageCrop.populateFields(_this.$reportbackForm);
 
-                // Add a button to edit the image.
-                _this.createEditButton();
+      //           // Create a crop preview on the client side.
+      //           ImageCropPreview.cropPreview(image,_this.getCropValues());
 
-                // The user clicked "done", so we can save this version of the crop
-                // and not reset the file field.
-                _this.readyToSave = true;
+      //           // Add a button to edit the image.
+      //           _this.createEditButton();
 
-                // Close the modal.
-                Modal.close();
-              });
-            }
-            // Show user an error if they upload an image that is too small.
-            else {
-              if (!$errorMsg.length) {
-                var $error = $("<div class='messages error'>Please upload a larger photo. Min. size is 480px by 480px.</div>");
-                $error.insertAfter(_this.$uploadButton.parent());
-              }
-            }
-          };
-        };
-      }
+      //           // The user clicked "done", so we can save this version of the crop
+      //           // and not reset the file field.
+      //           _this.readyToSave = true;
+
+      //           // Close the modal.
+      //           Modal.close();
+      //         });
+      //       }
+      //       // Show user an error if they upload an image that is too small.
+      //       else {
+      //         if (!$errorMsg.length) {
+      //           var $error = $("<div class='messages error'>Please upload a larger photo. Min. size is 480px by 480px.</div>");
+      //           $error.insertAfter(_this.$uploadButton.parent());
+      //         }
+      //       }
+      //     };
+      //   };
+      // }
     });
 
     // Close the modal when a user wants to change their photo.

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -45,6 +45,45 @@ define(function(require) {
         return;
       }
 
+      var fr = new FileReader();
+      fr.readAsArrayBuffer(this.files[0]);
+      fr.onload = function (){
+        var dv = new DataView(this.result);
+        var offset = 0, recess = 0;
+        var pieces = [];
+        var i = 0;
+        if (dv.getUint16(offset) == 0xffd8){
+            offset += 2;
+            var app1 = dv.getUint16(offset);
+            offset += 2;
+            while (offset < dv.byteLength){
+                console.log(offset, '0x'+app1.toString(16), recess);
+                if (app1 == 0xffe1){
+
+                    pieces[i] = {recess:recess,offset:offset-2};
+                    recess = offset + dv.getUint16(offset);
+                    i++;
+                }
+                else if (app1 == 0xffda){
+                    break;
+                }
+                offset += dv.getUint16(offset);
+                var app1 = dv.getUint16(offset);
+                offset += 2;
+            }
+            if (pieces.length > 0){
+                var newPieces = [];
+                pieces.forEach(function(v){
+                    newPieces.push(this.result.slice(v.recess, v.offset));
+                }, this);
+                newPieces.push(this.result.slice(recess));
+                var br = new Blob(newPieces, {type: 'image/jpeg'});
+                window.open(URL.createObjectURL(br), "_blank", "toolbar=yes, scrollbars=yes, resizable=yes, top=500, left=500, width=400, height=400");
+            }
+        }
+      }
+
+
       if (/^image/.test( files[0].type)) {
         var reader = new FileReader();
         reader.readAsDataURL(files[0]);

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -48,168 +48,62 @@ define(function(require) {
       var fr = new FileReader();
       fr.readAsArrayBuffer(this.files[0]);
       fr.onload = function (){
-        var dv = new DataView(this.result);
-        var offset = 0, recess = 0;
-        var pieces = [];
-        var i = 0;
-        if (dv.getUint16(offset) == 0xffd8){
-            offset += 2;
-            var app1 = dv.getUint16(offset);
-            offset += 2;
-            while (offset < dv.byteLength){
-                console.log(offset, '0x'+app1.toString(16), recess);
-                if (app1 == 0xffe1){
+        var imageUrl = _this.getStrippedBlob(this.result);
+        var image = new Image();
+        image.src = imageUrl;
 
-                    pieces[i] = {recess:recess,offset:offset-2};
-                    recess = offset + dv.getUint16(offset);
-                    i++;
-                }
-                else if (app1 == 0xffda){
-                    break;
-                }
-                offset += dv.getUint16(offset);
-                var app1 = dv.getUint16(offset);
-                offset += 2;
+        image.onload = function() {
+          var image = this;
+          var isValid = _this.validImage(this);
+          var $errorMsg = _this.$uploadButton.parent().siblings(".error");
+
+          if(isValid) {
+            // Remove any previously added error message.
+            if ($errorMsg.length) {
+              $errorMsg.remove();
             }
-            if (pieces.length > 0){
-                var newPieces = [];
-                pieces.forEach(function(v){
-                    newPieces.push(this.result.slice(v.recess, v.offset));
-                }, this);
-                newPieces.push(this.result.slice(recess));
-                var br = new Blob(newPieces, {type: 'image/jpeg'});
 
-                var urlCreator = window.URL || window.webkitURL;
-                var imageUrl = urlCreator.createObjectURL( br );
+            // Open the modal.
+            _this.openModal();
 
-                var image = new Image();
-                image.src = imageUrl;
+            // Add the preview image to the modal
+            _this.previewImage(image, _this.$imagePreview);
 
-                image.onload = function() {
-                  var image = this;
-                  var isValid = _this.validImage(this);
-                  var $errorMsg = _this.$uploadButton.parent().siblings(".error");
+            // When the user submits the modal form, send crop values to the form.
+            _this.$imageForm.submit(function(event) {
+              console.log("close");
+              // @TODO: This is a temporary solution until Neue is updated with capacity
+              // to distinguish between a client side only form.
+              // if (_this.$imageForm.data('validation-passed')) {}
+              event.preventDefault();
 
-                  if(isValid) {
-                    // Remove any previously added error message.
-                    if ($errorMsg.length) {
-                      $errorMsg.remove();
-                    }
+              // Send crop information to the main reportback form
+              // so backend can use to crop.
+              ImageCrop.populateFields(_this.$reportbackForm);
 
-                    // Open the modal.
-                    _this.openModal();
+              // Create a crop preview on the client side.
+              ImageCropPreview.cropPreview(image,_this.getCropValues());
 
-                    // Add the preview image to the modal
-                    _this.previewImage(image, _this.$imagePreview);
+              // Add a button to edit the image.
+              _this.createEditButton();
 
-                    // When the user submits the modal form, send crop values to the form.
-                    _this.$imageForm.submit(function(event) {
-                      console.log("close");
-                      // @TODO: This is a temporary solution until Neue is updated with capacity
-                      // to distinguish between a client side only form.
-                      // if (_this.$imageForm.data('validation-passed')) {}
-                      event.preventDefault();
+              // The user clicked "done", so we can save this version of the crop
+              // and not reset the file field.
+              _this.readyToSave = true;
 
-                      // Send crop information to the main reportback form
-                      // so backend can use to crop.
-                      ImageCrop.populateFields(_this.$reportbackForm);
-
-                      // Create a crop preview on the client side.
-                      ImageCropPreview.cropPreview(image,_this.getCropValues());
-
-                      // Add a button to edit the image.
-                      _this.createEditButton();
-
-                      // The user clicked "done", so we can save this version of the crop
-                      // and not reset the file field.
-                      _this.readyToSave = true;
-
-                      // Close the modal.
-                      Modal.close();
-                    });
-                  }
-                  // Show user an error if they upload an image that is too small.
-                  else {
-                    if (!$errorMsg.length) {
-                      var $error = $("<div class='messages error'>Please upload a larger photo. Min. size is 480px by 480px.</div>");
-                      $error.insertAfter(_this.$uploadButton.parent());
-                    }
-                  }
-
-                }
-
-                // window.open(URL.createObjectURL(br), "_blank", "toolbar=yes, scrollbars=yes, resizable=yes, top=500, left=500, width=400, height=400");
+              // Close the modal.
+              Modal.close();
+            });
+          }
+          // Show user an error if they upload an image that is too small.
+          else {
+            if (!$errorMsg.length) {
+              var $error = $("<div class='messages error'>Please upload a larger photo. Min. size is 480px by 480px.</div>");
+              $error.insertAfter(_this.$uploadButton.parent());
             }
+          }
         }
       }
-
-
-      // if (/^image/.test( files[0].type)) {
-      //   var reader = new FileReader();
-      //   reader.readAsDataURL(files[0]);
-
-      //   // var urlCreator = window.URL || window.webkitURL;
-      //   // var imageUrl = urlCreator.createObjectURL( _this.blob );
-
-      //   reader.onloadend = function() {
-      //     var result = this.result;
-
-      //     var image = new Image();
-      //     image.src = result;
-
-      //     image.onload = function() {
-      //       var image = this;
-      //       var isValid = _this.validImage(this);
-      //       var $errorMsg = _this.$uploadButton.parent().siblings(".error");
-
-      //       if(isValid) {
-      //         // Remove any previously added error message.
-      //         if ($errorMsg.length) {
-      //           $errorMsg.remove();
-      //         }
-
-      //         // Open the modal.
-      //         _this.openModal();
-
-      //         // Add the preview image to the modal
-      //         _this.previewImage(image, _this.$imagePreview);
-
-      //         // When the user submits the modal form, send crop values to the form.
-      //         _this.$imageForm.submit(function(event) {
-
-      //           // @TODO: This is a temporary solution until Neue is updated with capacity
-      //           // to distinguish between a client side only form.
-      //           // if (_this.$imageForm.data('validation-passed')) {}
-      //           event.preventDefault();
-
-      //           // Send crop information to the main reportback form
-      //           // so backend can use to crop.
-      //           ImageCrop.populateFields(_this.$reportbackForm);
-
-      //           // Create a crop preview on the client side.
-      //           ImageCropPreview.cropPreview(image,_this.getCropValues());
-
-      //           // Add a button to edit the image.
-      //           _this.createEditButton();
-
-      //           // The user clicked "done", so we can save this version of the crop
-      //           // and not reset the file field.
-      //           _this.readyToSave = true;
-
-      //           // Close the modal.
-      //           Modal.close();
-      //         });
-      //       }
-      //       // Show user an error if they upload an image that is too small.
-      //       else {
-      //         if (!$errorMsg.length) {
-      //           var $error = $("<div class='messages error'>Please upload a larger photo. Min. size is 480px by 480px.</div>");
-      //           $error.insertAfter(_this.$uploadButton.parent());
-      //         }
-      //       }
-      //     };
-      //   };
-      // }
     });
 
     // Close the modal when a user wants to change their photo.
@@ -349,6 +243,75 @@ define(function(require) {
         ImageCrop.dsCropperInit(image);
       }
     });
+  };
+
+  /**
+   * This function strips out EXIF data from a file and recreates a
+   * FileReader Blob that we use to create the image object that is used
+   * in the modal. This way we only deal with the RAW image file on both
+   * mobile and desktop with out having to wory about it rendering differently
+   * and causing all of our image cropping/preview logic to be wrong.
+   *
+   * @TODO!!!!
+   * This code is UGLY and complicated. Largely, if not entirely, based on this
+   * flickr blog post: http://code.flickr.net/2012/06/01/parsing-exif-client-side-using-javascript-2/
+   * and this JS fiddle. http://jsfiddle.net/mowglisanu/frhwm2xe/3/
+   * We need to revist this, some options:
+   *  - We can try writing our own EXIF parser to remove or edit orientation data
+   *  - Use the exif-js (https://github.com/jseidelin/exif-js) library to read EXIF information
+   *    and try to update or crop preview logic based on the EXIF data.
+   */
+  ImageUploadBeta.prototype.getStrippedBlob = function(fileReaderResult) {
+    var dv = new DataView(fileReaderResult);
+    var offset = 0;
+    var recess = 0;
+    var pieces = [];
+    var i = 0;
+    var imageUrl;
+
+    if (dv.getUint16(offset) == 0xffd8) {
+      offset   += 2;
+      var app1  = dv.getUint16(offset);
+      offset   += 2;
+
+      while (offset < dv.byteLength) {
+        if (app1 == 0xffe1) {
+          pieces[i] = {
+            recess : recess,
+            offset : offset - 2
+          };
+
+          recess = offset + dv.getUint16(offset);
+
+          i++;
+        }
+        else if (app1 == 0xffda) {
+          break;
+        }
+
+        offset   += dv.getUint16(offset);
+        var app1  = dv.getUint16(offset);
+        offset   += 2;
+      }
+
+      if (pieces.length > 0) {
+        var newPieces = [];
+
+        pieces.forEach(function(v) {
+          newPieces.push(fileReaderResult.slice(v.recess, v.offset));
+        }, this);
+
+        newPieces.push(fileReaderResult.slice(recess));
+
+        var br = new Blob(newPieces, {type: 'image/jpeg'});
+
+        var urlCreator = window.URL || window.webkitURL;
+
+        imageUrl = urlCreator.createObjectURL( br );
+      }
+    }
+
+    return imageUrl;
   };
 
   return ImageUploadBeta;

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -47,11 +47,13 @@ define(function(require) {
 
       var fr = new FileReader();
       fr.readAsArrayBuffer(this.files[0]);
-      fr.onload = function (){
-        var imageUrl = _this.getStrippedBlob(this.result);
+      fr.onload = function () {
+        var blob = _this.getStrippedBlob(this.result);
+        var urlCreator = window.URL || window.webkitURL;
+        var imageUrl = urlCreator.createObjectURL(blob);
         var image = new Image();
-        image.src = imageUrl;
 
+        image.src = imageUrl;
         image.onload = function() {
           var image = this;
           var isValid = _this.validImage(this);
@@ -261,26 +263,29 @@ define(function(require) {
    *    and try to update or crop preview logic based on the EXIF data.
    */
   ImageUploadBeta.prototype.getStrippedBlob = function(fileReaderResult) {
-    var dv = new DataView(fileReaderResult);
+    var dataView = new DataView(fileReaderResult);
     var offset = 0;
     var recess = 0;
     var pieces = [];
     var i = 0;
     var imageUrl;
+    var generatedBlob;
 
-    if (dv.getUint16(offset) == 0xffd8) {
+    if (dataView.getUint16(offset) == 0xffd8) {
       offset   += 2;
-      var app1  = dv.getUint16(offset);
+      var app1  = dataView.getUint16(offset);
       offset   += 2;
 
-      while (offset < dv.byteLength) {
+      // This loop doing the acutal reading of the data
+      // and creating an array with only the pieces we want.
+      while (offset < dataView.byteLength) {
         if (app1 == 0xffe1) {
           pieces[i] = {
             recess : recess,
             offset : offset - 2
           };
 
-          recess = offset + dv.getUint16(offset);
+          recess = offset + dataView.getUint16(offset);
 
           i++;
         }
@@ -288,11 +293,13 @@ define(function(require) {
           break;
         }
 
-        offset   += dv.getUint16(offset);
-        var app1  = dv.getUint16(offset);
+        offset   += dataView.getUint16(offset);
+        var app1  = dataView.getUint16(offset);
         offset   += 2;
       }
 
+      // If the file had EXIF data and it was removed,
+      // create a file blob with using the new array of file data.
       if (pieces.length > 0) {
         var newPieces = [];
 
@@ -302,15 +309,16 @@ define(function(require) {
 
         newPieces.push(fileReaderResult.slice(recess));
 
-        var br = new Blob(newPieces, {type: 'image/jpeg'});
-
-        var urlCreator = window.URL || window.webkitURL;
-
-        imageUrl = urlCreator.createObjectURL( br );
+        generatedBlob = new Blob(newPieces, {type: 'image/jpeg'});
+      }
+      // If no EXIF data existed on the file, then nothing was done to it.
+      // We can just create a blob with the original data.
+      else {
+        generatedBlob = new Blob([dataView], {type: 'image/jpeg'});
       }
     }
 
-    return imageUrl;
+    return generatedBlob;
   };
 
   return ImageUploadBeta;


### PR DESCRIPTION
## Problem

When images are taken with a phone or digital camera, EXIF data is attached to the image file which specifies image orientation. An image taken with a phone in "portrait" view, will actually create a landscape image, but the EXIF data tells the phone to view it as a portrait image. This was messing up the cropping and preview logic because it is heavily based on an images raw width and height, which was being flipped flopped on phones when the image was displayed. This caused the squishy image problem.
## Changes - Fixes #3909

Please see the comments in the code for more information, but basically, i'm removing the EXIF data on images entirely, allowing us to work with the RAW image on the front end. But since users can rotate images, if a portrait image appears landscape to the user, they can just rotate it back it's correct orientation.

@DoSomething/front-end 
/cc @mikefantini 
