### PR TITLE
Admin northstar inital setup

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.admin.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.admin.inc
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @file
+ * Zendesk admin settings.
+ */
+
+/**
+ * System settings form for northstar config.
+ */
+function dosomething_northstar_config_form($form, &$form_state) {
+   $form = array();
+
+  $form['northstar'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Northstar Settings'),
+  );
+  $form['northstar']['dosomething_northstar_url'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Northstar URL'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_northstar_url', 'http://northstar.dev'),
+  );
+  $form['northstar']['dosomething_northstar_port'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Northstar port'),
+    '#description' => t('This is most likely only needed on dev sites'),
+    '#required' => FALSE,
+    '#default_value' => variable_get('dosomething_northstar_port', '8888'),
+  );
+  $form['northstar']['dosomething_northstar_version'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Northstar API version number'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_northstar_version', '1'),
+  );
+  $form['northstar']['dosomething_northstar_app_id'] = array(
+    '#type' => 'textfield',
+    '#title' => t('App id'),
+    '#description' => t('The app id needed to connect to northstar (found in aurora).'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_northstar_app_id', '456'),
+  );
+  $form['northstar']['dosomething_northstar_app_key'] = array(
+    '#type' => 'textfield',
+    '#title' => t('App key'),
+    '#description' => t('The app key needed to connect to northstar (found in aurora).'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_northstar_app_key', 'abc4324'),
+  );
+
+  return system_settings_form($form);
+}

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.admin.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.admin.inc
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Zendesk admin settings.
+ * Northstar admin settings.
  */
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.info
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.info
@@ -1,5 +1,5 @@
 name = DoSomething Northstar
-description = Provides connection to our Norhtstar user database.
+description = Provides connection to our Northstar user database.
 core = 7.x
 package = DoSomething
 version = 7.x-0.3

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.info
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.info
@@ -1,0 +1,6 @@
+name = DoSomething Northstar
+description = Provides connection to our Norhtstar user database.
+core = 7.x
+package = DoSomething
+version = 7.x-0.3
+project = dosomething_northstar

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -5,6 +5,24 @@
  * Code for the dosomething_northstar module.
  */
 
+include_once('dosomething_northstar.admin.inc');
+
+
+/**
+ * Implements hook_menu().
+ */
+function dosomething_northstar_menu() {
+  $items = array();
+  $items['admin/config/services/northstar'] = array(
+    'title' => 'Northstar',
+    'description' => 'Manage Northstar connection settings.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_northstar_config_form'),
+    'access arguments' => array('administer modules'),
+    'file' => 'dosomething_northstar.admin.inc',
+  );
+  return $items;
+}
 /**
  * Implements hook_libraries_info().
  */

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Code for the dosomething_northstar module.
+ */
+
+/**
+ * Implements hook_libraries_info().
+ */
+function dosomething_northstar_libraries_info() {
+  $libraries['guzzle-php'] = array(
+    'name' => 'Guzzle',
+    'path' => 'lib',
+    'files' => array(
+      'php' => array(
+        'autoload.php',
+      ),
+    ),
+    'version' => 5.0,
+  );
+  return $libraries;
+}

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -81,6 +81,7 @@ dependencies[] = dosomething_fact
 dependencies[] = dosomething_fact_page
 dependencies[] = dosomething_image
 dependencies[] = dosomething_mbp
+dependencies[] = dosomething_northstar
 dependencies[] = dosomething_helpers
 dependencies[] = dosomething_home
 dependencies[] = dosomething_reportback

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -253,6 +253,10 @@ projects[stage_file_proxy][subdir] = "contrib"
 ;libraries[dsapi][download][type] = "git"
 ;libraries[dsapi][download][url] = "git@github.com:DoSomething/dsapi-php.git"
 
+; Guzzle
+libraries[guzzle][download][type] = "git"
+libraries[guzzle][download][url] = "https://github.com/guzzle/guzzle.git"
+
 ; Message Broker PHP Library
 libraries[messagebroker-phplib][download][type] = "git"
 libraries[messagebroker-phplib][download][url] = "https://github.com/DoSomething/messagebroker-phplib.git"


### PR DESCRIPTION
Adds new `dosomething_northstar` module
Currently only has an admin form to add settings. 
Add guzzle as a new library in `drupal-org.make`

Initial ground work for #4276 
