### PR TITLE
Header gallery styles

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -346,7 +346,7 @@ function paraneue_dosomething_build_reportbacks_gallery_collection ($reportbacks
       $reportbacks['prefetched'] = 0;
     }
     else {
-      return FALSE;
+      return NULL;
     }
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -27,10 +27,13 @@ $asset-path: "";
 @import "overrides/drupal";
 
 // Local patterns
+@import "patterns/container"; // @TODO: Move to Neue!
 @import "patterns/form-actions"; // @TODO: Move to Neue!
 @import "patterns/promotion"; // @TODO: Move to Neue!
 @import "patterns/statistic"; // @TODO: Move to Neue!
 @import "patterns/text-field"; // @TODO: Move to Neue!
+@import "patterns/photo"; // @TODO: Move to Neue!
+@import "patterns/gallery"; // @TODO: Move to Neue!
 @import "patterns/tile";
 @import "patterns/card";
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
@@ -1,38 +1,3 @@
-// @TODO: Patternize and move/merge into Neue!
-// ---------------------------------------------------------
-
-.photo {
-
-  &.-framed {
-    background-color: #fff;
-    padding: ($base-spacing / 4);
-
-    @include media($larger) {
-      padding: ($base-spacing / 2);
-    }
-
-    img {
-      width: 100%;
-    }
-
-    .__copy {
-      font-size: $font-smaller;
-      height: 60px;
-      line-height: 1.2;
-      overflow: hidden;
-      margin-top: ($base-spacing / 2);
-      word-wrap: break-word;
-
-      @include media($large) {
-        font-size: $font-small;
-        height: 90px;
-      }
-    }
-  }
-
-}
-
-
 .reportback {
   padding-bottom: $base-spacing;
 
@@ -106,6 +71,16 @@
     height: ($base_spacing / 4);
     margin: 0;
     width: 100%;
+  }
+
+  .photo {
+    &.-framed {
+      .__copy {
+        @include media($large) {
+          height: 90px;
+        }
+      }
+    }
   }
 
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_container.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_container.scss
@@ -1,0 +1,9 @@
+.container {
+  &.-showcase {
+    background-color: #000;
+
+    > .wrapper {
+      padding: $base-spacing 0;
+    }
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_container.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_container.scss
@@ -1,5 +1,5 @@
 .container {
-  &.-hidden {
+  &.optimizely-hidden {
     display: none;
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_container.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_container.scss
@@ -1,4 +1,8 @@
 .container {
+  &.-hidden {
+    display: none;
+  }
+
   &.-showcase {
     background-color: #000;
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_gallery.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_gallery.scss
@@ -1,0 +1,28 @@
+.gallery {
+
+  &.-shuffle {
+    li {
+      margin: 0;
+      position: relative;
+
+      &:nth-child(odd) {
+        top: 7px;
+        transform: rotate(-1deg);
+      }
+
+      &:nth-child(even) {
+        top: -5px;
+        transform: rotate(1deg);
+      }
+
+      &:nth-child(4n-1) {
+        transform: rotate(-3deg);
+      }
+
+      &:nth-child(5n-1) {
+        transform: rotate(3deg);
+      }
+    }
+  }
+
+}

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_photo.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_photo.scss
@@ -1,0 +1,29 @@
+.photo {
+
+  &.-framed {
+    background-color: #fff;
+    padding: ($base-spacing / 4);
+
+    @include media($larger) {
+      padding: ($base-spacing / 2);
+    }
+
+    img {
+      width: 100%;
+    }
+
+    .__copy {
+      font-size: $font-smaller;
+      height: 60px;
+      line-height: 1.2;
+      overflow: hidden;
+      margin-top: ($base-spacing / 2);
+      word-wrap: break-word;
+
+      @include media($large) {
+        font-size: $font-small;
+      }
+    }
+  }
+
+}

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -7,9 +7,6 @@
  * - $classes: Additional classes passed for output (string).
  * - $campaign_scholarship: Scholarship amount (string).
  */
-
-//dpm($variables);
-//dpm($reportbacks_showcase);
 ?>
 
 <section class="campaign campaign--pitch pitch">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -7,6 +7,9 @@
  * - $classes: Additional classes passed for output (string).
  * - $campaign_scholarship: Scholarship amount (string).
  */
+
+//dpm($variables);
+//dpm($reportbacks_showcase);
 ?>
 
 <section class="campaign campaign--pitch pitch">
@@ -26,13 +29,17 @@
     </div>
   </header>
 
-  <?php /* Temporarily hidden. Next step is the frontend!
   <?php if (isset($reportbacks_showcase)): ?>
-    <div class="showcase">
-      <?php print $reportbacks_showcase; ?>
+    <div class="container -showcase">
+      <div class="wrapper">
+        <ul class="gallery -quartet -shuffle">
+          <?php foreach ($reportbacks_showcase['items'] as $index => $reportback): ?>
+            <li><?php print $reportback; ?></li>
+          <?php endforeach; ?>
+        </ul>
+      </div>
     </div>
   <?php endif; ?>
- */?>
 
   <?php if (isset($campaign->value_proposition)): ?>
     <div class="container">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -30,7 +30,7 @@
   </header>
 
   <?php if (isset($reportbacks_showcase)): ?>
-    <div class="container -showcase -hidden">
+    <div class="container -showcase optimizely-hidden">
       <div class="wrapper">
         <ul class="gallery -quartet -shuffle">
           <?php foreach ($reportbacks_showcase['items'] as $index => $reportback): ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -30,7 +30,7 @@
   </header>
 
   <?php if (isset($reportbacks_showcase)): ?>
-    <div class="container -showcase">
+    <div class="container -showcase -hidden">
       <div class="wrapper">
         <ul class="gallery -quartet -shuffle">
           <?php foreach ($reportbacks_showcase['items'] as $index => $reportback): ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -20,6 +20,18 @@
   </div>
 </header>
 
+<?php if (isset($reportbacks_showcase)): ?>
+  <div class="container -showcase">
+    <div class="wrapper">
+      <ul class="gallery -quartet -shuffle">
+        <?php foreach ($reportbacks_showcase['items'] as $index => $reportback): ?>
+          <li><?php print $reportback; ?></li>
+        <?php endforeach; ?>
+      </ul>
+    </div>
+  </div>
+<?php endif; ?>
+
 <article class="campaign campaign--action">
   <nav class="campaign-nav js-fixedsticky">
     <ul class="waypoints -primary waypoints--action js-scroll-indicator">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -21,7 +21,7 @@
 </header>
 
 <?php if (isset($reportbacks_showcase)): ?>
-  <div class="container -showcase">
+  <div class="container -showcase -hidden">
     <div class="wrapper">
       <ul class="gallery -quartet -shuffle">
         <?php foreach ($reportbacks_showcase['items'] as $index => $reportback): ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -21,7 +21,7 @@
 </header>
 
 <?php if (isset($reportbacks_showcase)): ?>
-  <div class="container -showcase -hidden">
+  <div class="container -showcase optimizely-hidden">
     <div class="wrapper">
       <ul class="gallery -quartet -shuffle">
         <?php foreach ($reportbacks_showcase['items'] as $index => $reportback): ?>


### PR DESCRIPTION
### Fixes #4188
### Fixes #4186

This should wrap up the styles for the new **showcase gallery** in the header. Adds some modified patterns which will need to be moved into Neue. Also pulled out the `.photo` pattern and placed into `/patterns` directory for easier reference when moving to Neue.

The rotation with `nth-child` aims to rotate `odd` and `even` gallery items plus a could extra `nth-child` definitions to add some variety in between :dancer: 

The `.-hidden` class is only temporary and will be used for easy Optimizely tests to toggle between showing or not showing the showcase gallery.

@DoSomething/front-end 
