### PR TITLE
fixed spelling error that blocked ga reporting

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
@@ -51,8 +51,8 @@
                 </div>
                 <ul>
                   <li><a class="social-icon -facebook js-share-link js-analytics-fb-share" href="<?php print $fb_link; ?>"><span>Facebook</span></a></li>
-                  <li><a class="social-icon -twitter js-share-link js-analytiics-tw-share" href="<?php print $twitter_link; ?>"><span>Twitter</span></a></li>
-                  <li><a class="social-icon -tumblr js-share-link js-analytiics-tm-shhare" href="<?php print $tumblr_link; ?>"><span>Tumblr</span></a></li>
+                  <li><a class="social-icon -twitter js-share-link js-analytics-tw-share" href="<?php print $twitter_link; ?>"><span>Twitter</span></a></li>
+                  <li><a class="social-icon -tumblr js-share-link js-analytics-tm-share" href="<?php print $tumblr_link; ?>"><span>Tumblr</span></a></li>
                 </ul>
               </div>
             <?php endif; ?>


### PR DESCRIPTION
of course it was a because of typo :pencil2: 
![dd22f7daa36](https://cloud.githubusercontent.com/assets/645205/6987221/13c02e2a-da13-11e4-8c67-4d131a15f995.jpg)

fixes #4338
