### PR TITLE
Updates to incorportate mobile styles.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_container.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_container.scss
@@ -7,7 +7,7 @@
     background-color: #000;
 
     > .wrapper {
-      padding: $base-spacing 0;
+      padding: ($base-spacing / 2) 0;
     }
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_gallery.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_gallery.scss
@@ -1,9 +1,28 @@
 .gallery {
 
   &.-shuffle {
+    &.-quartet {
+      @include media($medium) {
+        margin: 0 auto;
+        width: span(10 of 12);
+      }
+
+      @include media($large) {
+        width: span(12 of 12);
+      }
+
+      li {
+        @include span(5 of 10);
+
+        @include media($large) {
+          @include span(3 of 12);
+        }
+      }
+    }
+
     li {
-      margin: 0;
       position: relative;
+
 
       &:nth-child(odd) {
         top: 7px;


### PR DESCRIPTION
Needed to add mobile styles for the **showcase gallery**!

These gallery styles for a `.-quartet` will need to be reconciled somehow with the Neue styles. For this particular version, on small/medium devices we want it to go 2 items per row and 4 per row at desktop. Not sure what the ideal alternative would be.

@DoSomething/front-end 
