### PR TITLE
Vagrant on Ansible.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,11 +2,19 @@ Vagrant.configure("2") do |config|
 
   ## Choose your base box
   config.vm.box = "dosomething/drupal"
-  config.vm.box_version = "0.4.0"
+  config.vm.box_version = "1.0.0.alpha1"
 
   config.vm.provider "virtualbox" do |v|
     v.customize ["modifyvm", :id, "--memory", 3072]
+    # Fixes slow DNS on virtual Ubuntu 14.04.
+    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
+
+  # Use custom created user to manage vagrant.
+  config.ssh.username = 'dosomething'
+  
+  # Since authorized keys were prepopulated, vagrant needs a path to your key.
+  config.ssh.private_key_path = '~/.ssh/id_rsa'
 
   # SSH Agent forwarding
   config.ssh.forward_agent = true
@@ -14,14 +22,14 @@ Vagrant.configure("2") do |config|
   if ENV['DS_VAGRANT_MOUNT_NFS']
     # NFS
     config.vm.network :private_network, ip: "10.11.12.13"
-    config.vm.synced_folder ".", "/var/www/vagrant", type: "nfs"
+    config.vm.synced_folder ".", "/var/www/dev.dosomething.org", type: "nfs"
   else
     # SSHFS -- reverse mount from within Vagrant box
-    config.sshfs.paths = { "/var/www/vagrant" => "../dosomething-mount" }
+    config.sshfs.paths = { "/var/www/dev.dosomething.org" => "../dosomething-mount" }
   end
 
   # Bare Apache httpd (http and https)
-  config.vm.network :forwarded_port, guest: 8888, host: 8888
+  config.vm.network :forwarded_port, guest: 80, host: 8888
   config.vm.network :forwarded_port, guest: 8889, host: 8889
 
   config.vm.host_name = "dev.dosomething.org"


### PR DESCRIPTION
#### What's this PR do?
- Configures vagrant to use [newest box](/DoSomething/vagrant-platform) built with Ansible
#### Testing
- Checkout this branch
- Start Vagrant `vagrant up`
- Log into VM `vagrant ssh`
- Run `setup-www`
- Change directory to `cd /var/www/dev.dosomething.org`
- Build project as usual `bin/ds build --install` or `bin/ds build && bin/ds pull --db`
#### Changelog
##### New and updated software:
- Ubuntu 14.04
- Nginx/php-fpm instead of Apache/mod_php
- Drush 6.5.0
- PHP 5.5.9-1
- MySQL 5.5.41
##### Changes:
- Now default user is `dosomething`
- Default web folder changed to `/var/www/dev.dosomething.org`
##### Not ready / In progress:
- Solr
- Varnish
- Https
