### PR TITLE
Removed redirect to old confirmation page.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -320,22 +320,16 @@ function dosomething_reportback_form_submit($form, &$form_state) {
   // Save values into reportback.
   $rid = dosomething_reportback_save($values);
 
-  // Redirect to confirmation.
-  $display_permalink = variable_get('dosomething_reportback_display_permalink');
-  if (!$is_admin_form && !$display_permalink) {
-    $redirect = dosomething_campaign_get_confirmation_path($values['nid']);
-    $form_state['redirect'] = $redirect;
-  }
-  if ($display_permalink) {
-    $form_state['redirect'] = array(
-      'reportback/' . $rid,
-      array(
-        'query' => array(
-          'fid' => $values['fid'],
-        ),
+  // Redirect to permalink page.
+  $form_state['redirect'] = array(
+    'reportback/' . $rid,
+    array(
+      'query' => array(
+        'fid' => $values['fid'],
       ),
-    );
-  }
+    ),
+  );
+
 }
 
 /**


### PR DESCRIPTION
Doesn't remove the confirmation page, just removes the redirect to the page after submitting a reportback
Refs #4095
