### PR TITLE
Add markup/styles for SMS first names Optimizely test.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -167,13 +167,7 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
   $form['group1'] = array(
     '#type' => 'fieldset',
     '#attributes' => array(
-      'class' => array('-columned first-group'),
-    ),
-  );
-  $form['group2'] = array(
-    '#type' => 'fieldset',
-    '#attributes' => array(
-      'class' => array('-columned second-group'),
+      'class' => array('campaign-sms-numbers'),
     ),
   );
   $form['group1']['alpha_mobile'] = array(
@@ -189,13 +183,7 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
     ),
   );
   for ($i = 0; $i < $num_friends; $i++) {
-    // Default to second fieldset.
-    $group = 'group2';
-    if ($i == 0) {
-      // Unless its the first beta.
-      $group = 'group1';
-    }
-    $form[$group]['beta_mobile_' .$i] = array(
+    $form['group1']['beta_mobile_' .$i] = array(
       '#type' => 'textfield',
       '#required' => TRUE,
       '#title' => 'Friend\'s Cell Number',

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -183,6 +183,11 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
     ),
   );
   for ($i = 0; $i < $num_friends; $i++) {
+    $form['group1']['beta_first_name_' .$i] = array(
+      '#type' => 'hidden',
+      '#title' => 'Your Friend\'s Name',
+    );
+
     $form['group1']['beta_mobile_' .$i] = array(
       '#type' => 'textfield',
       '#required' => TRUE,

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -776,11 +776,16 @@ function dosomething_signup_sms_game_multi_player_signup_request($values) {
     'beta_mobile_0',
     'beta_mobile_1',
     'beta_mobile_2',
+    'beta_first_name_0',
+    'beta_first_name_1',
+    'beta_first_name_2',
     'story_id',
     'story_type',
   );
   foreach ($data_vars as $var) {
-    $data[$var] = $values[$var];
+    if(isset($values[$var])) {
+      $data[$var] = $values[$var];
+    }
   }
   $options = array(
     'method' => 'POST',

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
@@ -15,7 +15,6 @@ function dosomething_signup_get_mobilecommons_friends_vars($values) {
   // Initialize arrays to send to the Mobilecommons API.
   $args = array();
   $friends = array();
-  $friend_names = array();
   $title = $values['title'];
 
   // If user is logged in already:
@@ -42,15 +41,11 @@ function dosomething_signup_get_mobilecommons_friends_vars($values) {
     if (!empty($values['beta_mobile_' . $i])) {
       $friends[] = $values['beta_mobile_' . $i];
     }
-
-    if (!empty($values['beta_first_name_' . $i])) {
-      $friend_names[] = $values['beta_first_name_' . $i];
-    }
   }
   if (!empty($friends)) {
     $args['friends_opt_in_path'] = $values['friends_opt_in_path'];
   }
-  return array('args' => $args, 'friends' => $friends, 'friend_names' => $friend_names);
+  return array('args' => $args, 'friends' => $friends);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.mobilecommons.inc
@@ -15,6 +15,7 @@ function dosomething_signup_get_mobilecommons_friends_vars($values) {
   // Initialize arrays to send to the Mobilecommons API.
   $args = array();
   $friends = array();
+  $friend_names = array();
   $title = $values['title'];
 
   // If user is logged in already:
@@ -41,11 +42,15 @@ function dosomething_signup_get_mobilecommons_friends_vars($values) {
     if (!empty($values['beta_mobile_' . $i])) {
       $friends[] = $values['beta_mobile_' . $i];
     }
+
+    if (!empty($values['beta_first_name_' . $i])) {
+      $friend_names[] = $values['beta_first_name_' . $i];
+    }
   }
   if (!empty($friends)) {
     $args['friends_opt_in_path'] = $values['friends_opt_in_path'];
   }
-  return array('args' => $args, 'friends' => $friends);
+  return array('args' => $args, 'friends' => $friends, 'friend_names' => $friend_names);
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/js/validators/auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validators/auth.js
@@ -52,6 +52,13 @@ define(function(require) {
     );
   });
 
+  Validation.registerValidationFunction("friend_name", function(string, done) {
+    validateNotBlank(string, done,
+      Drupal.t("Got it!", {"@name": string}),
+      Drupal.t("We need your friend's name.")
+    );
+  });
+
   Validation.registerValidationFunction("last_name", function(string, done) {
     validateNotBlank(string, done,
       Drupal.t("Got it, @name!", {"@name": string}),

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-sms.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-sms.scss
@@ -2,9 +2,9 @@
 .campaign--sms {
   .container--do {
     form {
+      @include clearfix;
       position: relative;
       clear: both;
-      overflow: hidden;
 
       // Callout on the top right of the form
       .message-callout.-above {
@@ -15,6 +15,20 @@
         @include media($tablet) {
           position: absolute;
           top: 0;
+          right: 20px;
+          margin: 0;
+        }
+      }
+    }
+
+    // @EXPERIMENTAL: Used for Optimizely test for first names on SMS forms.
+    .optimizely-sms-form {
+      padding-top: $base-spacing;
+
+      .message-callout.-above {
+        @include media($tablet) {
+          position: absolute;
+          top: -60px;
           right: 20px;
           margin: 0;
         }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-sms.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-sms.scss
@@ -29,6 +29,19 @@
       }
     }
 
+    .campaign-sms-numbers {
+      clear: both;
+
+      .form-item {
+        @include span(100%);
+
+        @include media($medium) {
+          @include span(50%);
+        }
+      }
+
+    }
+
     .form-wrapper.-columned {
       @include span(100%);
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -103,7 +103,7 @@
         <!-- with the below snippet. This allows us to swap out form fields -->
         <!-- without losing CSRF tokens: -->
 
-        <!--  var $ = jQuery; var $form = $("#dosomething-signup-sms-game-form"); $form.css('padding-top', '100px'); $form.find(".form-item-alpha-first-name").remove(); $form.find("#edit-group1").html($("#ab-test-sms-names").html());  --->
+        <!--  var $ = jQuery; var $form = $("#dosomething-signup-sms-game-form"); $form.addClass('optimizely-sms-form'); $form.find(".form-item-alpha-first-name").remove(); $form.find("#edit-group1").html($("#ab-test-sms-names").html());  --->
 
         <div id="ab-test-sms-names" style="display: none;">
           <div class="fieldset-wrapper">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -98,6 +98,58 @@
           <?php print render($signup_form); ?>
         <?php endif; ?>
 
+        <!-- ########## A/B Test For SMS First Names ##########  -->
+        <!-- We find the fieldset "edit-group1" in the form above, and replace  -->
+        <!-- with the below snippet. This allows us to swap out form fields -->
+        <!-- without losing CSRF tokens: -->
+
+        <!--  var $ = jQuery; var $form = $("#dosomething-signup-sms-game-form"); $form.css('padding-top', '100px'); $form.find(".form-item-alpha-first-name").remove(); $form.find("#edit-group1").html($("#ab-test-sms-names").html());  --->
+
+        <div id="ab-test-sms-names" style="display: none;">
+          <div class="fieldset-wrapper">
+            <div class="form-item form-type-textfield">
+              <label class="field-label" for="edit-alpha-first-name">Your First Name <span class="form-required" title="This field is required.">*</span></label>
+              <input data-validate="fname" data-validate-required="" placeholder="First Name" type="text" id="edit-alpha-first-name" name="alpha_first_name" value="" size="60" maxlength="128" class="text-field required has-success">
+            </div>
+
+            <div class="form-item form-type-textfield form-item-alpha-mobile">
+              <label class="field-label" for="edit-alpha-mobile">Your Cell Number <span class="form-required" title="This field is required.">*</span></label>
+              <input data-validate="phone" data-validate-required="" placeholder="(555) 555-5555" autocomplete="off" type="text" id="edit-alpha-mobile" name="alpha_mobile" value="" size="60" maxlength="128" class="text-field required">
+            </div>
+
+            <div class="form-item form-type-textfield">
+              <label class="field-label" for="edit-beta-first-name-0">Your Friend's Name <span class="form-required" title="This field is required.">*</span></label>
+              <input data-validate="friend_name" data-validate-required="" placeholder="Friend's Name" type="text" id="edit-beta-first-name-0" name="beta_first_name_0" value="" size="60" maxlength="128" class="text-field required has-success">
+            </div>
+
+            <div class="form-item form-type-textfield form-item-alpha-mobile">
+              <label class="field-label" for="edit-beta-mobile-0">Friend's Cell Number <span class="form-required" title="This field is required.">*</span></label>
+              <input data-validate="phone" data-validate-required="" placeholder="(555) 555-5555" autocomplete="off" type="text" id="edit-beta-mobile-0" name="beta_mobile_0" value="" size="60" maxlength="128" class="text-field required">
+            </div>
+
+            <div class="form-item form-type-textfield ">
+              <label class="field-label" for="edit-beta-first-name-1">Your Friend's Name <span class="form-required" title="This field is required.">*</span></label>
+              <input data-validate="friend_name" data-validate-required="" placeholder="Friend's Name" type="text" id="edit-beta-first-name-1" name="beta_first_name_1" value="" size="60" maxlength="128" class="text-field required has-success">
+            </div>
+
+            <div class="form-item form-type-textfield form-item-alpha-mobile">
+              <label class="field-label" for="edit-beta-mobile-1">Friend's Cell Number <span class="form-required" title="This field is required.">*</span></label>
+              <input data-validate="phone" data-validate-required="" placeholder="(555) 555-5555" autocomplete="off" type="text" id="edit-beta-mobile-1" name="beta_mobile_1" value="" size="60" maxlength="128" class="text-field required">
+            </div>
+
+            <div class="form-item form-type-textfield">
+              <label class="field-label" for="edit-beta-first-name-2">Your Friend's Name <span class="form-required" title="This field is required.">*</span></label>
+              <input data-validate="friend_name" data-validate-required="" placeholder="Friend's Name" type="text" id="edit-beta-first-name-2" name="beta_first_name_2" value="" size="60" maxlength="128" class="text-field required has-success">
+            </div>
+
+            <div class="form-item form-type-textfield form-item-alpha-mobile">
+              <label class="field-label" for="edit-beta-mobile-2">Friend's Cell Number <span class="form-required" title="This field is required.">*</span></label>
+              <input data-validate="phone" data-validate-required="" placeholder="(555) 555-5555" autocomplete="off" type="text" id="edit-beta-mobile-2" name="beta_mobile_2" value="" size="60" maxlength="128" class="text-field required">
+            </div>
+          </div>
+        </div>
+        <!-- ########## END A/B Test For SMS First Names ########## -->
+
         <div class="container__block -narrow">
           <?php if (isset($official_rules)): ?>
             <p class="footnote">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -103,7 +103,7 @@
         <!-- with the below snippet. This allows us to swap out form fields -->
         <!-- without losing CSRF tokens: -->
 
-        <!--  var $ = jQuery; var $form = $("#dosomething-signup-sms-game-form"); $form.addClass('optimizely-sms-form'); $form.find(".form-item-alpha-first-name").remove(); $form.find("#edit-group1").html($("#ab-test-sms-names").html());  --->
+        <!--  var $ = jQuery; var $form = $("#dosomething-signup-sms-game-form"); $form.addClass('optimizely-sms-form'); $form.find(".form-item-alpha-first-name").remove(); $form.find("#edit-group1").html($("#ab-test-sms-names").html());  -->
 
         <div id="ab-test-sms-names" style="display: none;">
           <div class="fieldset-wrapper">


### PR DESCRIPTION
# Changes
- Adds markup and styles for SMS first names Optimizely test. Closes #3568.
- Add hidden fields & whitelist them to be passed to Mobile Commons. We only validate them client-side, so Drupal doesn't need to know whether or not A/B test is functioning on page.
- Removes CSS column groups, instead floating individual fields as half-width blocks. This allows us to have adjacent fields side-by-side rather than stacked vertically (needed for friend name & number fields to be side-by-side in the A/B variant).

For review: @aaronschachter @DoSomething/front-end @jonuy 
# Snippet

``` js
var $ = jQuery;
var $form = $("#dosomething-signup-sms-game-form");
$form.addClass('optimizely-sms-form');
$form.find(".form-item-alpha-first-name").remove();
$form.find("#edit-group1").html($("#ab-test-sms-names").html()); 
```

(You can test this by copying and pasting into the web console on staging or your dev environment!)
# Updated Example Payload

The Node application will receive the exact same payload, but may include the extra `beta_first_name_#` fields if the test is activated on the page. For example:

```
array(10) { ["alpha_first_name"]=> string(4) "Dave" ["alpha_mobile"]=> string(10) "2035830429" ["beta_mobile_0"]=> string(10) "2025555692" ["beta_mobile_1"]=> string(10) "2025555672" ["beta_mobile_2"]=> string(10) "2025455692" ["beta_first_name_0"]=> string(3) "Jim" ["beta_first_name_1"]=> string(3) "Don" ["beta_first_name_2"]=> string(3) "Bob" ["story_id"]=> string(6) "176153" ["story_type"]=> string(6) "176155" }
```
# Screenshots
#### Before:

![screen shot 2015-03-19 at 11 24 48 am](https://cloud.githubusercontent.com/assets/583202/6733859/28eea95a-ce2b-11e4-9cd3-4d3e862e4c57.png)
#### After (with A/B test activated):

![screen shot 2015-03-19 at 11 25 42 am](https://cloud.githubusercontent.com/assets/583202/6733864/2cd4e2fa-ce2b-11e4-90eb-788b99e9504b.png)
