### PR TITLE
Mobile signup count

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -161,7 +161,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     $materials['content'] = $campaign->items_needed;
     $vars['plan'][] = $materials;
   }
- 
+
   // 2) Time
   if (isset($campaign->time_and_place)) {
     $time['category'] = 'time';
@@ -196,7 +196,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   if (!empty($location_copy)) {
     $vars['location_finder']['copy'] = $location_copy['safe_value'];
   }
-  
+
   $location_url = $wrapper->field_location_finder_url->value();
   if (!empty($location_url)) {
     $vars['location_finder']['url'] = $location_url['url'];
@@ -291,7 +291,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   // Add analytics custom event on action page.
   $js = 'if(typeof(ga) !== "undefined" && ga !== null) { ga("send", "event", "Action Page View", "' . $vars['title'] . '"); }';
   drupal_add_js($js, 'inline');
-  
+
 }
 
 /**
@@ -356,8 +356,9 @@ function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
 
   // Get sign up total and add it to cta
   $campaign_progress = dosomething_helpers_get_variable('node', $vars['nid'], 'sum_rb_quanity');
+  $signup_count = (int) dosomething_helpers_get_variable('node', $vars['nid'], 'web_signup_count') + (int) dosomething_helpers_get_variable('node', $vars['nid'], 'mobile_signup_count');
   $vars['signup_cta'] .= t('Join @signup_count people doing this.', array(
-      '@signup_count' => number_format($campaign_progress, 0, '', ','),
+      '@signup_count' => number_format($signup_count, 0, '', ','),
     ));
 }
 
@@ -403,7 +404,7 @@ function dosomething_campaign_preprocess_closed_reportback_gallery(&$vars, $styl
   // Loop through gallery_vars to only output what we need for theming:
   foreach ($result as $delta => $item) {
     $vars['reportback_gallery'][$delta]['image'] = dosomething_image_get_themed_image_by_fid($item->fid, $style);
-    
+
     if (isset($item->caption)) {
       $vars['reportback_gallery'][$delta]['caption'] = check_plain($item->caption);
     }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -168,17 +168,13 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
       '#disabled' => TRUE,
     );
 
-    $signup_count = dosomething_helpers_get_variable('node', $node->nid, 'signup_count') ?: dosomething_signup_get_signup_total_by_nid($node->nid);
+    $web_signup_count = dosomething_helpers_get_variable('node', $node->nid, 'web_signup_count') ?: dosomething_signup_get_signup_total_by_nid($node->nid);
 
-    if ($vars['signup'] > $signup_count) {
-      $signup_count = dosomething_helpers_set_variable('node', $node->nid, 'signup_count', $vars['signup']);
-    }
-
-    $form['goals']['signup_count'] = array(
+    $form['goals']['mobile_signup_count'] = array(
       '#type' => 'textfield',
-      '#title' => t('Signup Count'),
-      '#description'=> t('The total number of signups on the campaign. Currently this only supports web signups, but mobile signups can be added manually.'),
-      '#default_value' => $vars['signup'] ?: $signup_count,
+      '#title' => t('Mobile Count'),
+      '#description'=> t('The total number of signups from mobile, will be added to total web signups: '  . $web_signup_count),
+      '#default_value' => $vars['mobile_signup_count'],
     );
   }
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -169,7 +169,7 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     );
 
     $web_signup_count = dosomething_helpers_get_variable('node', $node->nid, 'web_signup_count') ?: dosomething_signup_get_signup_total_by_nid($node->nid);
-
+    dosomething_helpers_set_variable('node', $node->nid, 'web_signup_count', $web_signup_count);
     $form['goals']['mobile_signup_count'] = array(
       '#type' => 'textfield',
       '#title' => t('Mobile Count'),

--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.cron.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.cron.inc
@@ -18,9 +18,9 @@ function dosomething_signup_cron() {
 
   // Updated reportback counts accordingly.
   foreach ($results as $result) {
-    $previous_signups = dosomething_helpers_get_variable('node', $result->nid, 'signup_count');
+    $previous_signups = dosomething_helpers_get_variable('node', $result->nid, 'web_signup_count');
     $updated_signups = (int) $previous_signups + (int) $result->total_signups;
-    dosomething_helpers_set_variable('node', $result->nid, 'signup_count', $updated_signups);
+    dosomething_helpers_set_variable('node', $result->nid, 'web_signup_count', $updated_signups);
   }
 }
 


### PR DESCRIPTION
Created two signup count vars per node
`mobile_signup_count` is user input, can be updated
`web_signup_count` is automatically generated, and updated on a cron 1/hour

The two are added together to display on the optimizly test on the pitch page. 
Fixes #4394 

@sbsmith86 @mikefantini 
