### PR TITLE
Update to enable admin edit links in extended gallery.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -427,6 +427,9 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars) {
   else {
     $reportbacks_gallery['prefetched'] = 0;
   }
+
+  // Pass admin access boolean for JS purposes.
+  $reportbacks_gallery['admin_access'] = user_access('view any reportback') ? 'true' : 'false';
 }
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -37,6 +37,8 @@ define(function(require) {
 
     galleryInDom: false,
 
+    adminAccess: null,
+
 
     /**
      * Initialize the Reportback interface.
@@ -51,6 +53,8 @@ define(function(require) {
       this.$captionField       = this.$reportbackForm.find(".form-item-caption");
       this.$initialGallery     = $container.find(".gallery--reportback");
 
+      // Does the user have admin access?
+      this.adminAccess = $container.data("admin");
       // Number of Approved Reportbacks obtained to help fill initial gallery.
       this.itemsPrefetched = $container.data("prefetched");
       // Total number of Approved Reportbacks discounting any that were already prefetched.
@@ -332,6 +336,8 @@ define(function(require) {
           "status": items[i].status,
           "isListItem": true  // @TODO: probably a better way to address this... :insert shrug emoji here:
         };
+
+        data.adminLink = this.adminAccess ? '/admin/reportback/' + items[i].rbid : false;
 
         var markup = _.template(reportbackTplSrc, data);
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/templates/reportback.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/templates/reportback.tpl.html
@@ -1,5 +1,10 @@
 <% if (isListItem) { %><li><% } %>
 <figure class="photo -stacked -framed">
+  <% if (adminLink) { %>
+  <div class="admin-edit">
+    <a class="button -secondary" href="<%= adminLink %>">Edit Status</a>
+  </div>
+  <% } %>
   <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=" alt="<%= caption %>" data-src="<%= image %>" />
   <figcaption class="__copy"><%= caption %></figcaption>
 </figure>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -281,7 +281,7 @@
         <?php endif; ?>
       </div>
 
-      <div id="reportback" class="reportback" data-nid="<?php print $campaign->nid; ?>" data-prefetched="<?php print $reportbacks_gallery['prefetched']; ?>" data-total="<?php print $reportbacks_gallery['total_approved']; ?>">
+      <div id="reportback" class="reportback" data-nid="<?php print $campaign->nid; ?>" data-prefetched="<?php print $reportbacks_gallery['prefetched']; ?>" data-total="<?php print $reportbacks_gallery['total_approved']; ?>" data-admin="<?php print $reportbacks_gallery['admin_access']; ?>">
         <div class="wrapper">
 
           <ul class="gallery gallery--reportback">


### PR DESCRIPTION
### Fixes #4219

Wraps up adding the Admin edit links capability to the AJAX loaded in Reportbacks in the extended **Prove It** gallery when using the _view more_ button.

@DoSomething/front-end 
@angaither 

CC: @mikefantini 
