### PR TITLE
Progress on fixing image upload issue.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -145,22 +145,27 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
   $form['reportback_submissions']['crop_x'] = array(
     '#weight' => 20,
     '#type' => 'hidden',
+    '#default_value' => 0,
   );
   $form['reportback_submissions']['crop_y'] = array(
     '#weight' => 21,
     '#type' => 'hidden',
+    '#default_value' => 0,
   );
   $form['reportback_submissions']['crop_width'] = array(
     '#weight' => 22,
     '#type' => 'hidden',
+    '#default_value' => 480,
   );
   $form['reportback_submissions']['crop_height'] = array(
     '#weight' => 23,
     '#type' => 'hidden',
+    '#default_value' => 480,
   );
   $form['reportback_submissions']['crop_rotate'] = array(
     '#weight' => 24,
     '#type' => 'hidden',
+    '#default_value' => 0,
   );
 
   $form['divider'] = array(

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadFallback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadFallback.js
@@ -28,8 +28,8 @@ define(function(require) {
 
     /**
      * Initialize the fallback file input script.
-     * @param  jQuery  $input     Button input from form.
-     * @param  string  container  Container Class name for container that should house fallback components.
+     * @param  {jQuery}  $input     Button input from form.
+     * @param  {string}  container  Container Class name for container that should house fallback components.
      * @return void
      */
     init: function ($input, container) {
@@ -45,7 +45,7 @@ define(function(require) {
 
     /**
      * Activate the input to watch for file input change event.
-     * @param  jQuery  $input Specific file input.
+     * @param  {jQuery}  $input Specific file input.
      * @return void
      */
     activateInput: function ($input) {
@@ -76,8 +76,8 @@ define(function(require) {
 
     /**
      * Get the file name for the uploaded file.
-     * @param  string  path  Full path string for uploaded image.
-     * @return string        Extracted file name from the full path.
+     * @param  {string}  path  Full path string for uploaded image.
+     * @return string          Extracted file name from the full path.
      */
     getFileName: function (path) {
       var start = path.indexOf("fakepath\\");


### PR DESCRIPTION
## Fixes #3712

My suspicions were correct! After troubleshooting for a bit, found the `dosomething_reportback_image_edit($image, $x, $y, $width, $height, $rotate = NULL)` requires values for the `x`, `y`, `width`, `height`, that then get passed to `image_crop($image, $x, $y, $width, $height)`.

So, I'm passing along default `value` values for the hidden inputs. An alternative could be to set the defaults for the parameters in the function, but not sure what the best call is here. 

Either solution would work. I've also tested this using the technique described in the issue to reproduce the error and the error is gone :dancer: 

@DoSomething/front-end 
@angaither 
@barryclark 
