### PR TITLE
Set up pitch template for Optimizely testing

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -339,6 +339,8 @@ function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
   // Adds signup_button_primary and signup_button_secondary variables.
   $ids = array('primary', 'secondary');
   dosomething_signup_preprocess_signup_button($vars, $label, NULL, $ids);
+  // Render the form array now, so we can print it multiple times on the page.
+  $vars['signup_button_secondary'] = render($vars['signup_button_secondary']);
   // Begin $tagline variable:
   $vars['tagline'] = t('A DoSomething.org campaign.') . ' ';
   // If Member Count variable is set:

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
@@ -1,10 +1,43 @@
+// @TODO - This mixin is just here for optimizely testing.
+// This should be removed after testing and a perminent
+// solution is in place.
+@mixin optimizely-signup-count($display) {
+  &.optimizely-hide-count {
+    .cta__message {
+      &.with-count {
+        display: none;
+      }
+
+      &.without-count {
+        display: $display;
+      }
+    }
+  }
+
+  &.optimizely-show-count {
+    .cta__message {
+      &.with-count {
+        display: $display;
+      }
+
+      &.without-count {
+        display: none;
+      }
+    }
+  }
+}
+
 .cta {
+  @include optimizely-signup-count(block);
+
   &.-persistent {
     background-color: $black;
     border: none;
     position: sticky;
     top: 0;
     z-index: 100;
+
+    @include optimizely-signup-count(table-cell);
 
     // Fallback for position:sticky, through Filament Group's fixed-sticky
     &.fixedsticky-on {
@@ -59,46 +92,6 @@
         float: none;
         font-size: $font-medium;
         padding: 0px;
-      }
-    }
-
-    &.optimizely-hide-count {
-      .cta__message {
-        &.without-count {
-          display: table-cell;
-        }
-      }
-    }
-
-    &.optimizely-show-count {
-      .cta__message {
-        &.without-count {
-          display: table-cell;
-        }
-      }
-    }
-  }
-
-  &.optimizely-hide-count {
-    .cta__message {
-      &.with-count {
-        display: none;
-      }
-
-      &.without-count {
-        display: block;
-      }
-    }
-  }
-
-  &.optimizely-show-count {
-    .cta__message {
-      &.with-count {
-        display: block;
-      }
-
-      &.without-count {
-        display: none;
       }
     }
   }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -9,7 +9,7 @@
  */
 ?>
 
-<section class="campaign campaign--pitch pitch <?php if ($show_persistent_signup) { print 'optimizely-persistent'; } ?>">
+<section class="campaign campaign--pitch pitch">
   <header role="banner" class="header -hero <?php print $classes; ?>">
     <div class="wrapper">
       <?php print $campaign_headings; ?>
@@ -25,21 +25,19 @@
     </div>
   </header>
 
-  <?php if ($show_persistent_signup): ?>
-    <div class="cta -persistent optimizely-hide-count js-fixedsticky">
-      <div class="wrapper">
-        <?php if (isset($signup_button_secondary)): ?>
-          <div class="cta__button">
-            <?php print render($signup_button_secondary); ?>
-          </div>
-        <?php endif; ?>
-        <?php if (isset($campaign->secondary_call_to_action)): ?>
-          <h4 class="cta__message with-count"><?php print $signup_cta; ?></h4>
-          <h4 class="cta__message without-count"><?php print $campaign->secondary_call_to_action; ?></h4>
-        <?php endif; ?>
-      </div>
+  <div class="cta -persistent optimizely-hide-count js-fixedsticky">
+    <div class="wrapper">
+      <?php if (isset($signup_button_secondary)): ?>
+        <div class="cta__button">
+          <?php print $signup_button_secondary; ?>
+        </div>
+      <?php endif; ?>
+      <?php if (isset($campaign->secondary_call_to_action)): ?>
+        <h4 class="cta__message with-count"><?php print $signup_cta; ?></h4>
+        <h4 class="cta__message without-count"><?php print $campaign->secondary_call_to_action; ?></h4>
+      <?php endif; ?>
     </div>
-  <?php endif; ?>
+  </div>
 
   <?php if (isset($reportbacks_showcase)): ?>
     <div class="container -showcase optimizely-hidden">
@@ -81,18 +79,16 @@
     </div>
   <?php endif; ?>
 
-  <?php if (!$show_persistent_signup): ?>
-    <?php if (isset($campaign->secondary_call_to_action)): ?>
-      <div class="cta optimizely-hide-count">
-        <div class="wrapper">
-          <h2 class="cta__message with-count"><?php print $signup_cta; ?></h2>
-          <h2 class="cta__message without-count"><?php print $campaign->secondary_call_to_action; ?></h2>
-          <?php if (isset($signup_button_secondary)): ?>
-            <?php print render($signup_button_secondary); ?>
-          <?php endif; ?>
-        </div>
+  <?php if (isset($campaign->secondary_call_to_action)): ?>
+    <div class="cta optimizely-hide-count">
+      <div class="wrapper">
+        <h2 class="cta__message with-count"><?php print $signup_cta; ?></h2>
+        <h2 class="cta__message without-count"><?php print $campaign->secondary_call_to_action; ?></h2>
+        <?php if (isset($signup_button_secondary)): ?>
+          <?php print $signup_button_secondary; ?>
+        <?php endif; ?>
       </div>
-    <?php endif; ?>
+    </div>
   <?php endif; ?>
 
   <div class="info-bar -dark">

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -47,10 +47,6 @@ function paraneue_dosomething_form_system_theme_settings_alter(&$form, &$form_st
       '#title' => t('Show sponsors'),
       '#description' => t('Toggles the sponsors block on the home page when finder is enabled.')
     ),
-    'show_persistent_signup' => array(
-      '#title' => t('Persistent Signup Nav'),
-      '#description' => t('Toggles the cta on the campaign pitch page to show as a persistent nav')
-    ),
     'show_campaign_progress' => array(
       '#title' => t('Show campaign progress'),
       '#description' => t('Toggles the display of campaign progress on the action page')


### PR DESCRIPTION
## Ref #4364

We are setting up the campaign pitch page to have 4 Optimizely tests run (outlined in #4364). Changes in this PR: 
- Remove theme setting that was controlling the persistent CTA. It was just there for review purposes. Now we needed on the page so that it can be toggled on/off for the testing.
- Allows us to test both the cta as it is now, and the persistent version with or without the sign up count included.

@DoSomething/front-end 
