### PR TITLE
Update to enabled admins to click on button on Reportbacks to edit their status.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -286,8 +286,13 @@ function paraneue_dosomething_get_themed_reportbacks_by_status($campaign_id, $st
 
   $reportback_results = dosomething_reportback_get_reportback_files_query_result($params, $count);
 
+  $admin_link = user_access('view any reportback');
+
   foreach ($reportback_results as $reportback) {
     // @Todo: DRY. Potentially grab this data from the API endpoint to truly DRY?
+    if ($admin_link) {
+      $reportback->admin_link = '/admin/reportback/' . $reportback->rbid;
+    }
     $reportback->image = dosomething_image_get_themed_image_url_by_fid($reportback->fid, '400x400');
     $reportback_items[] = paraneue_dosomething_get_gallery_item((array) $reportback, 'photo');
   }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -286,11 +286,11 @@ function paraneue_dosomething_get_themed_reportbacks_by_status($campaign_id, $st
 
   $reportback_results = dosomething_reportback_get_reportback_files_query_result($params, $count);
 
-  $admin_link = user_access('view any reportback');
+  $admin_access = user_access('view any reportback');
 
   foreach ($reportback_results as $reportback) {
     // @Todo: DRY. Potentially grab this data from the API endpoint to truly DRY?
-    if ($admin_link) {
+    if ($admin_access) {
       $reportback->admin_link = '/admin/reportback/' . $reportback->rbid;
     }
     $reportback->image = dosomething_image_get_themed_image_url_by_fid($reportback->fid, '400x400');

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -34,6 +34,7 @@ $asset-path: "";
 @import "patterns/statistic"; // @TODO: Move to Neue!
 @import "patterns/tile";
 @import "patterns/card";
+@import "patterns/admin-edit"; // @TODO: Move to Neue!
 
 
 // Content styles by section

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_admin-edit.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_admin-edit.scss
@@ -1,0 +1,23 @@
+.admin-edit {
+  background: rgba(0,0,0,0.5);
+  height: 100%;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  transition: opacity 0.2s ease-in;
+  width: 100%;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  .button {
+    box-shadow: 0 3px 5px #000;
+    display: table;
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translateX(-50%) translateY(-50%);
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_photo.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_photo.scss
@@ -1,4 +1,15 @@
 .photo {
+  position: relative;
+
+  .admin-edit {
+    display: none;
+  }
+
+  &:hover {
+    .admin-edit {
+      display: block;
+    }
+  }
 
   &.-framed {
     background-color: #fff;

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -1,7 +1,7 @@
 <figure class="photo -stacked -framed">
   <?php if (isset($content['admin_link'])): ?>
     <div class="admin-edit">
-      <a class="button -secondary" href="<?php print $content['admin_link']?>">Edit Status</a>
+      <a class="button -secondary" href="<?php print $content['admin_link']; ?>">Edit Status</a>
     </div>
   <?php endif; ?>
   <img src="<?php print $content['image']; ?>" alt="<?php print check_plain($content['caption']); ?>" />

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -1,4 +1,9 @@
 <figure class="photo -stacked -framed">
+  <?php if (user_access('view any reportback')): ?>
+    <div class="admin-edit">
+      <a class="button -secondary" href="/admin/reportback/<?php print $content['rbid'] ?>">Edit Status</a>
+    </div>
+  <?php endif; ?>
   <img src="<?php print $content['image']; ?>" alt="<?php print check_plain($content['caption']); ?>" />
   <figcaption class="__copy">
     <?php print check_plain($content['caption']); ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -1,7 +1,7 @@
 <figure class="photo -stacked -framed">
-  <?php if (user_access('view any reportback')): ?>
+  <?php if (isset($content['admin_link'])): ?>
     <div class="admin-edit">
-      <a class="button -secondary" href="/admin/reportback/<?php print $content['rbid'] ?>">Edit Status</a>
+      <a class="button -secondary" href="<?php print $content['admin_link']?>">Edit Status</a>
     </div>
   <?php endif; ?>
   <img src="<?php print $content['image']; ?>" alt="<?php print check_plain($content['caption']); ?>" />


### PR DESCRIPTION
### Fixes #4219

This adds a nice little hover effect on each Reportback (both the Prove It gallery and the showcase gallery up at top of page) that shows an edit button admins can click on to head to the administration page in the CMS for that reportback.

![image](https://cloud.githubusercontent.com/assets/105849/6784917/ecc9fb4c-d158-11e4-911e-b20ecfd54940.png)

_Note_: This addresses Reportbacks output via PHP, however it does not address Reportbacks being viewed via the View More since they are added via JavaScript and need a little somethin', somethin' extra to get that working.

@angaither 
@DoSomething/front-end 

CC: @mikefantini 
