### PR TITLE
Update reportback totals on cron

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -165,6 +165,7 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
       '#title' => t('Progress'),
       '#description' => t('The total approved reportback quantity so far is: ' . $rb_progress),
       '#default_value' => $vars['progress'] ?: $rb_progress,
+      '#disabled' => TRUE,
     );
 
     $signup_count = dosomething_helpers_get_variable('node', $node->nid, 'signup_count') ?: dosomething_signup_get_signup_total_by_nid($node->nid);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
@@ -16,6 +16,7 @@ function dosomething_reportback_cron() {
                        INNER JOIN dosomething_reportback rb on n.nid = rb.nid
                        WHERE n.type = 'campaign'
                        AND s.field_campaign_status_value = 'active'
+                       AND rb.flagged = 0
                        GROUP BY n.nid;");
 
   // Updated reportback counts accordingly.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
@@ -10,16 +10,17 @@
  */
 function dosomething_reportback_cron() {
   // Get all reportbacks updated in the past hour.
-  $results = db_query("SELECT nid, sum(quantity) as quantity
-                     FROM dosomething_reportback
-                     WHERE from_unixtime(updated) >= date_add(now(), INTERVAL '-1' hour)
-                     GROUP BY nid;");
+  $results = db_query("SELECT n.nid, SUM(rb.quantity) as total
+                       FROM node n
+                       INNER JOIN field_data_field_campaign_status s on n.nid = s.entity_id
+                       INNER JOIN dosomething_reportback rb on n.nid = rb.nid
+                       WHERE n.type = 'campaign'
+                       AND s.field_campaign_status_value = 'active'
+                       GROUP BY n.nid;");
 
   // Updated reportback counts accordingly.
   foreach ($results as $result) {
-    $previous_progress = dosomething_helpers_get_variable('node', $result->nid, 'sum_rb_quanity');
-    $updated_progress = (int) $previous_progress + (int) $result->quantity;
-    dosomething_helpers_set_variable('node', $result->nid, 'sum_rb_quanity', $updated_progress);
+    dosomething_helpers_set_variable('node', $result->nid, 'sum_rb_quanity', (int) $result->total);
   }
 
 }


### PR DESCRIPTION
Add a cron job to run the reportback totals every hour, remove duplicate counting problems. 

However, this removes campaign the ability to override totals. I think that will have to be a different solution. @mikefantini 

Fixes #4335, Fixes #4326
