### PR TITLE
Fix theme variable naming for static content & fact search results.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -132,7 +132,7 @@ function paraneue_dosomething_get_search_vars($results) {
         }
         $item = array(
           'title' => $value['title'],
-          'link' => $value['link'],
+          'url' => $value['link'],
           'description' => $value['subtitle'],
         );
         $result_variables[$delta] = $item;
@@ -140,7 +140,7 @@ function paraneue_dosomething_get_search_vars($results) {
       default:
         $item = array(
           'title' => $value['title'],
-          'link' => $value['link'],
+          'url' => $value['link'],
           'description' => $value['subtitle'],
         );
         $result_variables[$delta] = $item;


### PR DESCRIPTION
# Changes
- Use correct variable name for static content & fact page links in search results. Fixes #4034.

For review: @DoSomething/front-end 
