### PR TITLE
Edit photo button styles

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
@@ -181,7 +181,8 @@
     @include visually-hidden();
   }
 
-  .button--file {
+  .button--file,
+  .button--edit {
     font-weight: $weight-bold;
     height: auto;
     margin: ($base-spacing / 2) 0 0;


### PR DESCRIPTION
Give edit button same styles as the "add a photo" button. Fixes #3924 

@DoSomething/front-end 
