### PR TITLE
Don't convert to table display until we are tablet. Fixes #4196

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback-permalink.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback-permalink.scss
@@ -12,8 +12,10 @@
   }
 
   .card__column > .wrapper {
-    display: table;
-    border-collapse: collapse;
+    @include media($tablet) {
+      display: table;
+      border-collapse: collapse;
+    }
   }
 
   .cta.-share {


### PR DESCRIPTION
I only need the `.card__column` to display as a table at the tablet breakpoint so that I can use `table-footer-group` to display the cta at the bottom of the card instead of the top on mobile.

@DoSomething/front-end 
