### PR TITLE
Use Inline Form Actions pattern on search page.

### DIFF
--- a/lib/modules/dosomething/dosomething_search/dosomething_search.module
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.module
@@ -51,9 +51,19 @@ function dosomething_search_form_alter(&$form, &$form_state, $form_id) {
     $form['#submit'] = array('dosomething_search_form_submit');
   }
   elseif ($form_id == 'search_form' || $form_id == 'apachesolr_search_custom_page_search_form') {
-    unset($form['basic']['keys']['#title']);
+    $form['basic']['#prefix'] = '<ul class="form-actions -padded -inline">';
+    $form['basic']['#suffix'] = '</ul>';
+
+    $form['basic']['keys']['#prefix'] = '<li>';
+    $form['basic']['keys']['#suffix'] = '</li>';
     $form['basic']['keys']['#theme'] = 'dosomething_search_field';
-    $form['basic']['submit']['#attributes'] = array('class' => array('button','-secondary'));
+    $form['basic']['keys']['#theme_wrappers'] = array();
+    unset($form['basic']['keys']['#title']);
+
+    $form['basic']['submit']['#attributes'] = array('class' => array('button'));
+    $form['basic']['submit']['#prefix'] = '<li>';
+    $form['basic']['submit']['#suffix'] = '</li>';
+
     $form['#action'] = url('search/apachesolr_search');
     $form['#submit'] = array('dosomething_search_form_submit');
   }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -31,6 +31,7 @@ $asset-path: "";
 @import "patterns/form-actions"; // @TODO: Move to Neue!
 @import "patterns/promotion"; // @TODO: Move to Neue!
 @import "patterns/statistic"; // @TODO: Move to Neue!
+@import "patterns/text-field"; // @TODO: Move to Neue!
 @import "patterns/tile";
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -28,6 +28,7 @@ $asset-path: "";
 
 // Local patterns
 @import "patterns/carousel";
+@import "patterns/form-actions"; // @TODO: Move to Neue!
 @import "patterns/promotion"; // @TODO: Move to Neue!
 @import "patterns/statistic"; // @TODO: Move to Neue!
 @import "patterns/tile";

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_search.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_search.scss
@@ -17,29 +17,3 @@
     @include gutters();
   }
 }
-
-// Search Form.
-.search-form {
-  @include clearfix;
-  margin: $base-spacing 0;
-
-  .form-type-textfield {
-    @include media($tablet) {
-      display: inline-block;
-      float: left;
-      width: span(6 of 9);
-      padding-right: gutter();
-    }
-  }
-
-  .form-submit {
-    float: left;
-    clear: right;
-    background: $blue;
-    margin: 0;
-
-    @include media($tablet) {
-      margin-left: gutter();
-    }
-  }
-}

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_form-actions.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_form-actions.scss
@@ -1,0 +1,9 @@
+// Overrides to Form Actions pattern.
+.form-actions.-inline {
+  .button {
+    font-size: $font-regular;
+    padding-top: ($base-spacing / 2) + 2px;
+    padding-bottom: ($base-spacing / 2) - 2px;
+  }
+
+}

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_text-field.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_text-field.scss
@@ -1,0 +1,10 @@
+// Text field overrides
+
+.text-field.-search {
+  padding-right: 0;
+
+  // Search "cancel" button does not render properly on fields with padding.
+  &::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+  }
+}


### PR DESCRIPTION
# Changes
- Use the [Inline Form Actions](http://neue.dosomething.org/#forms---inline-form-action) pattern for the search page. Much better! :art: 

For review: @DoSomething/front-end 
# Screenshots
#### Before:

![screen shot 2015-02-24 at 2 23 49 pm](https://cloud.githubusercontent.com/assets/583202/6357233/c8294cb2-bc30-11e4-82d1-14875dfe05d2.png)
#### After:

![screen shot 2015-02-24 at 2 24 22 pm](https://cloud.githubusercontent.com/assets/583202/6357238/dc8a728a-bc30-11e4-8457-4c6afd86b888.png)
