### PR TITLE
Send users to northstar

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.admin.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.admin.inc
@@ -26,7 +26,7 @@ function dosomething_northstar_config_form($form, &$form_state) {
     '#title' => t('Northstar port'),
     '#description' => t('This is most likely only needed on dev sites'),
     '#required' => FALSE,
-    '#default_value' => variable_get('dosomething_northstar_port', '8888'),
+    '#default_value' => variable_get('dosomething_northstar_port', '8000'),
   );
   $form['northstar']['dosomething_northstar_version'] = array(
     '#type' => 'textfield',

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -80,41 +80,41 @@ function dosomething_northstar_build_ns_user($user, $form_state) {
     'addr_zip'      => $user->field_address[LANGUAGE_NONE][0]['postal_code'],
   );
 }
+//@TODO: use this once we can use guzzle.
+// class Northstar {
 
-class Northstar {
+//   public $client;
 
-  public $client;
+//   public function __construct()
+//   {
 
-  public function __construct()
-  {
+//     $this->client = $library;
+//     $base_url = NORTHSTAR_URL;
+//     if (getenv('DS_ENVIRONMENT') === 'local') {
+//       $base_url .=  ":" . NORTHSTAR_PORT;
+//     }
+//     $version = NORTHSTAR_VERSION;
 
-    $this->client = $library;
-    $base_url = NORTHSTAR_URL;
-    if (getenv('DS_ENVIRONMENT') === 'local') {
-      $base_url .=  ":" . NORTHSTAR_PORT;
-    }
-    $version = NORTHSTAR_VERSION;
+//     $library = libraries_load('guzzle-php');
+//     //@TODO: this throws an error, because the above call doesn't load the guzzle.
+//     $client = new GuzzleHttp\Client(array(
+//       'base_url' => array($base_url . '/{version}/', array('version' => $version)),
+//       'defaults' => array(
+//         'headers' => array(
+//           'X-DS-Application-Id' => NORTHSTAR_APP_ID,
+//           'X-DS-REST-API-Key' => NORTHSTAR_APP_KEY,
+//           'Content-Type' => 'application/json',
+//           'Accept' => 'application/json'
+//           ),
+//         ),
+//     ));
+//     $this->client = $client;
+//   }
 
-    $library = libraries_load('guzzle-php');
-    //@TODO: this throws an error, because the above call doesn't load the guzzle.
-    $client = new GuzzleHttp\Client(array(
-      'base_url' => array($base_url . '/{version}/', array('version' => $version)),
-      'defaults' => array(
-        'headers' => array(
-          'X-DS-Application-Id' => NORTHSTAR_APP_ID,
-          'X-DS-REST-API-Key' => NORTHSTAR_APP_KEY,
-          'Content-Type' => 'application/json',
-          'Accept' => 'application/json'
-          ),
-        ),
-    ));
-    $this->client = $client;
-  }
+//   public function register($user) {
+//     $client->post('users', array(
+//       'body' => json_encode($user),
+//       ));
+//   }
 
-  public function register($user) {
-    $client->post('users', array(
-      'body' => json_encode($user),
-      ));
-  }
-
-}
+// }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -80,6 +80,30 @@ function dosomething_northstar_build_ns_user($user, $form_state) {
     'addr_zip'      => $user->field_address[LANGUAGE_NONE][0]['postal_code'],
   );
 }
+
+/**
+ * Build the drupal_http_request object for nothstar calls.
+ * This will be depricated once guzzle is introduced.
+ */
+function _dosomething_northstar_build_http_client() {
+  $base_url = NORTHSTAR_URL;
+  if (getenv('DS_ENVIRONMENT') === 'local') {
+      $base_url .=  ":" . NORTHSTAR_PORT;
+    }
+  $base_url .= '/' . NORTHSTAR_VERSION;
+
+  $client = array(
+    'base_url' => $base_url,
+    'headers' => array(
+      'X-DS-Application-Id' => NORTHSTAR_APP_ID,
+      'X-DS-REST-API-Key' => NORTHSTAR_APP_KEY,
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json',
+      ),
+    );
+
+  return $client;
+}
 //@TODO: use this once we can use guzzle.
 // class Northstar {
 

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -34,11 +34,11 @@ function dosomething_northstar_menu() {
  */
 function dosomething_northstar_libraries_info() {
   $libraries['guzzle-php'] = array(
-    'name' => 'Guzzle',
-    'path' => 'lib',
+    'name' => 'guzzle',
+    'path' => 'vendor',
     'files' => array(
       'php' => array(
-        'autoload.php',
+        'autoload.php'
       ),
     ),
     'version' => 5.0,
@@ -52,7 +52,8 @@ function dosomething_northstar_register_user($form_state) {
   $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
   // Send that to NS.
   $northstar = new Northstar();
-  $northstar->register($ns_user);
+
+  // $northstar->register($ns_user);
 }
 
 /**
@@ -86,11 +87,16 @@ class Northstar {
 
   public function __construct()
   {
+
+    $this->client = $library;
     $base_url = NORTHSTAR_URL;
     if (getenv('DS_ENVIRONMENT') === 'local') {
       $base_url .=  ":" . NORTHSTAR_PORT;
     }
     $version = NORTHSTAR_VERSION;
+
+    $library = libraries_load('guzzle-php');
+    //@TODO: this throws an error, because the above call doesn't load the guzzle.
     $client = new GuzzleHttp\Client(array(
       'base_url' => array($base_url . '/{version}/', array('version' => $version)),
       'defaults' => array(

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -57,6 +57,9 @@ function dosomething_northstar_register_user($form_state) {
     'method' => 'POST',
     'data' => json_encode($ns_user),
     ));
+  if ($response->code == '200' && module_exists('stathat')) {
+    stathat_send_ez_count('drupal - Northstar - user migrated - count', 1);
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -50,10 +50,9 @@ function dosomething_northstar_register_user($form_state) {
   global $user;
   // Build a user that Northstar expects.
   $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
-
   // Send that to NS.
-
-
+  $northstar = new Northstar();
+  $northstar->register($ns_user);
 }
 
 /**
@@ -89,21 +88,27 @@ class Northstar {
   {
     $base_url = NORTHSTAR_URL;
     if (getenv('DS_ENVIRONMENT') === 'local') {
-      $base_url .=  ":" NORTHSTAR_PORT;
+      $base_url .=  ":" . NORTHSTAR_PORT;
     }
     $version = NORTHSTAR_VERSION;
-    $client = new GuzzleHttp\Client([
-      'base_url' => [$base_url . '/{version}/', ['version' => $version]],
+    $client = new GuzzleHttp\Client(array(
+      'base_url' => array($base_url . '/{version}/', array('version' => $version)),
       'defaults' => array(
-        'headers' => [
+        'headers' => array(
           'X-DS-Application-Id' => NORTHSTAR_APP_ID,
           'X-DS-REST-API-Key' => NORTHSTAR_APP_KEY,
           'Content-Type' => 'application/json',
           'Accept' => 'application/json'
-          ]
+          ),
         ),
-    ]);
+    ));
     $this->client = $client;
+  }
+
+  public function register($user) {
+    $client->post('users', array(
+      'body' => json_encode($user),
+      ));
   }
 
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -51,9 +51,12 @@ function dosomething_northstar_register_user($form_state) {
   // Build a user that Northstar expects.
   $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
   // Send that to NS.
-  $northstar = new Northstar();
-
-  // $northstar->register($ns_user);
+  $client = _dosomething_northstar_build_http_client();
+  $response = drupal_http_request($client['base_url'] . '/users', array(
+    'headers' => $client['headers'],
+    'method' => 'POST',
+    'data' => json_encode($ns_user),
+    ));
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -7,6 +7,12 @@
 
 include_once('dosomething_northstar.admin.inc');
 
+// Config vars, if not set.
+define('NORTHSTAR_URL', variable_get('dosomething_northstar_url', 'http://northstar.dev'));
+define('NORTHSTAR_PORT', variable_get('dosomething_northstar_port', '8000'));
+define('NORTHSTAR_VERSION', variable_get('dosomething_northstar_version', '1'));
+define('NORTHSTAR_APP_ID', variable_get('dosomething_northstar_app_id', '456'));
+define('NORTHSTAR_APP_KEY', variable_get('dosomething_northstar_app_key', 'abc4324'));
 
 /**
  * Implements hook_menu().
@@ -73,4 +79,31 @@ function dosomething_northstar_build_ns_user($user, $form_state) {
     'addr_state'    => $user->field_address[LANGUAGE_NONE][0]['administrative_area'],
     'addr_zip'      => $user->field_address[LANGUAGE_NONE][0]['postal_code'],
   );
+}
+
+class Northstar {
+
+  public $client;
+
+  public function __construct()
+  {
+    $base_url = NORTHSTAR_URL;
+    if (getenv('DS_ENVIRONMENT') === 'local') {
+      $base_url .=  ":" NORTHSTAR_PORT;
+    }
+    $version = NORTHSTAR_VERSION;
+    $client = new GuzzleHttp\Client([
+      'base_url' => [$base_url . '/{version}/', ['version' => $version]],
+      'defaults' => array(
+        'headers' => [
+          'X-DS-Application-Id' => NORTHSTAR_APP_ID,
+          'X-DS-REST-API-Key' => NORTHSTAR_APP_KEY,
+          'Content-Type' => 'application/json',
+          'Accept' => 'application/json'
+          ]
+        ),
+    ]);
+    $this->client = $client;
+  }
+
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -39,3 +39,38 @@ function dosomething_northstar_libraries_info() {
   );
   return $libraries;
 }
+
+function dosomething_northstar_register_user($form_state) {
+  global $user;
+  // Build a user that Northstar expects.
+  $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
+
+  // Send that to NS.
+
+
+}
+
+/**
+ * Build a user json object, that's accepted by Northstar.
+ *
+ * @param obj $user
+ *  Drupal user object
+ *
+ */
+function dosomething_northstar_build_ns_user($user, $form_state) {
+  return $ns_user = array(
+    'email'         => $user->mail,
+    'mobile'        => $user->field_mobile[LANGUAGE_NONE][0]['value'],
+    'first_name'    => $user->field_first_name[LANGUAGE_NONE][0]['value'],
+    'birthdate'     => $user->field_birthdate[LANGUAGE_NONE][0]['value'],
+    'drupal_id'     => $user->uid,
+    'password'      => $form_state['values']['pass'],
+    // Address
+    'country'       => $user->field_address[LANGUAGE_NONE][0]['country'],
+    'addr_street1'  => $user->field_address[LANGUAGE_NONE][0]['thoroughfare'],
+    'addr_street2'  => $user->field_address[LANGUAGE_NONE][0]['premise'],
+    'addr_city'     => $user->field_address[LANGUAGE_NONE][0]['locality'],
+    'addr_state'    => $user->field_address[LANGUAGE_NONE][0]['administrative_area'],
+    'addr_zip'      => $user->field_address[LANGUAGE_NONE][0]['postal_code'],
+  );
+}

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -10,7 +10,7 @@ include_once('dosomething_northstar.admin.inc');
 // Config vars, if not set.
 define('NORTHSTAR_URL', variable_get('dosomething_northstar_url', 'http://northstar.dev'));
 define('NORTHSTAR_PORT', variable_get('dosomething_northstar_port', '8000'));
-define('NORTHSTAR_VERSION', variable_get('dosomething_northstar_version', '1'));
+define('NORTHSTAR_VERSION', variable_get('dosomething_northstar_version', 'v1'));
 define('NORTHSTAR_APP_ID', variable_get('dosomething_northstar_app_id', '456'));
 define('NORTHSTAR_APP_KEY', variable_get('dosomething_northstar_app_key', 'abc4324'));
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -556,6 +556,11 @@ function dosomething_user_login_submit($form, &$form_state) {
         dosomething_signup_user_signup($nid, NULL, $source);
       }
     }
+
+  }
+  // Send the user into northstar.
+  if (module_exists('dosomething_northstar')) {
+    dosomething_northstar_register_user($form_state);
   }
   // After all logins, except reportback pages redirect to page user was just on.
   if (isset($source) && stripos($source, 'reportback') > 0) {


### PR DESCRIPTION
When a user logs into dosomething, send that user into Northstar.
- Locally in vagrant to test you have to add `10.0.2.2 northstar.dev`  to `/etc/hosts`
  - there's a PR DoSomething/ansible-vagrant/pull/3 to do that
- Northstar module needs to be enabled

Fixes #4276 
