### PR TITLE
Issue4105 reportback image processor

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -121,6 +121,17 @@ function dosomething_mbp_update_7006(&$sandbox) {
 }
 
 /**
+ * Updates user_register production to:
+ * - include imageProcessingQueue
+ * - remove userCampaignActivityQueue
+ * from transactional_campaign_reportback production.
+ */
+function dosomething_mbp_update_7007(&$sandbox) {
+  db_drop_table('message_broker_producer_productions');
+  dosomething_mbp_install_productions();
+}
+
+/**
  * Common function for install and update of related DoSomething specific
  * message_broker_producer produciton settings.
  */

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -188,8 +188,8 @@ function dosomething_mbp_install_productions() {
   $productions[4]['queues'][] = 'transactionalQueue';
   $productions[4]['queues'][] = 'loggingQueue';
   $productions[4]['queues'][] = 'activityStatsQueue';
-  $productions[4]['queues'][] = 'userCampaignActivityQueue';
   $productions[4]['queues'][] = 'userAPICampaignActivityQueue';
+  $productions[4]['queues'][] = 'imageProcessingQueue';
   $productions[4]['routing_key'] = 'campaign.report_back.transactional';
   $productions[4]['status'] = 1;
 

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -125,8 +125,12 @@ function dosomething_mbp_update_7006(&$sandbox) {
  * - include imageProcessingQueue
  * - remove userCampaignActivityQueue
  * from transactional_campaign_reportback production.
+ *
+ * Note: For non-multipass updates, the signature can simply be;
+ * function hook_update_N()
+ * https://api.drupal.org/api/drupal/modules%21system%21system.api.php/function/hook_update_N/7
  */
-function dosomething_mbp_update_7007(&$sandbox) {
+function dosomething_mbp_update_7007() {
   db_drop_table('message_broker_producer_productions');
   dosomething_mbp_install_productions();
 }


### PR DESCRIPTION
### Fixes #4105
- Addition of `imageProcessingQueue` queue to support collection of report backs and their image uploads. The entries will be used to trigger the consumer mbc-image-processor.
- Removes `userCampaignActivityQueue`, cruft, not used.
