### PR TITLE
Overrides MailChimp settings for 26+ Club.

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -120,6 +120,14 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
         }
       }
 
+      // Override MailChimp group data if specified explicitly.
+      if (!empty($params['mailchimp_grouping_id'])) {
+        $payload['mailchimp_grouping_id'] = $params['mailchimp_grouping_id'];
+      }
+      if (!empty($params['mailchimp_group_name'])) {
+        $payload['mailchimp_group_name'] = $params['mailchimp_group_name'];
+      }
+
       $payload['merge_vars']['FNAME'] = $params['first_name'];
       $payload['email_tags'][] = 'drupal_user_register';
       break;

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -54,11 +54,17 @@ function dosomething_signup_opt_in_config_form($form, &$form_state) {
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
+
   $name = 'dosomething_signup_26plusclub_enabled';
+  $desc = t(
+    "Makes possible to override settings for users older than 26. "
+     . "Automatically disables emails from MailChimp on campaign signups for them."
+  );
   $form['26plusclub'][$name] = array(
     '#type' => 'checkbox',
     '#title' => 'Enable 26+ Club Overrides',
     '#default_value' => variable_get($name),
+    '#description' => $desc,
   );
   $form['26plusclub']['overrides'] = array(
     '#type' => 'container',

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -18,42 +18,67 @@ function dosomething_signup_opt_in_config_form($form, &$form_state) {
     '#collapsed' => TRUE,
   );
   $name = 'dosomething_signup_mailchimp_general_list_id';
-  $desc = t("String MailChimp List ID for registration and all signups.");
+  $desc = t("General MailChimp List ID used in registrations and signups.");
   $form['general'][$name] = array(
     '#type' => 'textfield',
     '#required' => TRUE,
-    '#title' => t('MailChimp General List ID'),
+    '#title' => 'MailChimp | mailchimp_list_id',
     '#default_value' => variable_get($name),
-    '#size' => 10,
     '#description' => $desc,
   );
 
   $name = 'dosomething_signup_mobilecommons_opt_in_path_general_campaign';
-  $desc = t("Numeric Mobilecommons opt-in path for general campaign signup.");
+  $desc = t("Numeric Mobile Commons opt-in path for general campaign signup.");
   $form['general'][$name] = array(
     '#type' => 'textfield',
     '#required' => TRUE,
-    '#title' => t('Mobilecommons Opt-In Path: General campaign signup'),
+    '#title' => t('Mobile Commons | General campaign | mobilecommons_opt_in_path'),
     '#default_value' => variable_get($name),
-    '#size' => 10,
     '#description' => $desc,
   );
 
-  // Registration.
-  $form['registration'] = array(
+  $name = 'dosomething_signup_mobilecommons_opt_in_path_user_register';
+  $desc = t("Numeric Mobile Commons opt-in path when user registers for site.");
+  $form['general'][$name] = array(
+    '#type' => 'textfield',
+    '#required' => TRUE,
+    '#title' => t('Mobile Commons | User registration | mobilecommons_opt_in_path'),
+    '#default_value' => variable_get($name),
+    '#description' => $desc,
+  );
+
+  // 26 Club.
+  $form['26plusclub'] = array(
     '#type' => 'fieldset',
-    '#title' => t('Registration'),
+    '#title' => t('26+ Club'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $name = 'dosomething_signup_mobilecommons_opt_in_path_user_register';
-  $desc = t("Numeric Mobilecommons opt-in path when user registers for site.");
-  $form['registration'][$name] = array(
+  $name = 'dosomething_signup_mailchimp_26plusclub_list_id';
+  $desc = t("Override MailChimp List ID for users older than 26.");
+  $form['26plusclub'][$name] = array(
     '#type' => 'textfield',
     '#required' => TRUE,
-    '#title' => t('Mobilecommons Opt-In Path: User registration'),
+    '#title' => 'MailChimp | mailchimp_list_id',
     '#default_value' => variable_get($name),
-    '#size' => 10,
+    '#description' => $desc,
+  );
+  $name = 'dosomething_signup_mailchimp_26plusclub_grouping_id_register';
+  $desc = t("Override MailChimp Registration Grouping ID for users older than 26.");
+  $form['26plusclub'][$name] = array(
+    '#type' => 'textfield',
+    '#required' => TRUE,
+    '#title' => 'MailChimp | User registration | mailchimp_grouping_id',
+    '#default_value' => variable_get($name),
+    '#description' => $desc,
+  );
+  $name = 'dosomething_signup_mailchimp_26plusclub_group_name_register';
+  $desc = t("Override MailChimp Registration Interest Group Name for users older than 26.");
+  $form['26plusclub'][$name] = array(
+    '#type' => 'textfield',
+    '#required' => TRUE,
+    '#title' => 'MailChimp | User registration | mailchimp_group_name',
+    '#default_value' => variable_get($name),
     '#description' => $desc,
   );
 
@@ -94,6 +119,9 @@ function dosomething_signup_opt_in_config_form_submit($form, &$form_state) {
     'dosomething_signup_mailchimp_general_list_id',
     'dosomething_signup_mobilecommons_opt_in_path_general_campaign',
     'dosomething_signup_mobilecommons_opt_in_path_user_register',
+    'dosomething_signup_mailchimp_26plusclub_list_id',
+    'dosomething_signup_mailchimp_26plusclub_grouping_id_register',
+    'dosomething_signup_mailchimp_26plusclub_group_name_register',
   );
   foreach ($config_variables as $var_name) {
     variable_set($var_name, $values[$var_name]);

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -54,33 +54,49 @@ function dosomething_signup_opt_in_config_form($form, &$form_state) {
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $name = 'dosomething_signup_mailchimp_26plusclub_list_id';
-  $desc = t("Override MailChimp List ID for users older than 26.");
+  $name = 'dosomething_signup_26plusclub_enabled';
   $form['26plusclub'][$name] = array(
+    '#type' => 'checkbox',
+    '#title' => 'Enable 26+ Club Overrides',
+    '#default_value' => variable_get($name),
+  );
+  $form['26plusclub']['overrides'] = array(
+    '#type' => 'container',
+    '#states' => array(
+      'visible' => array(
+        ':input[name="' . $name . '"]' => array('checked' => TRUE),
+      ),
+    ),
+  );
+  $form_26plusclub_overrides = &$form['26plusclub']['overrides'];
+
+  $name = 'dosomething_signup_26plusclub_mailchimp_list_id';
+  $desc = t("Override MailChimp List ID for users older than 26.");
+  $form_26plusclub_overrides[$name] = array(
     '#type' => 'textfield',
-    '#required' => TRUE,
     '#title' => 'MailChimp | mailchimp_list_id',
     '#default_value' => variable_get($name),
     '#description' => $desc,
   );
-  $name = 'dosomething_signup_mailchimp_26plusclub_grouping_id_register';
+
+  $name = 'dosomething_signup_26plusclub_mailchimp_grouping_id_register';
   $desc = t("Override MailChimp Registration Grouping ID for users older than 26.");
-  $form['26plusclub'][$name] = array(
+  $form_26plusclub_overrides[$name] = array(
     '#type' => 'textfield',
-    '#required' => TRUE,
     '#title' => 'MailChimp | User registration | mailchimp_grouping_id',
     '#default_value' => variable_get($name),
     '#description' => $desc,
   );
-  $name = 'dosomething_signup_mailchimp_26plusclub_group_name_register';
+
+  $name = 'dosomething_signup_26plusclub_mailchimp_group_name_register';
   $desc = t("Override MailChimp Registration Interest Group Name for users older than 26.");
-  $form['26plusclub'][$name] = array(
+  $form_26plusclub_overrides[$name] = array(
     '#type' => 'textfield',
-    '#required' => TRUE,
     '#title' => 'MailChimp | User registration | mailchimp_group_name',
     '#default_value' => variable_get($name),
     '#description' => $desc,
   );
+
 
   // Node helpers variables.
   $opt_in_helpers = dosomething_signup_get_opt_in_config_form_helpers_vars();
@@ -119,12 +135,25 @@ function dosomething_signup_opt_in_config_form_submit($form, &$form_state) {
     'dosomething_signup_mailchimp_general_list_id',
     'dosomething_signup_mobilecommons_opt_in_path_general_campaign',
     'dosomething_signup_mobilecommons_opt_in_path_user_register',
-    'dosomething_signup_mailchimp_26plusclub_list_id',
-    'dosomething_signup_mailchimp_26plusclub_grouping_id_register',
-    'dosomething_signup_mailchimp_26plusclub_group_name_register',
+    'dosomething_signup_26plusclub_enabled',
   );
   foreach ($config_variables as $var_name) {
     variable_set($var_name, $values[$var_name]);
+  }
+
+  // 26+ Club.
+  $club_enabled = !empty($values['dosomething_signup_26plusclub_enabled']);
+  $config_variables = array(
+    'dosomething_signup_26plusclub_mailchimp_list_id',
+    'dosomething_signup_26plusclub_mailchimp_grouping_id_register',
+    'dosomething_signup_26plusclub_mailchimp_group_name_register',
+  );
+  foreach ($config_variables as $var_name) {
+    if ($club_enabled) {
+      variable_set($var_name, $values[$var_name]);
+    } else {
+      variable_del($var_name);
+    }
   }
 
   // Save node helpers variables.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -58,7 +58,8 @@ function dosomething_signup_opt_in_config_form($form, &$form_state) {
   $name = 'dosomething_signup_26plusclub_enabled';
   $desc = t(
     "Makes possible to override settings for users older than 26. "
-     . "Automatically disables emails from MailChimp on campaign signups for them."
+     . "Automatically excludes them from MailChimp on campaign signups "
+     . "and MobileCommons on registrations."
   );
   $form['26plusclub'][$name] = array(
     '#type' => 'checkbox',

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -536,3 +536,17 @@ function dosomething_signup_update_7018() {
   variable_set($new_name, variable_get($old_name));
   variable_del($old_name);
 }
+
+/**
+ * Introduces new variables for 26+ Club.
+ */
+function dosomething_signup_update_7019() {
+  $name = 'dosomething_signup_mailchimp_26plusclub_list_id';
+  variable_set($name, getenv('DS_MB_MAILCHIMP_26PLUSCLUB_LIST_ID'));
+
+  $name = 'dosomething_signup_mailchimp_26plusclub_grouping_id_register';
+  variable_set($name, getenv('DS_MB_MAILCHIMP_26PLUSCLUB_GROUPING_ID_REGISTER'));
+
+  $name = 'dosomething_signup_mailchimp_26plusclub_group_name_register';
+  variable_set($name, getenv('DS_MB_MAILCHIMP_26PLUSCLUB_GROUP_NAME_REGISTER'));
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -541,12 +541,12 @@ function dosomething_signup_update_7018() {
  * Introduces new variables for 26+ Club.
  */
 function dosomething_signup_update_7019() {
-  $name = 'dosomething_signup_mailchimp_26plusclub_list_id';
+  $name = 'dosomething_signup_26plusclub_mailchimp_list_id';
   variable_set($name, getenv('DS_MB_MAILCHIMP_26PLUSCLUB_LIST_ID'));
 
-  $name = 'dosomething_signup_mailchimp_26plusclub_grouping_id_register';
+  $name = 'dosomething_signup_26plusclub_mailchimp_grouping_id_register';
   variable_set($name, getenv('DS_MB_MAILCHIMP_26PLUSCLUB_GROUPING_ID_REGISTER'));
 
-  $name = 'dosomething_signup_mailchimp_26plusclub_group_name_register';
+  $name = 'dosomething_signup_26plusclub_mailchimp_group_name_register';
   variable_set($name, getenv('DS_MB_MAILCHIMP_26PLUSCLUB_GROUP_NAME_REGISTER'));
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -590,14 +590,16 @@ function dosomething_signup_get_mbp_params_mailchimp(&$params, $node) {
  *   MailChimp List id.
  */
 function dosomething_signup_get_mailchimp_list_id() {
-  $variable_name = 'dosomething_signup_mailchimp_general_list_id';
-
   // 26+ Club override.
   if (dosomething_user_is_old_person()) {
-    $variable_name = 'dosomething_signup_mailchimp_26plusclub_list_id';
+    // If `dosomething_signup_mailchimp_26plusclub_list_id` isn't set,
+    // fallback to `dosomething_signup_mailchimp_general_list_id`.
+    if ($mli = variable_get('dosomething_signup_mailchimp_26plusclub_list_id')) {
+      return $mli;
+    }
   }
 
-  return variable_get($variable_name);
+  return variable_get('dosomething_signup_mailchimp_general_list_id');
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -467,7 +467,7 @@ function dosomething_signup_mbp_request($account, $node, $opt_in) {
   }
 
   // Exclude 26+ Club.
-  if (dosomething_user_is_old_person($account)) {
+  if (dosomething_signup_is_26plusclub_member($account)) {
     return;
   }
 
@@ -591,15 +591,33 @@ function dosomething_signup_get_mbp_params_mailchimp(&$params, $node) {
  */
 function dosomething_signup_get_mailchimp_list_id() {
   // 26+ Club override.
-  if (dosomething_user_is_old_person()) {
-    // If `dosomething_signup_mailchimp_26plusclub_list_id` isn't set,
+  if (dosomething_signup_is_26plusclub_member()) {
+    // If `dosomething_signup_26plusclub_mailchimp_list_id` isn't set,
     // fallback to `dosomething_signup_mailchimp_general_list_id`.
-    if ($mli = variable_get('dosomething_signup_mailchimp_26plusclub_list_id')) {
+    if ($mli = variable_get('dosomething_signup_26plusclub_mailchimp_list_id')) {
       return $mli;
     }
   }
 
   return variable_get('dosomething_signup_mailchimp_general_list_id');
+}
+
+/**
+ * Checks if 26+ club is enabled and the user is a member of it.
+ *
+ * @param object $user
+ *   (optional) The loaded user object.
+ *   If omitted, falls back to the current user.
+ *
+ * @return bool
+ *   True if 26+ club is enabled and the user is a member of it.
+ */
+function dosomething_signup_is_26plusclub_member($user = NULL) {
+  if ($user === NULL) {
+    global $user;
+  }
+  $club_enabld = variable_get('dosomething_signup_26plusclub_enabled', FALSE);
+  return $club_enabld && dosomething_user_is_old_person($user);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -465,6 +465,12 @@ function dosomething_signup_mbp_request($account, $node, $opt_in) {
   if (!module_exists('dosomething_mbp')) {
     return;
   }
+
+  // Exclude 26+ Club.
+  if (dosomething_user_is_old_person($account)) {
+    return;
+  }
+
   // Gather mbp params for the signup.
   $params = dosomething_signup_get_mbp_params($account, $node, $opt_in);
   // Send campaign mbp request.
@@ -565,8 +571,9 @@ function dosomething_signup_get_mbp_params_mailchimp(&$params, $node) {
   $nid = $node->nid;
   $grouping_id = dosomething_helpers_get_variable('node', $nid, 'mailchimp_grouping_id');
   $group_name = dosomething_helpers_get_variable('node', $nid, 'mailchimp_group_name');
+
   // MailChimp List Id.
-  $mli = variable_get('dosomething_signup_mailchimp_general_list_id');
+  $mli = dosomething_signup_get_mailchimp_list_id();
   // If a value is present for Mailchimp groups:
   if (!empty($mli) && !empty($grouping_id) && !empty($group_name)) {
     // Add it into the mbp_request params.
@@ -574,6 +581,23 @@ function dosomething_signup_get_mbp_params_mailchimp(&$params, $node) {
     $params['mailchimp_grouping_id'] = $grouping_id;
     $params['mailchimp_group_name'] = $group_name;
   }
+}
+
+/**
+ * Returns MailChimp list id for current user.
+ *
+ * @return string
+ *   MailChimp List id.
+ */
+function dosomething_signup_get_mailchimp_list_id() {
+  $variable_name = 'dosomething_signup_mailchimp_general_list_id';
+
+  // 26+ Club override.
+  if (dosomething_user_is_old_person()) {
+    $variable_name = 'dosomething_signup_mailchimp_26plusclub_list_id';
+  }
+
+  return variable_get($variable_name);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -450,8 +450,8 @@ function dosomething_user_new_user($form, &$form_state) {
     $opt_in = variable_get('dosomething_signup_mobilecommons_opt_in_path_user_register');
 
     if (!empty($opt_in) && !empty($mobile)) {
-      // Don't subscribe 26+ yo users for Mobile Commons.
-      if (!dosomething_user_is_old_person($account)) {
+      // Ignore 26+ Club is enabled and user is older than 26.
+      if (!dosomething_signup_is_26plusclub_member($account)) {
         $params['mobile'] = $mobile;
         $params['mc_opt_in_path_id'] = $opt_in;
       }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -459,13 +459,13 @@ function dosomething_user_new_user($form, &$form_state) {
   }
 
   // Override MailChimp group data for 26+ Club.
-  if (dosomething_user_is_old_person($account)) {
-    $grouping_id = variable_get('dosomething_signup_mailchimp_26plusclub_grouping_id_register');
+  if (dosomething_signup_is_26plusclub_member($account)) {
+    $grouping_id = variable_get('dosomething_signup_26plusclub_mailchimp_grouping_id_register');
     if ($grouping_id) {
       $params['mailchimp_grouping_id'] = $grouping_id;
     }
 
-    $group_name = variable_get('dosomething_signup_mailchimp_26plusclub_group_name_register');
+    $group_name = variable_get('dosomething_signup_26plusclub_mailchimp_group_name_register');
     if ($group_name) {
       $params['mailchimp_group_name']  = $group_name;
     }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -433,16 +433,12 @@ function dosomething_user_new_user($form, &$form_state) {
     return;
   }
 
-  // MailChimp List Id.
-  $mli = variable_get('dosomething_signup_mailchimp_general_list_id');
-
-
   global $user;
   $account = $user;
 
   // Send external message request.
   $params = array(
-    'mailchimp_list_id' => $mli,
+    'mailchimp_list_id' => dosomething_signup_get_mailchimp_list_id(),
     'email'             => $account->mail,
     'uid'               => $account->uid,
     'first_name'        => dosomething_user_get_field('field_first_name', $account),
@@ -461,6 +457,19 @@ function dosomething_user_new_user($form, &$form_state) {
       }
     }
   }
+
+  // Override MailChimp group data for 26+ Club.
+  if (dosomething_user_is_old_person($account)) {
+    $grouping_id = variable_get('dosomething_signup_mailchimp_26plusclub_grouping_id_register');
+    if ($grouping_id) {
+      $params['mailchimp_grouping_id'] = $grouping_id;
+    }
+
+    $group_name = variable_get('dosomething_signup_mailchimp_26plusclub_group_name_register');
+    if ($group_name) {
+      $params['mailchimp_group_name']  = $group_name;
+    }
+   }
 
   dosomething_mbp_request('user_register', $params);
 }


### PR DESCRIPTION
#### What's this PR do?
- Introduces 3 new setting overrides for 26+ Club:
  1. `dosomething_signup_mailchimp_26plusclub_list_id`: Overrides `mailchimp_list_id`
  2. `dosomething_signup_mailchimp_26plusclub_grouping_id_register`: Overrides `mailchimp_grouping_id` for registrations
  3. `dosomething_signup_mailchimp_26plusclub_group_name_register`: Overrides `mailchimp_group_name` for registrations
- Extends and imporves [Third Party Opt-Ins](http://dev.dosomething.org:8888/admin/config/dosomething/opt_in) configuration interface:
  ![image](https://cloud.githubusercontent.com/assets/672669/6757629/1ac7ccba-cf3b-11e4-9c76-798122a31bd2.png)
- Turns off MBP for 26+ Club signups
- Overrides settings for 26+ Club registrations
#### Any background context you want to provide?

New user payload before:

``` php
array (size=11)
  'activity' => string 'user_register' (length=13)
  'email' => string 'sergii+test-032015-7@dosomething.org' (length=36)
  'uid' => string '1704217' (length=7)
  'email_template' => string 'mb-user-register-US' (length=19)
  'merge_vars' => 
    array (size=2)
      'MEMBER_COUNT' => string '3 million' (length=9)
      'FNAME' => string 'Sergii' (length=6)
  'mailchimp_list_id' => string '* hidden *' (length=10)
  'birthdate' => string '580780800' (length=9)
  'subscribed' => int 1
  'email_tags' => 
    array (size=1)
      0 => string 'drupal_user_register' (length=20)
  'activity_timestamp' => int 1426871199
  'application_id' => string 'US' (length=2)
```

New user payload after:

``` php
array (size=13)
  'activity' => string 'user_register' (length=13)
  'email' => string 'sergii+test-032015-7@dosomething.org' (length=36)
  'uid' => string '1704233' (length=7)
  'email_template' => string 'mb-user-register-US' (length=19)
  'merge_vars' => 
    array (size=2)
      'MEMBER_COUNT' => string '3 million' (length=9)
      'FNAME' => string 'Sergii' (length=6)
  'mailchimp_list_id' => string '* hidden-2 *' (length=10)
  'birthdate' => string '580780800' (length=9)
  'subscribed' => int 1
  'mailchimp_grouping_id' => string '9613' (length=4)
  'mailchimp_group_name' => string 'Web Registrations' (length=17)
  'email_tags' => 
    array (size=1)
      0 => string 'drupal_user_register' (length=20)
  'activity_timestamp' => int 1426873547
  'application_id' => string 'US' (length=2)
```
#### What are the relevant tickets?

A part of #4058
