### PR TITLE
Content search view

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.views_default.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.views_default.inc
@@ -88,6 +88,10 @@ function dosomething_user_views_default_views() {
     ),
   );
   $handler->display->display_options['style_options']['sticky'] = TRUE;
+  /* Header: Global: Result summary */
+  $handler->display->display_options['header']['result']['id'] = 'result';
+  $handler->display->display_options['header']['result']['table'] = 'views';
+  $handler->display->display_options['header']['result']['field'] = 'result';
   /* Field: Content: Title */
   $handler->display->display_options['fields']['title']['id'] = 'title';
   $handler->display->display_options['fields']['title']['table'] = 'node';
@@ -190,6 +194,11 @@ function dosomething_user_views_default_views() {
     1 => 0,
     3 => 0,
     4 => 0,
+    6 => 0,
+    7 => 0,
+    8 => 0,
+    9 => 0,
+    10 => 0,
   );
   /* Filter criterion: Content: Has new content */
   $handler->display->display_options['filters']['timestamp']['id'] = 'timestamp';
@@ -233,6 +242,7 @@ function dosomething_user_views_default_views() {
     t('‹ previous'),
     t('next ›'),
     t('last »'),
+    t('Displaying @start - @end of @total'),
     t('Title'),
     t('Edit link'),
     t('Type'),

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.views_default.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.views_default.inc
@@ -182,7 +182,7 @@ function dosomething_user_views_default_views() {
   $handler->display->display_options['filters']['status']['id'] = 'status';
   $handler->display->display_options['filters']['status']['table'] = 'node';
   $handler->display->display_options['filters']['status']['field'] = 'status';
-  $handler->display->display_options['filters']['status']['value'] = '0';
+  $handler->display->display_options['filters']['status']['value'] = 'All';
   $handler->display->display_options['filters']['status']['group'] = 1;
   $handler->display->display_options['filters']['status']['exposed'] = TRUE;
   $handler->display->display_options['filters']['status']['expose']['operator_id'] = '';


### PR DESCRIPTION
- adds total count to content search view (easily see how many campaigns are published)
- set the default from not published/to any
  Fixes #4001 
