### PR TITLE
Lodash template

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/Campaign.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/Campaign.js
@@ -58,7 +58,9 @@ define(function(require) {
    * @return {jQuery} The jQuery object that is the rendered representation of this Campaign
    */
   Campaign.prototype.render = function () {
-    var $wrapper = template(campaignTplSrc, {
+    var renderTile = template(campaignTplSrc);
+
+    return renderTile({
       "image": this.image,
       "staffPick": this.staffPick,
       "featured": this.featured,
@@ -66,8 +68,6 @@ define(function(require) {
       "description": this.description,
       "url": this.url
     });
-
-    return $wrapper;
   };
 
   return Campaign;

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/FormView.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/FormView.js
@@ -129,9 +129,10 @@ define(function(require) {
      **/
     showErrorMessage: function() {
       var message = template(errorTplSrc);
+      var $message = message();
 
       if ($(".error").length < 1) {
-        FormView.$div.parents(".finder--form").after(message);
+        FormView.$div.parents(".finder--form").after($message);
       }
 
     },

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
@@ -76,7 +76,7 @@ define(function(require) {
      * Shows the empty slate div (no results state).
      */
     showEmptyState: function() {
-      var message = template(noResultsTplSrc);
+      var message = template(noResultsTplSrc)();
 
       ResultsView.$container.append(message);
     },
@@ -95,7 +95,8 @@ define(function(require) {
 
         // Loopy loop! (Like me after drinking coffeeeee)
         for (var i in data.result.response.docs) {
-          ResultsView.add(new Campaign(data.result.response.docs[i]));
+          let campaign = new Campaign(data.result.response.docs[i]);
+          ResultsView.add(campaign);
         }
 
         // There are more results than we've shown so far, add "Show More" button

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadFallback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUploadFallback.js
@@ -100,7 +100,9 @@ define(function(require) {
         "classes": this.component.classes.join(' '),
         "file": this.component.fileName
       };
-      var $markup = $(template(fallbackUploadTplSrc, data));
+
+      var markup = template(fallbackUploadTplSrc)(data);
+      var $markup = $(markup);
 
       this.component.$input.detach();
       $markup.find('.button--file').append(this.component.$input);

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -338,9 +338,9 @@ define(function(require) {
 
         data.adminLink = this.adminAccess ? '/admin/reportback/' + items[i].rbid : false;
 
-        var markup = template(reportbackTplSrc, data);
+        var markup = template(reportbackTplSrc);
 
-        this.inventory.push(markup);
+        this.inventory.push(markup(data));
       }
     }
 


### PR DESCRIPTION
# Changes
- Update Lodash template function usage after updating to Lodash 3.6.

There was a breaking change to the `_.template` function in Lodash 3.0 ([changelog](https://github.com/lodash/lodash/wiki/Changelog)):

``` js
// in 2.4.1
_.template(string, data, options); // → 'b'

// in 3.0.0
_.template(string, options)(data); // → 'b'
```

For review: @DoSomething/front-end 
