### PR TITLE
Improve build speed with shallow clones

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -135,7 +135,7 @@ function build {
 
   # Do the build
   echo 'Running drush make...'
-  drush make --prepare-install --no-gitinfofile --no-cache "$BUILD_MAKEFILE" "$WEB_DIR"
+  drush make --prepare-install --no-gitinfofile --shallow-clone --no-cache "$BUILD_MAKEFILE" "$WEB_DIR"
   set +e
 
   # Create symlinks


### PR DESCRIPTION
Adds a [--shallow-clone](http://api.drush.org/api/drush/commands!make!make.drush.inc/function/make_drush_command/master) parameter to the drush make command, which should improve dev box build time.

I'm not really that familiar with your build process, but I hope this helps in some way...
