### PR TITLE
Add container__block for padding on default pages.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/page.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/page.tpl.php
@@ -16,9 +16,11 @@
   <?php print $variables['navigation']; ?>
   <?php print $variables['header']; ?>
 
-  <main role="main" class="container">
+  <main role="main" class="container -padded">
     <div class="wrapper">
-      <?php print render($page['content']); ?>
+      <div class="container__block">
+        <?php print render($page['content']); ?>
+      </div>
     </div>
   </main>
 


### PR DESCRIPTION
# Changes
- Adds classes for proper padding on default (unthemed) Drupal pages. Fixes #3988.

For review: @DoSomething/front-end 
