### PR TITLE
Fixes scholarship callout on SMS campaigns.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -215,6 +215,12 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
       '#type' => 'submit',
       '#value' => $label,
     ),
+    'scholarship' => array(
+        '#markup' => theme('campaign_scholarship', array(
+          'amount' => 1000,
+          'classes' => array('-right'),
+        )),
+    ),
   );
   return $form;
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-sms.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-sms.scss
@@ -7,10 +7,10 @@
       overflow: hidden;
 
       // Callout on the top right of the form
-      .message-callout {
+      .message-callout.-above {
         margin: 0 auto;
         text-align: center;
-        width: 215px;
+        width: 250px;
 
         @include media($tablet) {
           position: absolute;
@@ -51,6 +51,7 @@
     .message-callout.-right {
       display: inline-block;
       position: relative;
+      width: 215px;
       left: ($base-spacing / 2);
       top: 10px;
       text-align: left;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-sms.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-sms.scss
@@ -6,6 +6,7 @@
       clear: both;
       overflow: hidden;
 
+      // Callout on the top right of the form
       .message-callout {
         margin: 0 auto;
         text-align: center;
@@ -16,12 +17,6 @@
           top: 0;
           right: 20px;
           margin: 0;
-        }
-
-        .message-callout__copy {
-          &:before {
-            right: -10px;
-          }
         }
       }
     }
@@ -52,14 +47,13 @@
       text-align: left;
     }
 
+    // Callout by the submit button
     .message-callout.-right {
-      position: absolute;
-      left: 144px;
-      bottom: -15px;
-
-      @include media($tablet) {
-        bottom: 0;
-      }
+      display: inline-block;
+      position: relative;
+      left: ($base-spacing / 2);
+      top: 10px;
+      text-align: left;
     }
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -98,8 +98,6 @@
           <?php print render($signup_form); ?>
         <?php endif; ?>
 
-        <?php print $campaign_scholarship; ?>
-
         <div class="container__block -narrow">
           <p class="footnote">
             <?php

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -99,14 +99,20 @@
         <?php endif; ?>
 
         <div class="container__block -narrow">
+          <?php if (isset($official_rules)): ?>
+            <p class="footnote">
+              <a class="official-rules" href="<?php print $official_rules_src; ?>"><?php print t('Official Rules'); ?></a>
+            </p>
+          <?php endif; ?>
+
           <p class="footnote">
             <?php
             print t("Taking part in this experience means you agree to our !terms_link &amp; to receive our weekly update. Message &amp; data rates may apply. Text STOP to opt-out, HELP for help.",
               array("!terms_link" => l(t('Terms of Service'), 'about/terms-service'))); ?>
           </p>
         </div>
-
       </div>
+
 
       <?php if ($info_bar): ?>
         <?php print $info_bar; ?>


### PR DESCRIPTION
# Changes
- Fixes bad alignment of scholarship callout on SMS campaigns.
- Moves message callout into form so that we don't have to use absolute positioning.
- Adds "Official Rules" link to the SMS games page template.

Fixes #3408.
For review: @DoSomething/front-end 
