### PR TITLE
Update to fix broken animation when unveiling gallery items in Reportback gallery.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -106,11 +106,11 @@ define(function(require) {
 
       $images = $cluster.find("img");
 
-      $images.unveil(200, function () {
+      $images.unveil(100, function () {
         var $this = $(this);
 
         $this.load(function () {
-          $this.parent(".photo").css({ opacity: 1});
+          $this.parent(".photo").addClass("-unveiled");
         });
       });
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
@@ -176,6 +176,15 @@
     }
   }
 
+  .photo.-framed {
+    opacity: 0;
+    transition: opacity 0.5s ease-in;
+
+    &.-unveiled {
+      opacity: 1;
+    }
+  }
+
 }
 
 


### PR DESCRIPTION
## Fixes #4087

Updates and fixes the unveiling animation bug on reportback gallery items after clicking _View More_. Also adds a class to the items, so if we want to add additional customizations to the animation, we can just do it within the css declaration :dancer: 

@DoSomething/front-end 
