### PR TITLE
Displaying Campaign Run reportbacks

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -226,6 +226,26 @@ function dosomething_campaign_run_get_closed_run_nid($nid) {
 }
 
 /**
+ * For given Campaign Run $nid, return its parent Campaign $nid.
+ *
+ * @param int $nid
+ *   A Campaign Run node nid.
+ *
+ * @return mixed
+ *   Returns the parent Campaign node $nid if exists, FALSE if not.
+ */
+function dosomething_campaign_run_get_parent_nid($nid) {
+   // Query field_data_field_campaigns for campaign_run node referencing $nid.
+   $result = db_select('field_data_field_campaigns', 'c')
+    ->fields('c', array('field_campaigns_target_id'))
+    ->condition('entity_id', $nid)
+    ->condition('bundle', 'campaign_run')
+    ->condition('entity_type', 'node')
+    ->execute();
+  return $result->fetchField(0);
+}
+
+/**
  * Given a campaign form and form state, check to see if there is a campgin run.
  * Adds the campaign run nid to the campaign form.
  *

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -33,6 +33,15 @@ class ReportbackEntity extends Entity {
     if (isset($this->nid)) {
       // Set properties found on the reportback's node nid.
       $this->node_title = $this->getNodeTitle();
+
+      if (module_exists('dosomething_campaign_run')) {
+        // Check if this reportback is associated with Campaign Run node.
+        if ($parent_nid = dosomething_campaign_run_get_parent_nid($this->nid)) {
+          // Use the Campaign node nid instead of the Run nid.
+          $this->nid = $parent_nid;
+        }
+      }
+
       $this->noun = $this->getNodeSingleTextValue('field_reportback_noun');
       $this->verb = $this->getNodeSingleTextValue('field_reportback_verb');
       $this->quantity_label = $this->noun . ' ' . $this->verb;


### PR DESCRIPTION
Fixes #3947

When viewing an archived reportback associated with a campaign run (not a campaign), set the Reportback nid to the original Campaign node nid reported back on, to load the relevant Noun/Verb and links within the User Profile.
