### PR TITLE
Improves dosomething_signup_update_7019().

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -541,12 +541,19 @@ function dosomething_signup_update_7018() {
  * Introduces new variables for 26+ Club.
  */
 function dosomething_signup_update_7019() {
-  $name = 'dosomething_signup_26plusclub_mailchimp_list_id';
-  variable_set($name, getenv('DS_MB_MAILCHIMP_26PLUSCLUB_LIST_ID'));
+  $name = 'dosomething_signup_26plusclub_enabled';
+  $club_enabled = getenv('DS_MB_26PLUSCLUB_ENABLED');
+  variable_set($name, $club_enabled);
 
-  $name = 'dosomething_signup_26plusclub_mailchimp_grouping_id_register';
-  variable_set($name, getenv('DS_MB_MAILCHIMP_26PLUSCLUB_GROUPING_ID_REGISTER'));
+  if ($club_enabled) {
+    $name = 'dosomething_signup_26plusclub_mailchimp_list_id';
+    variable_set($name, getenv('DS_MB_26PLUSCLUB_MAILCHIMP_LIST_ID'));
 
-  $name = 'dosomething_signup_26plusclub_mailchimp_group_name_register';
-  variable_set($name, getenv('DS_MB_MAILCHIMP_26PLUSCLUB_GROUP_NAME_REGISTER'));
+    $name = 'dosomething_signup_26plusclub_mailchimp_grouping_id_register';
+    variable_set($name, getenv('DS_MB_26PLUSCLUB_MAILCHIMP_GROUPING_ID_REGISTER'));
+
+    $name = 'dosomething_signup_26plusclub_mailchimp_group_name_register';
+    variable_set($name, getenv('DS_MB_26PLUSCLUB_MAILCHIMP_GROUP_NAME_REGISTER'));
+  }
+
 }


### PR DESCRIPTION
This is to make few improvements into `dosomething_signup_update_7019()`:
- Add `DS_MB_26PLUSCLUB_ENABLED` env variable to set preset "Enable 26+ Club"
- Renames other env variables in the hook install according to actual variable name change

Ref #4270.
