### PR TITLE
Open a new window everytime

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/app.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/app.js
@@ -113,7 +113,7 @@ define("app", function (require) {
         topPos = Math.round((winHeight / 2) - (height / 2));
       }
 
-      window.open(this.href, 'intent', windowOptions + ',width=' + width +
+      window.open(this.href, '_blank', windowOptions + ',width=' + width +
        ',height=' + height + ',left=' + leftPos + ',top=' + topPos);
     });
 


### PR DESCRIPTION
## Changes

Add `_blank` to the window so that a new popup is produced everytime. Otherwise (on mobile safari), if a user clicks one share button and goes through that process, when they go back to the original reportback tab and click to share again the page loads in the same window but doesn't come into focus which is confusing.

@DoSomething/front-end 
