### PR TITLE
Header gallery data

### DIFF
--- a/lib/modules/dosomething/dosomething_image/dosomething_image.module
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.module
@@ -146,6 +146,7 @@ function dosomething_image_get_themed_image_by_fid($fid, $style, $alt = '') {
       'path' => DS_ASSET_PATH .'/dist/images/no-image-found.png',
       'alt' => 'No image found placeholder',
       'title' => 'No Image Found',
+      'attributes' => NULL,
     );
     return theme_image($args);
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -97,7 +97,7 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
 
     foreach ($entity->fids as $index => $fid) {
       $reportback_submissions_data[$index] = reportback_file_load($fid);
-      $reportback_submissions_data[$index]->image = dosomething_image_get_themed_image_by_fid($fid, '300x300');
+      $reportback_submissions_data[$index]->image = dosomething_image_get_themed_image_by_fid($fid, '400x400');
     }
 
     $reportback_prior_submissions = array_reverse($reportback_submissions_data);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -822,6 +822,23 @@ function dosomething_reportback_get_reportback_total_by_nid($nid, $type = 'quant
 }
 
 /**
+ * Returns total number of Reportbacks by status (promoted, approved, etc).
+ *
+ * @param int $nid
+ *   Campaign node id.
+ * @param string $status
+ *   Reportback status (promoted, approved, etc).
+ * @return int
+ */
+function dosomething_reportback_get_reportback_total_by_status($nid, $status) {
+  $params = array();
+  $params['nid'] = $nid;
+  $params['status'] = $status;
+
+  return dosomething_reportback_get_reportback_files_query_count($params);
+}
+
+/**
  * Returns count of Reportbacks for a given node $uid.
  *
  * @param int $uid

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -274,25 +274,25 @@ function paraneue_dosomething_get_recommended_campaign_gallery($tid = NULL, $uid
 }
 
 /**
- * Returns specified number of themed Approved Reportbacks.
- *
- * @param  integer $count  Number of reportbacks to prepare.
- * @return array           Array of the specified number of Approved Reportbacks.
+ * Return a specified number of themed Reportbacks by status type.
  */
-function paraneue_dosomething_get_themed_approved_reportbacks($nid, $count = 6) {
-  // Set params to retrieve Approved Reportback for this nid.
-  $params['nid'] = $nid;
-  $params['status'] = 'approved';
-  $reportbacks = array();
-  $approved_reportbacks = dosomething_reportback_get_reportback_files_query_result($params, $count);
+function paraneue_dosomething_get_themed_reportbacks_by_status($campaign_id, $status, $count, $random = NULL) {
+  $reportback_items = array();
 
-  foreach ($approved_reportbacks as $reportback) {
+  $params = array();
+  $params['nid'] = $campaign_id;
+  $params['status'] = $status;
+  $params['random'] = $random;
+
+  $reportback_results = dosomething_reportback_get_reportback_files_query_result($params, $count);
+
+  foreach ($reportback_results as $reportback) {
     // @Todo: DRY. Potentially grab this data from the API endpoint to truly DRY?
-    $reportback->image = dosomething_image_get_themed_image_url_by_fid($reportback->fid, '300x300');
-    $reportbacks[] = paraneue_dosomething_get_gallery_item((array) $reportback, 'photo');
+    $reportback->image = dosomething_image_get_themed_image_url_by_fid($reportback->fid, '400x400');
+    $reportback_items[] = paraneue_dosomething_get_gallery_item((array) $reportback, 'photo');
   }
 
-  return $reportbacks;
+  return $reportback_items;
 }
 
 /**
@@ -326,6 +326,46 @@ function paraneue_dosomething_get_themed_placeholder_reportbacks($count = 6) {
   }
 
   return $placeholders;
+}
+
+/**
+ * Return an assimilated collection of Reportbacks based on Promoted & Approved Reportback counts.
+ *
+ * @param array $reportbacks
+ * @param bool $use_placeholders
+ * @return bool
+ */
+function paraneue_dosomething_build_reportbacks_gallery_collection ($reportbacks, $use_placeholders = FALSE) {
+  $fill_count = $reportbacks['desired_count'] - $reportbacks['total_promoted'];
+
+  // Absolutely no Approved Reportbacks to fulfill the fill count needed.
+  if ((int) $reportbacks['total_approved'] === 0) {
+    if ($use_placeholders) {
+      $placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks($fill_count);
+      $reportbacks['items'] = array_merge($reportbacks['items'], $placeholders);
+      $reportbacks['prefetched'] = 0;
+    }
+    else {
+      return FALSE;
+    }
+  }
+
+  // Some but not enough Approved Reportbacks to fulfill the fill count needed.
+  elseif ($reportbacks['total_approved'] < $fill_count) {
+    $approved_reportbacks = paraneue_dosomething_get_themed_reportbacks_by_status($reportbacks['campaign_id'], 'approved', $reportbacks['total_approved']);
+    $placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks($fill_count - $reportbacks['total_approved']);
+    $reportbacks['items'] = array_merge($reportbacks['items'], $approved_reportbacks, $placeholders);
+    $reportbacks['prefetched'] = $reportbacks['total_approved'];
+  }
+
+  // There are enough Approved Reportbacks to fulfill the fill count needed.
+  else {
+    $approved_reportbacks = paraneue_dosomething_get_themed_reportbacks_by_status($reportbacks['campaign_id'], 'approved', $fill_count);
+    $reportbacks['items'] = array_merge($reportbacks['items'], $approved_reportbacks);
+    $reportbacks['prefetched'] = $fill_count;
+  }
+
+  return $reportbacks;
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -397,91 +397,6 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
 
 
 /**
- * Get total number of Reportbacks by status (promoted, approved, etc).
- *
- * @param $nid  Campaign node id.
- * @param $status Reportback status (promoted, approved, etc).
- * @return int
- */
-function paraneue_dosomething_preprocess_reportbacks_total_by_status($nid, $status) {
-  $params = array();
-  $params['nid'] = $nid;
-  $params['status'] = $status;
-
-  return dosomething_reportback_get_reportback_files_query_count($params);
-}
-
-
-/**
- * Get a specified number of themed Promoted Reportbacks.
- *
- * @param $nid  Campaign node id.
- * @param $count Number of Promoted Reportbacks to retrieve.
- * @return array
- */
-function paraneue_dosomething_preprocess_themed_promoted_reportbacks($nid, $count, $random = FALSE) {
-  $promoted_items = array();
-
-  $params = array();
-  $params['nid'] = $nid;
-  $params['status'] = 'promoted';
-  $params['random'] = $random;
-
-  $promoted_results = dosomething_reportback_get_reportback_files_query_result($params, $count);
-
-  foreach ($promoted_results as $rb_file) {
-    $rb_file->image = dosomething_image_get_themed_image_url_by_fid($rb_file->fid, '400x400');
-    $promoted_items[] = paraneue_dosomething_get_gallery_item((array) $rb_file, 'photo');
-  }
-
-  return $promoted_items;
-}
-
-
-/**
- * Build Reportback collection based on Promoted & Approved Reportback counts.
- *
- * @param $reportbacks
- * @param $desired_count
- * @param bool $use_placeholders
- * @return bool
- */
-function paraneue_dosomething_preprocess_reportback_assimilation ($reportbacks, $use_placeholders = FALSE) {
-
-  $fill_count = $reportbacks['desired_count'] - $reportbacks['total_promoted'];
-
-  // Absolutely no Approved Reportbacks to fulfill the fill count needed.
-  if ($reportbacks['total_approved'] === 0) {
-    if ($use_placeholders) {
-      $placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks($fill_count);
-      $reportbacks['items'] = array_merge($reportbacks['items'], $placeholders);
-      $reportbacks['prefetched'] = 0;
-    }
-    else {
-      return FALSE;
-    }
-  }
-
-  // Some but not enough Approved Reportbacks to fulfill the fill count needed.
-  elseif ($reportbacks['total_approved'] < $fill_count) {
-    $approved_reportbacks = paraneue_dosomething_get_themed_approved_reportbacks($reportbacks['campaign_id'], $reportbacks['total_approved']);
-    $placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks($fill_count - $reportbacks['total_approved']);
-    $reportbacks['items'] = array_merge($reportbacks['items'], $approved_reportbacks, $placeholders);
-    $reportbacks['prefetched'] = $reportbacks['total_approved'];
-  }
-
-  // There are enough Approved Reportbacks to fulfill the fill count needed.
-  else {
-    $approved_reportbacks = paraneue_dosomething_get_themed_approved_reportbacks($reportbacks['campaign_id'], $fill_count);
-    $reportbacks['items'] = array_merge($reportbacks['items'], $approved_reportbacks);
-    $reportbacks['prefetched'] = $fill_count;
-  }
-
-  return $reportbacks;
-}
-
-
-/**
  * Expands $reportbacks_gallery array with themed Reportback items and data for given node preprocess $vars.
  */
 function paraneue_dosomething_preprocess_reportback_gallery(&$vars) {
@@ -497,15 +412,15 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars) {
 
 
   // Promoted Reportbacks:
-  $reportbacks_gallery['items'] = paraneue_dosomething_preprocess_themed_promoted_reportbacks($vars['nid'], $desired_count, TRUE);
+  $reportbacks_gallery['items'] = paraneue_dosomething_get_themed_reportbacks_by_status($vars['nid'], 'promoted', $desired_count, TRUE);
   $reportbacks_gallery['total_promoted'] = count($reportbacks_gallery['items']);
 
   // Approved Reportbacks:
-  $reportbacks_gallery['total_approved'] = paraneue_dosomething_preprocess_reportbacks_total_by_status($vars['nid'], 'approved');
+  $reportbacks_gallery['total_approved'] = dosomething_reportback_get_reportback_total_by_status($vars['nid'], 'approved');
 
   // Collect Reportbacks to fulfill desired amount.
   if ($reportbacks_gallery['total_promoted'] < $desired_count) {
-    $reportbacks_gallery = paraneue_dosomething_preprocess_reportback_assimilation($reportbacks_gallery);
+    $reportbacks_gallery = paraneue_dosomething_build_reportbacks_gallery_collection($reportbacks_gallery, TRUE);
   }
 
   // Enough Total Promoted Reportbacks to fulfill the required initial count.
@@ -527,15 +442,15 @@ function paraneue_dosomething_preprocess_reportback_showcase(&$vars) {
 
 
   // Promoted Reportbacks:
-  $reportbacks_showcase['items'] = paraneue_dosomething_preprocess_themed_promoted_reportbacks($vars['nid'], $desired_count, TRUE);
+  $reportbacks_showcase['items'] = paraneue_dosomething_get_themed_reportbacks_by_status($vars['nid'], 'promoted', $desired_count, TRUE);
   $reportbacks_showcase['total_promoted'] = count($reportbacks_showcase['items']);
 
   // Approved Reportbacks:
-  $reportbacks_showcase['total_approved'] = paraneue_dosomething_preprocess_reportbacks_total_by_status($vars['nid'], 'approved');
+  $reportbacks_showcase['total_approved'] = dosomething_reportback_get_reportback_total_by_status($vars['nid'], 'approved');
 
   // Collect Reportbacks to fulfill desired amount.
   if ($reportbacks_showcase['total_promoted'] < $desired_count) {
-    $reportbacks_showcase = paraneue_dosomething_preprocess_reportback_assimilation($reportbacks_showcase);
+    $reportbacks_showcase = paraneue_dosomething_build_reportbacks_gallery_collection($reportbacks_showcase);
   }
 
   // Enough Total Promoted Reportbacks to fulfill the required initial count.

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -388,7 +388,7 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
   // If this is not the pitch page:
   if (!isset($vars['is_pitch_page'])) {
     // Set the number of files to display in initial gallery.
-    $vars['reportbacks']['desired_count'] = 6;
+    $vars['reportbacks_gallery']['desired_count'] = 6;
     // Adds themed Reportback Files.
     paraneue_dosomething_preprocess_reportback_gallery($vars);
   }
@@ -397,32 +397,35 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
 
 
 /**
- * @param $nid
+ * Get total number of Reportbacks by status (promoted, approved, etc).
+ *
+ * @param $nid  Campaign node id.
+ * @param $status Reportback status (promoted, approved, etc).
  * @return int
  */
-function paraneue_dosomething_preprocess_approved_reportbacks_total($nid) {
-  // Set params to get the total number of Approved Reportbacks for this nid.
+function paraneue_dosomething_preprocess_reportbacks_total_by_status($nid, $status) {
   $params = array();
   $params['nid'] = $nid;
-  $params['status'] = 'approved';
+  $params['status'] = $status;
 
   return dosomething_reportback_get_reportback_files_query_count($params);
 }
 
 
 /**
- * @param $nid
- * @param $count
+ * Get a specified number of themed Promoted Reportbacks.
+ *
+ * @param $nid  Campaign node id.
+ * @param $count Number of Promoted Reportbacks to retrieve.
  * @return array
  */
-function paraneue_dosomething_preprocess_promoted_reportbacks($nid, $count) {
+function paraneue_dosomething_preprocess_themed_promoted_reportbacks($nid, $count, $random = FALSE) {
   $promoted_items = array();
 
-  // Set params to retrieve random Promoted Reportbacks for this nid.
   $params = array();
   $params['nid'] = $nid;
   $params['status'] = 'promoted';
-  $params['random'] = TRUE;
+  $params['random'] = $random;
 
   $promoted_results = dosomething_reportback_get_reportback_files_query_result($params, $count);
 
@@ -436,22 +439,23 @@ function paraneue_dosomething_preprocess_promoted_reportbacks($nid, $count) {
 
 
 /**
+ * Build Reportback collection based on Promoted & Approved Reportback counts.
  *
+ * @param $reportbacks
+ * @param $desired_count
+ * @param bool $use_placeholders
+ * @return bool
  */
-function paraneue_dosomething_preprocess_reportback_assimilation ($reportbacks, $desired_count, $use_placeholders = FALSE) {
-  dsm('PREPARE FOR ASSIMILATION');
-  dsm($desired_count);
-  dsm($use_placeholders);
+function paraneue_dosomething_preprocess_reportback_assimilation ($reportbacks, $use_placeholders = FALSE) {
 
-  $fill_count = $desired_count - $reportbacks['total_promoted'];
-
+  $fill_count = $reportbacks['desired_count'] - $reportbacks['total_promoted'];
 
   // Absolutely no Approved Reportbacks to fulfill the fill count needed.
   if ($reportbacks['total_approved'] === 0) {
     if ($use_placeholders) {
       $placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks($fill_count);
-      $reportbacks_gallery['items'] = array_merge($reportbacks_gallery['items'], $placeholders);
-      $reportbacks_gallery['prefetched'] = 0;
+      $reportbacks['items'] = array_merge($reportbacks['items'], $placeholders);
+      $reportbacks['prefetched'] = 0;
     }
     else {
       return FALSE;
@@ -459,26 +463,26 @@ function paraneue_dosomething_preprocess_reportback_assimilation ($reportbacks, 
   }
 
   // Some but not enough Approved Reportbacks to fulfill the fill count needed.
-  elseif ($reportbacks_gallery['total_approved'] < $fill_count) {
-    $approved_reportbacks = paraneue_dosomething_get_themed_approved_reportbacks($vars['nid'], $reportbacks_gallery['total_approved']);
-    $placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks($fill_count - $reportbacks_gallery['total_approved']);
-    $reportbacks_gallery['items'] = array_merge($reportbacks_gallery['items'], $approved_reportbacks, $placeholders);
-    $reportbacks_gallery['prefetched'] = $reportbacks_gallery['total_approved'];
+  elseif ($reportbacks['total_approved'] < $fill_count) {
+    $approved_reportbacks = paraneue_dosomething_get_themed_approved_reportbacks($reportbacks['campaign_id'], $reportbacks['total_approved']);
+    $placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks($fill_count - $reportbacks['total_approved']);
+    $reportbacks['items'] = array_merge($reportbacks['items'], $approved_reportbacks, $placeholders);
+    $reportbacks['prefetched'] = $reportbacks['total_approved'];
   }
 
   // There are enough Approved Reportbacks to fulfill the fill count needed.
   else {
-    $approved_reportbacks = paraneue_dosomething_get_themed_approved_reportbacks($vars['nid'], $fill_count);
-    $reportbacks_gallery['items'] = array_merge($reportbacks_gallery['items'], $approved_reportbacks);
-    $reportbacks_gallery['prefetched'] = $fill_count;
+    $approved_reportbacks = paraneue_dosomething_get_themed_approved_reportbacks($reportbacks['campaign_id'], $fill_count);
+    $reportbacks['items'] = array_merge($reportbacks['items'], $approved_reportbacks);
+    $reportbacks['prefetched'] = $fill_count;
   }
 
-  dsm($fill_count);
+  return $reportbacks;
 }
 
 
 /**
- * Exapnds $reportbacks_gallery array with themed Reportback items and data for given node preprocess $vars.
+ * Expands $reportbacks_gallery array with themed Reportback items and data for given node preprocess $vars.
  */
 function paraneue_dosomething_preprocess_reportback_gallery(&$vars) {
   $reportbacks_gallery = &$vars['reportbacks_gallery'];
@@ -488,49 +492,20 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars) {
   }
   $desired_count = $reportbacks_gallery['desired_count'];
 
+  $reportbacks_gallery['campaign_id'] = $vars['nid'];
   $reportbacks_gallery['items'] = array();
 
 
   // Promoted Reportbacks:
-  // ========================================================================
-  $reportbacks_gallery['items'] = paraneue_dosomething_preprocess_promoted_reportbacks($vars['nid'], $desired_count);
-
-  // Total number of Promoted Reportbacks obtained.
+  $reportbacks_gallery['items'] = paraneue_dosomething_preprocess_themed_promoted_reportbacks($vars['nid'], $desired_count, TRUE);
   $reportbacks_gallery['total_promoted'] = count($reportbacks_gallery['items']);
 
-
   // Approved Reportbacks:
-  // ========================================================================
-  $reportbacks_gallery['total_approved'] = paraneue_dosomething_preprocess_approved_reportbacks_total($vars['nid']);
+  $reportbacks_gallery['total_approved'] = paraneue_dosomething_preprocess_reportbacks_total_by_status($vars['nid'], 'approved');
 
-
-  // Build Reportback Gallery based on Promoted & Approved Reportback counts.
-  // ========================================================================
-  // Total Promoted Reportbacks less than required initial count.
+  // Collect Reportbacks to fulfill desired amount.
   if ($reportbacks_gallery['total_promoted'] < $desired_count) {
-    $fill_count = $desired_count - $reportbacks_gallery['total_promoted'];
-
-    // Absolutely no Approved Reportbacks to fulfill the fill count needed.
-    if ($reportbacks_gallery['total_approved'] === 0) {
-      $placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks($fill_count);
-      $reportbacks_gallery['items'] = array_merge($reportbacks_gallery['items'], $placeholders);
-      $reportbacks_gallery['prefetched'] = 0;
-    }
-
-    // Some but not enough Approved Reportbacks to fulfill the fill count needed.
-    elseif ($reportbacks_gallery['total_approved'] < $fill_count) {
-      $approved_reportbacks = paraneue_dosomething_get_themed_approved_reportbacks($vars['nid'], $reportbacks_gallery['total_approved']);
-      $placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks($fill_count - $reportbacks_gallery['total_approved']);
-      $reportbacks_gallery['items'] = array_merge($reportbacks_gallery['items'], $approved_reportbacks, $placeholders);
-      $reportbacks_gallery['prefetched'] = $reportbacks_gallery['total_approved'];
-    }
-
-    // There are enough Approved Reportbacks to fulfill the fill count needed.
-    else {
-      $approved_reportbacks = paraneue_dosomething_get_themed_approved_reportbacks($vars['nid'], $fill_count);
-      $reportbacks_gallery['items'] = array_merge($reportbacks_gallery['items'], $approved_reportbacks);
-      $reportbacks_gallery['prefetched'] = $fill_count;
-    }
+    $reportbacks_gallery = paraneue_dosomething_preprocess_reportback_assimilation($reportbacks_gallery);
   }
 
   // Enough Total Promoted Reportbacks to fulfill the required initial count.
@@ -544,28 +519,29 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars) {
  * Expands $reportbacks_showcase array with themed Reportback items and data for given node preprocess $vars.
  */
 function paraneue_dosomething_preprocess_reportback_showcase(&$vars) {
-  $desired_count = 20;
+  $reportbacks_showcase = &$vars['reportbacks_showcase'];
+
+  $reportbacks_showcase['desired_count'] = $desired_count = 4;
+  $reportbacks_showcase['campaign_id'] = $vars['nid'];
+  $reportbacks_showcase['items'] = array();
+
 
   // Promoted Reportbacks:
-  // ========================================================================
-  $reportbacks_showcase['items'] = paraneue_dosomething_preprocess_promoted_reportbacks($vars['nid'], $desired_count);
-
-  // Total number of Promoted Reportbacks obtained.
+  $reportbacks_showcase['items'] = paraneue_dosomething_preprocess_themed_promoted_reportbacks($vars['nid'], $desired_count, TRUE);
   $reportbacks_showcase['total_promoted'] = count($reportbacks_showcase['items']);
 
-
   // Approved Reportbacks:
-  // ========================================================================
-  $reportbacks_showcase['total_approved'] = paraneue_dosomething_preprocess_approved_reportbacks_total($vars['nid']);
+  $reportbacks_showcase['total_approved'] = paraneue_dosomething_preprocess_reportbacks_total_by_status($vars['nid'], 'approved');
 
-
+  // Collect Reportbacks to fulfill desired amount.
   if ($reportbacks_showcase['total_promoted'] < $desired_count) {
-    $reportbacks_showcase = paraneue_dosomething_preprocess_reportback_assimilation($reportbacks_showcase, $desired_count);
+    $reportbacks_showcase = paraneue_dosomething_preprocess_reportback_assimilation($reportbacks_showcase);
   }
 
-  dsm($reportbacks_showcase);
-
-  $vars['showcase'] = 'Nulla vitae elit libero, a pharetra augue.';
+  // Enough Total Promoted Reportbacks to fulfill the required initial count.
+  else {
+    $reportbacks_showcase['prefetched'] = 0;
+  }
 }
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -382,43 +382,118 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
     drupal_add_js($js, 'inline');
   }
 
+  // Setup the reportback showcase.
+  paraneue_dosomething_preprocess_reportback_showcase($vars);
+
   // If this is not the pitch page:
   if (!isset($vars['is_pitch_page'])) {
     // Set the number of files to display in initial gallery.
-    $vars['reportbacks']['initial_count'] = 6;
+    $vars['reportbacks']['desired_count'] = 6;
     // Adds themed Reportback Files.
-    paraneue_dosomething_preprocess_reportback_files($vars);
+    paraneue_dosomething_preprocess_reportback_gallery($vars);
   }
 
 }
 
+
 /**
- * Adds $gallery_items array of themed Reportback Files for given node preprocess $vars.
+ * @param $nid
+ * @return int
  */
-function paraneue_dosomething_preprocess_reportback_files(&$vars) {
+function paraneue_dosomething_preprocess_approved_reportbacks_total($nid) {
+  // Set params to get the total number of Approved Reportbacks for this nid.
+  $params = array();
+  $params['nid'] = $nid;
+  $params['status'] = 'approved';
+
+  return dosomething_reportback_get_reportback_files_query_count($params);
+}
+
+
+/**
+ * @param $nid
+ * @param $count
+ * @return array
+ */
+function paraneue_dosomething_preprocess_promoted_reportbacks($nid, $count) {
+  $promoted_items = array();
+
+  // Set params to retrieve random Promoted Reportbacks for this nid.
+  $params = array();
+  $params['nid'] = $nid;
+  $params['status'] = 'promoted';
+  $params['random'] = TRUE;
+
+  $promoted_results = dosomething_reportback_get_reportback_files_query_result($params, $count);
+
+  foreach ($promoted_results as $rb_file) {
+    $rb_file->image = dosomething_image_get_themed_image_url_by_fid($rb_file->fid, '400x400');
+    $promoted_items[] = paraneue_dosomething_get_gallery_item((array) $rb_file, 'photo');
+  }
+
+  return $promoted_items;
+}
+
+
+/**
+ *
+ */
+function paraneue_dosomething_preprocess_reportback_assimilation ($reportbacks, $desired_count, $use_placeholders = FALSE) {
+  dsm('PREPARE FOR ASSIMILATION');
+  dsm($desired_count);
+  dsm($use_placeholders);
+
+  $fill_count = $desired_count - $reportbacks['total_promoted'];
+
+
+  // Absolutely no Approved Reportbacks to fulfill the fill count needed.
+  if ($reportbacks['total_approved'] === 0) {
+    if ($use_placeholders) {
+      $placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks($fill_count);
+      $reportbacks_gallery['items'] = array_merge($reportbacks_gallery['items'], $placeholders);
+      $reportbacks_gallery['prefetched'] = 0;
+    }
+    else {
+      return FALSE;
+    }
+  }
+
+  // Some but not enough Approved Reportbacks to fulfill the fill count needed.
+  elseif ($reportbacks_gallery['total_approved'] < $fill_count) {
+    $approved_reportbacks = paraneue_dosomething_get_themed_approved_reportbacks($vars['nid'], $reportbacks_gallery['total_approved']);
+    $placeholders = paraneue_dosomething_get_themed_placeholder_reportbacks($fill_count - $reportbacks_gallery['total_approved']);
+    $reportbacks_gallery['items'] = array_merge($reportbacks_gallery['items'], $approved_reportbacks, $placeholders);
+    $reportbacks_gallery['prefetched'] = $reportbacks_gallery['total_approved'];
+  }
+
+  // There are enough Approved Reportbacks to fulfill the fill count needed.
+  else {
+    $approved_reportbacks = paraneue_dosomething_get_themed_approved_reportbacks($vars['nid'], $fill_count);
+    $reportbacks_gallery['items'] = array_merge($reportbacks_gallery['items'], $approved_reportbacks);
+    $reportbacks_gallery['prefetched'] = $fill_count;
+  }
+
+  dsm($fill_count);
+}
+
+
+/**
+ * Exapnds $reportbacks_gallery array with themed Reportback items and data for given node preprocess $vars.
+ */
+function paraneue_dosomething_preprocess_reportback_gallery(&$vars) {
   $reportbacks_gallery = &$vars['reportbacks_gallery'];
 
-  if (!isset($reportbacks_gallery['initial_count'])) {
-    $reportbacks_gallery['initial_count'] = 6;
+  if (!isset($reportbacks_gallery['desired_count'])) {
+    $reportbacks_gallery['desired_count'] = 6;
   }
-  $initial_count = $reportbacks_gallery['initial_count'];
+  $desired_count = $reportbacks_gallery['desired_count'];
 
   $reportbacks_gallery['items'] = array();
 
 
   // Promoted Reportbacks:
   // ========================================================================
-  // Set params to retrieve random Promoted Reportbacks for this nid.
-  $params = array();
-  $params['nid'] = $vars['nid'];
-  $params['status'] = 'promoted';
-  $params['random'] = TRUE;
-  $promoted_results = dosomething_reportback_get_reportback_files_query_result($params, $initial_count);
-
-  foreach ($promoted_results as $rb_file) {
-    $rb_file->image = dosomething_image_get_themed_image_url_by_fid($rb_file->fid, '400x400');
-    $reportbacks_gallery['items'][] = paraneue_dosomething_get_gallery_item((array) $rb_file, 'photo');
-  }
+  $reportbacks_gallery['items'] = paraneue_dosomething_preprocess_promoted_reportbacks($vars['nid'], $desired_count);
 
   // Total number of Promoted Reportbacks obtained.
   $reportbacks_gallery['total_promoted'] = count($reportbacks_gallery['items']);
@@ -426,19 +501,14 @@ function paraneue_dosomething_preprocess_reportback_files(&$vars) {
 
   // Approved Reportbacks:
   // ========================================================================
-  // Set params to get the total number of Approved Reportbacks for this nid.
-  $params['status'] = 'approved';
-  if (isset($params['random'])) {
-    unset($params['random']);
-  }
-  $reportbacks_gallery['total_approved'] = dosomething_reportback_get_reportback_files_query_count($params);
+  $reportbacks_gallery['total_approved'] = paraneue_dosomething_preprocess_approved_reportbacks_total($vars['nid']);
 
 
   // Build Reportback Gallery based on Promoted & Approved Reportback counts.
   // ========================================================================
   // Total Promoted Reportbacks less than required initial count.
-  if ($reportbacks_gallery['total_promoted'] < $initial_count) {
-    $fill_count = $initial_count - $reportbacks_gallery['total_promoted'];
+  if ($reportbacks_gallery['total_promoted'] < $desired_count) {
+    $fill_count = $desired_count - $reportbacks_gallery['total_promoted'];
 
     // Absolutely no Approved Reportbacks to fulfill the fill count needed.
     if ($reportbacks_gallery['total_approved'] === 0) {
@@ -467,6 +537,35 @@ function paraneue_dosomething_preprocess_reportback_files(&$vars) {
   else {
     $reportbacks_gallery['prefetched'] = 0;
   }
+}
+
+
+/**
+ * Expands $reportbacks_showcase array with themed Reportback items and data for given node preprocess $vars.
+ */
+function paraneue_dosomething_preprocess_reportback_showcase(&$vars) {
+  $desired_count = 20;
+
+  // Promoted Reportbacks:
+  // ========================================================================
+  $reportbacks_showcase['items'] = paraneue_dosomething_preprocess_promoted_reportbacks($vars['nid'], $desired_count);
+
+  // Total number of Promoted Reportbacks obtained.
+  $reportbacks_showcase['total_promoted'] = count($reportbacks_showcase['items']);
+
+
+  // Approved Reportbacks:
+  // ========================================================================
+  $reportbacks_showcase['total_approved'] = paraneue_dosomething_preprocess_approved_reportbacks_total($vars['nid']);
+
+
+  if ($reportbacks_showcase['total_promoted'] < $desired_count) {
+    $reportbacks_showcase = paraneue_dosomething_preprocess_reportback_assimilation($reportbacks_showcase, $desired_count);
+  }
+
+  dsm($reportbacks_showcase);
+
+  $vars['showcase'] = 'Nulla vitae elit libero, a pharetra augue.';
 }
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -7,6 +7,7 @@
  * - $classes: Additional classes passed for output (string).
  * - $campaign_scholarship: Scholarship amount (string).
  */
+dsm($variables);
 ?>
 
 <section class="campaign campaign--pitch pitch">
@@ -25,6 +26,12 @@
       <?php print $promotions; ?>
     </div>
   </header>
+
+  <?php if (isset($showcase)): ?>
+    <div class="showcase">
+      <?php print $showcase; ?>
+    </div>
+  <?php endif; ?>
 
   <?php if (isset($campaign->value_proposition)): ?>
     <div class="container">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -7,7 +7,6 @@
  * - $classes: Additional classes passed for output (string).
  * - $campaign_scholarship: Scholarship amount (string).
  */
-dsm($variables);
 ?>
 
 <section class="campaign campaign--pitch pitch">
@@ -27,11 +26,13 @@ dsm($variables);
     </div>
   </header>
 
-  <?php if (isset($showcase)): ?>
+  <?php /* Temporarily hidden. Next step is the frontend!
+  <?php if (isset($reportbacks_showcase)): ?>
     <div class="showcase">
-      <?php print $showcase; ?>
+      <?php print $reportbacks_showcase; ?>
     </div>
   <?php endif; ?>
+ */?>
 
   <?php if (isset($campaign->value_proposition)): ?>
     <div class="container">


### PR DESCRIPTION
### Fixes #4187

Did some refactoring of the preprocess Reportbacks output code now that there are 2 spots on a page where they could show up. There is now a **Reportback Showcase** gallery, apart from the normal Reportback gallery in the _Prove It_ section.

This required DRYing up the code a bit to allow it to be more versatile and work for both galleries.

Fixed an issue where PHP was squawking because the `theme_image()` was missing the `attributes` parameter (apparently the function doesn't have it default to anything).

_Note:_
I also did a quick update to upgrade the image style requested for reportbacks. They were set to `300x300`, but I bumped them to `400x400`. They actually need to be `480x480` but will address that in another issue since it requires a new image style to be created.

@aaronschachter @sergii-tkachenko @DFurnes 
