### PR TITLE
Update twitter meta tags to use photo card

### DIFF
--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -148,7 +148,7 @@ function dosomething_metatag_get_permalink_vars() {
     '#tag' => 'meta',
     '#attributes' => array(
       "property" => "twitter:card",
-      "content" => 'summary_large_image',
+      "content" => 'photo',
     ),
   );
   drupal_add_html_head($element, 'twitter:card');
@@ -165,11 +165,11 @@ function dosomething_metatag_get_permalink_vars() {
   $element = array(
     '#tag' => 'meta',
     '#attributes' => array(
-      "property" => "twitter:image:src",
+      "property" => "twitter:image",
       "content" => $image,
     ),
   );
-  drupal_add_html_head($element, 'twitter:image:src');
+  drupal_add_html_head($element, 'twitter:image');
 
   $element = array(
     '#tag' => 'meta',
@@ -179,16 +179,6 @@ function dosomething_metatag_get_permalink_vars() {
     ),
   );
   drupal_add_html_head($element, 'twitter:title');
-
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "twitter:description",
-      "content" => $share_copy,
-    ),
-  );
-
-  drupal_add_html_head($element, 'twitter:description');
 
   $element = array(
     '#tag' => 'meta',


### PR DESCRIPTION
## Fixes #4404

Updates the twitter meta tags on the permalink page to use the photo card instead of the summary card. :8ball: 
