### PR TITLE
Fixes #4305 by using proper tag for paragraph spacing rule.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -32,9 +32,9 @@
           <?php endif; ?>
 
           <?php if (isset($psa)): ?>
-            <aside <?php if ($is_video_psa) echo 'class="media-video"'; ?>>
+            <p <?php if ($is_video_psa) echo 'class="media-video"'; ?>>
               <?php print $psa; ?>
-            </aside>
+            </p>
           <?php else: ?>
             <?php if (isset($modals)): ?>
               <?php print $modals; ?>


### PR DESCRIPTION
# Changes
- Fixes #4305 by using proper tag for `p + p` paragraph spacing rule. I think this makes semantic sense to use a `p` tag here as well, but it might be worth pondering if there's a better long-term solution for cases like this.

For review: @DoSomething/front-end 
