### PR TITLE
Fixes #4135.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -33,6 +33,7 @@ $asset-path: "";
 @import "patterns/text-field"; // @TODO: Move to Neue!
 @import "patterns/tile";
 @import "patterns/card";
+@import "patterns/waypoints"; // @TODO: Move to Neue!
 
 
 // Content styles by section

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_waypoints.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_waypoints.scss
@@ -1,0 +1,10 @@
+// Overrides for Waypoints pattern
+.waypoints {
+  &.-primary {
+    padding: 12px 0;
+
+    li {
+      margin: 0 12px;
+    }
+  }
+}


### PR DESCRIPTION
# Changes
- Stops waypoints "action menu" on the campaign page from wrapping to two lines. Fixes #4135.

For review: @DoSomething/front-end 
# Screenshots
#### Before:

![screen shot 2015-03-19 at 3 10 54 pm](https://cloud.githubusercontent.com/assets/583202/6739038/716ab5ea-ce4c-11e4-87bf-13e765a37662.png)
#### After:

![screen shot 2015-03-19 at 3 24 38 pm](https://cloud.githubusercontent.com/assets/583202/6739035/6c98c660-ce4c-11e4-9c80-6b36ffca2051.png)
