### PR TITLE
Adjust queue setting in user_register production

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -111,7 +111,7 @@ function dosomething_mbp_install_productions() {
   $productions[0]['queues'][] = 'transactionalQueue';
   $productions[0]['queues'][] = 'loggingQueue';
   $productions[0]['queues'][] = 'activityStatsQueue';
-  $productions[0]['queues'][] = 'mailchimpCampaignSignupQueue';
+  $productions[0]['queues'][] = 'userRegistrationQueue';
   $productions[0]['queues'][] = 'mobileCommonsQueue';
   $productions[0]['queues'][] = 'userAPIRegistrationQueue';
   $productions[0]['routing_key'] = 'user.registration.transactional';


### PR DESCRIPTION
Fixes #4313 

The `user_register` Message Broker Producer production was misconfigured to point to wrong queue. This PR adjust the settings to use `userRegistrationQueue` rather than `mailchimpCampaignSignupQueue`.
