### PR TITLE
Signup Group endpoints for Inviter app prototype

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -6,4 +6,4 @@ dependencies[] = services
 features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
-mtime = 1426706833
+mtime = 1426706878

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -6,4 +6,4 @@ dependencies[] = services
 features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
-mtime = 1425655516
+mtime = 1426706833

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -7,6 +7,7 @@
 include_once 'dosomething_api.features.inc';
 include_once 'resources/campaign_resource.inc';
 include_once 'resources/member_resource.inc';
+include_once 'resources/signup_resource.inc';
 include_once 'resources/reportback_resource.inc';
 include_once 'resources/term_resource.inc';
 
@@ -41,6 +42,8 @@ function dosomething_api_services_resources() {
   $resources = array_merge_recursive($resources, _member_resource_defintion());
   // Add Reportback resource.
   $resources = array_merge_recursive($resources, _reportback_resource_defintion());
+  // Add Signup resource.
+  $resources = array_merge_recursive($resources, _signup_resource_defintion());
   // Add Term resource.
   $resources = array_merge_recursive($resources, _term_resource_defintion());
   return $resources;

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -93,6 +93,9 @@ function dosomething_api_default_services_endpoint() {
         'create' => array(
           'enabled' => '1',
         ),
+        'index' => array(
+          'enabled' => '1',
+        ),
       ),
     ),
     'system' => array(

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -88,6 +88,13 @@ function dosomething_api_default_services_endpoint() {
         ),
       ),
     ),
+    'signups' => array(
+      'operations' => array(
+        'create' => array(
+          'enabled' => '1',
+        ),
+      ),
+    ),
     'system' => array(
       'actions' => array(
         'connect' => array(

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -91,3 +91,35 @@ function _signup_resource_create($data) {
     services_error($e);
   }
 }
+
+/**
+ * Callback for Signups index.
+ *
+ * @param array $parameters
+ *   Array passed within query string. Possible keys:
+ *   - source (string).
+ *   - nid (int).
+ *
+ * @return mixed
+ *   Object of the newly created user if successful. String if errors.
+ */
+function _signup_resource_index($parameters) {
+  // Initialize output.
+  $index = array();
+
+  $query = db_select('dosomething_signup', 's');
+  $query->fields('s');
+  if (isset($parameters['source'])) {
+    $query->condition('source', $parameters['source']);
+  }
+  if (isset($parameters['nid'])) {
+    $query->condition('nid', $parameters['nid']);
+  }
+
+  // @todo: We still need to figure out how to include the alpha.
+  // This is only returning the betas that used the alpha signup as source.
+
+  // Return max of 25 records for now.
+  $query->range(0, 25);
+  return $query->execute()->fetchAll();
+}

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -97,21 +97,30 @@ function _signup_resource_create($data) {
  */
 function _signup_resource_index($parameters) {
   // Initialize output.
-  $index = array();
+  $result = array();
+  $alpha_sid = NULL;
 
   $query = db_select('dosomething_signup', 's');
-  $query->fields('s');
+  $query->fields('s', array('sid'));
   if (isset($parameters['source'])) {
     $query->condition('source', $parameters['source']);
+    // Check if the source is an invite code.
+    if ($nid = dosomething_signup_get_target_nid_for_source($parameters['source'])) {
+      // Strip out the sid.
+      $source_parts = explode('/', $parameters['source']);
+      // Add the alpha signup.
+      $result[] = signup_load((int)$source_parts[1]);
+    }
   }
   if (isset($parameters['nid'])) {
     $query->condition('nid', $parameters['nid']);
   }
 
-  // @todo: We still need to figure out how to include the alpha.
-  // This is only returning the betas that used the alpha signup as source.
-
   // Return max of 25 records for now.
   $query->range(0, 25);
-  return $query->execute()->fetchAll();
+  $query_results = $query->execute()->fetchAll();
+  foreach ($query_results as $record) {
+    $result[] = signup_load($record->sid);
+  }
+  return $result;
 }

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -1,0 +1,93 @@
+<?php
+
+function _signup_resource_defintion() {
+  $resource = array();
+  $resource['signups'] = array(
+    'operations' => array(
+      'create' => array(
+        'help' => 'Create a signup.',
+        'file' => array(
+          'type' => 'inc',
+          'module' => 'dosomething_api',
+          'name' => 'resources/signup_resource',
+        ),
+        'callback' => '_signup_resource_create',
+          'args' => array(
+            array(
+              'name' => 'source',
+              'type' => 'string',
+              'description' => 'The signup source.',
+              'source' => 'data',
+              'optional' => FALSE,
+            ),
+          ),
+        'access callback' => 'user_is_logged_in',
+      ),
+      'index' => array(
+        'help' => 'List of all signups.',
+        'file' => array(
+          'type' => 'inc',
+          'module' => 'dosomething_api',
+          'name' => 'resources/signup_reource',
+        ),
+        'callback' => '_signup_resource_index',
+        'access callback' => 'user_is_logged_in',
+        'args' => array(
+          array(
+            'name' => 'parameters',
+            'optional' => FALSE,
+            'type' => 'array',
+            'description' => 'Parameters',
+            'default value' => array(),
+            'source' => array('param' => 'parameters'),
+          ),
+        ),
+      ),
+    ),
+  );
+  return $resource;
+}
+
+/**
+ * Callback for Signup create.
+ *
+ * @param obj $signup
+ *   Array passed to the endpoint. Possible keys:
+ *   - source (string).
+ *   - nid (int).
+ *
+ *
+ * @return mixed
+ *   Object of the newly created sgnup if successful. String if errors.
+ */
+function _signup_resource_create($data) {
+  global $user;
+  if (!isset($data['source'])) {
+    return services_error("Source is required.");
+  }
+  $nid = NULL;
+  $source_parts = explode('/', $data['source']);
+  // Check if this source is a signup.
+  if (!empty($source_parts)) {
+    if ($source_parts[0] == 'signup' && is_numeric($source_parts[1])) {
+      // Find the node the source signup is associated with.
+      $source_signup = signup_load((int) $source_parts[1]);
+      $nid = $source_signup->nid;
+    }
+  }
+  if (!$nid) {
+    if (!isset($data['nid']) || !is_numeric($data['nid'])) {
+      return services_error("Numeric nid is required.");
+    }
+    $nid = $data['nid'];
+  }
+  try {
+    if ($sid = dosomething_signup_create($nid, $user->uid, $data['source'])) {
+      return signup_load($sid);
+    }
+    return services_error("Could not create signup.");
+  }
+  catch (Exception $e) {
+    services_error($e);
+  }
+}

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -65,16 +65,8 @@ function _signup_resource_create($data) {
   if (!isset($data['source'])) {
     return services_error("Source is required.");
   }
-  $nid = NULL;
-  $source_parts = explode('/', $data['source']);
-  // Check if this source is a signup.
-  if (!empty($source_parts)) {
-    if ($source_parts[0] == 'signup' && is_numeric($source_parts[1])) {
-      // Find the node the source signup is associated with.
-      $source_signup = signup_load((int) $source_parts[1]);
-      $nid = $source_signup->nid;
-    }
-  }
+  // Check if the given source has a target nid.
+  $nid = dosomething_signup_get_target_nid_for_source($data['source']);
   if (!$nid) {
     if (!isset($data['nid']) || !is_numeric($data['nid'])) {
       return services_error("Numeric nid is required.");

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -66,7 +66,7 @@ function _signup_resource_create($data) {
     return services_error("Source is required.");
   }
   // Check if the given source has a target nid.
-  $nid = dosomething_signup_get_target_nid_for_source($data['source']);
+  $nid = dosomething_signup_get_target_nid_for_source(check_plain($data['source']));
   if (!$nid) {
     if (!isset($data['nid']) || !is_numeric($data['nid'])) {
       return services_error("Numeric nid is required.");
@@ -103,11 +103,12 @@ function _signup_resource_index($parameters) {
   $query = db_select('dosomething_signup', 's');
   $query->fields('s', array('sid'));
   if (isset($parameters['source'])) {
-    $query->condition('source', $parameters['source']);
+    $source = check_plain($parameters['source']);
+    $query->condition('source', $source);
     // Check if the source is an invite code.
-    if ($nid = dosomething_signup_get_target_nid_for_source($parameters['source'])) {
+    if ($nid = dosomething_signup_get_target_nid_for_source($source)) {
       // Strip out the sid.
-      $source_parts = explode('/', $parameters['source']);
+      $source_parts = explode('/', $source);
       // Add the alpha signup.
       $result[] = signup_load((int)$source_parts[1]);
     }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -798,3 +798,27 @@ function dosomething_signup_sms_game_multi_player_signup_request($values) {
   }
   return $response;
 }
+
+/**
+ * For a given $source_string, find the target node to create the signup for.
+ *
+ * @param string $source_string
+ *   The string that will be used as the new Signup's source.
+ *
+ * @return
+ *   Integer if the $source_string refers to a target node, or NULL if not.
+ */
+function dosomething_signup_get_target_nid_for_source($source_string) {
+  // Current invite codes use an exciting "signup/:sid" format.
+  $source_parts = explode('/', $source_string);
+  // Check if this source is a signup.
+  if (!empty($source_parts)) {
+    if ($source_parts[0] == 'signup' && is_numeric($source_parts[1])) {
+      // Find the node the source signup is associated with.
+      if ($source_signup = signup_load((int) $source_parts[1])) {
+        return $source_signup->nid;
+      }
+    }
+  }
+  return NULL;
+}


### PR DESCRIPTION
Closes #4238 (details are listed in that issue).
- POST to new `api/v1/signups` endpoint with only a `source` string, if the `source` is in the format `signup/[sid]`. The `dosomething_signup_get_target_nid_for_source` function checks a given `source` string and gets the relevant node nid it is used to create the signup for.
- GET to new `api/v1/signups` endpoint with a parameters array:
  -- If a `signup/[sid]` string is passed to `parameters[source]`, return all Signups with that `signup/sid` as the source, including the alpha sid.

I know it's kind of weird to return the alpha signup as well as the betas, and we can clean this up with perhaps a better function name / endpoint if we go this route. Also open to different suggestions. 

The main purpose of adding this is not to make it perfect, as it won't be used in production for a long time, but to prototype whether or not the Alpha > Beta Signup Group per campaign flow will work in the Inviter app.
