### PR TITLE
Provides MailChimp list id in MB registration and signup payloads.

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -109,8 +109,9 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
   // Payload specific to each transaction type.
   switch ($origin) {
     case 'user_register':
-      $payload['birthdate'] = $params['birthdate'];
-      $payload['subscribed'] = 1;
+      $payload['mailchimp_list_id'] = $params['mailchimp_list_id'];
+      $payload['birthdate']         = $params['birthdate'];
+      $payload['subscribed']        = 1;
       if (!empty($params['mobile'])) {
         $payload['mobile'] = $params['mobile'];
 
@@ -174,14 +175,19 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
  *   $payload - Composed values ready to be sent as a message payload.
  */
 function dosomething_mbp_get_common_campaign_payload(&$payload, $params) {
-  $payload['subscribed'] = 1;
-  $payload['event_id'] = $params['event_id'];
+  $payload['subscribed']        = 1;
+  $payload['event_id']          = $params['event_id'];
+
   $payload['email_tags'][] = $params['event_id'];
   // Check for Mailchimp grouping_id+group_name:
-  $mailchimp = isset($params['mailchimp_group_name']) && isset($params['mailchimp_grouping_id']);
+  $mailchimp = !empty($params['mailchimp_group_name'])
+            && !empty($params['mailchimp_grouping_id'])
+            && !empty($params['mailchimp_list_id']);
+
   if ($mailchimp) {
+    $payload['mailchimp_list_id']     = $params['mailchimp_list_id'];
     $payload['mailchimp_grouping_id'] = $params['mailchimp_grouping_id'];
-    $payload['mailchimp_group_name'] = $params['mailchimp_group_name'];
+    $payload['mailchimp_group_name']  = $params['mailchimp_group_name'];
   }
   $payload['merge_vars']['FNAME'] = $params['first_name'];
   $payload['merge_vars']['CAMPAIGN_TITLE'] = $params['campaign_title'];

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -11,22 +11,47 @@
 function dosomething_signup_opt_in_config_form($form, &$form_state) {
 
   // General Drupal variables.
-  $name = 'dosomething_mobilecommons_opt_in_path_user_register';
-  $desc = t("Numeric Mobilecommons opt-in path when user registers for site.");
-  $form[$name] = array(
+  $form['general'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('General'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $name = 'dosomething_signup_mailchimp_general_list_id';
+  $desc = t("String MailChimp List ID for registration and all signups.");
+  $form['general'][$name] = array(
     '#type' => 'textfield',
     '#required' => TRUE,
-    '#title' => t('Mobilecommons Opt-In Path: User registration'),
+    '#title' => t('MailChimp General List ID'),
     '#default_value' => variable_get($name),
     '#size' => 10,
     '#description' => $desc,
   );
+
   $name = 'dosomething_mobilecommons_opt_in_path_general_campaign_signup';
   $desc = t("Numeric Mobilecommons opt-in path for general campaign signup.");
-  $form[$name] = array(
+  $form['general'][$name] = array(
     '#type' => 'textfield',
     '#required' => TRUE,
     '#title' => t('Mobilecommons Opt-In Path: General campaign signup'),
+    '#default_value' => variable_get($name),
+    '#size' => 10,
+    '#description' => $desc,
+  );
+
+  // Registration.
+  $form['registration'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Registration'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $name = 'dosomething_mobilecommons_opt_in_path_user_register';
+  $desc = t("Numeric Mobilecommons opt-in path when user registers for site.");
+  $form['registration'][$name] = array(
+    '#type' => 'textfield',
+    '#required' => TRUE,
+    '#title' => t('Mobilecommons Opt-In Path: User registration'),
     '#default_value' => variable_get($name),
     '#size' => 10,
     '#description' => $desc,
@@ -66,8 +91,9 @@ function dosomething_signup_opt_in_config_form_submit($form, &$form_state) {
 
   // Save general Drupal variables.
   $config_variables = array(
-    'dosomething_mobilecommons_opt_in_path_user_register',
+    'dosomething_signup_mailchimp_general_list_id',
     'dosomething_mobilecommons_opt_in_path_general_campaign_signup',
+    'dosomething_mobilecommons_opt_in_path_user_register',
   );
   foreach ($config_variables as $var_name) {
     variable_set($var_name, $values[$var_name]);

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -513,3 +513,11 @@ function dosomething_signup_update_7016() {
     }
   }
 }
+
+/**
+ * Introduces new variable for MailChimp generail list id.
+ */
+function dosomething_signup_update_7017() {
+  $name = 'dosomething_signup_mailchimp_general_list_id';
+  variable_get($name, getenv('DS_MB_MAILCHIMP_LIST_ID'));
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -459,16 +459,17 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL) {
  */
 function dosomething_signup_mbp_request($account, $node, $opt_in) {
   // Send MBP request.
-  if (module_exists('dosomething_mbp')) {
-    // Gather mbp params for the signup.
-    $params = dosomething_signup_get_mbp_params($account, $node, $opt_in);
-    // Send campaign mbp request.
-    if ($node->type == 'campaign') {
-      dosomething_mbp_request('campaign_signup', $params);
-    }
-    elseif ($node->type == 'campaign_group') {
-      dosomething_mbp_request('campaign_group_signup', $params);
-    }
+  if (!module_exists('dosomething_mbp')) {
+    return;
+  }
+  // Gather mbp params for the signup.
+  $params = dosomething_signup_get_mbp_params($account, $node, $opt_in);
+  // Send campaign mbp request.
+  if ($node->type == 'campaign') {
+    dosomething_mbp_request('campaign_signup', $params);
+  }
+  elseif ($node->type == 'campaign_group') {
+    dosomething_mbp_request('campaign_group_signup', $params);
   }
 }
 
@@ -561,9 +562,12 @@ function dosomething_signup_get_mbp_params_mailchimp(&$params, $node) {
   $nid = $node->nid;
   $grouping_id = dosomething_helpers_get_variable('node', $nid, 'mailchimp_grouping_id');
   $group_name = dosomething_helpers_get_variable('node', $nid, 'mailchimp_group_name');
+  // MailChimp List Id.
+  $mli = variable_get('dosomething_signup_mailchimp_general_list_id');
   // If a value is present for Mailchimp groups:
-  if (isset($grouping_id) && isset($group_name)) {
+  if (!empty($mli) && !empty($grouping_id) && !empty($group_name)) {
     // Add it into the mbp_request params.
+    $params['mailchimp_list_id'] = $mli;
     $params['mailchimp_grouping_id'] = $grouping_id;
     $params['mailchimp_group_name'] = $group_name;
   }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -433,15 +433,20 @@ function dosomething_user_new_user($form, &$form_state) {
     return;
   }
 
+  // MailChimp List Id.
+  $mli = variable_get('dosomething_signup_mailchimp_general_list_id');
+
+
   global $user;
   $account = $user;
 
   // Send external message request.
   $params = array(
-    'email'      => $account->mail,
-    'uid'        => $account->uid,
-    'first_name' => dosomething_user_get_field('field_first_name', $account),
-    'birthdate'  => dosomething_user_get_field('field_birthdate', $account),
+    'mailchimp_list_id' => $mli,
+    'email'             => $account->mail,
+    'uid'               => $account->uid,
+    'first_name'        => dosomething_user_get_field('field_first_name', $account),
+    'birthdate'         => dosomething_user_get_field('field_birthdate', $account),
   );
 
   if (module_exists('dosomething_signup')) {


### PR DESCRIPTION
#### What's this PR do?
- Adds `mailchimp_list_id` to signup and registration Message Broker payloads
- Provides a [Third Party Integrations](dev.dosomething.org:8888/admin/config/dosomething/opt_in) configuration to set `dosomething_signup_mailchimp_general_list_id`
- Presets the `dosomething_signup_mailchimp_general_list_id` variable from the environment var `DS_MB_MAILCHIMP_LIST_ID`
#### What are the relevant tickets?

A part of #4058.

**Related**:
https://github.com/DoSomething/mbc-registration-email/issues/45
