### PR TITLE
Updates CTools to 1.7.

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -32,7 +32,7 @@ projects[cdn][version] = "2.6"
 projects[cdn][subdir] = "contrib"
 
 ; Ctools
-projects[ctools][version] = "1.4"
+projects[ctools][version] = "1.7"
 projects[ctools][subdir] = "contrib"
 
 ; Date


### PR DESCRIPTION
Fixes https://www.drupal.org/node/2454909.

Build worked well, site seems to be as usual.
