### PR TITLE
Deprecates bin/ds syntax: makes ds script avaliable from anywhere.

### DIFF
--- a/bin/drush-intl
+++ b/bin/drush-intl
@@ -3,8 +3,12 @@
 # ==============================================================================
 # Globals
 
+# Absolute pathe of this script
+SCRIPT_PATH=`dirname "$0"`
+
 # The base project directory
-BASE_PATH=`pwd -P`
+# If DS_APP_ROOT is not provided, the script will use parent folder as base path
+BASE_PATH=${DS_APP_ROOT:-`dirname $SCRIPT_PATH`}
 
 # The webroot directory name for the dev environment
 WEB_DIR='html'

--- a/bin/ds
+++ b/bin/ds
@@ -4,8 +4,12 @@
 # GLOBALS
 # ==============================================================================
 
+# Absolute pathe of this script
+SCRIPT_PATH=`dirname "$0"`
+
 # The base project directory
-BASE_PATH=`pwd -P`
+# If DS_APP_ROOT is not provided, the script will use parent folder as base path
+BASE_PATH=${DS_APP_ROOT:-`dirname $SCRIPT_PATH`}
 
 # The webroot directory name for the dev environment
 WEB_DIR='html'


### PR DESCRIPTION
This PR deprecates `bin/ds`, `bin/drush-intl` syntax.

Instead, it uses `$DS_APP_ROOT` environment variable to determine `$BASE_PATH`.
If `$DS_APP_ROOT` isn't set (now only [1.0.0.rc1](/DoSomething/vagrant-platform/releases/tag/v1.0.0.rc1) Vagrant box provides it), script defaults `$BASE_PATH` to parent folder of current script (`../`), which makes it possible to run without mandatory `cd`ing directly to the `/var/www/dev.dosomething.org` folder.

[1.0.0.rc1](/DoSomething/vagrant-platform/releases/tag/v1.0.0.rc1) Vagrant box also makes `ds` and `drush-intl` available globally. With this PR you can run both scripts literally from anywhere.

Fixes #4299.

![image](https://cloud.githubusercontent.com/assets/672669/6900973/c9affa84-d712-11e4-9648-f30491c9d120.png)
