### PR TITLE
Permalink copy vars

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -150,6 +150,97 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#required' => TRUE,
     '#default_value' => variable_get('dosomething_campaign_run_no_winner_copy'),
   );
+  // Permalink page.
+  $form['permalink'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Permalink Page'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  // Permalink owners vars.
+  $form['permalink']['owners'] = array(
+    '#type' => 'fieldset',
+    '#title' => 'Owners Permalink',
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['permalink']['owners']['confirmation'] = array(
+    '#type' => 'fieldset',
+    '#title' => 'Owners Permalink as confirmation page',
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['permalink']['owners']['confirmation']['dosomething_campaign_permalink_confirmation_owners_page_subtitle'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Permalink confirmation page subtitle'),
+    '#description' => t('Appears on the confirmation page above the reportbackback to the owner.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_campaign_permalink_confirmation_owners_page_subtitle'),
+  );
+  $form['permalink']['owners']['confirmation']['dosomething_campaign_permalink_confirmation_owners_scholarship'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Permalink confirmation page scholarship addition'),
+    '#description' => t('Displays scholarhship info if a campaign has it.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_campaign_permalink_confirmation_owners_scholarship'),
+  );
+  $form['permalink']['owners']['confirmation']['dosomething_campaign_permalink_confirmation_owners_important_to_you'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Permalink confirmation page important to you header'),
+    '#description' => t('Appears above the why is this important to you user copy.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_campaign_permalink_confirmation_owners_important_to_you'),
+  );
+  $form['permalink']['owners']['confirmation']['dosomething_campaign_permalink_confirmation_owners_social_header'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Social header on reportback permalink page.'),
+    '#description' => t('Appears above the social share on the reportback confirmation page.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_campaign_permalink_confirmation_owners_social_header'),
+  );
+  $form['permalink']['owners']['confirmation']['dosomething_campaign_permalink_confirmation_owners_social_copy'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Social copy on reportback permalink page.'),
+    '#description' => t('Appears above the social share on the reportback confirmation page.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_campaign_permalink_confirmation_owners_social_copy'),
+  );
+  $form['permalink']['owners']['confirmation']['dosomething_campaign_permalink_confirmation_owners_social_cta'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Social cta on reportback permalink page.'),
+    '#description' => t('Appears above the social share on the reportback confirmation page.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_campaign_permalink_confirmation_owners_social_cta'),
+  );
+
+  $form['permalink']['owners']['dosomething_campaign_permalink_owners_page_title'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Permalink owners title'),
+    '#description' => t('Appears above the reportback if the owner user is viewing the permalink page.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_campaign_permalink_owners_page_title'),
+  );
+  $form['permalink']['owners']['dosomething_campaign_permalink_owners_page_subtitle'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Permalink owners subtitle'),
+    '#description' => t('Appears above the reportback if the owner user is viewing the permalink page.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_campaign_permalink_owners_page_subtitle'),
+  );
+    // Permalink owners vars.
+  $form['permalink']['nonowners'] = array(
+    '#type' => 'fieldset',
+    '#title' => 'Non-owners Permalink',
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['permalink']['nonowners']['dosomething_campaign_permalink_nonowners_page_title'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Permalink non-owners page title'),
+    '#description' => t('Appears above the reportback if an anonymous user (or a non-owner) is viewing the permalink page.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_campaign_permalink_nonowners_page_title'),
+  );
   return system_settings_form($form);
 }
 
@@ -216,7 +307,7 @@ function dosomething_campaign_admin_status_page() {
  */
 function dosomething_campaign_admin_status_get_row_array($record) {
   return array(
-    $record->nid, 
+    $record->nid,
     l($record->title, 'node/' . $record->nid . '/edit', array(
       // Link back to admin status page for editor to verify char count is ok.
       'query' => array('destination' => 'admin/content/campaign-status'))

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -429,7 +429,7 @@ function dosomething_reportback_view_entity($entity) {
       'owners_rb_social_cta' => variable_get('dosomething_campaign_permalink_confirmation_owners_social_cta', ''),
       'owners_title' => variable_get('dosomething_campaign_permalink_owners_page_title', ''),
       'owners_subtitle' => variable_get('dosomething_campaign_permalink_owners_page_subtitle', ''),
-      'non_owners_' =>variable_get('dosomething_campaign_permalink_nonowners_page_title', ''),
+      'non_owners_' => variable_get('dosomething_campaign_permalink_nonowners_page_title', ''),
 
     );
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -420,6 +420,19 @@ function dosomething_reportback_view_entity($entity) {
     }
     $node = dosomething_campaign_load(node_load($entity->nid));
 
+    $copy_vars = array(
+      'owners_rb_subtitle' => variable_get('dosomething_campaign_permalink_confirmation_owners_page_subtitle', ''),
+      'owners_rb_scholarship' => variable_get('dosomething_campaign_permalink_confirmation_owners_scholarship', ''),
+      'owners_rb_important' => variable_get('dosomething_campaign_permalink_confirmation_owners_important_to_you', ''),
+      'owners_rb_social_header' => variable_get('dosomething_campaign_permalink_confirmation_owners_social_header', ''),
+      'owners_rb_social_copy' => variable_get('dosomething_campaign_permalink_confirmation_owners_social_copy', ''),
+      'owners_rb_social_cta' => variable_get('dosomething_campaign_permalink_confirmation_owners_social_cta', ''),
+      'owners_title' => variable_get('dosomething_campaign_permalink_owners_page_title', ''),
+      'owners_subtitle' => variable_get('dosomething_campaign_permalink_owners_page_subtitle', ''),
+      'non_owners_' =>variable_get('dosomething_campaign_permalink_nonowners_page_title', ''),
+
+    );
+
     //@TODO: cache_set this content.
     return theme('reportback_permalink', array(
       'rb_image' => $rb_image,
@@ -427,6 +440,7 @@ function dosomething_reportback_view_entity($entity) {
       'node' => $node,
       'user' => $rb_user,
       'is_current' => $is_current,
+      'copy_vars' => $copy_vars,
       )
     );
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.theme.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.theme.inc
@@ -45,6 +45,7 @@ function dosomething_reportback_theme($existing, $type, $theme, $path) {
         'reportback' => NULL,
         'node' => NULL,
         'user' => NULL,
+        'copy_vars' => NULL,
         ),
       )
     );

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
@@ -16,13 +16,18 @@
 
 <?php // Used to determine if the curernt logged in user is the user who submitted the rb. ?>
 <?php if ($is_current): ?>
-
+  <?php echo $copy_vars['owners_rb_subtitle'] ?>
+  <?php echo $copy_vars['owners_rb_scholarship'] ?>
   <?php echo $reportback->caption ?>
   <?php echo $user->first_name ?>
 
-  <h3> <?php t('In your words') ?> </h3>
+  <h3>
+  <?php echo $copy_vars['owners_rb_important'] ?>
+ </h3>
   <?php echo $reportback->why_participated ?>
 
   <?php echo $reportback->quantity ?> <?php echo $reportback->quantity_label ?>
+
+
 
 <?php endif ?>


### PR DESCRIPTION
Added campaign permalink copy variables to dosomething campaign admin form.
Updated theme function to add an array of those vars to the template.

Printed the first round of vars in the template (more will be added at a later date, when we use them)

Fixes #4085 
