### PR TITLE
Reindexes Solr automaticall after ds pull stage.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -487,6 +487,9 @@ function pull_db {
       echo "Unsetting tagged version variable..."
       drush variable-delete ds_version -y
 
+      echo "Reindexing Solr..."
+      drush solr-mark-all && drush solr-index
+
     else
       echo "Pulling down the db from ${alias[1]} staging"
       drush -y sql-sync @ds.${alias[1]}.staging @ds.${alias[1]}.dev


### PR DESCRIPTION
Automatically reindex Solr after `ds pull stage`.
Takes about 20 seconds, which is nothing compared to pulling and importing the database itself.
Closes #4290.
