### PR TITLE
Add link to permalink from user profile

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -610,6 +610,9 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
         // Link to the full reportback entity view.
         $impact = l($impact, 'admin/reportback/' . $rbid);
       }
+      else {
+        $impact = l($impact, 'reportback/' . $rbid);
+      }
       $img = dosomething_image_get_themed_image_by_fid($reportback->fids[0], '300x300');
       // Media gallery template expects a full URL.
       $url = $base_url . '/' . drupal_get_path_alias('node/' . $reportback->nid);


### PR DESCRIPTION
Links x verbs nouned to the public permalink page for non-admins.
Leaves the existing link (for admins) to admin reportback there.
Fixes #4218
