### PR TITLE
Update paths for custom Modernizr build.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
+++ b/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
@@ -157,9 +157,11 @@ module.exports = function(grunt) {
           "src": [
             "js/**/*.js",
             "scss/**/*.scss",
-            "bower_components/neue/js/**/*.js",
-            "!bower_components/neue/js/modernizr/**/*.js",
-            "bower_components/neue/scss/**/*.scss"
+            "node_modules/dosomething-neue/js/**/*.js",
+            "!node_modules/dosomething-neue/js/modernizr/**/*.js",
+            "node_modules/dosomething-neue/scss/**/*.scss",
+            "node_modules/dosomething-modal/src/**/*.js",
+            "node_modules/dosomething-validation/src/**/*.js"
           ]
         },
         extensibility : {
@@ -177,8 +179,8 @@ module.exports = function(grunt) {
         },
         "matchCommunityTests": true,
         "customTests": [
-          "bower_components/neue/js/modernizr/checked.js",
-          "bower_components/neue/js/modernizr/label-click.js"
+          "node_modules/dosomething-neue/js/modernizr/checked.js",
+          "node_modules/dosomething-neue/js/modernizr/label-click.js"
         ]
       }
     },


### PR DESCRIPTION
# Changes
- Use the right include path for checking Neue, Modal, and Validation packages for Modernizr usage.

For review: @DoSomething/front-end 
