### PR TITLE
Export Modal API for displaying campaign signup form.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -378,7 +378,7 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
       $closeButton = 'skip';
     }
 
-    $js = 'require(["modal"], function(Modal) { Modal.open( jQuery("#' . $id . '"), {animated: false, closeButton: "' . $closeButton . '", skipForm: "' . $skipForm . '"}); });';
+    $js = 'jQuery(document).ready(function() { DSModal.open( jQuery("#' . $id . '"), {animated: false, closeButton: "' . $closeButton . '", skipForm: "' . $skipForm . '"}); });';
     drupal_add_js($js, 'inline');
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/app.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/app.js
@@ -13,8 +13,11 @@ import Reportback from 'reportback/Reportback';
 import Share from 'utils/Share';
 
 import 'dosomething-neue';
-import 'dosomething-modal';
 import 'dosomething-validation';
+import Modal from 'dosomething-modal';
+
+// Attach Modal to the window so `<script>` tags can use it.
+window.DSModal = Modal;
 
 import 'campaign/SchoolFinder';
 import 'validators/auth';


### PR DESCRIPTION
# Changes
- Fixes #4415. After moving from RequireJS to Webpack for script bundling, we can't require modules from the browser, so we need to export `window.DSModal` to access that API from a script tag.

For review: @DoSomething/front-end 
