### PR TITLE
Persistent Sign up button on the pitch pages

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -393,6 +393,9 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
     paraneue_dosomething_preprocess_reportback_gallery($vars);
   }
 
+  if (isset($vars['is_pitch_page'])) {
+    $vars['show_persistent_signup'] = theme_get_setting('show_persistent_signup');
+  }
 }
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -131,8 +131,9 @@
 
 }
 
-.campaign--pitch.-persistent-beta {
-  .cta {
+.campaign--pitch.-persistent {
+  .cta.-persistent {
+    display: block;
     background-color: $black;
     border: none;
     position: sticky;
@@ -173,19 +174,23 @@
       clear: none;
       text-align: left;
       margin-bottom: 0px;
-      font-size: 18px;
+      font-size: $font-regular;
       float: none;
       vertical-align: middle;
 
       @include media($medium) {
         width: auto;
-        font-size: 24px;
+        font-size: $font-medium;
         float: left;
         padding: 0px;
         display: inline-block;
-        padding: 12px 0px 0px 60px;
+        padding: ($base-spacing/2) 0px 0px ($base-spacing * 2.5);
       }
     }
+  }
+
+  .cta {
+    display: none;
   }
 
   // Need to hide this cloned element that is injected by the fixed-sticky js.

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -131,66 +131,76 @@
 
 }
 
-.campaign--pitch.-persistent {
+.campaign--pitch {
   .cta.-persistent {
-    display: block;
-    background-color: $black;
-    border: none;
-    position: sticky;
-    top: 0;
-    z-index: 100;
-
-    // Fallback for position:sticky, through Filament Group's fixed-sticky
-    &.fixedsticky-on {
-      position: fixed;
-      width: 100%;
-      max-width: 1440px;
-    }
-
-    > .wrapper {
-      @include clearfix;
-      display: table;
-      padding: $base-spacing / 2 0px;
-    }
-
-    .cta__button {
-      display: table-cell;
-      @include span(5 of 12);
-      float: none;
-      padding: 0px;
-      text-align: left;
-
-      @include media($medium) {
-        width: auto;
-        float: left;
-        display: inline-block;
-      }
-    }
-
-    .cta__message {
-      display: table-cell;
-      @include span(7 of 12);
-      color: $white;
-      clear: none;
-      text-align: left;
-      margin-bottom: 0px;
-      font-size: $font-regular;
-      float: none;
-      vertical-align: middle;
-
-      @include media($medium) {
-        width: auto;
-        font-size: $font-medium;
-        float: left;
-        padding: 0px;
-        display: inline-block;
-        padding: ($base-spacing/2) 0px 0px ($base-spacing * 2.5);
-      }
-    }
+    display: none;
   }
 
-  .cta {
-    display: none;
+  &.-persistent-beta {
+    .cta {
+      display: none;
+    }
+
+    .header__signup {
+      display: none;
+    }
+
+    .cta.-persistent {
+      display: block;
+      background-color: $black;
+      border: none;
+      position: sticky;
+      top: 0;
+      z-index: 100;
+
+      // Fallback for position:sticky, through Filament Group's fixed-sticky
+      &.fixedsticky-on {
+        position: fixed;
+        width: 100%;
+        max-width: 1440px;
+      }
+
+      > .wrapper {
+        @include clearfix;
+        display: table;
+        padding: $base-spacing / 2 0px;
+      }
+
+      .cta__button {
+        display: table-cell;
+        @include span(5 of 12);
+        float: none;
+        padding: 0px;
+        text-align: left;
+
+        @include media($medium) {
+          width: auto;
+          float: left;
+          display: inline-block;
+        }
+      }
+
+      .cta__message {
+        display: table-cell;
+        @include span(7 of 12);
+        color: $white;
+        clear: none;
+        text-align: left;
+        margin-bottom: 0px;
+        font-size: $font-regular;
+        float: none;
+        vertical-align: middle;
+
+        @include media($medium) {
+          width: auto;
+          font-size: $font-medium;
+          float: left;
+          padding: 0px;
+          display: inline-block;
+          padding: ($base-spacing/2) 0px 0px ($base-spacing * 2.5);
+        }
+      }
+    }
   }
 
   // Need to hide this cloned element that is injected by the fixed-sticky js.

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -136,7 +136,7 @@
     display: none;
   }
 
-  &.-persistent-beta {
+  &.optimizely-persistent {
     .cta {
       display: none;
     }
@@ -163,14 +163,14 @@
       > .wrapper {
         @include clearfix;
         display: table;
-        padding: $base-spacing / 2 0px;
+        padding: $base-spacing / 2 0;
       }
 
       .cta__button {
         display: table-cell;
         @include span(5 of 12);
         float: none;
-        padding: 0px;
+        padding: 0;
         text-align: left;
 
         @include media($medium) {
@@ -186,7 +186,7 @@
         color: $white;
         clear: none;
         text-align: left;
-        margin-bottom: 0px;
+        margin-bottom: 0;
         font-size: $font-regular;
         float: none;
         vertical-align: middle;
@@ -195,9 +195,9 @@
           width: auto;
           font-size: $font-medium;
           float: left;
-          padding: 0px;
+          padding: 0;
           display: inline-block;
-          padding: ($base-spacing/2) 0px 0px ($base-spacing * 2.5);
+          padding: ($base-spacing/2) 0 0 ($base-spacing * 2.5);
         }
       }
     }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -130,3 +130,66 @@
   }
 
 }
+
+.campaign--pitch.-persistent-beta {
+  .cta {
+    background-color: $black;
+    border: none;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+
+    // Fallback for position:sticky, through Filament Group's fixed-sticky
+    &.fixedsticky-on {
+      position: fixed;
+      width: 100%;
+      max-width: 1440px;
+    }
+
+    > .wrapper {
+      @include clearfix;
+      display: table;
+      padding: $base-spacing / 2 0px;
+    }
+
+    .cta__button {
+      display: table-cell;
+      @include span(5 of 12);
+      float: none;
+      padding: 0px;
+      text-align: left;
+
+      @include media($medium) {
+        width: auto;
+        float: left;
+        display: inline-block;
+      }
+    }
+
+    .cta__message {
+      display: table-cell;
+      @include span(7 of 12);
+      color: $white;
+      clear: none;
+      text-align: left;
+      margin-bottom: 0px;
+      font-size: 18px;
+      float: none;
+      vertical-align: middle;
+
+      @include media($medium) {
+        width: auto;
+        font-size: 24px;
+        float: left;
+        padding: 0px;
+        display: inline-block;
+        padding: 12px 0px 0px 60px;
+      }
+    }
+  }
+
+  // Need to hide this cloned element that is injected by the fixed-sticky js.
+  .fixedsticky-dummy {
+    display: none;
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -167,8 +167,8 @@
       }
 
       .cta__button {
-        display: table-cell;
         @include span(5 of 12);
+        display: table-cell;
         float: none;
         padding: 0;
         text-align: left;
@@ -181,8 +181,8 @@
       }
 
       .cta__message {
-        display: table-cell;
         @include span(7 of 12);
+        display: table-cell;
         color: $white;
         clear: none;
         text-align: left;

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -9,18 +9,18 @@
  */
 ?>
 
-<section class="campaign campaign--pitch -persistent pitch">
+<section class="campaign campaign--pitch pitch <?php if ($show_persistent_signup) { print '-persistent-beta'; } ?>">
 
   <header role="banner" class="header -hero <?php print $classes; ?>">
     <div class="wrapper">
       <?php print $campaign_headings; ?>
 
-      <?php /* if (isset($signup_button_primary)): ?>
+      <?php if (isset($signup_button_primary)): ?>
         <div class="header__signup">
           <?php print render($signup_button_primary); ?>
           <?php print $campaign_scholarship; ?>
         </div>
-      <?php endif; */?>
+      <?php endif; ?>
 
       <?php print $promotions; ?>
     </div>
@@ -38,13 +38,6 @@
       </div>
     </div>
   <?php endif; ?>
-<!-- 
-  <div class="cta -inline js-fixedsticky fixedsticky">
-    <div class="wrapper">
-      <p class="cta__message">You must pay homage to our future <em>kitten</em> overlords.</p>
-      <div class="cta__action"><a href="#" class="button">Do This</a></div>
-    </div>
-  </div> -->
 
   <?php if (isset($reportbacks_showcase)): ?>
     <div class="container -showcase optimizely-hidden">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -9,22 +9,42 @@
  */
 ?>
 
-<section class="campaign campaign--pitch pitch">
+<section class="campaign campaign--pitch pitch -persistent-beta">
 
   <header role="banner" class="header -hero <?php print $classes; ?>">
     <div class="wrapper">
       <?php print $campaign_headings; ?>
 
-      <?php if (isset($signup_button_primary)): ?>
+      <?php /* if (isset($signup_button_primary)): ?>
         <div class="header__signup">
           <?php print render($signup_button_primary); ?>
           <?php print $campaign_scholarship; ?>
         </div>
-      <?php endif; ?>
+      <?php endif; */?>
 
       <?php print $promotions; ?>
     </div>
   </header>
+
+  <?php if (isset($campaign->secondary_call_to_action)): ?>
+    <div class="cta js-fixedsticky fixedsticky">
+      <div class="wrapper">
+        <?php if (isset($signup_button_secondary)): ?>
+          <div class="cta__button">
+            <?php print render($signup_button_secondary); ?>
+          </div>
+        <?php endif; ?>
+        <h4 class="cta__message"><?php print $campaign->secondary_call_to_action; ?></h4>
+      </div>
+    </div>
+  <?php endif; ?>
+<!-- 
+  <div class="cta -inline js-fixedsticky fixedsticky">
+    <div class="wrapper">
+      <p class="cta__message">You must pay homage to our future <em>kitten</em> overlords.</p>
+      <div class="cta__action"><a href="#" class="button">Do This</a></div>
+    </div>
+  </div> -->
 
   <?php if (isset($reportbacks_showcase)): ?>
     <div class="container -showcase optimizely-hidden">
@@ -66,7 +86,7 @@
     </div>
   <?php endif; ?>
 
-  <?php if (isset($campaign->secondary_call_to_action)): ?>
+  <?php /* if (isset($campaign->secondary_call_to_action)): ?>
     <div class="cta">
       <div class="wrapper">
         <h2 class="cta__message"><?php print $campaign->secondary_call_to_action; ?></h2>
@@ -75,7 +95,7 @@
         <?php endif; ?>
       </div>
     </div>
-  <?php endif; ?>
+  <?php endif; */?>
 
   <div class="info-bar -dark">
     <div class="wrapper">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -9,7 +9,7 @@
  */
 ?>
 
-<section class="campaign campaign--pitch pitch -persistent-beta">
+<section class="campaign campaign--pitch -persistent pitch">
 
   <header role="banner" class="header -hero <?php print $classes; ?>">
     <div class="wrapper">
@@ -27,7 +27,7 @@
   </header>
 
   <?php if (isset($campaign->secondary_call_to_action)): ?>
-    <div class="cta js-fixedsticky fixedsticky">
+    <div class="cta -persistent js-fixedsticky fixedsticky">
       <div class="wrapper">
         <?php if (isset($signup_button_secondary)): ?>
           <div class="cta__button">
@@ -86,7 +86,7 @@
     </div>
   <?php endif; ?>
 
-  <?php /* if (isset($campaign->secondary_call_to_action)): ?>
+  <?php if (isset($campaign->secondary_call_to_action)): ?>
     <div class="cta">
       <div class="wrapper">
         <h2 class="cta__message"><?php print $campaign->secondary_call_to_action; ?></h2>
@@ -95,7 +95,7 @@
         <?php endif; ?>
       </div>
     </div>
-  <?php endif; */?>
+  <?php endif; ?>
 
   <div class="info-bar -dark">
     <div class="wrapper">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -9,7 +9,7 @@
  */
 ?>
 
-<section class="campaign campaign--pitch pitch <?php if ($show_persistent_signup) { print '-persistent-beta'; } ?>">
+<section class="campaign campaign--pitch pitch <?php if ($show_persistent_signup) { print 'optimizely-persistent'; } ?>">
 
   <header role="banner" class="header -hero <?php print $classes; ?>">
     <div class="wrapper">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -27,7 +27,7 @@
   </header>
 
   <?php if (isset($campaign->secondary_call_to_action)): ?>
-    <div class="cta -persistent js-fixedsticky fixedsticky">
+    <div class="cta -persistent js-fixedsticky">
       <div class="wrapper">
         <?php if (isset($signup_button_secondary)): ?>
           <div class="cta__button">

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -46,7 +46,11 @@ function paraneue_dosomething_form_system_theme_settings_alter(&$form, &$form_st
     'show_sponsors' => array(
       '#title' => t('Show sponsors'),
       '#description' => t('Toggles the sponsors block on the home page when finder is enabled.')
-    )
+    ),
+    'show_persistent_signup' => array(
+      '#title' => t('Persistent Signup Nav'),
+      '#description' => t('Toggles the cta on the campaign pitch page to show as a persistent nav')
+    ),
   );
 
   foreach ($flags as $name => $flag) {


### PR DESCRIPTION
## Addresses #4308

I added a feature flag that can be used to turn on the "persistent sign up nav" on the pitch page. It introduces a new look for the cta pattern and I am using a `-persistent` class as a modifier. Also added a `.-persistent-beta` class to the `campaign--pitch` container so that I can use it to hide/show various elements on the pitch page when the persistent nav is turned on.  

The idea is to get this on staging so we can test what is feels like on actual devices and then, if we decide to move forward, run an optimizely test to gauge performance. 

@DoSomething/front-end 
