### PR TITLE
Fixes #4139.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
@@ -27,7 +27,7 @@ function dosomething_signup_get_mobilecommons_friends_vars($values) {
   else {
     $args['opt_in_path[]'] = $values['opt_in_path'];
     $args['person[first_name]'] = $values['alpha_name'];
-    $args['person[campaign_name]'] = $title;  
+    $args['person[campaign_name]'] = $title;
   }
 
   // Logged in user may not have a mobile #, so we check if its been set here,
@@ -70,4 +70,36 @@ function dosomething_signup_mobilecommons_opt_in_friends($values) {
     // Log the error.
     watchdog('dosomething_signup', $e, array(), WATCHDOG_ERROR);
   }
+}
+
+/**
+ * Prepares array of arguments to pass to a Mobilecommons opt-in request.
+ *
+ * @param object $account
+ *   The user object of user to opt-in.
+ * @param int $lid
+ *   The opt-in path to use for opt-in.
+ * @param string $title
+ *   Optional -- The campaign title the user has signed up for.
+ *
+ * @return mixed
+ *   Array of arguments to pass to a Mobilecommons request, or FALSE if no mobile.
+ */
+function dosomething_signup_get_mobilecommons_vars($account, $lid, $title = NULL) {
+  $args = array(
+    'opt_in_path[]' => $lid,
+    'person[phone]' => dosomething_user_get_field('field_mobile', $account),
+    'person[email]' => $account->mail,
+  );
+  if ($first_name = dosomething_user_get_field('field_first_name', $account)) {
+    $args['person[first_name]'] = $first_name;
+  }
+  // Expected DOB format is YYYY-MM-DD.
+  if ($dob = dosomething_user_get_field('field_birthdate', $account, 'Y-m-d')) {
+    $args['person[date_of_birth]'] = $dob;
+  }
+  if (isset($title)) {
+    $args['person[campaign_name]'] = $title;
+  }
+  return $args;
 }


### PR DESCRIPTION
Function `dosomething_signup_get_mobilecommons_vars()` has been removed in #4024, but it is still used by `dosomething_signup_get_mobilecommons_friends_vars()`. This PR restores it in the previous state.
