### PR TITLE
Removed cta message scope to account for different mark up

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
@@ -3,26 +3,22 @@
 // solution is in place.
 @mixin optimizely-signup-count($display) {
   &.optimizely-hide-count {
-    .cta__message {
-      .with-count {
-        display: none;
-      }
+    .with-count {
+      display: none;
+    }
 
-      .without-count {
-        display: $display;
-      }
+    .without-count {
+      display: $display;
     }
   }
 
   &.optimizely-show-count {
-    .cta__message {
-      .with-count {
-        display: $display;
-      }
+    .with-count {
+      display: $display;
+    }
 
-      .without-count {
-        display: none;
-      }
+    .without-count {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
## Fixes #4403

The persistent nav and the regular cta have different markup so I needed to remove scoping specific to the `cta__message` element and only target the state classes.

@DoSomething/front-end 
