### PR TITLE
Add sign up count to pitch page

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -346,10 +346,9 @@ function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
   }
   // Moar $tagline.
   $vars['tagline'] .= t('Any cause, anytime, anywhere.');
-  // Get sign up total
-  $node = $vars['node'];
+  // Get sign up total and add it to cta
   $vars['signup_cta'] .= t('Join @signup_count people doing this.', array(
-      '@signup_count' => dosomething_signup_get_signup_total_by_nid($node->nid),
+      '@signup_count' => $vars['campaign']->variables['signup_count'],
     ));
 }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -346,6 +346,11 @@ function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
   }
   // Moar $tagline.
   $vars['tagline'] .= t('Any cause, anytime, anywhere.');
+  // Get sign up total
+  $node = $vars['node'];
+  $vars['signup_cta'] .= t('Join @signup_count people doing this.', array(
+      '@signup_count' => dosomething_signup_get_signup_total_by_nid($node->nid),
+    ));
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -34,6 +34,7 @@ $asset-path: "";
 @import "patterns/statistic"; // @TODO: Move to Neue!
 @import "patterns/tile";
 @import "patterns/card";
+@import "patterns/cta";
 @import "patterns/admin-edit"; // @TODO: Move to Neue!
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -147,59 +147,6 @@
 
     .cta.-persistent {
       display: block;
-      background-color: $black;
-      border: none;
-      position: sticky;
-      top: 0;
-      z-index: 100;
-
-      // Fallback for position:sticky, through Filament Group's fixed-sticky
-      &.fixedsticky-on {
-        position: fixed;
-        width: 100%;
-        max-width: 1440px;
-      }
-
-      > .wrapper {
-        @include clearfix;
-        display: table;
-        padding: $base-spacing / 2 0;
-      }
-
-      .cta__button {
-        @include span(5 of 12);
-        display: table-cell;
-        float: none;
-        padding: 0;
-        text-align: left;
-
-        @include media($medium) {
-          width: auto;
-          float: left;
-          display: inline-block;
-        }
-      }
-
-      .cta__message {
-        @include span(7 of 12);
-        display: table-cell;
-        color: $white;
-        clear: none;
-        text-align: left;
-        margin-bottom: 0;
-        font-size: $font-regular;
-        float: none;
-        vertical-align: middle;
-
-        @include media($medium) {
-          width: auto;
-          font-size: $font-medium;
-          float: left;
-          padding: 0;
-          display: inline-block;
-          padding: ($base-spacing/2) 0 0 ($base-spacing * 2.5);
-        }
-      }
     }
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
@@ -1,11 +1,69 @@
 .cta {
-  .cta__message {
-    &.with-count {
-      display: none;
+  &.-persistent {
+    background-color: $black;
+    border: none;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+
+    // Fallback for position:sticky, through Filament Group's fixed-sticky
+    &.fixedsticky-on {
+      position: fixed;
+      width: 100%;
+      max-width: 1440px;
     }
 
-    &.without-count {
-      display: block;
+    > .wrapper {
+      @include clearfix;
+      display: table;
+      padding: $base-spacing / 2 0;
+    }
+
+    .cta__button {
+      @include span(5 of 12);
+      display: table-cell;
+      float: none;
+      padding: 0;
+      text-align: left;
+
+      @include media($medium) {
+        width: auto;
+        float: left;
+        display: inline-block;
+      }
+    }
+
+    .cta__message {
+      @include span(7 of 12);
+      display: table-cell;
+      color: $white;
+      clear: none;
+      text-align: left;
+      margin-bottom: 0;
+      font-size: $font-regular;
+      float: none;
+      vertical-align: middle;
+
+      @include media($medium) {
+        width: auto;
+        font-size: $font-medium;
+        float: left;
+        padding: 0;
+        display: inline-block;
+        padding: ($base-spacing/2) 0 0 ($base-spacing * 2.5);
+      }
+    }
+  }
+
+  &.optimizely-hide-count {
+    .cta__message {
+      &.with-count {
+        display: none;
+      }
+
+      &.without-count {
+        display: block;
+      }
     }
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
@@ -1,0 +1,23 @@
+.cta {
+  .cta__message {
+    &.with-count {
+      display: none;
+    }
+
+    &.without-count {
+      display: block;
+    }
+  }
+
+  &.optimizely-show-count {
+    .cta__message {
+      &.with-count {
+        display: block;
+      }
+
+      &.without-count {
+        display: none;
+      }
+    }
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -26,7 +26,7 @@
   </header>
 
   <?php if (isset($campaign->secondary_call_to_action)): ?>
-    <div class="cta optimizely-hide-count -persistent js-fixedsticky">
+    <div class="cta -persistent optimizely-hide-count js-fixedsticky">
       <div class="wrapper">
         <?php if (isset($signup_button_secondary)): ?>
           <div class="cta__button">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -26,14 +26,15 @@
   </header>
 
   <?php if (isset($campaign->secondary_call_to_action)): ?>
-    <div class="cta -persistent js-fixedsticky">
+    <div class="cta optimizely-hide-count -persistent js-fixedsticky">
       <div class="wrapper">
         <?php if (isset($signup_button_secondary)): ?>
           <div class="cta__button">
             <?php print render($signup_button_secondary); ?>
           </div>
         <?php endif; ?>
-        <h4 class="cta__message"><?php print $campaign->secondary_call_to_action; ?></h4>
+        <h4 class="cta__message with-count"><?php print $signup_cta; ?></h4>
+        <h4 class="cta__message without-count"><?php print $campaign->secondary_call_to_action; ?></h4>
       </div>
     </div>
   <?php endif; ?>
@@ -79,7 +80,7 @@
   <?php endif; ?>
 
   <?php if (isset($campaign->secondary_call_to_action)): ?>
-    <div class="cta">
+    <div class="cta optimizely-hide-count">
       <div class="wrapper">
         <h2 class="cta__message with-count"><?php print $signup_cta; ?></h2>
         <h2 class="cta__message without-count"><?php print $campaign->secondary_call_to_action; ?></h2>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -10,7 +10,6 @@
 ?>
 
 <section class="campaign campaign--pitch pitch <?php if ($show_persistent_signup) { print 'optimizely-persistent'; } ?>">
-
   <header role="banner" class="header -hero <?php print $classes; ?>">
     <div class="wrapper">
       <?php print $campaign_headings; ?>
@@ -82,7 +81,8 @@
   <?php if (isset($campaign->secondary_call_to_action)): ?>
     <div class="cta">
       <div class="wrapper">
-        <h2 class="cta__message"><?php print $campaign->secondary_call_to_action; ?></h2>
+        <h2 class="cta__message with-count"><?php print $signup_cta; ?></h2>
+        <h2 class="cta__message without-count"><?php print $campaign->secondary_call_to_action; ?></h2>
         <?php if (isset($signup_button_secondary)): ?>
           <?php print render($signup_button_secondary); ?>
         <?php endif; ?>


### PR DESCRIPTION
## Fixes #4288

Adds sign up count to the pitch page cta for optimizely testing.
- Using classes `.optimizely-show-count` and `.optimizely-hide-count` to toggle the display of the different  cta's
- I moved the persistent nav stuff to the `patterns` directory to keep it separate. 

@DoSomething/front-end cc @angaither 
