### PR TITLE
Store scaled minimum in a separate variable

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageCrop.js
@@ -20,12 +20,14 @@ define(function(require) {
   var moveDown;
   var resizeHorizontal;
   var resizeVertical;
+  var minScaled;
+  var minimum              = 480;
   var $cropBox             = $("<div class='cropbox'><div class='resize-handle'></div></div>");
   var resizeClickPositionX = 0;
   var resizeClickPositionY = 0;
   var scale                = 1;
   var degrees              = 0;
-  var minThreshold         = 480;
+
 
   /**
    * Returns the coordinates of a touch or mouse event.
@@ -52,8 +54,8 @@ define(function(require) {
   /**
    * Returns a value equal to the minimum allowed crop size scaled down to fit the image.
    */
-  var getMinimumSize = function() {
-    return minThreshold / scale;
+  var getMinimumSize = function(minimum, scale) {
+    return minimum / scale;
   };
 
   /**
@@ -216,7 +218,7 @@ define(function(require) {
       resizeVertical   = initialCropBoxHeight + (coords.pageX - resizeClickPositionX);
 
       // Set the bounding values based on the how much the box can be increased to
-      // and the minium allowed size of the box.
+      // and the minimum allowed size of the box.
       if (increasingSize) {
         if (resizeHorizontal >= widthMax) {
           resizeHorizontal = widthMax;
@@ -230,9 +232,9 @@ define(function(require) {
       }
 
       if (decreasingSize) {
-        if (resizeHorizontal <= minThreshold) {
-          resizeHorizontal = minThreshold;
-          resizeVertical = minThreshold;
+        if (resizeHorizontal <= minScaled) {
+          resizeHorizontal = minScaled;
+          resizeVertical = minScaled;
         }
       }
     }
@@ -317,7 +319,7 @@ define(function(require) {
     }
 
     var $cropContainer = $previewImage.parent();
-    var cropBoxSize = getCropBoxSize(width, height, minThreshold);
+    var cropBoxSize = getCropBoxSize(width, height, minScaled);
     var left = Math.floor((width / 2) - (cropBoxSize / 2));
     var top  = Math.floor((height / 2) - (cropBoxSize / 2))
 
@@ -435,7 +437,7 @@ define(function(require) {
     previewImageWidth  = $previewImage.width();
     previewImageHeight = $previewImage.height();
     scale              = origImage.width / $previewImage.width();
-    minThreshold       = getMinimumSize();
+    minScaled          = getMinimumSize(minimum, scale);
 
     // Create the crop area.
     $previewImage.wrap($("<div class='crop-bounding-box'></div>"));


### PR DESCRIPTION
Fixes a small bug where the minimum wasn't being a reset when the image changed by storing the global minimum (480x480) in a different variable than the scaled minimum (480 scaled down based on the image size) so it doesn't get overwritten. 

@DoSomething/front-end 
