### PR TITLE
Permalink share updates

### DIFF
--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -234,4 +234,14 @@ function dosomething_metatag_get_permalink_vars() {
   );
 
   drupal_add_html_head($element, 'og:image');
+
+  $element = array(
+    '#tag' => 'meta',
+    '#attributes' => array(
+      "property" => "og:description",
+      "content" => $share_copy,
+    ),
+  );
+
+  drupal_add_html_head($element, 'og:description');
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -454,7 +454,7 @@ function dosomething_reportback_view_entity($entity) {
     // Set tumblr options
     $tumblr_options = array(
       'source' =>  $file->getImageURL('large'),
-      'caption' => $share_text,
+      'caption' => $share_text . " " . $reportback_url,
       'clickthru' => $reportback_url,
     );
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
@@ -83,10 +83,6 @@
               <?php elseif ($node->solution_copy): ?>
                 <?php print $node->solution_copy; ?>
               <?php endif; ?>
-
-              <?php if ($node->solution_support): ?>
-                <?php print($node->solution_support); ?>
-              <?php endif; ?>
             </div>
             <div class="cta">
               <div class="wrapper">


### PR DESCRIPTION
- Adds an og:description metatag to pull in the campaign CTA to facebook shares
- Adds a link to the permalink page in the tumblr share text. Fixes #4177 
- Remove the solution supporting language since it made the card to long.

@DoSomething/front-end 
