### PR TITLE
Provides users/:uid/activity API endpoint

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -6,4 +6,4 @@ dependencies[] = services
 features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
-mtime = 1425416358
+mtime = 1425655516

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -124,6 +124,11 @@ function dosomething_api_default_services_endpoint() {
           'enabled' => '1',
         ),
       ),
+      'relationships' => array(
+        'activity' => array(
+          'enabled' => '1',
+        ),
+      ),
       'targeted_actions' => array(
         'password_reset_url' => array(
           'enabled' => '1',

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -46,6 +46,36 @@ function _member_resource_defintion() {
         ),
       ),
     ),
+    'relationships' => array(
+      'activity' => array(
+        'file' => array(
+          'type' => 'inc',
+          'module' => 'dosomething_api',
+          'name' => 'resources/member_resource',
+        ),
+        'help'   => 'Returns Current User Activity. GET from users/current/activity, users/23423/activity',
+        'access callback' => '_member_resource_access',
+        'access arguments' => array('activity'),
+        'access arguments append' => TRUE,
+        'callback' => '_member_resource_get_activity',
+        'args'     => array(
+          array(
+            'name' => 'uid',
+            'optional' => FALSE,
+            'source' => array('path' => 0),
+            'type' => 'string',
+            'description' => 'The uid of the user whose activity to retrieve. Use current for logged in user.',
+          ),
+          array(
+            'name' => 'nid',
+            'type' => 'int',
+            'description' => t('Node nid to filter by.'),
+            'source' => array('param' => 'nid'),
+            'optional' => FALSE,
+          ),
+        ),
+      ),
+    ),
     'actions' => array(
       'get_member_count' => array(
         'help' => 'Returns current member count.',
@@ -204,6 +234,35 @@ function _member_resource_index($parameters) {
   // Return max of ten records.
   $query->range(0, 10);
   return $query->execute()->fetchAll();
+}
+
+/**
+ * Returns User Activity for given $uid and $nid.
+ */
+function _member_resource_get_activity($uid, $nid) {
+  if ($uid === 'current') {
+    global $user;
+    $uid = $user->uid;
+  }
+  elseif (is_numeric($uid)) {
+    $uid = (int) $uid;
+  }
+  $result = new StdClass();
+  if ($sid = dosomething_signup_exists($nid, $uid)) {
+    $signup = signup_load($sid);
+    $result->sid = $signup->sid;
+    $result->signed_up = $signup->timestamp;
+    $result->source = $signup->source;
+    $result->rbid = NULL;
+  }
+  if ($rbid = dosomething_reportback_exists($nid, $uid)) {
+    $reportback = reportback_load($rbid);
+    $result = (object) array_merge((array) $result, (array) $reportback);
+    // Remove unneeded properties.
+    unset($result->uid);
+    unset($result->nid);
+  }
+  return $result;
 }
 
 /**


### PR DESCRIPTION
Fixes #4119 to access a given (or the current) user's activity for a specified nid.

**GET** http://dev.dosomething.org:8888/api/v1/users/8/activity.json?nid=1619

**GET** http://dev.dosomething.org:8888/api/v1/users/current/activity.json?nid=1619

![screen shot 2015-03-06 at 9 49 04 am](https://cloud.githubusercontent.com/assets/1236811/6530474/10ff5b22-c3e6-11e4-83ed-d23d9a92c16b.png)
