### PR TITLE
Cron all the things

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -225,21 +225,6 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
     if (!$save) {
       form_set_error(t("An error has occurred."));
     }
-    // If it's not a flagged reportback update the node quantity.
-    // @TODO: remove this code, this is just a test of updating rb_quanity.
-    if ($values['status'] != 'flagged') {
-      $rb = reportback_load($rbf->rbid);
-      $nid = $rb->nid;
-      // First get the total quantity.
-      $quantity = dosomething_helpers_get_variable('node', $nid, 'sum_rb_quanity');
-      //@TODO: remove the messages.
-      // This is intentionally left in to show @fanitni how screwy this update stuff is.
-      drupal_set_message('before file: ' . $rbf->fid . ' quanity: ' . $quantity);
-      $quantity = $quantity + $rb->quantity;
-      // Update the variable.
-      dosomething_helpers_set_variable('node', $nid, 'sum_rb_quanity', $quantity);
-      drupal_set_message('after file: ' . $rbf->fid . ' quanity: '. $quantity);
-    }
   }
 
   drupal_set_message(t("Updated."));

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Provides cron job/drush command for dosomething_reportback.module.
+ */
+
+/**
+ * Implements hook_cron().
+ */
+function dosomething_reportback_cron() {
+  // Get all reportbacks updated in the past hour.
+  $results = db_query("SELECT nid, sum(quantity) as quantity
+                     FROM dosomething_reportback
+                     WHERE from_unixtime(updated) >= date_add(now(), INTERVAL '-1' hour)
+                     GROUP BY nid;");
+
+  // Updated reportback counts accordingly.
+  foreach ($results as $result) {
+    $previous_progress = dosomething_helpers_get_variable('node', $result->nid, 'sum_rb_quanity');
+    $updated_progress = (int) $previous_progress + (int) $result->quantity;
+    dosomething_helpers_set_variable('node', $result->nid, 'sum_rb_quanity', $updated_progress);
+  }
+
+}

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -8,6 +8,7 @@ define('DOSOMETHING_REPORTBACK_LOG', variable_get('dosomething_reportback_log') 
 include_once 'dosomething_reportback.features.inc';
 include_once 'dosomething_reportback.forms.inc';
 include_once 'dosomething_reportback.theme.inc';
+include_once 'dosomething_reportback.cron.inc';
 
 /**
  * Implements hook_entity_info().


### PR DESCRIPTION
#### What this pr does

This cron will pull reportbacks updated in the past hour and update the quantity count for those nodes.
#### Known issue

I still think we will see higher numbers than the reality from over adding (numbers may look higher than they actually are)
(eg) If a user updates a reportback that quantity number will get added to the total as many times as the user updates the reportback. 
#### N.B.

I looked into pulling the quantity from the log, but that still isn't a difference of the past quantity and the current quantity. 
Until we have endpoints from the dashboard to set these numbers correctly every so often, I think this is our best option. 

Refs #4282
Refs #3899

@mshmsh5000 @mikefantini @joshcusano 
