### PR TITLE
Set progress as default on campaign variables page

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -156,10 +156,12 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
       '#description' => t('The goal of total number of reportbacks'),
       '#default_value' => $vars['goal'],
     );
+    $progress = dosomething_helpers_get_variable('node', $node->nid, 'sum_count') ?: dosomething_reportback_get_reportback_total_by_nid($node->nid);
+
     $form['goals']['progress'] = array(
       '#type' => 'textfield',
       '#title' => t('Progress'),
-      '#description' => t('The total number of approved reportback quantity.'),
+      '#description' => t('The total number of approved reportback quantity.' . $progress . ' so far'),
       '#default_value' => $vars['progress'],
     );
   }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -156,13 +156,23 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
       '#description' => t('The goal of total number of reportbacks'),
       '#default_value' => $vars['goal'],
     );
-    $progress = dosomething_helpers_get_variable('node', $node->nid, 'sum_count') ?: dosomething_reportback_get_reportback_total_by_nid($node->nid);
+
+    // @TODO: move this into a function.
+    // If the progress set is higher than the var, save the var as higher.
+    // This allows for campaigns run with external partners to account for
+    // counts submitted directly to the third party, but haven't been
+    // reported back on our site
+    if ($vars['progress'] > $rb_progress) {
+      dosomething_helpers_set_variable('node', $node->nid, 'sum_rb_quanity', $vars['progress']);
+    }
+    // Get the progress from the set variable, else do a query for it.
+    $rb_progress = dosomething_helpers_get_variable('node', $node->nid, 'sum_rb_quanity') ?: dosomething_reportback_get_reportback_total_by_nid($node->nid);
 
     $form['goals']['progress'] = array(
       '#type' => 'textfield',
       '#title' => t('Progress'),
-      '#description' => t('The total number of approved reportback quantity.' . $progress . ' so far'),
-      '#default_value' => $vars['progress'],
+      '#description' => t('The total approved reportback quantity so far is: ' . $rb_progress),
+      '#default_value' => $vars['progress'] ?: $rb_progress,
     );
   }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -225,7 +225,21 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
     if (!$save) {
       form_set_error(t("An error has occurred."));
     }
-
+    // If it's not a flagged reportback update the node quantity.
+    // @TODO: remove this code, this is just a test of updating rb_quanity.
+    if ($values['status'] != 'flagged') {
+      $rb = reportback_load($rbf->rbid);
+      $nid = $rb->nid;
+      // First get the total quantity.
+      $quantity = dosomething_helpers_get_variable('node', $nid, 'sum_rb_quanity');
+      //@TODO: remove the print_r().
+      // This is intentionally left in to show @fanitni how screwy this update stuff is.
+      drupal_set_message('before file: ' . $rbf->fid . ' quanity: ' . $quantity);
+      $quantity = $quantity + $rb->quantity;
+      // Update the variable.
+      dosomething_helpers_set_variable('node', $nid, 'sum_rb_quanity', $quantity);
+      drupal_set_message('after file: ' . $rbf->fid . ' quanity: '. $quantity);
+    }
   }
 
   drupal_set_message(t("Updated."));

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -232,7 +232,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
       $nid = $rb->nid;
       // First get the total quantity.
       $quantity = dosomething_helpers_get_variable('node', $nid, 'sum_rb_quanity');
-      //@TODO: remove the print_r().
+      //@TODO: remove the messages.
       // This is intentionally left in to show @fanitni how screwy this update stuff is.
       drupal_set_message('before file: ' . $rbf->fid . ' quanity: ' . $quantity);
       $quantity = $quantity + $rb->quantity;

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -829,7 +829,7 @@ function dosomething_reportback_get_reportback_total_by_nid($nid, $type = 'quant
     $query->addExpression('SUM(quantity)', 'quantity');
     $result = $query->execute()->fetchAll();
     $quantity = $result[0]->quantity;
-    dosomething_helpers_set_variable('node', $nid, 'sum_count', $quantity);
+    dosomething_helpers_set_variable('node', $nid, 'sum_rb_quanity', $quantity);
     return $quantity;
   }
   elseif ($type == 'count') {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -828,7 +828,9 @@ function dosomething_reportback_get_reportback_total_by_nid($nid, $type = 'quant
     $query->fields('rb', array('quantity'));
     $query->addExpression('SUM(quantity)', 'quantity');
     $result = $query->execute()->fetchAll();
-    return $result[0]->quantity;
+    $quantity = $result[0]->quantity;
+    dosomething_helpers_set_variable('node', $nid, 'sum_count', $quantity);
+    return $quantity;
   }
   elseif ($type == 'count') {
     $query->fields('rb', array('rbid'));


### PR DESCRIPTION
This code is not ready for prod, but is a TEST for @mikefantini to see how updating the `rb_quanity` would work on each reportback approval.

I _intentionally_ left in messages/debug statements to help visualize what is going on when this code runs.
I would like to deploy this to staging to play around with this. 

Refs #3899 Refs #4282
