### PR TITLE
Prevents ds script from overriding local bash environment.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -151,11 +151,11 @@ function build {
     build_helper 'default' $1 $2
   fi
 
-  if [ ! -e "~/.bash_profile" ]
+  if [ ! -e "~/.bashrc" ]
   then
     echo 'Setting up PHP CodeSniffer...'
-    echo 'alias codercs="phpcs --standard=$WEB_PATH/profiles/dosomething/modules/contrib/coder/coder_sniffer/Drupal/ruleset.xml --extensions=php,module,inc,install,test,profile,theme"' >> ~/.bash_profile
-    source ~/.bash_profile
+    echo 'alias codercs="phpcs --standard=$WEB_PATH/profiles/dosomething/modules/contrib/coder/coder_sniffer/Drupal/ruleset.xml --extensions=php,module,inc,install,test,profile,theme"' >> ~/.bashrc
+    source ~/.bashrc
   fi
 
   echo 'Adding APC script at /apc.php...'


### PR DESCRIPTION
Originally Vagrant box comes with no `.bash_profile` and existing code used to create one in order to set a `codercs` alias.
Instead, it was overridding normal execution of pre-provided `.bashrc` with default bash settings.
Normally `.bash_profile` should include `.bashrc` manually: http://www.joshstaiger.org/archives/2005/07/bash_profile_vs.html

```
if [ -f ~/.bashrc ]; then
   source ~/.bashrc
fi
```

This led to loosing default aliases and environment settting in `.bashrc`, such as `$PATH` variable and colored prompt.
This PR adds the `codercs` alias to `.bashrc` instead so its execution will not be overridden.
