### PR TITLE
Persistent nav updates

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
@@ -4,11 +4,11 @@
 @mixin optimizely-signup-count($display) {
   &.optimizely-hide-count {
     .cta__message {
-      &.with-count {
+      .with-count {
         display: none;
       }
 
-      &.without-count {
+      .without-count {
         display: $display;
       }
     }
@@ -16,11 +16,11 @@
 
   &.optimizely-show-count {
     .cta__message {
-      &.with-count {
+      .with-count {
         display: $display;
       }
 
-      &.without-count {
+      .without-count {
         display: none;
       }
     }
@@ -50,48 +50,103 @@
       @include clearfix;
       display: table;
       padding: $base-spacing / 2 0;
+    }
 
-      @include media($medium) {
-        @include span(12);
-        padding: $base-spacing / 2 0;
+    // Layout for for campaigns with a scholarship
+    &.with-scholarship {
+      .cta__button {
+        @include media($medium) {
+          width: auto;
+        }
+
+        @include media($larger) {
+          @include span(6 of 12 no-gutters);
+          float: none;
+        }
+
+        .button {
+          @include span(3 of 6 no-gutters);
+          display: table-cell;
+          float: none;
+          vertical-align: middle;
+
+          @include media($larger) {
+            width: auto;
+          }
+        }
       }
 
-      @include media($larger) {
-        @include span(6);
-        padding: $base-spacing / 2 0;
+      .cta__message {
+        display: none;
+
+        @include media($larger) {
+          display: table-cell;
+          @include span(6 of 12 no-gutters);
+          float: none;
+        }
       }
     }
 
+    // Default layout, campaigns with no scholarship.
     .cta__button {
-      @include span(6 of 12);
-      display: table-cell;
-      float: none;
-      padding: 0;
-
       @include media($medium) {
-        @include span(4 of 12);
+        display: table-cell;
+        width: 145px;
         text-align: left;
+      }
+
+      .button {
+        font-size: 21px;
+
+        @include media($medium) {
+          font-size: $font-medium;
+        }
+      }
+
+      .message-callout {
+        @include span(3 of 6 no-gutters);
+        display: table-cell;
         float: none;
-        padding: 0px;
+        vertical-align: middle;
+        padding-top: 0px;
+        width: 130px;
+
+        @include media($medium) {
+          transform: none;
+          padding-left: $base-spacing / 2;
+        }
+
+        .message-callout__copy {
+          padding: 0px;
+
+          &:before {
+            display: none;
+          }
+        }
       }
     }
+
 
     .cta__message {
-      @include span(6 of 12);
+      @include span(6 of 12 no-gutters);
       display: table-cell;
       float: none;
       padding: 0px 0px 0px ($base-spacing / 2);
       vertical-align: middle;
-      color: $white;
-      text-align: left;
-      font-size: $font-regular;
 
       @include media($medium) {
-        @include span(8 of 12);
+        margin: 0px;
+        width: auto;
+      }
+
+      h4 {
+        color: $white;
         text-align: left;
-        float: none;
-        font-size: $font-medium;
-        padding: 0px;
+        font-size: $font-regular;
+
+        @include media($medium) {
+          font-size: $font-medium;
+        }
       }
     }
   }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
@@ -90,11 +90,13 @@
       @include media($medium) {
         display: table-cell;
         text-align: left;
+        // Set explicit width so that button doesn't wrap to two lines.
         width: 145px;
       }
 
       .cta__button {
         .button {
+          // Set explicit font size so that button is smaller and doesn't wrap on mobile.
           font-size: 21px;
 
           @include media($medium) {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
@@ -52,19 +52,17 @@
       padding: $base-spacing / 2 0;
     }
 
-    // Layout for for campaigns with a scholarship
+    // Layout for campaigns with a scholarship.
     &.with-scholarship {
-      .cta__button {
-        @include media($medium) {
-          width: auto;
-        }
+      .cta__action {
+        width: auto;
 
         @include media($larger) {
           @include span(6 of 12 no-gutters);
           float: none;
         }
 
-        .button {
+        .cta__button {
           @include span(3 of 6 no-gutters);
           display: table-cell;
           float: none;
@@ -87,19 +85,21 @@
       }
     }
 
-    // Default layout, campaigns with no scholarship.
-    .cta__button {
+    // Layout for campaigns without a scholarship.
+    .cta__action {
       @include media($medium) {
         display: table-cell;
-        width: 145px;
         text-align: left;
+        width: 145px;
       }
 
-      .button {
-        font-size: 21px;
+      .cta__button {
+        .button {
+          font-size: 21px;
 
-        @include media($medium) {
-          font-size: $font-medium;
+          @include media($medium) {
+            font-size: $font-medium;
+          }
         }
       }
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -9,7 +9,7 @@
  */
 ?>
 
-<section class="campaign campaign--pitch pitch">
+<section class="campaign campaign--pitch pitch optimizely-persistent">
   <header role="banner" class="header -hero <?php print $classes; ?>">
     <div class="wrapper">
       <?php print $campaign_headings; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -25,16 +25,21 @@
     </div>
   </header>
 
-  <div class="cta -persistent optimizely-hide-count js-fixedsticky">
+  <div class="cta -persistent optimizely-hide-count js-fixedsticky <?php if ($campaign_scholarship) { print 'with-scholarship'; } ?>">
     <div class="wrapper">
       <?php if (isset($signup_button_secondary)): ?>
         <div class="cta__button">
           <?php print $signup_button_secondary; ?>
+          <?php if ($campaign_scholarship): ?>
+            <?php print $campaign_scholarship; ?>
+          <?php endif; ?>
         </div>
       <?php endif; ?>
       <?php if (isset($campaign->secondary_call_to_action)): ?>
-        <h4 class="cta__message with-count"><?php print $signup_cta; ?></h4>
-        <h4 class="cta__message without-count"><?php print $campaign->secondary_call_to_action; ?></h4>
+        <div class="cta__message">
+          <h4 class="with-count"><?php print $signup_cta; ?></h4>
+          <h4 class="without-count"><?php print $campaign->secondary_call_to_action; ?></h4>
+        </div>
       <?php endif; ?>
     </div>
   </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -28,8 +28,10 @@
   <div class="cta -persistent optimizely-hide-count js-fixedsticky <?php if ($campaign_scholarship) { print 'with-scholarship'; } ?>">
     <div class="wrapper">
       <?php if (isset($signup_button_secondary)): ?>
-        <div class="cta__button">
-          <?php print $signup_button_secondary; ?>
+        <div class="cta__action">
+          <div class="cta__button">
+            <?php print $signup_button_secondary; ?>
+          </div>
           <?php if ($campaign_scholarship): ?>
             <?php print $campaign_scholarship; ?>
           <?php endif; ?>


### PR DESCRIPTION
## Fixes #4390  and Adds scholarship callout back

This PR adds the scholarship callout to the persistent nav, if there is one, and fixes an issue where the cta message was wrapping. 
### Without Scholarship

![screen shot 2015-04-21 at 10 22 02 am](https://cloud.githubusercontent.com/assets/1700409/7254311/4dcc5b1a-e810-11e4-99f8-335616c6c037.png)
### With Scholarship

![screen shot 2015-04-21 at 10 21 27 am](https://cloud.githubusercontent.com/assets/1700409/7254316/5324386c-e810-11e4-8ac5-1c15167c34f6.png)

@DoSomething/front-end 
