### PR TITLE
Adding in reportback divider and soem style updates.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -142,20 +142,40 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
   }
 
   // Hidden fields to collect cropping information.
-  $form['crop_x'] = array(
+  $form['reportback_submissions']['crop_x'] = array(
+    '#weight' => 20,
     '#type' => 'hidden',
   );
-  $form['crop_y'] = array(
+  $form['reportback_submissions']['crop_y'] = array(
+    '#weight' => 21,
     '#type' => 'hidden',
   );
-  $form['crop_width'] = array(
+  $form['reportback_submissions']['crop_width'] = array(
+    '#weight' => 22,
     '#type' => 'hidden',
   );
-  $form['crop_height'] = array(
+  $form['reportback_submissions']['crop_height'] = array(
+    '#weight' => 23,
     '#type' => 'hidden',
   );
-  $form['crop_rotate'] = array(
+  $form['reportback_submissions']['crop_rotate'] = array(
+    '#weight' => 24,
     '#type' => 'hidden',
+  );
+
+  $form['divider'] = array(
+    '#markup' => '<hr class="divider inline-alt-background-color">',
+  );
+
+  // Reportback Inputs container.
+  $form['reportback_inputs'] = array(
+    '#type' => 'container',
+    '#id' => 'reportback-inputs',
+    '#attributes' => array(
+      'class' => array(
+        'reportback__inputs',
+      ),
+    ),
   );
 
   $caption = NULL;
@@ -164,7 +184,7 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     $caption = isset($reportback_latest_submission->caption) ? $reportback_latest_submission->caption : t('DoSomething? Just did!');
   }
 
-  $form['caption'] = array(
+  $form['reportback_inputs']['caption'] = array(
     '#type' => 'textfield',
     '#required' => TRUE,
     '#attributes' => array(
@@ -176,7 +196,8 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     '#title' => t("Caption"),
     '#default_value' => $caption,
   );
-  $form['quantity'] = array(
+
+  $form['reportback_inputs']['quantity'] = array(
     '#type' => 'textfield',
     '#required' => TRUE,
     '#attributes' => array(
@@ -203,7 +224,7 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     // Check for the num_participants_label variable.
     $var_name = 'dosomething_reportback_num_participants_label';
     $label = variable_get($var_name, $label_default);
-    $form['num_participants'] = array(
+    $form['reportback_inputs']['num_participants'] = array(
       '#type' => 'textfield',
       '#required' => TRUE,
       '#attributes' => array(
@@ -218,7 +239,7 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     );
   }
 
-  $form['why_participated'] = array(
+  $form['reportback_inputs']['why_participated'] = array(
     '#type' => 'textarea',
     '#required' => TRUE,
     '#attributes' => array(
@@ -230,13 +251,22 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     '#title' => t('Why is this important to you?'),
     '#default_value' => $entity->why_participated,
   );
-  $form['actions'] = array(
+
+  $form['reportback_inputs']['actions'] = array(
     '#type' => 'actions',
     'submit' => array(
       '#type' => 'submit',
       '#value' => $submit_label,
+      // Unique scenario with container around the form-actions so need to set
+      // button class here specifically.
+      '#attributes' => array(
+        'class' => array(
+          'button form-submit'
+        ),
+      ),
     ),
   );
+
   return $form;
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
@@ -8,6 +8,7 @@
     padding: ($base-spacing / 4);
 
     @include media($larger) {
+      min-height: 335px;
       padding: ($base-spacing / 2);
     }
 
@@ -19,7 +20,9 @@
       font-size: $font-smaller;
       height: 75px;
       line-height: 1.1;
-      padding-top: ($base-spacing / 2);
+      overflow: hidden;
+      margin-top: ($base-spacing / 2);
+      word-wrap: break-word;
 
       @include media($large) {
         font-size: $font-small;
@@ -57,10 +60,6 @@
     height: 100%;
     margin: $base-spacing ($base-spacing / 2) 0;
 
-    > div {
-      padding: gutters();
-    }
-
     @include media($medium) {
       direction: ltr;
       display: table-cell;
@@ -95,6 +94,14 @@
     &:focus {
       box-shadow: none;
     }
+  }
+
+  .divider {
+    background-color: $yellow;
+    border: 0 none;
+    height: ($base_spacing / 4);
+    margin: 0;
+    width: 100%;
   }
 
 }
@@ -171,7 +178,8 @@
 // @TODO: move to proper locations
 // Temporary additions to work through fix for upload button issues.
 .reportback__submissions {
-  margin-bottom: ($base-spacing / 2);
+  padding: gutters();
+  // margin-bottom: ($base-spacing / 2);
 
   figure {
     img { width: 100%; }
@@ -226,8 +234,13 @@
 
   > li {
     float: left;
+    margin-bottom: 0;
     width: span(25%);
   }
+}
+
+.reportback__inputs {
+  padding: gutters();
 }
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
@@ -179,7 +179,6 @@
 // Temporary additions to work through fix for upload button issues.
 .reportback__submissions {
   padding: gutters();
-  // margin-bottom: ($base-spacing / 2);
 
   figure {
     img { width: 100%; }


### PR DESCRIPTION
## Fixes #4020

Adds a divider between the crop preview/mini gallery and the form below it. The divider will also use the custom background color setting if it is specified in the administrative interface for the campaign custom settings.

Had to readjust the markup slightly and add some wrapping divs around the form input elements so that the padding is added to the `reportback__submissions` and `reportback__inputs` containers instead of the immediate child div of the form. This helps so that the `<hr>` added can span the full width of the form container. Also cleaned up the markup slightly to wrap the crop related hidden inputs into the `reportback__submissions` container.

Lastly, did some style cleanup to help deal with old captions that are too long and or long words, so there's no visual overflow.

@DoSomething/front-end 
