### PR TITLE
Fix spacing on figure gallery on closed campaign. Fixes #4040.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
@@ -111,14 +111,18 @@
             <li class="<?php print $reportback_gallery_item['order_class']; ?>">
               <div class="figure">
                 <?php if (isset($reportback_gallery_item['image'])): ?>
-                  <?php print $reportback_gallery_item['image']; ?>
+                  <div class="figure__media">
+                    <?php print $reportback_gallery_item['image']; ?>
+                  </div>
                 <?php endif; ?>
-                <?php if (isset($reportback_gallery_item['first_name'])): ?>
-                  <h3><?php print $reportback_gallery_item['first_name']; ?></h3>
-                <?php endif; ?>
-                <?php if (isset($reportback_gallery_item['caption'])): ?>
-                  <div class="figure__body"><?php print $reportback_gallery_item['caption']; ?></div>
-                <?php endif; ?>
+                <div class="figure__body">
+                  <?php if (isset($reportback_gallery_item['first_name'])): ?>
+                    <h3><?php print $reportback_gallery_item['first_name']; ?></h3>
+                  <?php endif; ?>
+                  <?php if (isset($reportback_gallery_item['caption'])): ?>
+                    <?php print $reportback_gallery_item['caption']; ?>
+                  <?php endif; ?>
+                </div>
               </div>
             </li>
 


### PR DESCRIPTION
# Changes

Figure markup on closed campaign template wasn't up-to-date. Fixes #4040.

For review: @DoSomething/front-end 
