### PR TITLE
Kudos resource

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -5,11 +5,13 @@
  */
 
 include_once 'dosomething_api.features.inc';
+include_once 'dosomething_api.transformer.inc';
 include_once 'resources/campaign_resource.inc';
 include_once 'resources/member_resource.inc';
 include_once 'resources/reportback_resource.inc';
 include_once 'resources/reportback_item_resource.inc';
 include_once 'resources/reportback_file_resource.inc';
+include_once 'resources/kudos_resource.inc';
 include_once 'resources/signup_resource.inc';
 include_once 'resources/term_resource.inc';
 
@@ -26,6 +28,7 @@ function dosomething_api_services_resources() {
   $resources += _reportback_resource_definition();
   $resources += _reportback_item_resource_definition();
   $resources += _reportback_file_resource_definition();
+  $resources += _kudos_resource_definition();
   $resources += _signup_resource_definition();
   $resources += _term_resource_definition();
 

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.transformer.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.transformer.inc
@@ -1,0 +1,10 @@
+<?php
+
+abstract class Transformer {
+
+  public function __construct() {
+    // Load Services module to use its index_query functions in subclass methods.
+    module_load_include('inc', 'services', 'services.module');
+  }
+
+}

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -1,0 +1,156 @@
+<?php
+
+function _kudos_resource_definition() {
+  $kudos_resource = array();
+  $kudos_resource['kudos'] = array(
+    'operations' => array(
+
+      'retrieve' => array(
+        'help' => 'Retrieve a specified kudos record on a reportback item.',
+        'file' => array(
+          'type' => 'inc',
+          'module' => 'dosomething_api',
+          'name' => 'resources/kudos_resource',
+        ),
+        'callback' => '_kudos_resource_retrieve',
+        'args' => array(
+          array(
+            'name' => 'kid',
+            'description' => 'The kid of the kudos record to retrieve.',
+            'optional' => FALSE,
+            'type' => 'int',
+            'source' => array('path' => 0),
+          ),
+        ),
+        'access callback' => '_kudos_resource_access',
+      ),
+
+      'index' => array(
+        'help' => 'List all kudos.',
+        'file' => array(
+          'type' => 'inc',
+          'module' => 'dosomething_api',
+          'name' => 'resources/kudos_resource',
+        ),
+        'callback' => '_kudos_resource_index',
+        'args' => array(
+          array(
+            'name' => 'reportbackitems',
+            'description' => 'The ids of specified reportbacks to get kudos.',
+            'optional' => TRUE,
+            'type' => 'string',
+            'source' => array(
+              'param' => 'reportbackitems'
+            ),
+            'default value' => NULL,
+          ),
+        ),
+        'access callback' => '_kudos_resource_access',
+      ),
+
+      'create' => array(
+        'help' => 'Create a new kudos record.',
+        'file' => array(
+          'type' => 'inc',
+          'module' => 'dosomething_api',
+          'name' => 'resources/kudos_resource',
+        ),
+        'callback' => '_kudos_resource_create',
+        'args' => array(
+          array(
+            'name' => 'reportback_item_id',
+            'description' => 'The id of reportback item to create kudos record.',
+            'optional' => FALSE,
+            'type' => 'int',
+            'source' => array(
+              'data' => 'reportback_item_id',
+            ),
+          ),
+          array(
+            'name' => 'user_id',
+            'description' => 'The ID of the user executing a kudos.',
+            'optional' => FALSE,
+            'type' => 'int',
+            'source' => array(
+              'data' => 'user_id',
+            ),
+          ),
+          array(
+            'name' => 'term_ids',
+            'description' => 'An array of kudos term IDs.',
+            'optional' => FALSE,
+            'type' => 'array',
+            'source' => array(
+              'data' => 'term_ids',
+            ),
+          ),
+        ),
+        'access callback' => '_kudos_resource_access',
+      ),
+
+      'delete' => array(
+        'help' => 'Delete a kudos record.',
+        'file' => array(
+          'type' => 'inc',
+          'module' => 'dosomething_api',
+          'name' => 'resources/kudos_resource',
+        ),
+        'callback' => '_kudos_resource_delete',
+        'args' => array(
+          array(
+            'name' => 'kudos_id',
+            'optional' => FALSE,
+            'type' => 'int',
+            'source' => array(
+              'path' => 0,
+            )
+          ),
+        ),
+        'access callback' => '_kudos_resource_access',
+      ),
+    ),
+
+  );
+
+  return $kudos_resource;
+}
+
+
+function _kudos_resource_access() {
+  // @TODO: Temp universal access for now.
+  // Permissions are still in effect for certain fields returned.
+  return TRUE;
+}
+
+
+function _kudos_resource_index($reportbackitems) {
+  $parameters = array(
+    'fid' => $reportbackitems,
+  );
+
+  $kudos = new Kudos;
+  return $kudos->index($parameters);
+}
+
+
+function _kudos_resource_retrieve($kid) {
+  return 'retrieving specific request';
+}
+
+
+function _kudos_resource_create($reportback_item_id, $user_id, $term_ids) {
+  $parameters = array(
+    'fid' => $reportback_item_id,
+    'uid' => $user_id,
+    'tids' => $term_ids,
+  );
+
+  // Returns ID of newly added kudos record in database table.
+  return dosomething_kudos_create($parameters);
+}
+
+
+function _kudos_resource_delete($kudos_id) {
+  // Returns number of rows affected.
+  return dosomething_kudos_delete($kudos_id);
+}

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -165,5 +165,5 @@ function _reportback_item_resource_kudos($fid, $user_id, $term_ids) {
   );
 
   // @TODO: temporarily returning back the header body data for testing.
-  return $parameters;
+  return dosomething_kudos_create($parameters);
 }

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -80,50 +80,6 @@ function _reportback_item_resource_definition() {
 
     ),
 
-    'targeted_actions' => array(
-
-      'kudos' => array(
-        'help' => 'Register a kudos action being applied to a reportback item.',
-        'file' => array(
-          'type' => 'inc',
-          'module' => 'dosomething_api',
-          'name' => 'resources/reportback_item_resource',
-        ),
-        'callback' => '_reportback_item_resource_kudos',
-        'args' => array(
-          array(
-            'name' => 'fid',
-            'description' => 'The reportback item file ID.',
-            'optional' => FALSE,
-            'type' => 'int',
-            'source' => array(
-              'path' => 0
-            ),
-          ),
-          array(
-            'name' => 'user_id',
-            'description' => 'The ID of the user executing a kudos.',
-            'optional' => FALSE,
-            'type' => 'int',
-            'source' => array(
-              'data' => 'user_id',
-            ),
-          ),
-          array(
-            'name' => 'term_ids',
-            'description' => 'An array of kudos term IDs.',
-            'optional' => FALSE,
-            'type' => 'array',
-            'source' => array(
-              'data' => 'term_ids',
-            ),
-          ),
-        ),
-        'access callback' => '_reportback_item_resource_access',
-      ),
-
-    ),
-
   );
 
   return $reportback_item_resource;
@@ -154,16 +110,4 @@ function _reportback_item_resource_index($campaigns, $status, $count, $random, $
 function _reportback_item_resource_retrieve($fid) {
   $reportbackItems = new ReportbackItem;
   return $reportbackItems->show($fid);
-}
-
-
-function _reportback_item_resource_kudos($fid, $user_id, $term_ids) {
-  $parameters = array(
-    'fid' => $fid,
-    'uid' => $user_id,
-    'tids' => $term_ids,
-  );
-
-  // @TODO: temporarily returning back the header body data for testing.
-  return dosomething_kudos_create($parameters);
 }

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.info
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.info
@@ -1,0 +1,5 @@
+name = DoSomething Kudos
+description = Functionality for adding social interaction on reportback photos.
+core = 7.x
+package = DoSomething
+version = 7.x-0.3

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.install
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.install
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @file
+ * Installation and schema hooks for dosomething_kudos.module
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function dosomething_kudos_schema() {
+  $schema = array();
+  $schema['dosomething_kudos'] = array(
+    'description' => 'Table of kudos interactions on reportback items.',
+    'fields' => array(
+      'kid' => array(
+        'description' => 'The primary identifier for a kudos record.',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'fid' => array(
+        'description' => 'The {reportback_file}.fid that this kudos applies to.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'uid' => array(
+        'description' => 'The {users}.uid that applied the kudos.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'tid' => array(
+        'description' => 'The {taxonomy_term}.tid that this kudos belongs to.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+    ),
+    'primary key' => array('kid'),
+    'indexes' => array(
+      'fid' => array('fid'),
+      'uid' => array('uid'),
+      'tid' => array('tid'),
+    ),
+  );
+
+  return $schema;
+}
+

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.install
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.install
@@ -15,27 +15,23 @@ function dosomething_kudos_schema() {
       'kid' => array(
         'description' => 'The primary identifier for a kudos record.',
         'type' => 'serial',
-        'unsigned' => TRUE,
         'not null' => TRUE,
       ),
       'fid' => array(
         'description' => 'The {reportback_file}.fid that this kudos applies to.',
         'type' => 'int',
-        'unsigned' => TRUE,
         'not null' => TRUE,
         'default' => 0,
       ),
       'uid' => array(
         'description' => 'The {users}.uid that applied the kudos.',
         'type' => 'int',
-        'unsigned' => TRUE,
         'not null' => TRUE,
         'default' => 0,
       ),
       'tid' => array(
         'description' => 'The {taxonomy_term}.tid that this kudos belongs to.',
         'type' => 'int',
-        'unsigned' => TRUE,
         'not null' => TRUE,
         'default' => 0,
       ),

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.kudos.inc
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.kudos.inc
@@ -1,0 +1,33 @@
+<?php
+
+
+/**
+ * Class Kudos
+ */
+class Kudos extends Transformer {
+
+  public function index($parameters) {
+    return $parameters;
+  }
+
+
+  public function show($id) {
+    return 'class show item';
+  }
+
+
+  public function create() {
+    return 'class create item';
+  }
+
+
+  public function delete() {
+    return 'class delete item';
+  }
+
+
+  public function transform() {
+    return 'autobots transform!';
+  }
+
+}

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -4,20 +4,38 @@
  * Module file for DoSomething Kudos functionality.
  */
 
-//function dosomething_kudos_init() {
-//  drupal_set_message('Kudos are live!');
-//}
+include_once 'dosomething_kudos.kudos.inc';
 
 
-function dosomething_kudos_save($fid, $uid, $tid) {
+/**
+ * @param $parameters
+ * @return array  IDs of newly created records.
+ * @throws Exception
+ */
+function dosomething_kudos_create($parameters) {
+  $records = array();
+
   $values = array(
-    'fid' => $fid,
-    'uid' => $uid,
-    'tid' => $tid,
+    'fid' => $parameters['fid'],
+    'uid' => $parameters['uid'],
   );
 
-  $record = db_insert('dosomething_kudos')->fields($values)->execute();
+  foreach($parameters['tids'] as $id) {
+    $values['tid'] = $id;
 
-  dpm($record);
+    $records[] = db_insert('dosomething_kudos')->fields($values)->execute();
+  }
+
+  return $records;
 }
 
+
+/**
+ * Delete a specified Kudos record.
+ *
+ * @param $kid
+ * @return DatabaseStatementInterface
+ */
+function dosomething_kudos_delete($kid) {
+  return db_delete('dosomething_kudos')->condition('kid', $kid)->execute();
+}

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @file
+ * Module file for DoSomething Kudos functionality.
+ */
+
+//function dosomething_kudos_init() {
+//  drupal_set_message('Kudos are live!');
+//}
+
+
+function dosomething_kudos_save($fid, $uid, $tid) {
+  $values = array(
+    'fid' => $fid,
+    'uid' => $uid,
+    'tid' => $tid,
+  );
+
+  $record = db_insert('dosomething_kudos')->fields($values)->execute();
+
+  dpm($record);
+}
+

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.reportback_transformer.inc
@@ -123,7 +123,6 @@ abstract class ReportbackTransformer {
    * Get metadata for pagination of response data.
    *
    * @param $parameters
-   * @param $count
    * @param $endpoint
    *
    * @return array

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -80,6 +80,7 @@ dependencies[] = dosomething_campaign_run
 dependencies[] = dosomething_fact
 dependencies[] = dosomething_fact_page
 dependencies[] = dosomething_image
+dependencies[] = dosomething_kudos
 dependencies[] = dosomething_mbp
 dependencies[] = dosomething_northstar
 dependencies[] = dosomething_helpers

--- a/lib/profiles/dosomething/dosomething.make
+++ b/lib/profiles/dosomething/dosomething.make
@@ -67,6 +67,12 @@ projects[dosomething_image][download][type] = local
 projects[dosomething_image][download][source] = './lib/modules/dosomething/dosomething_image'
 projects[dosomething_image][subdir] = "dosomething"
 
+; Dosomething Kudos
+projects[dosomething_kudos][type] = "module"
+projects[dosomething_kudos][download][type] = local
+projects[dosomething_kudos][download][source] = './lib/modules/dosomething/dosomething_kudos'
+projects[dosomething_kudos][subdir] = "dosomething"
+
 ; Dosomething MBP (Message Broker Producer)
 projects[dosomething_mbp][type] = "module"
 projects[dosomething_mbp][download][type] = local


### PR DESCRIPTION
### Fixes #4431

This PR adds a new **Kudos** module and also creates a new **Kudos API Resource**. The module sets up a `dosomething_kudos` database table which will contain all kudos records that are attached to specific reportback items.

There is more work to be done, but this PR sets up a lot of the groundwork. The `/api/v1/kudos` basic endpoints work and can successfully create a kudos record (or multiple records at once) and delete individual records. 

Just to note, the newly added abstract `Transformer` class residing in the `dosomething_api` module will set up universal transformer methods that the resource classes can extend. This abstract class will be fleshed out in following PRs.

@jonuy @angaither 
