### PR TITLE
Add ImageCache Actions color actions submodule.

### DIFF
--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -36,6 +36,7 @@ dependencies[] = field_collection
 dependencies[] = field_group
 dependencies[] = file_entity
 dependencies[] = imagecache_actions
+dependencies[] = imagecache_coloractions
 dependencies[] = i18n
 dependencies[] = libraries
 dependencies[] = l10n_update


### PR DESCRIPTION
# Changes
- I forgot to enable the `imagecache_coloractions` submodule in #4092, resulting in an [error on the pitch page](https://cloud.githubusercontent.com/assets/6330971/6535514/829b1230-c413-11e4-856a-d55439efde44.png). This adds `imagecache_coloractions` dependency to enable the "Change file format" action.

Fixes #4130. For review: @aaronschachter 
