### PR TITLE
SMS Campaigns: Pull in scholarship amount and display if it exists

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -202,19 +202,26 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
   }
   // Check if varaible is set for the Friends Form submit button label.
   $label = variable_get('dosomething_campaign_sms_game_signup_friends_form_button_copy', t('Share'));
+
+  // Get scholarship amount.
+  $wrapper = entity_metadata_wrapper('node', $node);
+  $amount = $wrapper->field_scholarship_amount->value();
+  $scholarship = array(
+    '#markup' => theme('campaign_scholarship', array(
+      'amount' => $amount,
+      'classes' => array('-right'),
+    )),
+  );
+
   $form['actions'] = array(
     '#type' => 'actions',
     'submit' => array(
       '#type' => 'submit',
       '#value' => $label,
     ),
-    'scholarship' => array(
-        '#markup' => theme('campaign_scholarship', array(
-          'amount' => 1000,
-          'classes' => array('-right'),
-        )),
-    ),
+    'scholarship' => ($amount) ? $scholarship : NULL,
   );
+
   return $form;
 }
 


### PR DESCRIPTION
## Fixes #4328

SMS campaigns were always showing a $1000 scholarship call out next to the submit button. This updates it so it no longer pulls in a hard coded value, and only displays the scholarship call out if there is a scholarship amount attached to the campaign.

@angaither @aaronschachter 
