### PR TITLE
Turn off modal-container click event when the modal opens

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -27,7 +27,7 @@ define(function(require) {
     this.imageValues     = {};
     this.cropEnabled     = (typeof Drupal.settings.dsReportback.cropEnabled !== "undefined") ? Drupal.settings.dsReportback.cropEnabled : false;
     this.readyToSave     = false;
-
+    this.$body           = $("body");
     this.init();
   };
 
@@ -72,7 +72,7 @@ define(function(require) {
 
               // Open the modal.
               _this.openModal();
-              
+
               // Add the preview image to the modal
               _this.previewImage(image, _this.$imagePreview);
 
@@ -208,11 +208,16 @@ define(function(require) {
    */
   ImageUploadBeta.prototype.openModal = function() {
     this.enableSubmit();
+
     Modal.open(this.$cropModal,
       {
         animated: false,
       }
     );
+
+    // Turn off the click event that closes
+    // the modal when a user clicks outside of the modal.
+    this.$body.off("click", ".modal-container");
   };
 
   /**


### PR DESCRIPTION
## Problem

While a user resizes the cropbox, if they mouse up outside of the modal, the modal closes.
## Changes - Fixes #3953

Turn off the click event tied to the `.modal-container` that calls the close handler in Modal.js, when the modal opens. I feel like most modal experiences allow the user to click outside of the modal to close it, so it seems to make since to just turn it off in this particular case. 

@DoSomething/front-end 
