### PR TITLE
Updating to allow for property set in plain text.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -112,6 +112,7 @@ function dosomething_campaign_load($node, $public = FALSE) {
 
   // Plain text properties.
   $plain_text = dosomething_campaign_get_property_names_plain_text();
+
   foreach ($plain_text as $property) {
     $field_name = 'field_' . $property;
     if (isset($wrapper->{$field_name})) {
@@ -123,9 +124,15 @@ function dosomething_campaign_load($node, $public = FALSE) {
   $filtered_text = dosomething_campaign_get_property_names_filtered_text();
   foreach ($filtered_text as $property) {
     $field_name = 'field_' . $property;
+
     if ($value = $wrapper->{$field_name}->value()) {
       // Store filtered text.
-      $campaign->{$property} = $value['safe_value'];
+      if (isset($value['safe_value'])) {
+        $campaign->{$property} = $value['safe_value'];
+      }
+      else {
+        $campaign->{$property} = $value;
+      }
     }
     else {
       $campaign->{$property} = NULL;


### PR DESCRIPTION
### Fixes #4214

If the contents of the `$value` variable contain an array then check for the `safe_value` otherwise default to setting the property as just the plain text `$value`.

@aaronschachter @sergii-tkachenko
