### PR TITLE
Allow `npm link` for dosomething-neue.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,14 +24,13 @@ Vagrant.configure("2") do |config|
     config.vm.network :private_network, ip: "10.11.12.13"
     config.vm.synced_folder ".", "/var/www/dev.dosomething.org", type: "nfs"
 
-    # Allow `npm link`
-    if File.exists?(File.expand_path(File.join("/usr/local/lib/node_modules/dosomething-neue")))
+    # Allow `npm link` for Neue
+    if File.exists?("/usr/local/lib/node_modules/dosomething-neue")
       config.vm.synced_folder "/usr/local/lib/node_modules/dosomething-neue",
         "/usr/local/lib/node_modules/dosomething-neue",
         :owner => "www-data",
         :group => "www-data"
     end
-
   else
     # SSHFS -- reverse mount from within Vagrant box
     config.sshfs.paths = { "/var/www/dev.dosomething.org" => "../dosomething-mount" }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,21 +19,21 @@ Vagrant.configure("2") do |config|
   # SSH Agent forwarding
   config.ssh.forward_agent = true
 
+  # Mount shared folders
   if ENV['DS_VAGRANT_MOUNT_NFS']
     # NFS
     config.vm.network :private_network, ip: "10.11.12.13"
     config.vm.synced_folder ".", "/var/www/dev.dosomething.org", type: "nfs"
-
-    # Allow `npm link` for Neue
-    if File.exists?("/usr/local/lib/node_modules/dosomething-neue")
-      config.vm.synced_folder "/usr/local/lib/node_modules/dosomething-neue",
-        "/usr/local/lib/node_modules/dosomething-neue",
-        :owner => "www-data",
-        :group => "www-data"
-    end
   else
     # SSHFS -- reverse mount from within Vagrant box
     config.sshfs.paths = { "/var/www/dev.dosomething.org" => "../dosomething-mount" }
+  end
+
+  # Allow `npm link` for Neue
+  if File.exists?("/usr/local/lib/node_modules/dosomething-neue")
+    config.vm.synced_folder "/usr/local/lib/node_modules/dosomething-neue",
+      "/usr/local/lib/node_modules/dosomething-neue",
+      owner: "www-data", group: "www-data"
   end
 
   # Http and https.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,15 @@ Vagrant.configure("2") do |config|
     # NFS
     config.vm.network :private_network, ip: "10.11.12.13"
     config.vm.synced_folder ".", "/var/www/dev.dosomething.org", type: "nfs"
+
+    # Allow `npm link`
+    if File.exists?(File.expand_path(File.join("/usr/local/lib/node_modules/dosomething-neue")))
+      config.vm.synced_folder "/usr/local/lib/node_modules/dosomething-neue",
+        "/usr/local/lib/node_modules/dosomething-neue",
+        :owner => "www-data",
+        :group => "www-data"
+    end
+
   else
     # SSHFS -- reverse mount from within Vagrant box
     config.sshfs.paths = { "/var/www/dev.dosomething.org" => "../dosomething-mount" }


### PR DESCRIPTION
# Changes
- This allows us to work on local Neue copy and see changes reflected in the Vagrant box, without having to compile and copy the whole directory. Read more: [npm link](https://docs.npmjs.com/cli/link).
# Discussion

As far as I can tell, there's no easy way to do this for multiple NPM packages without manually whitelisting each one. Open to any suggestions though if people have ideas!

For review: @DoSomething/front-end @sergii-tkachenko @blisteringherb 
