### PR TITLE
Update to fix slight bug in caption placeholder.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -308,7 +308,7 @@
                 <div id="dosomething-reportback-image-form" class="pseudo-form">
                   <div class="form-item">
                     <label class="field-label" for="modal-caption">Caption</label>
-                    <input class="text-field" placeholder="<?php print $reportback_form['caption']['#attributes']['placeholder'] ?>" type="text" id="modal-caption" name="modal-caption" data-validate="caption" data-validate-required maxlength="60" >
+                    <input class="text-field" placeholder="<?php print $reportback_form['reportback_inputs']['caption']['#attributes']['placeholder'] ?>" type="text" id="modal-caption" name="modal-caption" data-validate="caption" data-validate-required maxlength="60" >
                   </div>
                   <div class="form-action">
                     <button class="button -done">Crop</button>


### PR DESCRIPTION
## Fixes #4081

After wrapping the input items to allow for new divider line, the reference to the placeholder caption default value was off. Now updated.

@DoSomething/front-end 
