### PR TITLE
Updating placeholder text, errr... text.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -225,7 +225,7 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     '#attributes' => array(
       'data-validate' => 'caption',
       'data-validate-required' => '',
-      'placeholder' => t('Write something in 60 characters or less'),
+      'placeholder' => t('60 characters or less'),
       'maxlength' => '60',
     ),
     '#title' => t("Caption"),

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -302,7 +302,7 @@
                   <div id="dosomething-reportback-image-form" class="pseudo-form">
                     <div class="form-item">
                       <label class="field-label" for="modal-caption">Caption</label>
-                      <input class="text-field" placeholder="Write something in 60 characters or less" type="text" id="modal-caption" name="modal-caption" data-validate="caption" data-validate-required maxlength="60" >
+                      <input class="text-field" placeholder="<?php print $reportback_form['caption']['#attributes']['placeholder'] ?>" type="text" id="modal-caption" name="modal-caption" data-validate="caption" data-validate-required maxlength="60" >
                     </div>
                     <div class="form-action">
                       <button class="button -done">Crop</button>


### PR DESCRIPTION
## FIxes #3952

Updated the caption text so it's shorter and fits nicely on narrow viewports.

I also updated the template so if we need further changes to the text it happens only in one place, even though we use the caption placeholder in two inputs. DRY that shiznit.

@DFurnes @sbsmith86 
