### PR TITLE
Fixes the version of vagrant box in code.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@ Vagrant.configure("2") do |config|
 
   ## Choose your base box
   config.vm.box = "dosomething/drupal"
+  config.vm.box_version = "0.4.0"
 
   config.vm.provider "virtualbox" do |v|
     v.customize ["modifyvm", :id, "--memory", 3072]


### PR DESCRIPTION
Specifies explicitly the version of vagrant box in code so it's controlled programmatically and we can test other released versions in branches.
