### PR TITLE
Updates to add pagination to reportback-items endpoint.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -72,7 +72,7 @@ function _reportback_item_resource_definition() {
             'optional' => TRUE,
             'type' => 'int',
             'source' => array('param' => 'page'),
-            'default value' => 0,
+            'default value' => 1,
           ),
         ),
         'access callback' => '_reportback_item_resource_access',
@@ -99,6 +99,7 @@ function _reportback_item_resource_index($campaigns, $status, $count, $random, $
     'status' => $status,
     'count' => $count,
     'random' => $random,
+    'page' => $page,
   );
 
   $reportbackItems = new ReportbackItem;

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
@@ -72,7 +72,7 @@ function _reportback_resource_definition() {
             'optional' => TRUE,
             'type' => 'int',
             'source' => array('param' => 'page'),
-            'default value' => 0,
+            'default value' => 1,
           ),
         ),
         'access callback' => '_reportback_resource_access',

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -925,6 +925,7 @@ function dosomething_reportback_flush_caches() {
  *   An associative array of conditions to filter by. Possible keys:
  *   - rbid: A reportback rbid to filter by.
  *   - random: If set, randomly sort the results.
+ *
  * @return SelectQuery object
  */
 function dosomething_reportback_get_reportbacks_query($params = array()) {
@@ -996,6 +997,7 @@ function dosomething_reportback_get_reportbacks_query_result($params = array(), 
  *   - fid: A reportback item fid to filter by.
  *   - status: The RB File status.
  *   - random: If set, randomly sort the results.
+ *
  * @return SelectQuery object
  */
 function dosomething_reportback_get_reportback_files_query($params = array()) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback.inc
@@ -7,6 +7,7 @@ class Reportback extends ReportbackTransformer {
 
   /**
    * @param array $parameters Any parameters obtained from query string.
+   *
    * @return array
    */
   public function index($parameters) {
@@ -41,6 +42,7 @@ class Reportback extends ReportbackTransformer {
 
   /**
    * @param string $id Resource id.
+   *
    * @return array
    */
   public function show($id) {
@@ -66,6 +68,7 @@ class Reportback extends ReportbackTransformer {
 
   /**
    * @param object $reportback Single object of retrieved data.
+   *
    * @return array
    */
   protected function transform($reportback) {
@@ -105,6 +108,7 @@ class Reportback extends ReportbackTransformer {
 
   /**
    * @param $ids
+   *
    * @return array
    */
   protected function getItems($ids) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_item.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_item.inc
@@ -7,6 +7,7 @@ class ReportbackItem extends ReportbackTransformer {
 
   /**
    * @param array $parameters Any parameters obtained from query string.
+   *
    * @return array
    */
   public function index($parameters) {
@@ -48,6 +49,7 @@ class ReportbackItem extends ReportbackTransformer {
 
   /**
    * @param string $id Resource id.
+   *
    * @return array
    */
   public function show($id) {
@@ -65,6 +67,7 @@ class ReportbackItem extends ReportbackTransformer {
 
   /**
    * @param object $item Single object of retrieved data.
+   *
    * @return array
    */
   protected function transform($item) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_item.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_item.inc
@@ -16,14 +16,18 @@ class ReportbackItem extends ReportbackTransformer {
     $filters = array(
       'nid' => $this->formatData($parameters['campaigns']),
       'status' => $this->formatData($parameters['status']),
-      'count' => $parameters['count'] ?: 25,
+      'count' => (int) $parameters['count'] ?: 25,
+      'page' => (int) $parameters['page'],
     );
+
+    $filters['offset'] = $this->setOffset($filters['page'], $filters['count']);
+
     // @TODO: Logic update!
     // Not ideal that this is NULL instead of FALSE but due to how logic happens in original query function. It should be updated!
     // Logic currently checks for isset() instead of just boolean, so won't change until endpoints switched.
     $filters['random'] = $parameters['random'] === 'true' ? TRUE : NULL;
 
-    $query = dosomething_reportback_get_reportback_files_query_result($filters, $filters['count']);
+    $query = dosomething_reportback_get_reportback_files_query_result($filters, $filters['count'], $filters['offset']);
     $reportbackItems = services_resource_build_index_list($query, 'reportback-items', 'fid');
 
     if (!$reportbackItems) {
@@ -35,7 +39,7 @@ class ReportbackItem extends ReportbackTransformer {
     }
 
     return array(
-      'total' => $this->countItems($filters),
+      'pagination' => $this->paginate($filters, count($reportbackItems), 'reportback-items'),
       'data' => $this->transformCollection($reportbackItems),
     );
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_item.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_item.inc
@@ -39,7 +39,8 @@ class ReportbackItem extends ReportbackTransformer {
     }
 
     return array(
-      'pagination' => $this->paginate($filters, count($reportbackItems), 'reportback-items'),
+      'pagination' => $this->paginate($filters, 'reportback-items'),
+      'retrieved_count' => count($reportbackItems),
       'data' => $this->transformCollection($reportbackItems),
     );
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
@@ -14,6 +14,7 @@ abstract class ReportbackTransformer {
    * @param $data
    * @param $parameters
    * @param $endpoint
+   *
    * @return null|string
    */
   protected function getNextPageUri($data, $parameters, $endpoint) {
@@ -36,6 +37,7 @@ abstract class ReportbackTransformer {
    * @param $data
    * @param $parameters
    * @param $endpoint
+   *
    * @return null|string
    */
   protected function getPrevPageUri($data, $parameters, $endpoint) {
@@ -57,6 +59,7 @@ abstract class ReportbackTransformer {
    *
    * @param $parameters
    * @param $endpoint
+   *
    * @return string
    */
   protected function getPathParameters($parameters, $endpoint) {
@@ -84,6 +87,7 @@ abstract class ReportbackTransformer {
    * each status requested.
    *
    * @param array $parameters Query parameters.
+   *
    * @return int Total number of reportback items.
    */
   protected function countItems($parameters) {
@@ -101,6 +105,7 @@ abstract class ReportbackTransformer {
 
   /**
    * @param string $data Single or multiple comma separated data items.
+   *
    * @return string or array
    */
   protected function formatData($data) {
@@ -120,6 +125,7 @@ abstract class ReportbackTransformer {
    * @param $parameters
    * @param $count
    * @param $endpoint
+   *
    * @return array
    */
   protected function paginate($parameters, $endpoint) {
@@ -145,6 +151,7 @@ abstract class ReportbackTransformer {
    *
    * @param $page
    * @param $count
+   *
    * @return int
    */
   protected function setOffset($page, $count) {
@@ -162,6 +169,7 @@ abstract class ReportbackTransformer {
 
   /**
    * @param array $items Collection of item objects retrieved data.
+   *
    * @return array
    */
   protected function transformCollection($items) {
@@ -171,6 +179,7 @@ abstract class ReportbackTransformer {
 
   /**
    * @param object $data
+   *
    * @return array
    */
   protected function transformCampaignData($data) {
@@ -185,6 +194,7 @@ abstract class ReportbackTransformer {
 
   /**
    * @param object $data
+   *
    * @return array
    */
   protected function transformReportback($data) {
@@ -209,6 +219,7 @@ abstract class ReportbackTransformer {
 
   /**
    * @param object $data
+   *
    * @return array
    */
   protected function transformReportbackItemData($data) {
@@ -233,6 +244,7 @@ abstract class ReportbackTransformer {
 
   /**
    * @param object $data
+   *
    * @return array
    */
   protected function transformUserData($data) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
@@ -122,11 +122,10 @@ abstract class ReportbackTransformer {
    * @param $endpoint
    * @return array
    */
-  protected function paginate($parameters, $count, $endpoint) {
+  protected function paginate($parameters, $endpoint) {
     $data = array();
 
     $data['total'] = $this->countItems($parameters);
-    $data['count'] = $count;
     $data['per_page'] = $parameters['count'];
     $data['current_page'] = (isset($parameters['page']) && $parameters['page'] > 0) ? (int) $parameters['page'] : 1;
     $data['total_pages'] = ceil($data['total'] / $data['per_page']);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
@@ -155,7 +155,9 @@ abstract class ReportbackTransformer {
    * @return int
    */
   protected function setOffset($page, $count) {
-    $page = ($page > 0) ? $page -= 1 : $page;
+    if ($page > 0 ) {
+      $page -= 1;
+    }
 
     return $page * $count;
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
@@ -9,6 +9,77 @@ abstract class ReportbackTransformer {
 
 
   /**
+   * Get the URI for the next page in the collection of data.
+   *
+   * @param $data
+   * @param $parameters
+   * @param $endpoint
+   * @return null|string
+   */
+  protected function getNextPageUri($data, $parameters, $endpoint) {
+    $uri = $this->getPathParameters($parameters, $endpoint);
+
+    $next = $data['current_page'] + 1;
+
+    if ($next <= $data['total_pages']) {
+      return $uri . '&page=' . $next;
+    }
+    else {
+      return NULL;
+    }
+  }
+
+
+  /**
+   * Get the URI for the previous page in the collection of data.
+   *
+   * @param $data
+   * @param $parameters
+   * @param $endpoint
+   * @return null|string
+   */
+  protected function getPrevPageUri($data, $parameters, $endpoint) {
+    $uri = $this->getPathParameters($parameters, $endpoint);
+
+    $prev = $data['current_page'] - 1;
+
+    if ($prev > 0) {
+      return $uri . '&page=' . $prev;
+    }
+    else {
+      return NULL;
+    }
+  }
+
+
+  /**
+   * Extract the path parameters passed and recreate the query string.
+   *
+   * @param $parameters
+   * @param $endpoint
+   * @return string
+   */
+  protected function getPathParameters($parameters, $endpoint) {
+    $path = services_resource_uri(array($endpoint));
+    $path .= '.json?';
+
+    if (isset($parameters['nid'])) {
+      $path .= '&campaigns=' . implode(',', (array) $parameters['nid']);
+    }
+
+    if (isset($parameters['status'])) {
+      $path .= '&status=' . implode(',', (array) $parameters['status']);
+    }
+
+    if (isset($parameters['count'])) {
+      $path .= '&count=' . implode(',', (array) $parameters['count']);
+    }
+
+    return $path;
+  }
+
+
+  /**
    * Calculate total number of Reportback items for the specified campaigns by
    * each status requested.
    *
@@ -40,6 +111,47 @@ abstract class ReportbackTransformer {
     }
 
     return $data;
+  }
+
+
+  /**
+   * Get metadata for pagination of response data.
+   *
+   * @param $parameters
+   * @param $count
+   * @param $endpoint
+   * @return array
+   */
+  protected function paginate($parameters, $count, $endpoint) {
+    $data = array();
+
+    $data['total'] = $this->countItems($parameters);
+    $data['count'] = $count;
+    $data['per_page'] = $parameters['count'];
+    $data['current_page'] = (isset($parameters['page']) && $parameters['page'] > 0) ? (int) $parameters['page'] : 1;
+    $data['total_pages'] = ceil($data['total'] / $data['per_page']);
+
+    $prevUri = $this->getPrevPageUri($data, $parameters, $endpoint);
+    $nextUri = $this->getNextPageUri($data, $parameters, $endpoint);
+
+    $data['prev_uri'] = $prevUri;
+    $data['next_uri'] = $nextUri;
+
+    return $data;
+  }
+
+
+  /**
+   * Get the offset for requests based on specified page number and count of items.
+   *
+   * @param $page
+   * @param $count
+   * @return int
+   */
+  protected function setOffset($page, $count) {
+    $page = ($page > 0) ? $page -= 1 : $page;
+
+    return $page * $count;
   }
 
 


### PR DESCRIPTION
## Fixes #4381

:sparkles: _Now with PAGINATION!_ :sparkles: 

Request:

```
http://dev.dosomething.org:8888/api/v1/reportback-items.json?&campaigns=362,1321&status=promoted&count=4&page=3
```

Response:

```
{
  pagination: {
    total: 20,
    per_page: 4,
    current_page: 3,
    total_pages: 5,
    prev_uri: "http://dosomething.org/api/v1/reportback-items.json?&campaigns=362,1321&status=promoted&count=4&page=2",
    next_uri: "http://dosomething.org/api/v1/reportback-items.json?&campaigns=362,1321&status=promoted&count=4&page=4"
  },
  retrieved_count: 4,
  data: [
    {...},
    {...},
    {...},
    {...}
  ]
}
```

Something's to note... currently (I think only on staging and local, maybe production too), the value that gets calculated for the `total` is based off of what counts are in cache. These counts get updated when Reportbacks are submitted for a campaign, etc... However, I believe there's an issue with them not updating properly if reportbacks are deleted (which we've done a bit on staging). So on local testing, the `total` and `total_pages` can be a little skewed since the number reported for the calculation are off.

The code could probs also benefit from a refactor pass, but wanted to get something up. Might also make sense to rip out the pagination methods into their own class specifically for API stuff :dancer: 

I place all the pagination data in a `pagination` object. Hopefully that's cool :) Also we should discuss the property name differences between Northstar and this, so we can agree upon some standard naming...

@uy @angaither @drewish

CC: (might be of interest to) @DFurnes @barryclark @DeeZone 
