### PR TITLE
Reportback endpoints updates

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1080,7 +1080,7 @@ function dosomething_reportback_get_reportback_files_query($params = array()) {
  */
 function dosomething_reportback_get_reportback_files_query_result($params = array(), $count = 25, $start = 0) {
   $query = dosomething_reportback_get_reportback_files_query($params);
-  if ($count) {
+  if ($count && $count !== 'all') {
     $query->range($start, $count);
   }
   $result = $query->execute();

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1041,6 +1041,7 @@ function dosomething_reportback_get_reportback_files_query($params = array()) {
   if (user_access('view any reportback')) {
     $rbf_fields[] = 'status';
     $rb_fields[] = 'why_participated';
+    $rb_fields[] = 'flagged';
   }
 
   $query->fields('rbf', $rbf_fields);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1012,7 +1012,11 @@ function dosomething_reportback_get_reportback_files_query($params = array()) {
   }
 
   if (isset($params['status'])) {
-    $query->condition('rbf.status', $params['status']);
+    if (is_array($params['status'])) {
+      $query->condition('rbf.status', $params['status'], 'IN');
+    } else {
+      $query->condition('rbf.status', $params['status']);
+    }
   }
 
   if (isset($params['nid'])) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback.inc
@@ -69,6 +69,7 @@ class Reportback extends ReportbackTransformer {
    * @return array
    */
   protected function transform($reportback) {
+//    return $reportback;
     $data = array();
 
     // Main Reportback data

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback.inc
@@ -69,7 +69,6 @@ class Reportback extends ReportbackTransformer {
    * @return array
    */
   protected function transform($reportback) {
-//    return $reportback;
     $data = array();
 
     // Main Reportback data
@@ -85,7 +84,7 @@ class Reportback extends ReportbackTransformer {
       }
 
       $data['items'] = array(
-        'total_retrieved' => count($items),
+        'total' => count($items),
         'data' => $output,
       );
     }
@@ -113,7 +112,8 @@ class Reportback extends ReportbackTransformer {
       'fid' => $this->formatData($ids),
     );
 
-    $query = dosomething_reportback_get_reportback_files_query_result($filters);
+    // Obtaining all Reportback items.
+    $query = dosomething_reportback_get_reportback_files_query_result($filters, 'all');
 
     return services_resource_build_index_list($query, 'reportback-items', 'fid');
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_item.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_item.inc
@@ -35,7 +35,7 @@ class ReportbackItem extends ReportbackTransformer {
     }
 
     return array(
-      'total_retrieved' => count($reportbackItems),
+      'total' => $this->countData($filters),
       'data' => $this->transformCollection($reportbackItems),
     );
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_item.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_item.inc
@@ -35,7 +35,7 @@ class ReportbackItem extends ReportbackTransformer {
     }
 
     return array(
-      'total' => $this->countData($filters),
+      'total' => $this->countItems($filters),
       'data' => $this->transformCollection($reportbackItems),
     );
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_item.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_item.inc
@@ -15,7 +15,7 @@ class ReportbackItem extends ReportbackTransformer {
     // validated to a specific data type (eg: nid needs to be an int)
     $filters = array(
       'nid' => $this->formatData($parameters['campaigns']),
-      'status' => $parameters['status'],
+      'status' => $this->formatData($parameters['status']),
       'count' => $parameters['count'] ?: 25,
     );
     // @TODO: Logic update!

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
@@ -60,12 +60,15 @@ abstract class ReportbackTransformer {
       'id' => $data->rbid,
       'created_at' => $data->created,
       'updated_at' => $data->updated,
-      'flagged' => (int) $data->flagged ? TRUE : FALSE,
       'quantity' => (int) $data->quantity,
     );
 
-    if ($data->why_participated) {
+    if (isset($data->why_participated)) {
       $output['why_participated'] = $data->why_participated;
+    }
+
+    if (isset($data->flagged)) {
+      $output['flagged'] = (int) $data->flagged ? TRUE : FALSE;
     }
 
     return $output;
@@ -88,7 +91,7 @@ abstract class ReportbackTransformer {
       'created_at' => $data->timestamp,  // @TODO: Not sure if timestamp applies as created_at?
     );
 
-    if ($data->status) {
+    if (isset($data->status)) {
       $output['status'] = $data->status;
     }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
@@ -8,7 +8,7 @@ abstract class ReportbackTransformer {
   }
 
 
-  protected function countData($parameters) {
+  protected function countItems($parameters) {
     $total = 0;
 
     foreach((array) $parameters['nid'] as $id) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
@@ -7,6 +7,20 @@ abstract class ReportbackTransformer {
     module_load_include('inc', 'services', 'services.module');
   }
 
+
+  protected function countData($parameters) {
+    $total = 0;
+
+    foreach((array) $parameters['nid'] as $id) {
+      foreach((array) $parameters['status'] as $status) {
+        $total += (int) dosomething_reportback_get_reportback_total_by_status($id, $status);
+      }
+    }
+
+    return $total;
+  }
+
+
   /**
    * @param string $data Single or multiple comma separated data items.
    * @return string or array

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
@@ -82,7 +82,7 @@ abstract class ReportbackTransformer {
   protected function transformReportbackItemData($data) {
     $output = array(
       'id' => $data->fid,
-      'caption' => isset($data->caption) ? $data->caption : t('DoSomething? Just did!'),
+      'caption' => !empty($data->caption) ? $data->caption : t('DoSomething? Just did!'),
       'uri' => $data->uri,
       'media' => array(
         'uri' => dosomething_image_get_themed_image_url_by_fid($data->fid, '480x480'),

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
@@ -8,6 +8,13 @@ abstract class ReportbackTransformer {
   }
 
 
+  /**
+   * Calculate total number of Reportback items for the specified campaigns by
+   * each status requested.
+   *
+   * @param array $parameters Query parameters.
+   * @return int Total number of reportback items.
+   */
   protected function countItems($parameters) {
     $total = 0;
 


### PR DESCRIPTION
Addresses allowing you to pass multiple status types to get a collection of results:

```
/api/v1/reportback-items.json?campaign=362&status=promoted,approved
```

*Note: for the time being, a campaign needs to be specified due to how a legacy function works.

Also does some cleanup and fixes a bug or two, in addition to adding `total` for a collection to being adding data for pagination.

@jonuy @angaither

CC: @drewish @DFurnes 
