### PR TITLE
Remove check for cta to display sign up button

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/lib.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/lib.js
@@ -7,16 +7,16 @@ window.$ = jQuery;
 import 'mailcheck';
 
 // jQuery Once plugin
-import 'jquery-once';
+var once = require('jquery-once');
 
 // $.unveil plugin for lazy-loading images
-import 'unveil';
+var unveil = require('unveil');
 
 // IE8 polyfill for $.ajax CORS support
-import 'jquery.iecors';
+var iecors = require('jquery.iecors');
 
 // RequestAnimationFrame polyfill
 import 'raf.js';
 
 // Filament Group's fixed-sticky polyfill for `position: sticky`
-import 'fixed-sticky';
+var fixedsticky = require('fixed-sticky');

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -25,19 +25,19 @@
     </div>
   </header>
 
-  <?php if (isset($campaign->secondary_call_to_action)): ?>
-    <div class="cta -persistent optimizely-hide-count js-fixedsticky">
-      <div class="wrapper">
-        <?php if (isset($signup_button_secondary)): ?>
-          <div class="cta__button">
-            <?php print render($signup_button_secondary); ?>
-          </div>
-        <?php endif; ?>
+  <div class="cta -persistent optimizely-hide-count js-fixedsticky">
+    <div class="wrapper">
+      <?php if (isset($signup_button_secondary)): ?>
+        <div class="cta__button">
+          <?php print render($signup_button_secondary); ?>
+        </div>
+      <?php endif; ?>
+      <?php if (isset($campaign->secondary_call_to_action)): ?>
         <h4 class="cta__message with-count"><?php print $signup_cta; ?></h4>
         <h4 class="cta__message without-count"><?php print $campaign->secondary_call_to_action; ?></h4>
-      </div>
+      <?php endif; ?>
     </div>
-  <?php endif; ?>
+  </div>
 
   <?php if (isset($reportbacks_showcase)): ?>
     <div class="container -showcase optimizely-hidden">


### PR DESCRIPTION
## Fixes #4336

Fixed a bug where, when the persistent nav setting is turned on, the sign up button would only display if there was a secondary call to action. Now, the sign up button will display even if there is no secondary call to action. 

Also, switched `import` statements to `require` statements in `lib.js` for a quick fix for a hoisting issue causing jquery not to be ready before libraries need to use it. 

@DoSomething/front-end 
