### PR TITLE
Reportback request animation frame

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/bower.json
+++ b/lib/themes/dosomething/paraneue_dosomething/bower.json
@@ -34,7 +34,8 @@
     "respond": "~1.4.2",
     "almond": "~0.2.9",
     "jquery.iecors": "*",
-    "filament-sticky": "~0.1.4"
+    "filament-sticky": "~0.1.4",
+    "raf.js" : "0.0.4"
   },
   "resolutions": {
     "jquery": "1.8.3"

--- a/lib/themes/dosomething/paraneue_dosomething/js/config.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/config.js
@@ -18,7 +18,8 @@ require.config({
     "jquery-iecors": "../bower_components/jquery.iecors/jquery.iecors",
     "lodash": "../bower_components/lodash/dist/lodash",
     "mailcheck": "../bower_components/mailcheck/src/mailcheck",
-    "text": "../bower_components/requirejs-text/text"
+    "raf" : "../bower_components/raf.js/raf",
+    "text": "../bower_components/requirejs-text/text",
   },
   packages: [
     {
@@ -55,7 +56,8 @@ require.config({
         "jquery-unveil",
         "jquery-iecors",
         "mailcheck",
-        "lodash"
+        "lodash",
+        "raf",
       ]
     },
     {

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
@@ -1,3 +1,12 @@
+// window.requestAnimFrame = (function(){
+//   return  window.requestAnimationFrame       ||
+//           window.webkitRequestAnimationFrame ||
+//           window.mozRequestAnimationFrame    ||
+//           function( callback ){
+//             window.setTimeout(callback, 1000 / 60);
+//           };
+// })();
+
 define(function(require) {
   "use strict";
 
@@ -16,9 +25,6 @@ define(function(require) {
   var origImage;
   var resizeState          = false;
   var dragState            = false;
-  var lastMousePosition    = { x : 0, y : 0 };
-  var withinTopBounds;
-  var withinLeftBounds;
   var moveRight;
   var moveDown;
   var resizeHorizontal;
@@ -119,55 +125,8 @@ define(function(require) {
   };
 
   /**
-   * Turns on the ability to drag the crop box.
+   * When the user clicks down, grab initial information.
    */
-  // var dragCropBoxInit = function() {
-  //   // Bind touch and mouse events.
-  //   $cropBox.on("touchstart mousedown", function(event) {
-  //     event.preventDefault();
-
-  //     var coords = getCoords(event);
-
-  //     // Set the initial position of the mouse.
-  //     xInitPos = coords.pageX;
-  //     yInitPos = coords.pageY;
-
-  //     // Sets the initial positioning of the crop box.
-  //     if ($cropBox.length) {
-  //       offsetLeft = parseInt($cropBox.css("left"), 10);
-  //       offsetTop  = parseInt($cropBox.css("top"), 10);
-  //     }
-
-  //     // Turns on dragging.
-  //     dragState = true;
-  //   });
-  // };
-
-  // *
-  //  * Turns on the ability to resize the crop box.
-   
-  // var resizeCropBoxInit = function() {
-  //   $(".resize-handle").on("touchstart mousedown", function(event) {
-  //     event.preventDefault();
-
-  //     // Grab the postioning of the event.
-  //     var coords = getCoords(event);
-
-  //     // Set the initial size of the crop box.
-  //     if ($cropBox.length) {
-  //       initialCropBoxHeight = parseInt($cropBox.css("height"), 10);
-  //       initialCropBoxWidth  = parseInt($cropBox.css("width"), 10);
-  //     }
-
-  //     // Set the position of the mouse.
-  //     resizeClickPositionX = coords.pageX;
-  //     resizeClickPositionY = coords.pageY;
-
-  //     // Turn on resizing.
-  //     resizeState = true;
-  //   });
-  // };
-
   var onMouseDown = function(event) {
     var coords = getCoords(event);
 
@@ -182,6 +141,7 @@ define(function(require) {
         offsetTop  = parseInt($cropBox.css("top"), 10);
       }
 
+      // Animate the drag.
       requestAnimationFrame(function() {
         dragBox();
       });
@@ -198,17 +158,25 @@ define(function(require) {
       resizeClickPositionX = coords.pageX;
       resizeClickPositionY = coords.pageY;
 
+      // Animate the resizing.
       requestAnimationFrame(function() {
         resizeBox();
       });
     }
-  }
+  };
 
+  /**
+   * Turn off the dragging and resizing when the user releases.
+   */
   var onMouseUp = function() {
     dragState = false;
     resizeState = false;
-  }
+  };
 
+  /**
+   * As the user moves the mouse, handle all the calculations needed to determine
+   * how to redraw the cropbox. This doesn't do the actual animation, just the math!
+   */
   var onMouseMove = function(width, height, event) {
     var coords        = getCoords(event);
     var cropBoxHeight = parseInt($cropBox.css("height"),10);
@@ -221,9 +189,11 @@ define(function(require) {
       moveRight = offsetLeft + (coords.pageX - xInitPos);
       moveDown  = offsetTop + (coords.pageY - yInitPos);
 
-      withinLeftBounds = (width - cropBoxWidth) > moveRight ? true : false;
-      withinTopBounds  = (height - cropBoxHeight) > moveDown ? true : false;
+      // Test if the box is being moved within the bounds of the image.
+      var withinLeftBounds = (width - cropBoxWidth) > moveRight ? true : false;
+      var withinTopBounds  = (height - cropBoxHeight) > moveDown ? true : false;
 
+      // Set the amount to move right or down base on if the box is within bounds.
       if (withinLeftBounds) {
         moveRight = (moveRight < 0) ? 0 : moveRight;
       }
@@ -242,18 +212,24 @@ define(function(require) {
     if (resizeState) {
       dragState = false;
 
-      // Calculate how much to resize the cropbox.
+      // Calculate the max amount the user can resize the box based on it's current position.
       var widthMax = width - cropBoxLeft;
       var heightMax = height - cropBoxTop;
+
+      // Test if the user is increasing or decreasing the size of the box.
       var increasingSize     = (coords.pageX - resizeClickPositionX) > 0 ? true : false;
       var decreasingSize     = (coords.pageX - resizeClickPositionX) < 0 ? true : false;
+
+      // How much to resize the box.
       resizeHorizontal = initialCropBoxWidth + (coords.pageX - resizeClickPositionX);
       resizeVertical   = initialCropBoxHeight + (coords.pageX - resizeClickPositionX);
 
+      // Set the bounding values based on the how much the box can be increased to
+      // and the minium allowed size of the box.
       if (increasingSize) {
         if (resizeHorizontal >= widthMax) {
           resizeHorizontal = widthMax;
-          resizeVertical = widthMax
+          resizeVertical = widthMax;
         }
 
         if (resizeVertical >= heightMax) {
@@ -269,8 +245,11 @@ define(function(require) {
         }
       }
     }
-  }
+  };
 
+  /*
+   * Uses requestAnimationFrame to redraw the box in the DOM as the user drags the cropbox.
+   */
   var dragBox = function() {
     if(dragState) {
       requestAnimationFrame(function() {
@@ -280,8 +259,11 @@ define(function(require) {
 
     $cropBox.css("top", moveDown);
     $cropBox.css( "left", moveRight);
-  }
+  };
 
+  /*
+   * Uses requestAnimationFrame to redraw the box in the DOM as the user resizes the cropbox.
+   */
   var resizeBox = function() {
     if(resizeState) {
       requestAnimationFrame(function() {
@@ -293,7 +275,7 @@ define(function(require) {
     $cropBox.css( "width", resizeHorizontal);
     $cropBox.css( "height", resizeVertical);
     $cropBox.css( "width", resizeHorizontal);
-  }
+  };
 
 
   /**
@@ -304,97 +286,34 @@ define(function(require) {
    */
   var croppingReset = function (width, height) {
 
-    // // Turn off any previously bound events so
-    // // we can rebind them later using new settings.
+    // Turn off any previously bound events so
+    // we can rebind them later using new settings.
     $(document).off("touchmove mousemove");
     $(document).off("touchend mouseup");
 
-    $cropBox.on('mousedown', function(event) {
+    // Allow the user to drag the cropbox.
+    $cropBox.on("touchstart mousedown", function(event) {
       event.preventDefault();
       dragState = true;
       onMouseDown(event);
     });
 
-    $(".resize-handle").on('mousedown', function(event) {
+    // Allow the user to resize the cropbox.
+    $(".resize-handle").on("touchstart mousedown", function(event) {
       event.preventDefault();
       resizeState = true;
       onMouseDown(event);
     });
 
-    $(document).on('mouseup', function() {
+    // Turn off any interaction when the user releases the mouse.
+    $(document).on("touchend mouseup", function() {
       onMouseUp();
     });
 
-    $(document).on('mousemove', function(event) {
+    // Calculate all the things needed to animate the box as the user moves the mouse.
+    $(document).on("touchmove mousemove", function(event) {
       onMouseMove(width, height, event);
     });
-
-    // // Turn off any previously bound events so
-    // // we can rebind them later using new settings.
-    // $(document).off("touchmove mousemove");
-    // $(document).off("touchend mouseup");
-
-    // // Bind move events to the document.
-    // $(document).on("touchmove mousemove", function(event) {
-    //   var coords        = getCoords(event);
-    //   var cropBoxHeight = parseInt($cropBox.css("height"),10);
-    //   var cropBoxWidth  = parseInt($cropBox.css("width"),10);
-    //   var cropBoxTop    = parseInt($cropBox.css("top"), 10);
-    //   var cropBoxLeft   = parseInt($cropBox.css("left"), 10);
-
-    //   // If dragging, drag the crop box along.
-    //   if (dragState) {
-    //     // Calculate how far to move the box down and right based on the mouse position.
-    //     var moveRight = offsetLeft + (coords.pageX - xInitPos);
-    //     var moveDown  = offsetTop + (coords.pageY - yInitPos);
-
-    //     // Boundary threshold tests.
-    //     var withinTopBounds  = (height - cropBoxHeight) > moveDown ? true : false;
-    //     var withinLeftBounds = (width - cropBoxWidth) > moveRight ? true : false;
-
-    //     // Make sure we are still within the bounds of the image and then actully move the box.
-    //     if (withinTopBounds && (moveDown > 0)) {
-    //       $cropBox.css("top", moveDown);
-    //     }
-    //     if (withinLeftBounds && (moveRight > 0)) {
-    //       $cropBox.css( "left", moveRight);
-    //     }
-    //   }
-
-    //   // If resizing, resize the crop box.
-    //   if (resizeState) {
-    //     dragState = false;
-    //     // Calculate how much to resize the cropbox.
-    //     var resizeHorizontal = initialCropBoxWidth + (coords.pageX - resizeClickPositionX);
-    //     var resizeVertical   = initialCropBoxHeight + (coords.pageX - resizeClickPositionX);
-
-    //     // Boundary threshold tests.
-    //     var withinHeightBounds = (cropBoxHeight + cropBoxTop) < height ? true : false;
-    //     var withinWidthBounds  = (cropBoxWidth + cropBoxLeft) < width ? true : false;
-    //     var cropBoxSizeAllowed = (cropBoxWidth > minThreshold) ? true : false;
-    //     var increasingSize     = (coords.pageX - resizeClickPositionX) > 0 ? true : false;
-    //     var decreasingSize     = (coords.pageX - resizeClickPositionX) < 0 ? true : false;
-
-    //     // Make sure we are still in the boundaries of the image, and then resize the box.
-    //     if (withinHeightBounds && withinWidthBounds && (cropBoxSizeAllowed || increasingSize)) {
-    //       $cropBox.css( "height", resizeVertical);
-    //       $cropBox.css( "width", resizeHorizontal);
-    //     }
-    //     else if (decreasingSize && cropBoxSizeAllowed) {
-    //       $cropBox.css( "height", resizeVertical);
-    //       $cropBox.css( "width", resizeHorizontal);
-    //     }
-    //   }
-    // });
-
-    // /**
-    //  *  When the user stops moving the mouse or touching the screen, turn of the drag and resizing events.
-    //  *  Get the final position and size of the crop and populate hidden form elements with them.
-    //  */
-    // $(document).on("touchend mouseup", function() {
-    //   dragState   = false;
-    //   resizeState = false;
-    // });
   };
 
   /**
@@ -423,10 +342,6 @@ define(function(require) {
       "width"  : cropBoxSize,
       "height" : cropBoxSize,
     });
-
-    // Initiate dragging and resizing.
-    // dragCropBoxInit();
-    // resizeCropBoxInit();
 
     croppingReset(width, height);
   };
@@ -543,6 +458,10 @@ define(function(require) {
       degrees = (degrees === 360) ? 90 : degrees + 90;
       rotateImage($previewImage, degrees);
     });
+
+    Modernizr.prefixed;
+    console.log(Modernizr.raf);
+
   };
 
   return {

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
@@ -16,6 +16,11 @@ define(function(require) {
   var origImage;
   var resizeState          = false;
   var dragState            = false;
+  var lastMousePosition    = { x : 0, y : 0 };
+  var withinTopBounds;
+  var withinLeftBounds;
+  var moveRight;
+  var moveDown;
   var $cropBox             = $("<div class='cropbox'><div class='resize-handle'></div></div>");
   var resizeClickPositionX = 0;
   var resizeClickPositionY = 0;
@@ -161,6 +166,70 @@ define(function(require) {
     });
   };
 
+  var onMouseDown = function(event) {
+    var coords = getCoords(event);
+
+    // Set the initial position of the mouse.
+    xInitPos = coords.pageX;
+    yInitPos = coords.pageY;
+
+    // Sets the initial positioning of the crop box.
+    if ($cropBox.length) {
+      offsetLeft = parseInt($cropBox.css("left"), 10);
+      offsetTop  = parseInt($cropBox.css("top"), 10);
+    }
+
+    requestAnimationFrame(function() {
+      update();
+    });
+  }
+
+  var onMouseUp = function() {
+    dragState = false;
+  }
+
+  var onMouseMove = function(width, height, event) {
+    var coords        = getCoords(event);
+    var cropBoxHeight = parseInt($cropBox.css("height"),10);
+    var cropBoxWidth  = parseInt($cropBox.css("width"),10);
+    var cropBoxTop    = parseInt($cropBox.css("top"), 10);
+    var cropBoxLeft   = parseInt($cropBox.css("left"), 10);
+
+    if (dragState) {
+      // Calculate how far to move the box down and right based on the mouse position.
+      moveRight = offsetLeft + (coords.pageX - xInitPos);
+      moveDown  = offsetTop + (coords.pageY - yInitPos);
+
+      withinLeftBounds = (width - cropBoxWidth) > moveRight ? true : false;
+      withinTopBounds  = (height - cropBoxHeight) > moveDown ? true : false;
+
+      if (withinLeftBounds) {
+        moveRight = (moveRight < 0) ? 0 : moveRight;
+      }
+      else {
+        moveRight = (width - cropBoxWidth);
+      }
+
+      if (withinTopBounds) {
+        moveDown = (moveDown < 0) ? 0 : moveDown;
+      }
+      else {
+        moveDown = (height - cropBoxHeight);
+      }
+    }
+  }
+
+  var update = function() {
+    if(dragState) {
+      requestAnimationFrame(function() {
+        update();
+      });
+    }
+
+    $cropBox.css("top", moveDown);
+    $cropBox.css( "left", moveRight);
+  }
+
   /**
    * Sets up the mouse events on the cropping interface using a give width and height.
    *
@@ -168,72 +237,87 @@ define(function(require) {
    * @param {number} height    Height of the crop area.
    */
   var croppingReset = function (width, height) {
-    // Turn off any previously bound events so
-    // we can rebind them later using new settings.
-    $(document).off("touchmove mousemove");
-    $(document).off("touchend mouseup");
 
-    // Bind move events to the document.
-    $(document).on("touchmove mousemove", function(event) {
-      var coords        = getCoords(event);
-      var cropBoxHeight = parseInt($cropBox.css("height"),10);
-      var cropBoxWidth  = parseInt($cropBox.css("width"),10);
-      var cropBoxTop    = parseInt($cropBox.css("top"), 10);
-      var cropBoxLeft   = parseInt($cropBox.css("left"), 10);
-
-      // If dragging, drag the crop box along.
-      if (dragState) {
-        // Calculate how far to move the box down and right based on the mouse position.
-        var moveRight = offsetLeft + (coords.pageX - xInitPos);
-        var moveDown  = offsetTop + (coords.pageY - yInitPos);
-
-        // Boundary threshold tests.
-        var withinTopBounds  = (height - cropBoxHeight) > moveDown ? true : false;
-        var withinLeftBounds = (width - cropBoxWidth) > moveRight ? true : false;
-
-        // Make sure we are still within the bounds of the image and then actully move the box.
-        if (withinTopBounds && (moveDown > 0)) {
-          $cropBox.css("top", moveDown);
-        }
-        if (withinLeftBounds && (moveRight > 0)) {
-          $cropBox.css( "left", moveRight);
-        }
-      }
-
-      // If resizing, resize the crop box.
-      if (resizeState) {
-        dragState = false;
-        // Calculate how much to resize the cropbox.
-        var resizeHorizontal = initialCropBoxWidth + (coords.pageX - resizeClickPositionX);
-        var resizeVertical   = initialCropBoxHeight + (coords.pageX - resizeClickPositionX);
-
-        // Boundary threshold tests.
-        var withinHeightBounds = (cropBoxHeight + cropBoxTop) < height ? true : false;
-        var withinWidthBounds  = (cropBoxWidth + cropBoxLeft) < width ? true : false;
-        var cropBoxSizeAllowed = (cropBoxWidth > minThreshold) ? true : false;
-        var increasingSize     = (coords.pageX - resizeClickPositionX) > 0 ? true : false;
-        var decreasingSize     = (coords.pageX - resizeClickPositionX) < 0 ? true : false;
-
-        // Make sure we are still in the boundaries of the image, and then resize the box.
-        if (withinHeightBounds && withinWidthBounds && (cropBoxSizeAllowed || increasingSize)) {
-          $cropBox.css( "height", resizeVertical);
-          $cropBox.css( "width", resizeHorizontal);
-        }
-        else if (decreasingSize && cropBoxSizeAllowed) {
-          $cropBox.css( "height", resizeVertical);
-          $cropBox.css( "width", resizeHorizontal);
-        }
-      }
+    $cropBox.on('mousedown', function(event) {
+      event.preventDefault();
+      dragState = true;
+      onMouseDown(event);
     });
 
-    /**
-     *  When the user stops moving the mouse or touching the screen, turn of the drag and resizing events.
-     *  Get the final position and size of the crop and populate hidden form elements with them.
-     */
-    $(document).on("touchend mouseup", function() {
-      dragState   = false;
-      resizeState = false;
+    $(document).on('mouseup', function() {
+      onMouseUp();
     });
+
+    $(document).on('mousemove', function(event) {
+      onMouseMove(width, height, event);
+    });
+
+    // // Turn off any previously bound events so
+    // // we can rebind them later using new settings.
+    // $(document).off("touchmove mousemove");
+    // $(document).off("touchend mouseup");
+
+    // // Bind move events to the document.
+    // $(document).on("touchmove mousemove", function(event) {
+    //   var coords        = getCoords(event);
+    //   var cropBoxHeight = parseInt($cropBox.css("height"),10);
+    //   var cropBoxWidth  = parseInt($cropBox.css("width"),10);
+    //   var cropBoxTop    = parseInt($cropBox.css("top"), 10);
+    //   var cropBoxLeft   = parseInt($cropBox.css("left"), 10);
+
+    //   // If dragging, drag the crop box along.
+    //   if (dragState) {
+    //     // Calculate how far to move the box down and right based on the mouse position.
+    //     var moveRight = offsetLeft + (coords.pageX - xInitPos);
+    //     var moveDown  = offsetTop + (coords.pageY - yInitPos);
+
+    //     // Boundary threshold tests.
+    //     var withinTopBounds  = (height - cropBoxHeight) > moveDown ? true : false;
+    //     var withinLeftBounds = (width - cropBoxWidth) > moveRight ? true : false;
+
+    //     // Make sure we are still within the bounds of the image and then actully move the box.
+    //     if (withinTopBounds && (moveDown > 0)) {
+    //       $cropBox.css("top", moveDown);
+    //     }
+    //     if (withinLeftBounds && (moveRight > 0)) {
+    //       $cropBox.css( "left", moveRight);
+    //     }
+    //   }
+
+    //   // If resizing, resize the crop box.
+    //   if (resizeState) {
+    //     dragState = false;
+    //     // Calculate how much to resize the cropbox.
+    //     var resizeHorizontal = initialCropBoxWidth + (coords.pageX - resizeClickPositionX);
+    //     var resizeVertical   = initialCropBoxHeight + (coords.pageX - resizeClickPositionX);
+
+    //     // Boundary threshold tests.
+    //     var withinHeightBounds = (cropBoxHeight + cropBoxTop) < height ? true : false;
+    //     var withinWidthBounds  = (cropBoxWidth + cropBoxLeft) < width ? true : false;
+    //     var cropBoxSizeAllowed = (cropBoxWidth > minThreshold) ? true : false;
+    //     var increasingSize     = (coords.pageX - resizeClickPositionX) > 0 ? true : false;
+    //     var decreasingSize     = (coords.pageX - resizeClickPositionX) < 0 ? true : false;
+
+    //     // Make sure we are still in the boundaries of the image, and then resize the box.
+    //     if (withinHeightBounds && withinWidthBounds && (cropBoxSizeAllowed || increasingSize)) {
+    //       $cropBox.css( "height", resizeVertical);
+    //       $cropBox.css( "width", resizeHorizontal);
+    //     }
+    //     else if (decreasingSize && cropBoxSizeAllowed) {
+    //       $cropBox.css( "height", resizeVertical);
+    //       $cropBox.css( "width", resizeHorizontal);
+    //     }
+    //   }
+    // });
+
+    // /**
+    //  *  When the user stops moving the mouse or touching the screen, turn of the drag and resizing events.
+    //  *  Get the final position and size of the crop and populate hidden form elements with them.
+    //  */
+    // $(document).on("touchend mouseup", function() {
+    //   dragState   = false;
+    //   resizeState = false;
+    // });
   };
 
   /**

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
@@ -1,12 +1,3 @@
-// window.requestAnimFrame = (function(){
-//   return  window.requestAnimationFrame       ||
-//           window.webkitRequestAnimationFrame ||
-//           window.mozRequestAnimationFrame    ||
-//           function( callback ){
-//             window.setTimeout(callback, 1000 / 60);
-//           };
-// })();
-
 define(function(require) {
   "use strict";
 
@@ -142,7 +133,7 @@ define(function(require) {
       }
 
       // Animate the drag.
-      requestAnimationFrame(function() {
+      window.requestAnimationFrame(function() {
         dragBox();
       });
     }
@@ -159,7 +150,7 @@ define(function(require) {
       resizeClickPositionY = coords.pageY;
 
       // Animate the resizing.
-      requestAnimationFrame(function() {
+      window.requestAnimationFrame(function() {
         resizeBox();
       });
     }
@@ -248,11 +239,11 @@ define(function(require) {
   };
 
   /*
-   * Uses requestAnimationFrame to redraw the box in the DOM as the user drags the cropbox.
+   * Uses window.requestAnimationFrame to redraw the box in the DOM as the user drags the cropbox.
    */
   var dragBox = function() {
     if(dragState) {
-      requestAnimationFrame(function() {
+      window.requestAnimationFrame(function() {
         dragBox();
       });
     }
@@ -262,11 +253,11 @@ define(function(require) {
   };
 
   /*
-   * Uses requestAnimationFrame to redraw the box in the DOM as the user resizes the cropbox.
+   * Uses window.requestAnimationFrame to redraw the box in the DOM as the user resizes the cropbox.
    */
   var resizeBox = function() {
     if(resizeState) {
-      requestAnimationFrame(function() {
+      window.requestAnimationFrame(function() {
         resizeBox();
       });
     }
@@ -458,10 +449,6 @@ define(function(require) {
       degrees = (degrees === 360) ? 90 : degrees + 90;
       rotateImage($previewImage, degrees);
     });
-
-    Modernizr.prefixed;
-    console.log(Modernizr.raf);
-
   };
 
   return {

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
@@ -21,6 +21,8 @@ define(function(require) {
   var withinLeftBounds;
   var moveRight;
   var moveDown;
+  var resizeHorizontal;
+  var resizeVertical;
   var $cropBox             = $("<div class='cropbox'><div class='resize-handle'></div></div>");
   var resizeClickPositionX = 0;
   var resizeClickPositionY = 0;
@@ -119,13 +121,57 @@ define(function(require) {
   /**
    * Turns on the ability to drag the crop box.
    */
-  var dragCropBoxInit = function() {
-    // Bind touch and mouse events.
-    $cropBox.on("touchstart mousedown", function(event) {
-      event.preventDefault();
+  // var dragCropBoxInit = function() {
+  //   // Bind touch and mouse events.
+  //   $cropBox.on("touchstart mousedown", function(event) {
+  //     event.preventDefault();
 
-      var coords = getCoords(event);
+  //     var coords = getCoords(event);
 
+  //     // Set the initial position of the mouse.
+  //     xInitPos = coords.pageX;
+  //     yInitPos = coords.pageY;
+
+  //     // Sets the initial positioning of the crop box.
+  //     if ($cropBox.length) {
+  //       offsetLeft = parseInt($cropBox.css("left"), 10);
+  //       offsetTop  = parseInt($cropBox.css("top"), 10);
+  //     }
+
+  //     // Turns on dragging.
+  //     dragState = true;
+  //   });
+  // };
+
+  // *
+  //  * Turns on the ability to resize the crop box.
+   
+  // var resizeCropBoxInit = function() {
+  //   $(".resize-handle").on("touchstart mousedown", function(event) {
+  //     event.preventDefault();
+
+  //     // Grab the postioning of the event.
+  //     var coords = getCoords(event);
+
+  //     // Set the initial size of the crop box.
+  //     if ($cropBox.length) {
+  //       initialCropBoxHeight = parseInt($cropBox.css("height"), 10);
+  //       initialCropBoxWidth  = parseInt($cropBox.css("width"), 10);
+  //     }
+
+  //     // Set the position of the mouse.
+  //     resizeClickPositionX = coords.pageX;
+  //     resizeClickPositionY = coords.pageY;
+
+  //     // Turn on resizing.
+  //     resizeState = true;
+  //   });
+  // };
+
+  var onMouseDown = function(event) {
+    var coords = getCoords(event);
+
+    if (dragState) {
       // Set the initial position of the mouse.
       xInitPos = coords.pageX;
       yInitPos = coords.pageY;
@@ -136,21 +182,12 @@ define(function(require) {
         offsetTop  = parseInt($cropBox.css("top"), 10);
       }
 
-      // Turns on dragging.
-      dragState = true;
-    });
-  };
+      requestAnimationFrame(function() {
+        dragBox();
+      });
+    }
 
-  /**
-   * Turns on the ability to resize the crop box.
-   */
-  var resizeCropBoxInit = function() {
-    $(".resize-handle").on("touchstart mousedown", function(event) {
-      event.preventDefault();
-
-      // Grab the postioning of the event.
-      var coords = getCoords(event);
-
+    if (resizeState) {
       // Set the initial size of the crop box.
       if ($cropBox.length) {
         initialCropBoxHeight = parseInt($cropBox.css("height"), 10);
@@ -161,31 +198,15 @@ define(function(require) {
       resizeClickPositionX = coords.pageX;
       resizeClickPositionY = coords.pageY;
 
-      // Turn on resizing.
-      resizeState = true;
-    });
-  };
-
-  var onMouseDown = function(event) {
-    var coords = getCoords(event);
-
-    // Set the initial position of the mouse.
-    xInitPos = coords.pageX;
-    yInitPos = coords.pageY;
-
-    // Sets the initial positioning of the crop box.
-    if ($cropBox.length) {
-      offsetLeft = parseInt($cropBox.css("left"), 10);
-      offsetTop  = parseInt($cropBox.css("top"), 10);
+      requestAnimationFrame(function() {
+        resizeBox();
+      });
     }
-
-    requestAnimationFrame(function() {
-      update();
-    });
   }
 
   var onMouseUp = function() {
     dragState = false;
+    resizeState = false;
   }
 
   var onMouseMove = function(width, height, event) {
@@ -217,18 +238,63 @@ define(function(require) {
         moveDown = (height - cropBoxHeight);
       }
     }
+
+    if (resizeState) {
+      dragState = false;
+
+      // Calculate how much to resize the cropbox.
+      var widthMax = width - cropBoxLeft;
+      var heightMax = height - cropBoxTop;
+      var increasingSize     = (coords.pageX - resizeClickPositionX) > 0 ? true : false;
+      var decreasingSize     = (coords.pageX - resizeClickPositionX) < 0 ? true : false;
+      resizeHorizontal = initialCropBoxWidth + (coords.pageX - resizeClickPositionX);
+      resizeVertical   = initialCropBoxHeight + (coords.pageX - resizeClickPositionX);
+
+      if (increasingSize) {
+        if (resizeHorizontal >= widthMax) {
+          resizeHorizontal = widthMax;
+          resizeVertical = widthMax
+        }
+
+        if (resizeVertical >= heightMax) {
+          resizeVertical = heightMax;
+          resizeHorizontal = heightMax;
+        }
+      }
+
+      if (decreasingSize) {
+        if (resizeHorizontal <= minThreshold) {
+          resizeHorizontal = minThreshold;
+          resizeVertical = minThreshold;
+        }
+      }
+    }
   }
 
-  var update = function() {
+  var dragBox = function() {
     if(dragState) {
       requestAnimationFrame(function() {
-        update();
+        dragBox();
       });
     }
 
     $cropBox.css("top", moveDown);
     $cropBox.css( "left", moveRight);
   }
+
+  var resizeBox = function() {
+    if(resizeState) {
+      requestAnimationFrame(function() {
+        resizeBox();
+      });
+    }
+
+    $cropBox.css( "height", resizeVertical);
+    $cropBox.css( "width", resizeHorizontal);
+    $cropBox.css( "height", resizeVertical);
+    $cropBox.css( "width", resizeHorizontal);
+  }
+
 
   /**
    * Sets up the mouse events on the cropping interface using a give width and height.
@@ -238,9 +304,20 @@ define(function(require) {
    */
   var croppingReset = function (width, height) {
 
+    // // Turn off any previously bound events so
+    // // we can rebind them later using new settings.
+    $(document).off("touchmove mousemove");
+    $(document).off("touchend mouseup");
+
     $cropBox.on('mousedown', function(event) {
       event.preventDefault();
       dragState = true;
+      onMouseDown(event);
+    });
+
+    $(".resize-handle").on('mousedown', function(event) {
+      event.preventDefault();
+      resizeState = true;
       onMouseDown(event);
     });
 
@@ -348,8 +425,8 @@ define(function(require) {
     });
 
     // Initiate dragging and resizing.
-    dragCropBoxInit();
-    resizeCropBoxInit();
+    // dragCropBoxInit();
+    // resizeCropBoxInit();
 
     croppingReset(width, height);
   };

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
@@ -264,8 +264,6 @@ define(function(require) {
 
     $cropBox.css( "height", resizeVertical);
     $cropBox.css( "width", resizeHorizontal);
-    $cropBox.css( "height", resizeVertical);
-    $cropBox.css( "width", resizeHorizontal);
   };
 
 
@@ -320,6 +318,8 @@ define(function(require) {
 
     var $cropContainer = $previewImage.parent();
     var cropBoxSize = getCropBoxSize(width, height, minThreshold);
+    var left = Math.floor((width / 2) - (cropBoxSize / 2));
+    var top  = Math.floor((height / 2) - (cropBoxSize / 2))
 
     // Expicitly set the dimensions of the crop area.
     $cropContainer.width(width);
@@ -328,11 +328,17 @@ define(function(require) {
     // Set the initial position of the cropbox in the center of the image
     // and with a minimum value of 480px.
     $cropBox.insertBefore($previewImage).css({
-      "left"   : Math.floor((width / 2) - (cropBoxSize / 2)),
-      "top"    : Math.floor((height / 2) - (cropBoxSize / 2)),
+      "left"   : left,
+      "top"    : top,
       "width"  : cropBoxSize,
       "height" : cropBoxSize,
     });
+
+    // Set the starting positions for the animations
+    moveDown         = top;
+    moveRight        = left;
+    resizeVertical   = cropBoxSize;
+    resizeHorizontal = cropBoxSize;
 
     croppingReset(width, height);
   };

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/requirejs.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/requirejs.js
@@ -12,7 +12,7 @@ module.exports = {
         compress: {
           dead_code: true,
           drop_debugger: true,
-          drop_console: true,
+          drop_console: false,
           global_defs: {
             DEBUG: false
           }

--- a/lib/themes/dosomething/paraneue_dosomething/tasks/requirejs.js
+++ b/lib/themes/dosomething/paraneue_dosomething/tasks/requirejs.js
@@ -12,7 +12,7 @@ module.exports = {
         compress: {
           dead_code: true,
           drop_debugger: true,
-          drop_console: false,
+          drop_console: true,
           global_defs: {
             DEBUG: false
           }


### PR DESCRIPTION
## Changes

Refactors the ImageCrop script to use `window.requestAnimationFrame()` for better performance and smoother animations. Adds a requestAnimationFrame polyfill.

Fixes #3790  - Moving to requestAnimationFrame() creates a smoother animation by separating the tasks of calculating the new position of the cropbox, and redrawing the cropbox at the new position. 

Fixes #3963 - We keep track of the last position of the cropbox to do the animation now, so we can use that to set a boundary by fixing the position. So, if the new position of the box will be outside of the crop area, then don't allow it to go there.

Fixes #4032 - Similar to above, we can track if the user is resizing the box too big and stop the animation before redrawing the box, so that the cropbox never breaks the crop area. This should stop black bars being generated in reportback images. 

@DoSomething/front-end 
