### PR TITLE
unbind click event when modal closes

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -100,6 +100,7 @@ define(function(require) {
     });
 
     Modal.Events.subscribe("Modal:Close", function() {
+      _this.$cropButton.off("click");
       _this.resetFileField();
     });
   };


### PR DESCRIPTION
Need to unbind the click event on the "crop" button when the modal closes so it doesn't fire multiple times when the modal re-opens.

@DoSomething/front-end 
