### PR TITLE
Updates Contact Us modal to use new modal blocks.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
@@ -14,8 +14,12 @@
       <?php print t('Questions?'); ?> <a href="#" data-modal-href="#modal-contact-form"><?php print t('Contact Us'); ?></a>
       <div data-modal id="modal-contact-form" class="modal--contact" role="dialog">
         <h2 class="heading -banner"><?php print t('Contact Us'); ?></h2>
-        <p><?php print $zendesk_form_header; ?></p>
-        <?php print render($zendesk_form); ?>
+        <div class="modal__block">
+          <p><?php print $zendesk_form_header; ?></p>
+        </div>
+        <div class="modal__block">
+          <?php print render($zendesk_form); ?>
+        </div>
       </div>
     </div>
     <?php endif; ?>


### PR DESCRIPTION
# Changes
- The Contact Us modal didn't get the new `.modal__block` containers added in Neue 6.0-beta5. This adds them.

Fixes #3933. For review: @DoSomething/front-end 
