### PR TITLE
Removes `codercs` alias.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -180,13 +180,6 @@ function build {
     build_helper 'default' $1 $2
   fi
 
-  if [ ! -e "~/.bashrc" ]
-  then
-    echo 'Setting up PHP CodeSniffer...'
-    echo 'alias codercs="phpcs --standard=$WEB_PATH/profiles/dosomething/modules/contrib/coder/coder_sniffer/Drupal/ruleset.xml --extensions=php,module,inc,install,test,profile,theme"' >> ~/.bashrc
-    source ~/.bashrc
-  fi
-
   # Run grunt task to configure front-end environment
   # this will install Bower/NPM dependencies
   grunt


### PR DESCRIPTION
It'd be better to setup this with ansible, if needed. Current version adds this alias to `.bashrc` on each build.
Ref #1488.
