### PR TITLE
Update signup cron count query

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.cron.inc
+++ b/lib/modules/dosomething/dosomething_signup/includes/dosomething_signup.cron.inc
@@ -13,14 +13,11 @@ function dosomething_signup_cron() {
   // Get all reportbacks updated in the past hour.
   $results = db_query("SELECT nid, count(nid) as total_signups
                       FROM dosomething_signup
-                      WHERE from_unixtime(timestamp) >= date_add(now(), INTERVAL '-1' hour)
                       GROUP BY nid;");
 
   // Updated reportback counts accordingly.
   foreach ($results as $result) {
-    $previous_signups = dosomething_helpers_get_variable('node', $result->nid, 'web_signup_count');
-    $updated_signups = (int) $previous_signups + (int) $result->total_signups;
-    dosomething_helpers_set_variable('node', $result->nid, 'web_signup_count', $updated_signups);
+    dosomething_helpers_set_variable('node', $result->nid, 'web_signup_count', $result->total_signups);
   }
 }
 


### PR DESCRIPTION
Since we aren't overriding the web signup count, we no longer need to do a time based query to look up and override the old var
Fixes #4437
