### PR TITLE
Permalink as pitch page

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -167,7 +167,7 @@ function dosomething_campaign_scholarship_block_content() {
       unset($rows[$key]['data']['src']);
       $rows[$key]['data']['amount'] = '$' . $scholarship['amount'];
       $rows[$key]['data']['deadline'] = $scholarship['deadline'];
-      $rows[$key]['data']['image'] = "<img src=" . $rows[$key]['data']['image'] . "</img>"; 
+      $rows[$key]['data']['image'] = "<img src=" . $rows[$key]['data']['image'] . "</img>";
     }
 
     $vars['header'] = array('nid', 'title', 'cta', 'image', 'path', 'pretty path', 'staff pick', 'amount', 'deadline');

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -424,13 +424,9 @@ function _dosomething_reportback_get_permalink_copy_vars($user, $node) {
  * Alters the signup form that is attached to permalink pages.
  */
 function dosomething_reportback_form_alter(&$form, &$form_state, $form_id) {
-  // A signup form, on a reportback page.
-  if ($form_id == 'dosomething_signup_form' && drupal_match_path($path = current_path(), 'reportback/*')) {
-    $form['source'] = array(
-      '#type' => 'hidden',
-      '#value' => $path,
-      '#access' => FALSE,
-    );
+  // A signup/login/register form, on a reportback page.
+  $forms = array('dosomething_signup_form', 'user_register_form', 'user_login', 'user_login_block');
+  if (in_array($form_id, $forms) && drupal_match_path($path = current_path(), 'reportback/*')) {
     $form['#submit'][] = 'dosomething_reportback_signup_submit';
   }
 }
@@ -512,11 +508,11 @@ function dosomething_reportback_view_entity($entity) {
  * Custom submit handler for signup form.
  * @see dosomething_reportback_form_alter().
  */
-function dosomething_reportback_signup_submit($form, &$form_state) {
+function dosomething_reportback_signup_submit(&$form, &$form_state) {
   // Add a redirect to the campaign node.
   if (isset($form['nid']['#value'])) {
     $nid = $form['nid']['#value'];
-    $form_state['redirect'] = 'node/' . $nid;
+    $form_state['redirect'] = drupal_get_path_alias('node/' . $nid);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -405,7 +405,7 @@ function dosomething_reportback_admin_view_entity($entity) {
 /**
  * Returns all copy variables set on the permalink page.
  */
-function _dosomething_reportback_get_permalink_copy_vars() {
+function _dosomething_reportback_get_permalink_copy_vars($user, $node) {
   return array(
     'owners_rb_subtitle' => variable_get('dosomething_campaign_permalink_confirmation_owners_page_subtitle', ''),
     'owners_rb_scholarship' => variable_get('dosomething_campaign_permalink_confirmation_owners_scholarship', ''),
@@ -415,7 +415,7 @@ function _dosomething_reportback_get_permalink_copy_vars() {
     'owners_rb_social_cta' => variable_get('dosomething_campaign_permalink_confirmation_owners_social_cta', ''),
     'owners_title' => variable_get('dosomething_campaign_permalink_owners_page_title', ''),
     'owners_subtitle' => variable_get('dosomething_campaign_permalink_owners_page_subtitle', ''),
-    'non_owners_title' => token_replace(variable_get('dosomething_campaign_permalink_nonowners_page_title', ''), array('user' => $rb_user)),
+    'non_owners_title' => token_replace(variable_get('dosomething_campaign_permalink_nonowners_page_title', ''), array('user' => $user)),
   );
 }
 
@@ -440,9 +440,10 @@ function dosomething_reportback_view_entity($entity) {
     $file = reportback_file_load($fid);
     $rb['image'] = $file->getImage('large');
     $rb['caption'] = $file->caption;
-    $copy_vars = _dosomething_reportback_get_permalink_copy_vars();
 
     $node = dosomething_campaign_load(node_load($entity->nid));
+    $copy_vars = _dosomething_reportback_get_permalink_copy_vars($rb_user, $node);
+
 
     $incentive = ($node->scholarship) ? $copy_vars['owners_rb_scholarship'] : "";
     $title = ($is_owner) ? $copy_vars['owners_title'] : $copy_vars['non_owners_title'];

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -444,6 +444,8 @@ function dosomething_reportback_view_entity($entity) {
     $node = dosomething_campaign_load(node_load($entity->nid));
     $copy_vars = _dosomething_reportback_get_permalink_copy_vars($rb_user, $node);
 
+    $signup = dosomething_signup_get_signup_button('Sign Up', $entity->nid, 'dosomething_signup_form');
+
 
     $incentive = ($node->scholarship) ? $copy_vars['owners_rb_scholarship'] : "";
     $title = ($is_owner) ? $copy_vars['owners_title'] : $copy_vars['non_owners_title'];
@@ -480,7 +482,7 @@ function dosomething_reportback_view_entity($entity) {
       'copy_vars' => $copy_vars,
       'title' => $title,
       'subtitle' => $subtitle,
-      'link' => $link,
+      'signup_button' => $signup,
       'fb_link' => $fb_link,
       'twitter_link' => $twitter_link,
       'tumblr_link' => $tumblr_link,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -402,6 +402,22 @@ function reportback_file_load($fid) {
 function dosomething_reportback_admin_view_entity($entity) {
   return entity_view('reportback', array($entity->rbid => $entity), 'full');
 }
+/**
+ * Returns all copy variables set on the permalink page.
+ */
+function _dosomething_reportback_get_permalink_copy_vars() {
+  return array(
+    'owners_rb_subtitle' => variable_get('dosomething_campaign_permalink_confirmation_owners_page_subtitle', ''),
+    'owners_rb_scholarship' => variable_get('dosomething_campaign_permalink_confirmation_owners_scholarship', ''),
+    'owners_rb_important' => variable_get('dosomething_campaign_permalink_confirmation_owners_important_to_you', ''),
+    'owners_rb_social_header' => variable_get('dosomething_campaign_permalink_confirmation_owners_social_header', ''),
+    'owners_rb_social_copy' => token_replace(variable_get('dosomething_campaign_permalink_confirmation_owners_social_copy', ''), array('node' => $node)),
+    'owners_rb_social_cta' => variable_get('dosomething_campaign_permalink_confirmation_owners_social_cta', ''),
+    'owners_title' => variable_get('dosomething_campaign_permalink_owners_page_title', ''),
+    'owners_subtitle' => variable_get('dosomething_campaign_permalink_owners_page_subtitle', ''),
+    'non_owners_title' => token_replace(variable_get('dosomething_campaign_permalink_nonowners_page_title', ''), array('user' => $rb_user)),
+  );
+}
 
 /**
  * Callback for /rbf/FID page.
@@ -424,20 +440,9 @@ function dosomething_reportback_view_entity($entity) {
     $file = reportback_file_load($fid);
     $rb['image'] = $file->getImage('large');
     $rb['caption'] = $file->caption;
+    $copy_vars = _dosomething_reportback_get_permalink_copy_vars();
 
     $node = dosomething_campaign_load(node_load($entity->nid));
-
-    $copy_vars = array(
-      'owners_rb_subtitle' => variable_get('dosomething_campaign_permalink_confirmation_owners_page_subtitle', ''),
-      'owners_rb_scholarship' => variable_get('dosomething_campaign_permalink_confirmation_owners_scholarship', ''),
-      'owners_rb_important' => variable_get('dosomething_campaign_permalink_confirmation_owners_important_to_you', ''),
-      'owners_rb_social_header' => variable_get('dosomething_campaign_permalink_confirmation_owners_social_header', ''),
-      'owners_rb_social_copy' => token_replace(variable_get('dosomething_campaign_permalink_confirmation_owners_social_copy', ''), array('node' => $node)),
-      'owners_rb_social_cta' => variable_get('dosomething_campaign_permalink_confirmation_owners_social_cta', ''),
-      'owners_title' => variable_get('dosomething_campaign_permalink_owners_page_title', ''),
-      'owners_subtitle' => variable_get('dosomething_campaign_permalink_owners_page_subtitle', ''),
-      'non_owners_title' => token_replace(variable_get('dosomething_campaign_permalink_nonowners_page_title', ''), array('user' => $rb_user)),
-    );
 
     $incentive = ($node->scholarship) ? $copy_vars['owners_rb_scholarship'] : "";
     $title = ($is_owner) ? $copy_vars['owners_title'] : $copy_vars['non_owners_title'];
@@ -1108,4 +1113,5 @@ function dosomething_reportback_generate($nid = NULL, $num_reportbacks = 5) {
     watchdog('dosomething_reportback', "Generated RB:" . json_encode($values));
     dosomething_reportback_save($values);
   }
+
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -418,6 +418,22 @@ function _dosomething_reportback_get_permalink_copy_vars($user, $node) {
     'non_owners_title' => token_replace(variable_get('dosomething_campaign_permalink_nonowners_page_title', ''), array('user' => $user)),
   );
 }
+/**
+ * Implements hook_form_alter().
+ *
+ * Alters the signup form that is attached to permalink pages.
+ */
+function dosomething_reportback_form_alter(&$form, &$form_state, $form_id) {
+  // A signup form, on a reportback page.
+  if ($form_id == 'dosomething_signup_form' && drupal_match_path($path = current_path(), 'reportback/*')) {
+    $form['source'] = array(
+      '#type' => 'hidden',
+      '#value' => $path,
+      '#access' => FALSE,
+    );
+    $form['#submit'][] = 'dosomething_reportback_signup_submit';
+  }
+}
 
 /**
  * Callback for /rbf/FID page.
@@ -440,7 +456,6 @@ function dosomething_reportback_view_entity($entity) {
     $file = reportback_file_load($fid);
     $rb['image'] = $file->getImage('large');
     $rb['caption'] = $file->caption;
-
     $node = dosomething_campaign_load(node_load($entity->nid));
     $copy_vars = _dosomething_reportback_get_permalink_copy_vars($rb_user, $node);
 
@@ -491,6 +506,17 @@ function dosomething_reportback_view_entity($entity) {
     );
     cache_set('ds_permalink_' . $entity->rbid . '_' . $fid . '_' . $is_owner, $permalink, 'cache_dosomething_reportback');
     return $permalink;
+  }
+}
+/**
+ * Custom submit handler for signup form.
+ * @see dosomething_reportback_form_alter().
+ */
+function dosomething_reportback_signup_submit($form, &$form_state) {
+  // Add a redirect to the campaign node.
+  if (isset($form['nid']['#value'])) {
+    $nid = $form['nid']['#value'];
+    $form_state['redirect'] = 'node/' . $nid;
   }
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -128,6 +128,9 @@ function dosomething_signup_get_query_source() {
   if (isset($_GET['source'])) {
     return check_plain($_GET['source']);
   }
+  elseif (drupal_match_path($path = current_path(), 'reportback/*')) {
+    return $path;
+  }
   return NULL;
 }
 
@@ -670,6 +673,10 @@ function dosomething_signup_get_login_signup_nid() {
       default:
         return NULL;
     }
+  }
+  elseif (drupal_match_path($path = current_path(), 'reportback/*')) {
+    $reportback = reportback_load(arg(1));
+    return $reportback->nid;
   }
   return NULL;
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -398,7 +398,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       '#markup' => $school_help_text . $contact_link,
       '#suffix' => '</div>',
     );
-    
+
     $label = $config['school_not_affiliated_label'];
     if (empty($label)) {
       $label = t("I am not affiliated with a school.");
@@ -551,7 +551,7 @@ function dosomething_signup_update_signup_data($values, $response = 1) {
     if ($response) {
       if (isset($values['why_signedup'])) {
         $entity->why_signedup = $values['why_signedup'];
-      } 
+      }
     }
     $entity->save();
     return TRUE;

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
@@ -8,7 +8,7 @@
 /**
  * Preprocesses variables for a signup button.
  *
- * Adds a $signup_button variable into $vars, which is set to either a signup form, 
+ * Adds a $signup_button variable into $vars, which is set to either a signup form,
  * or a link to open the login/registration modal.
  *
  * @param array $vars

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -545,8 +545,14 @@ function dosomething_user_login_submit($form, &$form_state) {
       }
     }
   }
-  // After all logins redirect to page user was just on.
-  $form_state['redirect'] = drupal_get_path_alias($_SERVER['HTTP_REFERER']);
+  // After all logins, except reportback pages redirect to page user was just on.
+  if (isset($source) && stripos($source, 'reportback') > 0) {
+   $form_state['redirect'] = drupal_get_path_alias($_SERVER['HTTP_REFERER']);
+  }
+  elseif (isset($nid)) {
+    // Redirect to campaign node on reportback permalink pages.
+    $form_state['redirect'] = drupal_get_path_alias('/node/' . $nid);
+  }
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
@@ -89,7 +89,7 @@
                 <?php if ($node->secondary_call_to_action): ?>
                   <p class="cta__message"><?php print $node->secondary_call_to_action; ?></p>
                 <?php endif; ?>
-                <a href="<?php print $link ?>" class="button">do it</a>
+                <?php print render($signup_button); ?>
               </div>
             </div>
           <?php endif; ?>


### PR DESCRIPTION
This turns the `do it` button on a permalink page into the `Sign Up` button
Currently, this only supports Authenticated Users (and shouldn't be merged just yet)

This also includes some light refactoring and of course, ever present :space_invader: fixes

Fixes #4154 
Fixes #4190 
Fixes #4115

@aaronschachter I created #4197 for the anon users, but it doesn't seem like that get_signup_button is the way to go for that. do you have any feels on how to handle that?
