### PR TITLE
ds test: changes directory to $BASE_PATH.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -641,6 +641,7 @@ fi
 if [[ $1 == "test" ]]
 then
   shift
+  cd $BASE_PATH
   $BASE_PATH/bin/test $@
 fi
 


### PR DESCRIPTION
`$BASE_PATH` now can be determined from evn variable #4312.
Makes `ds test` available from any path by cd'ing to `$BASE_PATH` dir.

Note: test software is not available yet, see https://github.com/DoSomething/ansible-dosomething-dev/issues/2. This PR is to help testing proper installation of this software.
