### PR TITLE
Disable Drupal core email messages

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -24,6 +24,13 @@ function dosomething_mbp_install() {
 
   // Install the DoSomething production settings in message_broker_producer.
   dosomething_mbp_install_productions();
+
+  variable_set('user_mail_register_admin_created_notify', 0);
+  variable_set('user_mail_register_pending_approval_notify', 0);
+  variable_set('user_mail_register_no_approval_required_notify', 0);
+  variable_set('user_mail_password_reset_notify', 0);
+  variable_set('user_mail_cancel_confirm_notify', 0);
+
 }
 
 /**
@@ -36,6 +43,11 @@ function dosomething_mbp_uninstall() {
     'message_broker_producer_rabbitmq_username',
     'message_broker_producer_rabbitmq_password',
     'message_broker_producer_rabbitmq_vhost',
+    'user_mail_register_admin_created_notify',
+    'user_mail_register_pending_approval_notify',
+    'user_mail_register_no_approval_required_notify',
+    'user_mail_password_reset_notify',
+    'user_mail_cancel_confirm_notify',
   );
   foreach ($vars as $var) {
     variable_del($var);
@@ -94,6 +106,21 @@ function dosomething_mbp_update_7004(&$sandbox) {
 function dosomething_mbp_update_7005(&$sandbox) {
   db_drop_table('message_broker_producer_productions');
   dosomething_mbp_install_productions();
+}
+
+/**
+ * Disables Drupal core email messages. Message Broker powered transactionals replace Drupal core
+ * text based email functionality. Not disabling these messages results in duplicate message
+ * from Drupal core and Message Broker for each of the message events.
+ */
+function dosomething_mbp_update_7006(&$sandbox) {
+
+  variable_set('user_mail_register_admin_created_notify', 0);
+  variable_set('user_mail_register_pending_approval_notify', 0);
+  variable_set('user_mail_register_no_approval_required_notify', 0);
+  variable_set('user_mail_password_reset_notify', 0);
+  variable_set('user_mail_cancel_confirm_notify', 0);
+
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -25,11 +25,8 @@ function dosomething_mbp_install() {
   // Install the DoSomething production settings in message_broker_producer.
   dosomething_mbp_install_productions();
 
-  variable_set('user_mail_register_admin_created_notify', 0);
-  variable_set('user_mail_register_pending_approval_notify', 0);
-  variable_set('user_mail_register_no_approval_required_notify', 0);
-  variable_set('user_mail_password_reset_notify', 0);
-  variable_set('user_mail_cancel_confirm_notify', 0);
+  // Disable Drupal core user event email messages
+  dosomething_mbp_update_7006();
 
 }
 


### PR DESCRIPTION
Fixes #4388 

A `hook_update` via the `mbp_dosomething` module to disable all Drupal core text based email messages for user events. There's not a UI setting for adjusting the setting that disable this functionality within Drupal core without adding a contributed module ((http://drupal.org/project/mailcontrol). System variables are toggled to enable / disable the functionality.

All user trigger transactional messaging are managed by the Message Broker system. Not disabling these system variables results in duplicate messages from both Message Broker (as templated message via Mandrill) and text based emails from Drupal core.

The goal is to apply these settings to all sites including each of the affiliate sites.
