### PR TITLE
Disable reportback form when image is invalid

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUpload.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUpload.js
@@ -21,6 +21,7 @@ define(function(require) {
     this.$uploadButtonLabel     = this.$uploadButton.closest('label');
     this.$cropModal             = $("#modal--crop");
     this.$reportbackForm        = $("#dosomething-reportback-form");
+    this.$reportbackFormSubmit  = this.$reportbackForm.find(".form-submit");
     this.$imageForm             = this.$cropModal.find("#dosomething-reportback-image-form");
     this.$imageCaption          = this.$imageForm.find("#modal-caption");
     this.$cropButton            = this.$imageForm.find(".button");
@@ -68,6 +69,9 @@ define(function(require) {
 
         return;
       }
+
+      // The image is valid, so let users submit the reportback form.
+      _this.enableSubmit(_this.$reportbackFormSubmit);
 
       var fr = new FileReader();
 
@@ -166,7 +170,7 @@ define(function(require) {
    * Opens the modal making sure the done button is reset.
    */
   ImageUpload.prototype.openModal = function() {
-    this.enableSubmit();
+    this.enableSubmit(this.$cropButton);
 
     Modal.open(this.$cropModal,
       {
@@ -222,8 +226,7 @@ define(function(require) {
   /**
    * Enables submit button in modal when it opens.
    */
-  ImageUpload.prototype.enableSubmit = function() {
-    var $submitButton = this.$cropModal.find(".-done");
+  ImageUpload.prototype.enableSubmit = function($submitButton) {
 
     if ($submitButton.prop("disabled")) {
       $submitButton.prop("disabled", false);
@@ -276,7 +279,8 @@ define(function(require) {
   };
 
   /**
-   * Show an error message.
+   * Show an error message and disable the reportback form
+   * so it can't be submitted
    *
    * param {string}  Error message to be shown.
    */
@@ -291,6 +295,8 @@ define(function(require) {
     }
 
     this.$reportbackSubmissions.prepend($error);
+
+    this.$reportbackFormSubmit.prop("disabled", true);
   };
 
   /**


### PR DESCRIPTION
## Fixes #4054

Disables the submit button on the reportback form if the user uploads an image that is not valid. 

@DoSomething/front-end 
