### PR TITLE
Caption bug fix

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -212,21 +212,20 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
       '#type' => 'hidden',
     );
   }
+
   $caption = NULL;
-  if (isset($entity->caption)) {
-    $caption = $entity->caption;
-  } 
-  else {
-    $caption = '&nbsp;';
+
+  if ($reportback_latest_submission) {
+    $caption = isset($reportback_latest_submission->caption) ? $reportback_latest_submission->caption : t('DoSomething? Just did!');
   }
-  dpm($entity);
+
   $form['caption'] = array(
     '#type' => 'textfield',
     '#required' => TRUE,
     '#attributes' => array(
       'data-validate' => 'caption',
       'data-validate-required' => '',
-      'placeholder' => t("Write something in 60 characters or less"),
+      'placeholder' => t('Write something in 60 characters or less'),
       'maxlength' => '60',
     ),
     '#title' => t("Caption"),

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -215,13 +215,17 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
   $caption = NULL;
   if (isset($entity->caption)) {
     $caption = $entity->caption;
+  } 
+  else {
+    $caption = '&nbsp;';
   }
+  dpm($entity);
   $form['caption'] = array(
     '#type' => 'textfield',
     '#required' => TRUE,
     '#attributes' => array(
-      // 'data-validate' => 'caption',
-      // 'data-validate-required' => '',
+      'data-validate' => 'caption',
+      'data-validate-required' => '',
       'placeholder' => t("Write something in 60 characters or less"),
       'maxlength' => '60',
     ),


### PR DESCRIPTION
## Fixes #3962

There are three potential scenarios this address:
- old Reportback exists, but was submitted prior to caption addition and thus doesn't have a caption, so we add a placeholder (only happens if user is updating one of these old reportbacks).
- new Reportback exists, and caption exists, so grab it and pass it to the form caption field.
- no reportback exists because user hasn't submitted anything, so leave the caption field blank.

This should fix the bug we were seeing with users trying to update a recent reportback in Reportbacks v2.0, but they were getting error messages that the caption field needs to be filled out.

@aaronschachter 

CC: @sbsmith86  @mikefantini
