### PR TITLE
Prefer square-crop over poster on mobile video tiles.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/tiles.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/tiles.js
@@ -19,7 +19,7 @@ define(function(require) {
    * attribute of the video, or an included `img` fallback source.
    */
   function replaceVideoWithImage() {
-    var poster = $(this).attr('poster') || $(this).find('img').attr('src');
+    var poster = $(this).find('img').attr('src') || $(this).attr('poster');
     $(this).replaceWith($("<img>").attr('src', poster));
   }
 


### PR DESCRIPTION
# Changes
- Prefer nested images over the poster when setting fallback image on mobile. See DoSomething/neue#430.

Still considering whether there's a better solution for feature-detecting this!
For review: @DoSomething/front-end 
