### PR TITLE
Update to fix odd IE8 bug with labels and inputs in Reportback fallback.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -166,7 +166,7 @@ function paraneue_dosomething_file($variables) {
     return '<label class="gigantor" id="' . $id . '">' . $message . '<input' . drupal_attributes($element['#attributes']) . ' /></label>';
   }
   else {
-    return '<label class="button button--file -tertiary" id="' . $id . '"><span>' . t('Add another photo') . '</span><input' . drupal_attributes($element['#attributes']) . ' /></label>';
+    return '<label class="button button--file -tertiary"><span>' . t('Add another photo') . '</span><input' . drupal_attributes($element['#attributes']) . ' /></label>';
   }
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
@@ -260,7 +260,7 @@ define(function(require) {
       "left"   : Math.floor((width / 2) - (cropBoxSize / 2)),
       "top"    : Math.floor((height / 2) - (cropBoxSize / 2)),
       "width"  : cropBoxSize,
-      "height" : cropBoxSize,
+      "height" : cropBoxSize
     });
 
     // Initiate dragging and resizing.
@@ -288,7 +288,7 @@ define(function(require) {
 
     if (degrees === 90 || degrees === 270) {
       $cropContainer.css({
-        height: width,
+        height: width
       });
 
       // reset cropping events with new dimensions of crop area.
@@ -296,7 +296,7 @@ define(function(require) {
     }
     else {
       $cropContainer.css({
-        height: height,
+        height: height
       });
 
       setupCrop(width,height);
@@ -304,7 +304,7 @@ define(function(require) {
 
     // Actually do the rotation and translation.
     $image.css({
-      "transform" : "rotate("+ degrees + "deg) translate(" + translateDiff + "px, " + translateDiff + "px)",
+      "transform" : "rotate("+ degrees + "deg) translate(" + translateDiff + "px, " + translateDiff + "px)"
     });
   };
 
@@ -330,7 +330,7 @@ define(function(require) {
       left    :  Math.round(($cropBox.offset().left - $previewImage.offset().left) * scale),
       width   :  Math.round($cropBox.outerWidth() * scale),
       height  :  Math.round($cropBox.outerHeight() * scale),
-      degrees :  degrees,
+      degrees :  degrees
     };
 
     // Populate fields.
@@ -386,6 +386,6 @@ define(function(require) {
 
   return {
     dsCropperInit  : dsCropperInit,
-    populateFields : populateFields,
+    populateFields : populateFields
   };
 });

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUpload.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUpload.js
@@ -18,6 +18,7 @@ define(function(require) {
    */
   var ImageUpload = function($button) {
     this.$uploadButton          = $button;
+    this.$uploadButtonLabel     = this.$uploadButton.closest('label');
     this.$cropModal             = $("#modal--crop");
     this.$reportbackForm        = $("#dosomething-reportback-form");
     this.$imageForm             = this.$cropModal.find("#dosomething-reportback-image-form");
@@ -93,7 +94,7 @@ define(function(require) {
       _this.resetFileField();
 
       // Move the upload button back into the form.
-      _this.moveUploadButton($("#edit-reportback-file"));
+      _this.moveUploadButton(_this.$uploadButtonLabel);
 
       if (_this.readyToSave) {
         // Add a button to edit the image.
@@ -110,7 +111,7 @@ define(function(require) {
 
   /**
    * Detatches and moves the current upload button
-   * @param {jQuery}  The element to move the button to.
+   * @param {jQuery}  $el  The element to move the button to.
    */
   ImageUpload.prototype.moveUploadButton = function($el) {
     var $button = this.$uploadButton.detach();
@@ -170,7 +171,7 @@ define(function(require) {
     Modal.open(this.$cropModal,
       {
         animated: false,
-        closeButton: "closeButtonOnly",
+        closeButton: "closeButtonOnly"
       }
     );
   };
@@ -214,7 +215,7 @@ define(function(require) {
       width   : this.$reportbackForm.find("input[name='crop_width']").val(),
       height  : this.$reportbackForm.find("input[name='crop_height']").val(),
       degrees : parseInt(this.$reportbackForm.find("input[name='crop_rotate']").val()),
-      caption : this.$reportbackForm.find("input[name='caption']").val(),
+      caption : this.$reportbackForm.find("input[name='caption']").val()
     };
   };
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/templates/fallback-upload-interface.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/templates/fallback-upload-interface.tpl.html
@@ -2,7 +2,7 @@
   <p class="file-selection__indicator">
     <strong>Selected Photo:</strong> <span class="file-selection__name"><%= file %></span>
   </p>
-  <label class="<%= classes %>" for="<%= id %>">
+  <label class="<%= classes %>">
     <span>Change photo</span>
   </label>
 </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -68,7 +68,7 @@ define(function(require) {
         this.imageUploadInit();
       }
       else {
-         ImageUploadFallback.init(this.$uploadButton, '.reportback__submissions');
+        ImageUploadFallback.init(this.$uploadButton, '.reportback__submissions');
       }
     },
 


### PR DESCRIPTION
## Fixes #3866

So as it turns out if an `<input>` sits inside of a `<label>`, then you don't need a `for` attribute on the label that allows you to click the label to select the input. It will naturally behave that way. You only need the `for` attribute to match the `id` of the input to allow this behavior if the `<input>` sits outside the `<label>`.

In modern browsers, if you happen to add a `for` attribute to the label and an input sits inside of it, it's not a big deal and should still behave the same way; click the label and it selects the input. However, IE8 apparent :hankey: the bed and needs to not have any `for` attribute in the label if the input sits inside the label.

![themoreyouknow](https://cloud.githubusercontent.com/assets/105849/6421044/6f1a290a-be99-11e4-8543-29212898e7ce.gif)

We also had the same `id` on the `<label>` and `<input>` which was a boo boo, so that wasn't helping things.

Also removed some extraneous commas because my snazzy new IDE was getting mad at them.

@DoSomething/front-end 
