### PR TITLE
Renames dosomething_mobilecommons_* variables.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -28,7 +28,7 @@ function dosomething_signup_opt_in_config_form($form, &$form_state) {
     '#description' => $desc,
   );
 
-  $name = 'dosomething_mobilecommons_opt_in_path_general_campaign_signup';
+  $name = 'dosomething_signup_mobilecommons_opt_in_path_general_campaign';
   $desc = t("Numeric Mobilecommons opt-in path for general campaign signup.");
   $form['general'][$name] = array(
     '#type' => 'textfield',
@@ -46,7 +46,7 @@ function dosomething_signup_opt_in_config_form($form, &$form_state) {
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $name = 'dosomething_mobilecommons_opt_in_path_user_register';
+  $name = 'dosomething_signup_mobilecommons_opt_in_path_user_register';
   $desc = t("Numeric Mobilecommons opt-in path when user registers for site.");
   $form['registration'][$name] = array(
     '#type' => 'textfield',
@@ -92,8 +92,8 @@ function dosomething_signup_opt_in_config_form_submit($form, &$form_state) {
   // Save general Drupal variables.
   $config_variables = array(
     'dosomething_signup_mailchimp_general_list_id',
-    'dosomething_mobilecommons_opt_in_path_general_campaign_signup',
-    'dosomething_mobilecommons_opt_in_path_user_register',
+    'dosomething_signup_mobilecommons_opt_in_path_general_campaign',
+    'dosomething_signup_mobilecommons_opt_in_path_user_register',
   );
   foreach ($config_variables as $var_name) {
     variable_set($var_name, $values[$var_name]);

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -521,3 +521,18 @@ function dosomething_signup_update_7017() {
   $name = 'dosomething_signup_mailchimp_general_list_id';
   variable_set($name, getenv('DS_MB_MAILCHIMP_LIST_ID'));
 }
+
+/**
+ * Renames dosomething_mobilecommons_* variables.
+ */
+function dosomething_signup_update_7018() {
+  $old_name = 'dosomething_mobilecommons_opt_in_path_general_campaign_signup';
+  $new_name = 'dosomething_signup_mobilecommons_opt_in_path_general_campaign';
+  variable_set($new_name, variable_get($old_name));
+  variable_del($old_name);
+
+  $old_name = 'dosomething_mobilecommons_opt_in_path_user_register';
+  $new_name = 'dosomething_signup_mobilecommons_opt_in_path_user_register';
+  variable_set($new_name, variable_get($old_name));
+  variable_del($old_name);
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -401,7 +401,7 @@ function dosomething_signup_third_party_subscribe($account, $node) {
   // If not:
   if (!$opt_in) {
     // Use general opt_in_path.
-    $var_name = 'dosomething_mobilecommons_opt_in_path_general_campaign_signup';
+    $var_name = 'dosomething_signup_mobilecommons_opt_in_path_general_campaign';
     $opt_in = variable_get($var_name);
   }
   // Send message broker request.

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -451,7 +451,7 @@ function dosomething_user_new_user($form, &$form_state) {
 
   if (module_exists('dosomething_signup')) {
     $mobile = dosomething_user_get_field('field_mobile', $account);
-    $opt_in = variable_get('dosomething_mobilecommons_opt_in_path_user_register');
+    $opt_in = variable_get('dosomething_signup_mobilecommons_opt_in_path_user_register');
 
     if (!empty($opt_in) && !empty($mobile)) {
       // Don't subscribe 26+ yo users for Mobile Commons.


### PR DESCRIPTION
This PR renames `dosomething_mobilecommons_*` variables to `dosomething_signup_mobilecommons_*` because `dosomething_mobilecommons` module does not exists anymore.
This needed for consistency of further development, such as introducing new similar variables as part of in #4058.
