### PR TITLE
Always load fids from a reportback.

### DIFF
--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -121,8 +121,11 @@ function dosomething_metatag_get_permalink_vars() {
   $rbid = arg(1);
   $fid = ($_GET['fid']);
   $rb_entity = reportback_load($rbid);
-  if (!$fid) {
-    $fid = $rb_entity->fids[0];
+  if (!$fid && !empty($rb_entity->fids)) {
+    $fid = array_pop($rb_entity->fids);
+  }
+  else {
+    $fid = array_pop($rb_entity->getFids());
   }
   $file = reportback_file_load($fid);
   $image = $file->getImageURL('large');

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -121,10 +121,7 @@ function dosomething_metatag_get_permalink_vars() {
   $rbid = arg(1);
   $fid = ($_GET['fid']);
   $rb_entity = reportback_load($rbid);
-  if (!$fid && !empty($rb_entity->fids)) {
-    $fid = array_pop($rb_entity->fids);
-  }
-  else {
+  if (!$fid) {
     $fid = array_pop($rb_entity->getFids());
   }
   $file = reportback_file_load($fid);


### PR DESCRIPTION
Metatag module was attempting to call `file->getImageURL` on not a file.
Because of _science_ `reportback_load` doesn't always grab the fids from the entity.
This calls the function in the reportback class to manually get the fids.

`¯\_(ツ)_/¯`
Fixes #4203
