### PR TITLE
Fix homepage headers on affiliate sites

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_affiliate.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_affiliate.scss
@@ -1,16 +1,14 @@
 body.-affiliate {
-  .home-banner {
-    .header {
-      .title {
+  .header--home {
+    .header__title {
+      @include visually-restored();
+    }
+
+    .header__subtitle {
+      @include visually-hidden();
+
+      @include media($tablet) {
         @include visually-restored();
-      }
-
-      .subtitle {
-        @include visually-hidden();
-
-        @include media($tablet) {
-          @include visually-restored();
-        }
       }
     }
   }


### PR DESCRIPTION
# Changes
- Fixes issue where both homepage headers were not showing on affiliate sites. (This was caused by updating the homepage markup to use standard header pattern in #4060 but not updating affiliate override classes.)

For review: @DoSomething/front-end 
# Screenshots
#### Before

![screen shot 2015-02-26 at 10 21 14 am](https://cloud.githubusercontent.com/assets/583202/6394730/8df22470-bda1-11e4-8615-f9acac4bac71.png)
#### After

![screen shot 2015-02-26 at 10 21 53 am](https://cloud.githubusercontent.com/assets/583202/6394729/8a567596-bda1-11e4-950d-07204db6e8dd.png)
