### PR TITLE
Use 'left' Figure modifier for duo galleries.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/static_content/node--static_content.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/static_content/node--static_content.tpl.php
@@ -79,7 +79,7 @@
         <ul class="gallery <?php print $gallery['class']; ?>">
           <?php foreach ($gallery['items'] as $gallery_item): ?>
             <li>
-              <div class="figure">
+              <div class="figure <?php if ($gallery['class'] == '-duo'): print '-left'; endif; ?>">
                 <?php if (isset($gallery_item['image'])): ?>
                   <div class="figure__media">
                     <?php if (isset($gallery_item['image_title']) AND $gallery_item['image_url'] !== '') : ?>


### PR DESCRIPTION
# Changes
- If a gallery is being display using the Duo Gallery pattern, display all figures in the gallery with the `-left` modifier. Fixes #4363.

_Ideally_, we could have separate toggles for how to display the Gallery and how to display the child elements, but this is a quick fix for now.

For review: @DoSomething/front-end 
# Screenshots
#### Before:

![screen shot 2015-04-23 at 1 48 34 pm](https://cloud.githubusercontent.com/assets/583202/7303539/79b9e732-e9bf-11e4-9b3c-edf1f1167ac8.png)
#### After:

![screen shot 2015-04-23 at 1 48 27 pm](https://cloud.githubusercontent.com/assets/583202/7303543/7da03b4e-e9bf-11e4-9d82-fc87cf062ff5.png)
