### PR TITLE
Add ES5 shim for Internet Explorer 8.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -14,6 +14,7 @@
     "dosomething-modal": "~0.3.0",
     "dosomething-neue": "~6.4.1",
     "dosomething-validation": "~0.2.0",
+    "es5-shim": "^4.1.1",
     "fixed-sticky": "DFurnes/fixed-sticky#umd",
     "html5shiv": "~3.7.2",
     "jquery": "~1.11.0",

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -24,6 +24,8 @@
 
   <!--[if lte IE 8]>
       <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/html5shiv/dist/html5shiv.min.js"></script>
+      <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/es5-shim/es5-shim.min.js"></script>
+      <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/es5-shim/es5-sham.min.js"></script>
 
       <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/respond.js/dest/respond.min.js"></script>
       <link href="<?php print VENDOR_ASSET_PATH; ?>/respond.js/cross-domain/respond-proxy.html" id="respond-proxy" rel="respond-proxy" />


### PR DESCRIPTION
# Changes

Adds [ES5 shim & sham](https://www.npmjs.com/package/es5-shim) for Internet Explorer 8 (included in conditional comment). This shims ES5 methods that aren't supported or are bugged in IE8 (like `Object.defineProperty`). The "sham" includes workable versions of some methods that are not supported by the engine.

This fixes a bug in IE8 that was introduced because Babel assumes a functioning ES5 environment, and seems like a good baseline for curing some browser headaches anyways! (Closes #4430.)

For review: @DoSomething/front-end 
