### PR TITLE
Using closeButtonOnly option when modal opens

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/bower.json
+++ b/lib/themes/dosomething/paraneue_dosomething/bower.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "neue": "DoSomething/neue#~6.0.0",
     "dosomething-validation": "DoSomething/validation#~0.1.0",
-    "dosomething-modal": "DoSomething/modal#~0.1.0",
+    "dosomething-modal": "DoSomething/modal#~0.2.0",
     "jquery": "1.8.3",
     "mailcheck": "~1.0.3",
     "html5shiv": "~3.7.0",

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadBeta.js
@@ -211,6 +211,7 @@ define(function(require) {
     Modal.open(this.$cropModal,
       {
         animated: false,
+        closeButton: "closeButtonOnly",
       }
     );
   };


### PR DESCRIPTION
## Fixes #3953

Disable close on the modal overlay so users can't accidentally close the modal when resizing the crop box. 

@DoSomething/front-end 
