### PR TITLE
Adds get reset url resource to API

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -6,4 +6,4 @@ dependencies[] = services
 features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
-mtime = 1424984318
+mtime = 1425416358

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -6,4 +6,4 @@ dependencies[] = services
 features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
-mtime = 1421093306
+mtime = 1424984318

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -6,4 +6,4 @@ dependencies[] = services
 features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
-mtime = 1420822034
+mtime = 1421093306

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -124,6 +124,11 @@ function dosomething_api_default_services_endpoint() {
           'enabled' => '1',
         ),
       ),
+      'targeted_actions' => array(
+        'password_reset_url' => array(
+          'enabled' => '1',
+        ),
+      ),
     ),
   );
   $endpoint->debug = 0;

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -9,7 +9,7 @@ function _member_resource_defintion() {
         'file' => array(
           'type' => 'inc',
           'module' => 'dosomething_api',
-          'name' => 'resources/member.resource',
+          'name' => 'resources/member_resource',
         ),
         'callback' => '_member_resource_create',
           'args' => array(
@@ -62,32 +62,17 @@ function _member_resource_defintion() {
     'targeted_actions' => array(
       'password_reset_url' => array(
         'help' => 'Gets the user password reset URL.',
-        'file' => array('
-          type' => 'inc', 
+        'file' => array(
+          'type' => 'inc', 
           'module' => 'dosomething_api', 
-          'name' => 'resources/member_resource'
+          'name' => 'resources/member_resource',
         ),
-        'callback' => 'stuff to do',
-        'access callback' => '_campaign_resource_access',
+        'callback' => '_member_resource_reset',
+        'access callback' => '_member_resource_access',
         'access arguments' => array('password_reset_url'),
-        'access arguments append' => TRUE, // ? // everything past here needs updatin prob
-        'args' => array(
-          array(
-            'name' => 'nid',
-            'optional' => FALSE,
-            'source' => array('path' => 0),
-            'type' => 'int',
-            'description' => 'The nid of the Campaign node to signup for.',
-          ),
-          array(
-            'name' => 'values',
-            'optional' => FALSE,
-            'source' => 'data',
-            'description' => 'The Signup data',
-            'type' => 'array',
-          ),
-        ),
-      ),    
+        'access arguments append' => TRUE,
+      ), 
+    ),   
   );
   return $member_resource;
 }
@@ -96,7 +81,7 @@ function _member_resource_defintion() {
  * Access callback for User resources.
  */
 function _member_resource_access($op) {
-  if ($op == 'create' || $op == 'get_member_count') {
+  if ($op == 'create' || $op == 'get_member_count' || $op == 'password_reset_url') {
     return TRUE;
   }
   global $user;
@@ -211,4 +196,19 @@ function _member_resource_index($parameters) {
   // Return max of ten records.
   $query->range(0, 10);
   return $query->execute()->fetchAll();
+}
+
+/**
+ * Callback for user password reset URL
+ *
+ * @param array $parameters
+ *   Array passed within query string.
+ *   - email (string)..
+ *
+ * @return string
+ *   String of the password reset URL or errors.
+ */
+function _member_resource_reset($nid, $parameters) {
+  watchdog('api', 'it was called');
+  return $nid . ' + ' . $parameters;
 }

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -81,6 +81,7 @@ function _member_resource_defintion() {
  * Access callback for User resources.
  */
 function _member_resource_access($op) {
+  watchdog('dosomething_api', $op);
   if ($op == 'create' || $op == 'get_member_count' || $op == 'password_reset_url') {
     return TRUE;
   }
@@ -209,6 +210,6 @@ function _member_resource_index($parameters) {
  *   String of the password reset URL or errors.
  */
 function _member_resource_reset($nid, $parameters) {
-  watchdog('api', 'it was called');
+  watchdog('dosomething_api', 'it was called');
   return $nid . ' + ' . $parameters;
 }

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -89,7 +89,7 @@ function _member_resource_defintion() {
  * Access callback for User resources.
  */
 function _member_resource_access($op) {
-  if ($op == 'create' || $op == 'get_member_count' || $op == 'password_reset_url') {
+  if ($op == 'create' || $op == 'get_member_count') {
     return TRUE;
   }
   global $user;

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -52,13 +52,42 @@ function _member_resource_defintion() {
         'file' => array(
           'type' => 'inc',
           'module' => 'dosomething_api',
-          'name' => 'resources/member.resource',
+          'name' => 'resources/member_resource',
         ),
         'callback' => '_member_resource_get_member_count',
         'access callback' => '_member_resource_access',
         'access arguments' => array('get_member_count'),
       ),
     ),
+    'targeted_actions' => array(
+      'password_reset_url' => array(
+        'help' => 'Gets the user password reset URL.',
+        'file' => array('
+          type' => 'inc', 
+          'module' => 'dosomething_api', 
+          'name' => 'resources/member_resource'
+        ),
+        'callback' => 'stuff to do',
+        'access callback' => '_campaign_resource_access',
+        'access arguments' => array('password_reset_url'),
+        'access arguments append' => TRUE, // ? // everything past here needs updatin prob
+        'args' => array(
+          array(
+            'name' => 'nid',
+            'optional' => FALSE,
+            'source' => array('path' => 0),
+            'type' => 'int',
+            'description' => 'The nid of the Campaign node to signup for.',
+          ),
+          array(
+            'name' => 'values',
+            'optional' => FALSE,
+            'source' => 'data',
+            'description' => 'The Signup data',
+            'type' => 'array',
+          ),
+        ),
+      ),    
   );
   return $member_resource;
 }

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -67,10 +67,18 @@ function _member_resource_defintion() {
           'module' => 'dosomething_api', 
           'name' => 'resources/member_resource',
         ),
+        'args' => array(
+          array(
+            'name' => 'uid',
+            'optional' => FALSE,
+            'source' => array('path' => 0),
+            'type' => 'int',
+            'description' => 'The uid of the user whose password reset url we are getting',
+          ),
+        ),        
         'callback' => '_member_resource_reset',
         'access callback' => '_member_resource_access',
         'access arguments' => array('password_reset_url'),
-        'access arguments append' => TRUE,
       ), 
     ),   
   );
@@ -209,7 +217,7 @@ function _member_resource_index($parameters) {
  * @return string
  *   String of the password reset URL or errors.
  */
-function _member_resource_reset($nid, $parameters) {
+function _member_resource_reset($uid) {
   watchdog('dosomething_api', 'it was called');
   return $nid . ' + ' . $parameters;
 }

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -89,7 +89,6 @@ function _member_resource_defintion() {
  * Access callback for User resources.
  */
 function _member_resource_access($op) {
-  watchdog('dosomething_api', $op);
   if ($op == 'create' || $op == 'get_member_count' || $op == 'password_reset_url') {
     return TRUE;
   }
@@ -219,8 +218,7 @@ function _member_resource_index($parameters) {
  */
 function _member_resource_reset($uid) {
   //Fix this http://dev.dosomething.org:8888/admin/reports/event/657554
-  $account = array('uid' => $uid);
+  $account = user_load($uid);
   $reset_url = user_pass_reset_url($account);
-  watchdog('dosomething_api', $reset_url);
-  return $uid;
+  return $reset_url;
 }

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -218,6 +218,9 @@ function _member_resource_index($parameters) {
  *   String of the password reset URL or errors.
  */
 function _member_resource_reset($uid) {
-  watchdog('dosomething_api', 'it was called');
-  return $nid . ' + ' . $parameters;
+  //Fix this http://dev.dosomething.org:8888/admin/reports/event/657554
+  $account = array('uid' => $uid);
+  $reset_url = user_pass_reset_url($account);
+  watchdog('dosomething_api', $reset_url);
+  return $uid;
 }

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -217,7 +217,6 @@ function _member_resource_index($parameters) {
  *   String of the password reset URL or errors.
  */
 function _member_resource_reset($uid) {
-  //Fix this http://dev.dosomething.org:8888/admin/reports/event/657554
   $account = user_load($uid);
   $reset_url = user_pass_reset_url($account);
   return $reset_url;


### PR DESCRIPTION
Fixes #4062 

Creates targeted ation at /users/<uid>/password_reset_url

Required for
https://github.com/DoSomething/mb-toolbox/issues/29

@aaronschachter 
