### PR TITLE
Move non-owner cta to correct spot in tpl

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback-permalink.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback-permalink.scss
@@ -28,7 +28,7 @@
     }
   }
 
-  .cta.-share {
+  .cta {
     border-top: none;
 
     @include media($tablet) {

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
@@ -65,6 +65,14 @@
             </div>
           <!--Show non-owner the call to action page -->
           <?php else: ?>
+            <div class="cta">
+              <div class="wrapper">
+                <?php if ($node->secondary_call_to_action): ?>
+                  <p class="cta__message"><?php print $node->secondary_call_to_action; ?></p>
+                <?php endif; ?>
+                <?php print render($signup_button); ?>
+              </div>
+            </div>
             <div class="card__copy">
               <p class="heading -alpha"><?php print $node->title; ?></p>
 
@@ -79,14 +87,6 @@
               <?php elseif ($node->solution_copy): ?>
                 <?php print $node->solution_copy; ?>
               <?php endif; ?>
-            </div>
-            <div class="cta">
-              <div class="wrapper">
-                <?php if ($node->secondary_call_to_action): ?>
-                  <p class="cta__message"><?php print $node->secondary_call_to_action; ?></p>
-                <?php endif; ?>
-                <?php print render($signup_button); ?>
-              </div>
             </div>
           <?php endif; ?>
           </div>


### PR DESCRIPTION
## Fixes #4194

I forgot to move the cta for non-owners to the right place in the template, and target it the same as the share cta in the styling for the permalink page.

@DoSomething/front-end 
