### PR TITLE
Theme that report back back back

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -410,7 +410,7 @@ function dosomething_reportback_view_entity($entity) {
   $rb_user = dosomething_user_load(user_load($entity->uid));
   global $user;
   // For now, only display this page to the user, unless it's a staff member.
-  if ($user->uid == $rb_user->uid || dosomething_user_is_staff($user)) {
+  if (($is_current = $user->uid == $rb_user->uid) || dosomething_user_is_staff($user)) {
     $fid = $_GET['fid'];
     if ($fid) {
       $rb_image = dosomething_image_get_themed_image_by_fid($fid, '300x300');
@@ -425,6 +425,7 @@ function dosomething_reportback_view_entity($entity) {
       'reportback' => $entity,
       'node' => $node,
       'user' => $rb_user,
+      'is_current' => $is_current,
       )
     );
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -430,7 +430,7 @@ function dosomething_reportback_view_entity($entity) {
       )
     );
   }
-  return drupal_not_found();
+  drupal_not_found();
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -407,7 +407,20 @@ function dosomething_reportback_admin_view_entity($entity) {
  * Callback for /rbf/FID page.
  */
 function dosomething_reportback_view_entity($entity) {
-  return theme('reportback_permalink', array('reportback' => $entity));
+  $fid = $_GET['fid'];
+  if ($fid) {
+    $rb_image = dosomething_image_get_themed_image_by_fid($fid, '300x300');
+  }
+  else {
+    $rb_image = dosomething_image_get_themed_image_by_fid($entity->fids[0], '300x300');
+  }
+  $node = dosomething_campaign_load(node_load($entity->nid));
+  return theme('reportback_permalink', array(
+    'rb_image' => $rb_image,
+    'reportback' => $entity,
+    'node' => $node,
+    )
+  );
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -407,6 +407,7 @@ function dosomething_reportback_admin_view_entity($entity) {
  * Callback for /rbf/FID page.
  */
 function dosomething_reportback_view_entity($entity) {
+  $user = dosomething_user_load(user_load($entity->uid));
   $fid = $_GET['fid'];
   if ($fid) {
     $rb_image = dosomething_image_get_themed_image_by_fid($fid, '300x300');
@@ -415,10 +416,12 @@ function dosomething_reportback_view_entity($entity) {
     $rb_image = dosomething_image_get_themed_image_by_fid($entity->fids[0], '300x300');
   }
   $node = dosomething_campaign_load(node_load($entity->nid));
+
   return theme('reportback_permalink', array(
     'rb_image' => $rb_image,
     'reportback' => $entity,
     'node' => $node,
+    'user' => $user,
     )
   );
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -7,6 +7,7 @@ define('DOSOMETHING_REPORTBACK_LOG', variable_get('dosomething_reportback_log') 
 
 include_once 'dosomething_reportback.features.inc';
 include_once 'dosomething_reportback.forms.inc';
+include_once 'dosomething_reportback.theme.inc';
 
 /**
  * Implements hook_entity_info().
@@ -187,9 +188,9 @@ function dosomething_reportback_menu() {
       'file' => 'dosomething_reportback.admin.inc',
     );
   }
-  $items['rb/%reportback_file'] = array(
+  $items['reportback/%reportback'] = array(
     'title' => 'Reportback',
-    'page callback' => 'dosomething_reportback_file_view_entity',
+    'page callback' => 'dosomething_reportback_view_entity',
     'page arguments' => array(1),
     //'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('administer modules'),
@@ -319,41 +320,7 @@ function dosomething_reportback_review_page_access($entity) {
   return FALSE;
 }
 
-/**
- * Implements hook_theme().
- */
-function dosomething_reportback_theme($existing, $type, $theme, $path) {
-  return array(
-    // @TODO_RBv2 - temp theme function; remove when RBv2 launched to Prod.
-    'old_reportback_submitted_images' => array(
-      'template' => 'old-reportback-submitted-images',
-      'path' => drupal_get_path('module', 'dosomething_reportback') . '/theme',
-      'variables' => array(
-        'updated' => NULL,
-        'images' => NULL,
-      ),
-    ),
-    'reportback_prior_submissions' => array(
-      'template' => 'reportback-prior-submissions',
-      'path' => drupal_get_path('module', 'dosomething_reportback') . '/theme',
-      'variables' => array(
-        'updated' => NULL,
-        'images' => NULL,
-      ),
-    ),
-    'reportback_latest_submission' => array(
-      'template' => 'reportback-latest-submission',
-      'path' => drupal_get_path('module', 'dosomething_reportback') . '/theme',
-      'variables' => array(
-        'image' => NULL,
-      ),
-    ),
-    'dosomething_reportback_files_form' => array(
-      'render element' => 'form',
-      'file' => 'dosomething_reportback.admin.inc',
-    ),
-  );
-}
+
 
 /**
  * Implements hook_admin_paths().
@@ -439,8 +406,8 @@ function dosomething_reportback_admin_view_entity($entity) {
 /**
  * Callback for /rbf/FID page.
  */
-function dosomething_reportback_file_view_entity($entity) {
-  return entity_view('reportback_file', array($entity->rbid => $entity), 'full');
+function dosomething_reportback_view_entity($entity) {
+  return theme('reportback_permalink', array('reportback' => $entity));
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -420,6 +420,7 @@ function dosomething_reportback_view_entity($entity) {
     }
     $node = dosomething_campaign_load(node_load($entity->nid));
 
+    //@TODO: cache_set this content.
     return theme('reportback_permalink', array(
       'rb_image' => $rb_image,
       'reportback' => $entity,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -407,23 +407,28 @@ function dosomething_reportback_admin_view_entity($entity) {
  * Callback for /rbf/FID page.
  */
 function dosomething_reportback_view_entity($entity) {
-  $user = dosomething_user_load(user_load($entity->uid));
-  $fid = $_GET['fid'];
-  if ($fid) {
-    $rb_image = dosomething_image_get_themed_image_by_fid($fid, '300x300');
-  }
-  else {
-    $rb_image = dosomething_image_get_themed_image_by_fid($entity->fids[0], '300x300');
-  }
-  $node = dosomething_campaign_load(node_load($entity->nid));
+  $rb_user = dosomething_user_load(user_load($entity->uid));
+  global $user;
+  // For now, only display this page to the user, unless it's a staff member.
+  if ($user->uid == $rb_user->uid || dosomething_user_is_staff($user)) {
+    $fid = $_GET['fid'];
+    if ($fid) {
+      $rb_image = dosomething_image_get_themed_image_by_fid($fid, '300x300');
+    }
+    else {
+      $rb_image = dosomething_image_get_themed_image_by_fid($entity->fids[0], '300x300');
+    }
+    $node = dosomething_campaign_load(node_load($entity->nid));
 
-  return theme('reportback_permalink', array(
-    'rb_image' => $rb_image,
-    'reportback' => $entity,
-    'node' => $node,
-    'user' => $user,
-    )
-  );
+    return theme('reportback_permalink', array(
+      'rb_image' => $rb_image,
+      'reportback' => $entity,
+      'node' => $node,
+      'user' => $rb_user,
+      )
+    );
+  }
+  return drupal_not_found();
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.theme.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.theme.inc
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @file
+ * Code for dosomething_reportback theme.
+ */
+
+/**
+ * Implements hook_theme().
+ */
+function dosomething_reportback_theme($existing, $type, $theme, $path) {
+  return array(
+    // @TODO_RBv2 - temp theme function; remove when RBv2 launched to Prod.
+    'old_reportback_submitted_images' => array(
+      'template' => 'old-reportback-submitted-images',
+      'path' => drupal_get_path('module', 'dosomething_reportback') . '/theme',
+      'variables' => array(
+        'updated' => NULL,
+        'images' => NULL,
+      ),
+    ),
+    'reportback_prior_submissions' => array(
+      'template' => 'reportback-prior-submissions',
+      'path' => drupal_get_path('module', 'dosomething_reportback') . '/theme',
+      'variables' => array(
+        'updated' => NULL,
+        'images' => NULL,
+      ),
+    ),
+    'reportback_latest_submission' => array(
+      'template' => 'reportback-latest-submission',
+      'path' => drupal_get_path('module', 'dosomething_reportback') . '/theme',
+      'variables' => array(
+        'image' => NULL,
+      ),
+    ),
+    'dosomething_reportback_files_form' => array(
+      'render element' => 'form',
+      'file' => 'dosomething_reportback.admin.inc',
+    ),
+    'reportback_permalink' => array(
+      'template' => 'reportback-permalink',
+      'path' => drupal_get_path('module', 'dosomething_reportback') . '/theme',
+      'variables' => array('reportback' => NULL),
+      )
+    );
+}

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.theme.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.theme.inc
@@ -44,6 +44,7 @@ function dosomething_reportback_theme($existing, $type, $theme, $path) {
         'rb_image' => NULL,
         'reportback' => NULL,
         'node' => NULL,
+        'user' => NULL,
         ),
       )
     );

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.theme.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.theme.inc
@@ -40,7 +40,11 @@ function dosomething_reportback_theme($existing, $type, $theme, $path) {
     'reportback_permalink' => array(
       'template' => 'reportback-permalink',
       'path' => drupal_get_path('module', 'dosomething_reportback') . '/theme',
-      'variables' => array('reportback' => NULL),
+      'variables' => array(
+        'rb_image' => NULL,
+        'reportback' => NULL,
+        'node' => NULL,
+        ),
       )
     );
 }

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -308,7 +308,7 @@ class ReportbackEntityController extends EntityAPIController {
     if ($entity->uid != $user->uid) {
       // And current user can't edit any reportback:
       if (!user_access('edit any reportback') && !drupal_is_cli()) {
-        watchdog('dosomething_reportback', "Attempted uid override for @reportback by User @uid", 
+        watchdog('dosomething_reportback', "Attempted uid override for @reportback by User @uid",
           array(
             '@reportback' => json_encode($entity),
             '@uid' => $user->uid,

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1271,3 +1271,34 @@ function dosomething_user_tokens($type, $tokens, array $data = array(), array $o
   }
   return $replacements;
 }
+
+/**
+ * Returns a scaled down version of a user object.
+ *
+ * @param obj $user
+ *  (optional) The loaded user object.
+ * @return obj
+ *   Available properties:
+ *
+ *   - uid: (int)
+ *   - email: (int)
+ *   - mobile: (int)
+ *   - first_name: (string)
+ *   - last_name: (string)
+ *
+ */
+function dosomething_user_load($user = NULL) {
+  if (!$user) {
+    global $user;
+    $user = $user;
+  }
+  // Create a dummy object to return.
+  $nice_user = new stdClass();
+  $nice_user->uid = $user->uid;
+  $nice_user->first_name = dosomething_user_get_field('field_first_name', $user);
+  $nice_user->last_name = dosomething_user_get_field('field_last_name', $user);
+  $nice_user->mobile = dosomething_user_get_field('field_mobile', $user);
+  $nice_user->email = $user->mail;
+
+  return $nice_user;
+}

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -272,7 +272,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
 
       $form['#after_build'][] = 'dosomething_user_remove_extra_values_from_address_field';
       if ($is_validate_address_set) {
-        $form['#after_build'][] = 'dosomething_user_add_validation_attributes_to_address_fields'; 
+        $form['#after_build'][] = 'dosomething_user_add_validation_attributes_to_address_fields';
       }
       // Custom validation & submission handlers.
       $form['#validate'][] = 'dosomething_user_register_validate';
@@ -610,7 +610,7 @@ function _dosomething_user_register_helper_text(&$form) {
  * @see dosomething_user_form_alter().
  *
  * @param array $form
- *  A Drupal Form API array, expected forms are User Register/Profile forms. 
+ *  A Drupal Form API array, expected forms are User Register/Profile forms.
  */
 function _dosomething_user_global_display_fields(&$form) {
   // List of fields to globally turn on/off.
@@ -1122,7 +1122,7 @@ function dosomething_user_get_records($tbl_name, $uid) {
     ->fields('t')
     ->condition('uid', $uid, '=')
     ->execute()
-    ->fetchAll();   
+    ->fetchAll();
   }
   else {
     watchdog('dosomething_user', 'Table %tbl_name', array('%tbl_name' => $tbl_name), WATCHDOG_WARNING);

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
@@ -11,6 +11,7 @@
 <?php echo $rb_image ?>
 
 <?php echo $reportback->caption ?>
+<?php echo $user->first_name ?>
 
 <?php echo $reportback->why_participated ?>
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
@@ -1,20 +1,29 @@
 
 <h2> <?php echo $node->title ?> </h2>
-<?php echo $node->call_to_action ?>
 
-<h3> The Problem </h3>
-<?php echo $node->fact_problem['fact'] ?>
+<?php if (!$is_current): ?>
+  <?php echo $node->call_to_action ?>
 
-<h3> The Solution </h3>
-<?php echo $node->fact_solution['fact'] ?>
+  <h3> The Problem </h3>
+  <?php echo $node->fact_problem['fact'] ?>
+
+  <h3> The Solution </h3>
+  <?php echo $node->fact_solution['fact'] ?>
+
+<?php endif ?>
 
 <?php echo $rb_image ?>
 
-<?php echo $reportback->caption ?>
-<?php echo $user->first_name ?>
+<?php // Used to determine if the curernt logged in user is the user who submitted the rb. ?>
+<?php if ($is_current): ?>
 
-<?php echo $reportback->why_participated ?>
+  <?php echo $reportback->caption ?>
+  <?php echo $user->first_name ?>
 
-<?php echo $reportback->quantity ?> <?php echo $reportback->quantity_label ?>
+  <h3> In your words </h3>
+  <?php echo $reportback->why_participated ?>
 
-<?php echo $reportback->participates ?>
+  <?php echo $reportback->quantity ?> <?php echo $reportback->quantity_label ?>
+
+  <?php echo $reportback->participates ?>
+<?php endif ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
@@ -1,0 +1,1 @@
+<?php var_dump($entity) ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
@@ -1,1 +1,19 @@
-<?php var_dump($entity) ?>
+
+<h2> <?php echo $node->title ?> </h2>
+<?php echo $node->call_to_action ?>
+
+<h3> The Problem </h3>
+<?php echo $node->fact_problem['fact'] ?>
+
+<h3> The Solution </h3>
+<?php echo $node->fact_solution['fact'] ?>
+
+<?php echo $rb_image ?>
+
+<?php echo $reportback->caption ?>
+
+<?php echo $reportback->why_participated ?>
+
+<?php echo $reportback->quantity ?> <?php echo $reportback->quantity_label ?>
+
+<?php echo $reportback->participates ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
@@ -4,10 +4,10 @@
 <?php if (!$is_current): ?>
   <?php echo $node->call_to_action ?>
 
-  <h3> The Problem </h3>
+  <h3> <?php t('The Problem') ?> </h3>
   <?php echo $node->fact_problem['fact'] ?>
 
-  <h3> The Solution </h3>
+  <h3> <?php t('The Solution') ?> </h3>
   <?php echo $node->fact_solution['fact'] ?>
 
 <?php endif ?>
@@ -20,10 +20,9 @@
   <?php echo $reportback->caption ?>
   <?php echo $user->first_name ?>
 
-  <h3> In your words </h3>
+  <h3> <?php t('In your words') ?> </h3>
   <?php echo $reportback->why_participated ?>
 
   <?php echo $reportback->quantity ?> <?php echo $reportback->quantity_label ?>
 
-  <?php echo $reportback->participates ?>
 <?php endif ?>


### PR DESCRIPTION
#### Changes
- Added a `dosomething_user_load` function  (similar to `dosomething_campaign_load` which sends better info with the user object.
- Removed the `rb/[reportback_file]` menu item
- Created a 'reportback/[reportback]` menu item to view reportbacks as a whole. 
  - pulls in the fid from the url to load a specific file, if none, pull first image.
  - only visible to person who submitted the reportback
- Added bare bones reportback template with content needed for the permalink pages
#### Known issues
- this will break the links on the reportback views (and anywhere else `rb/` is referenced... will fix tomorrow)
- it's not themed.

Fixes #4004 
Fixes #3540
