### PR TITLE
Reportback rotate fix

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
@@ -279,7 +279,6 @@ define(function(require) {
    * @param {number} degrees    How many degrees to rotate the image.
    */
   var rotateImage = function($image, degrees) {
-    console.log(degrees);
     var width          = $image.width();
     var height         = $image.height();
     var $cropContainer = $previewImage.parent();

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
@@ -279,6 +279,7 @@ define(function(require) {
    * @param {number} degrees    How many degrees to rotate the image.
    */
   var rotateImage = function($image, degrees) {
+    console.log(degrees);
     var width          = $image.width();
     var height         = $image.height();
     var $cropContainer = $previewImage.parent();
@@ -374,7 +375,10 @@ define(function(require) {
     // Rotation
     var $rotateButton = $(".image-editor").find(".-rotate");
 
-    $rotateButton.click(function(e) {
+    // Turn off any previously bound events to this button.
+    $rotateButton.off("click");
+
+    $rotateButton.on("click", function(e) {
       e.preventDefault();
       degrees = (degrees === 360) ? 90 : degrees + 90;
       rotateImage($previewImage, degrees);

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -103,8 +103,8 @@ define(function(require) {
               $error.insertAfter(_this.$uploadButton.parent());
             }
           }
-        }
-      }
+        };
+      };
     });
 
     // Close the modal when a user wants to change their photo.
@@ -268,10 +268,9 @@ define(function(require) {
     var recess = 0;
     var pieces = [];
     var i = 0;
-    var imageUrl;
     var generatedBlob;
 
-    if (dataView.getUint16(offset) == 0xffd8) {
+    if (dataView.getUint16(offset) === 0xffd8) {
       offset   += 2;
       var app1  = dataView.getUint16(offset);
       offset   += 2;
@@ -279,7 +278,7 @@ define(function(require) {
       // This loop doing the acutal reading of the data
       // and creating an array with only the pieces we want.
       while (offset < dataView.byteLength) {
-        if (app1 == 0xffe1) {
+        if (app1 === 0xffe1) {
           pieces[i] = {
             recess : recess,
             offset : offset - 2
@@ -289,12 +288,12 @@ define(function(require) {
 
           i++;
         }
-        else if (app1 == 0xffda) {
+        else if (app1 === 0xffda) {
           break;
         }
 
         offset   += dataView.getUint16(offset);
-        var app1  = dataView.getUint16(offset);
+        app1  = dataView.getUint16(offset);
         offset   += 2;
       }
 
@@ -309,12 +308,12 @@ define(function(require) {
 
         newPieces.push(fileReaderResult.slice(recess));
 
-        generatedBlob = new Blob(newPieces, {type: 'image/jpeg'});
+        generatedBlob = new Blob(newPieces, {type: "image/jpeg"});
       }
       // If no EXIF data existed on the file, then nothing was done to it.
       // We can just create a blob with the original data.
       else {
-        generatedBlob = new Blob([dataView], {type: 'image/jpeg'});
+        generatedBlob = new Blob([dataView], {type: "image/jpeg"});
       }
     }
 


### PR DESCRIPTION
## Problem

If user closed the modal and then clicked add a new photo, the previously bound click event to the modal was being re-initiated when it opened again so it was firing twice.
# Changes - Fixes #3935

Unbind any click event on the rotate button before turning it on to reset it. Can probably do with a refactor later to just set degrees to 0 when the modal opens. 

I also cleaned up some js linting errors I was getting. 

@DoSomething/front-end 
