### PR TITLE
Add Image API rule to ensure images are always compressed JPEGs.

### DIFF
--- a/lib/modules/dosomething/dosomething_image/dosomething_image.features.inc
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.features.inc
@@ -161,7 +161,7 @@ function dosomething_image_image_default_styles() {
     'name' => '400x400',
     'label' => '400x400',
     'effects' => array(
-      2 => array(
+      3 => array(
         'label' => 'Scale and crop',
         'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
         'effect callback' => 'image_scale_and_crop_effect',
@@ -175,6 +175,21 @@ function dosomething_image_image_default_styles() {
           'height' => 400,
         ),
         'weight' => 1,
+      ),
+      4 => array(
+        'label' => 'Change file format',
+        'help' => 'Choose to save the image as a different filetype.',
+        'effect callback' => 'coloractions_convert_effect',
+        'dimensions passthrough' => TRUE,
+        'form callback' => 'coloractions_convert_form',
+        'summary theme' => 'coloractions_convert_summary',
+        'module' => 'imagecache_coloractions',
+        'name' => 'coloractions_convert',
+        'data' => array(
+          'format' => 'image/jpeg',
+          'quality' => 65,
+        ),
+        'weight' => 2,
       ),
     ),
   );

--- a/lib/modules/dosomething/dosomething_image/dosomething_image.features.inc
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.features.inc
@@ -69,6 +69,21 @@ function dosomething_image_image_default_styles() {
         ),
         'weight' => 1,
       ),
+      2 => array(
+        'label' => 'Change file format',
+        'help' => 'Choose to save the image as a different filetype.',
+        'effect callback' => 'coloractions_convert_effect',
+        'dimensions passthrough' => TRUE,
+        'form callback' => 'coloractions_convert_form',
+        'summary theme' => 'coloractions_convert_summary',
+        'module' => 'imagecache_coloractions',
+        'name' => 'coloractions_convert',
+        'data' => array(
+          'format' => 'image/jpeg',
+          'quality' => 55,
+        ),
+        'weight' => 2,
+      ),
     ),
   );
 

--- a/lib/modules/dosomething/dosomething_image/dosomething_image.info
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.info
@@ -64,4 +64,4 @@ features[variable][] = node_preview_image
 features[variable][] = node_submitted_image
 features[variable][] = pathauto_node_image_pattern
 features[views_view][] = search_images
-mtime = 1423774951
+mtime = 1423842993

--- a/lib/modules/dosomething/dosomething_image/dosomething_image.info
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.info
@@ -64,4 +64,4 @@ features[variable][] = node_preview_image
 features[variable][] = node_submitted_image
 features[variable][] = pathauto_node_image_pattern
 features[views_view][] = search_images
-mtime = 1423842993
+mtime = 1425068142

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -35,6 +35,7 @@ dependencies[] = features
 dependencies[] = field_collection
 dependencies[] = field_group
 dependencies[] = file_entity
+dependencies[] = imagecache_actions
 dependencies[] = i18n
 dependencies[] = libraries
 dependencies[] = l10n_update

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -87,6 +87,9 @@ projects[google_analytics][subdir] = "contrib"
 projects[http_client][version] = "2.4"
 projects[http_client][subdir] = "contrib"
 
+; ImageCache Actions
+projects[imagecache_actions][version] = "1.5"
+
 ; Internationalization (required for Sitemap, among others)
 projects[i18n][version] = "1.11"
 projects[i18n][subdir] = "contrib"

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -89,6 +89,7 @@ projects[http_client][subdir] = "contrib"
 
 ; ImageCache Actions
 projects[imagecache_actions][version] = "1.5"
+projects[imagecache_actions][subdir] = "contrib"
 
 ; Internationalization (required for Sitemap, among others)
 projects[i18n][version] = "1.11"


### PR DESCRIPTION
# Changes
- Use the [ImageCache Actions](https://www.drupal.org/project/imagecache_actions) module to convert all header (`1440x810` image style) and tile images (`400x400` image style) to compressed JPEGs. :gift: 
# Why?

This was previously unenforced, so we ended up with a couple really big images (think 1MB) when people would upload PNGs. That's not great. By letting Drupal handle image compression, we can upload ginormous high-quality source images, and know that they'll always be nicely packaged up for users.

For review: @aaronschachter @angaither 
