### PR TITLE
Move "Why signed up" field into elements wrapper. Fixes #4229.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -422,7 +422,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
   // If we are collecting why_signedup:
   if ($config['collect_why_signedup']) {
     // Add it as a form element.
-    $form['why_signedup'] = array(
+    $form['elements']['why_signedup'] = array(
       '#type' => 'textarea',
       '#required' => TRUE,
       '#title' => $config['why_signedup_label'],


### PR DESCRIPTION
# Changes
- Moves "Why signed up" field into elements wrapper with other form fields. Fixes #4229.

For review: @DoSomething/front-end 
# Screenshot

![ahhhhhhh that's soo much better](https://cloud.githubusercontent.com/assets/583202/6737434/fa53d554-ce41-11e4-8d6c-02af9fc63dba.png)
