### PR TITLE
Changing reserved variable names to unique names

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/app.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/app.js
@@ -106,15 +106,15 @@ define("app", function (require) {
 
     $('body').on('click', 'a.js-share-link', function(event) {
       event.preventDefault();
-      left = Math.round((winWidth / 2) - (width / 2));
-      top = 0;
+      var leftPos = Math.round((winWidth / 2) - (width / 2));
+      var topPos = 0;
 
       if (winHeight > height) {
-        top = Math.round((winHeight / 2) - (height / 2));
+        topPos = Math.round((winHeight / 2) - (height / 2));
       }
 
       window.open(this.href, 'intent', windowOptions + ',width=' + width +
-       ',height=' + height + ',left=' + left + ',top=' + top);
+       ',height=' + height + ',left=' + leftPos + ',top=' + topPos);
     });
 
     $("html").addClass("js-ready");


### PR DESCRIPTION
## Fixes #4216

We can't use variable names like `top` in IE8 since it is a reserved name in the outer most window object, and IE8 doesn't ignore it like other browsers. 

@DoSomething/front-end 
