### PR TITLE
Adding goal animation fields to campaign config form

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -254,42 +254,26 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $form['goal_animation_files']['dosomething_campaign_animation_1'] = array(
-    '#type' => 'managed_file',
-    '#title' => t('Animation 1'),
-    '#description' => t("This animation will be played when goal progress is between 0 and 20%"),
-    '#default_value' => variable_get('dosomething_campaign_animation_1'),
-  );
-  $form['goal_animation_files']['dosomething_campaign_animation_2'] = array(
-    '#type' => 'managed_file',
-    '#title' => t('Animation 2'),
-    '#description' => t("This animation will be played when goal progress is between 21% and 40%"),
-    '#default_value' => variable_get('dosomething_campaign_animation_2'),
-  );
-  $form['goal_animation_files']['dosomething_campaign_animation_3'] = array(
-    '#type' => 'managed_file',
-    '#title' => t('Animation 3'),
-    '#description' => t("This animation will be played when goal progress is between 41% and 60%"),
-    '#default_value' => variable_get('dosomething_campaign_animation_3'),
-  );
-  $form['goal_animation_files']['dosomething_campaign_animation_4'] = array(
-    '#type' => 'managed_file',
-    '#title' => t('Animation 4'),
-    '#description' => t("This animation will be played when goal progress is between 61% and 80%"),
-    '#default_value' => variable_get('dosomething_campaign_animation_4'),
-  );
-  $form['goal_animation_files']['dosomething_campaign_animation_5'] = array(
-    '#type' => 'managed_file',
-    '#title' => t('Animation 5'),
-    '#description' => t("This animation will be played when goal progress is between 81% and 99%"),
-    '#default_value' => variable_get('dosomething_campaign_animation_5'),
-  );
-  $form['goal_animation_files']['dosomething_campaign_animation_6'] = array(
-    '#type' => 'managed_file',
-    '#title' => t('Animation 6'),
-    '#description' => t("This animation will be played when goal has been met 100%"),
-    '#default_value' => variable_get('dosomething_campaign_animation_6'),
-  );
+
+  $goal_description_ranges = ['between 0 and 20%', 'between 21% and 40%', 'between 41% and 60%', 'between 61% and 80%', 'between 81% and 99%', 'at 100%'];
+
+  for ($i = 0; $i < 6 ; $i++) {
+    $form['goal_animation_files']['dosomething_campaign_animation_' . $i] = array(
+      '#type' => 'managed_file',
+      '#title' => t('Animation ' . $i),
+      '#description' => t("This animation will be played when goal progress is " . $goal_description_ranges[$i]),
+      '#default_value' => variable_get('dosomething_campaign_animation_' . $i),
+    );
+  }
+
+  foreach ($goal_description_ranges as $key => $range) {
+    $form['goal_animation_files']['dosomething_campaign_animation_' . $key] = array(
+      '#type' => 'managed_file',
+      '#title' => t('Animation ' . $range),
+      '#description' => t("This animation will be played when goal progress is " . $range),
+      '#default_value' => variable_get('dosomething_campaign_animation_' . $key),
+    );
+  }
   return system_settings_form($form);
 }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -255,7 +255,7 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#collapsed' => TRUE,
   );
 
-  $goal_description_ranges = ['between 0 and 20%', 'between 21% and 40%', 'between 41% and 60%', 'between 61% and 80%', 'between 81% and 99%', 'at 100%'];
+  $goal_description_ranges = array('between 0 and 20%', 'between 21% and 40%', 'between 41% and 60%', 'between 61% and 80%', 'between 81% and 99%', 'at 100%');
 
   foreach ($goal_description_ranges as $key => $range) {
     $form['goal_animation_files']['dosomething_campaign_animation_' . $key] = array(

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -247,6 +247,49 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#required' => TRUE,
     '#default_value' => variable_get('dosomething_campaign_permalink_nonowners_closed_button_copy'),
   );
+  // Goal Animations.
+  $form['goal_animation_files'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Goal Animation Files'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['goal_animation_files']['dosomething_campaign_animation_1'] = array(
+    '#type' => 'managed_file',
+    '#title' => t('Animation 1'),
+    '#description' => t("This animation will be played when goal progress is between 0 and 20%"),
+    '#default_value' => variable_get('dosomething_campaign_animation_1'),
+  );
+  $form['goal_animation_files']['dosomething_campaign_animation_2'] = array(
+    '#type' => 'managed_file',
+    '#title' => t('Animation 2'),
+    '#description' => t("This animation will be played when goal progress is between 21% and 40%"),
+    '#default_value' => variable_get('dosomething_campaign_animation_2'),
+  );
+  $form['goal_animation_files']['dosomething_campaign_animation_3'] = array(
+    '#type' => 'managed_file',
+    '#title' => t('Animation 3'),
+    '#description' => t("This animation will be played when goal progress is between 41% and 60%"),
+    '#default_value' => variable_get('dosomething_campaign_animation_3'),
+  );
+  $form['goal_animation_files']['dosomething_campaign_animation_4'] = array(
+    '#type' => 'managed_file',
+    '#title' => t('Animation 4'),
+    '#description' => t("This animation will be played when goal progress is between 61% and 80%"),
+    '#default_value' => variable_get('dosomething_campaign_animation_4'),
+  );
+  $form['goal_animation_files']['dosomething_campaign_animation_5'] = array(
+    '#type' => 'managed_file',
+    '#title' => t('Animation 5'),
+    '#description' => t("This animation will be played when goal progress is between 81% and 99%"),
+    '#default_value' => variable_get('dosomething_campaign_animation_5'),
+  );
+  $form['goal_animation_files']['dosomething_campaign_animation_6'] = array(
+    '#type' => 'managed_file',
+    '#title' => t('Animation 6'),
+    '#description' => t("This animation will be played when goal has been met 100%"),
+    '#default_value' => variable_get('dosomething_campaign_animation_6'),
+  );
   return system_settings_form($form);
 }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -257,15 +257,6 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
 
   $goal_description_ranges = ['between 0 and 20%', 'between 21% and 40%', 'between 41% and 60%', 'between 61% and 80%', 'between 81% and 99%', 'at 100%'];
 
-  for ($i = 0; $i < 6 ; $i++) {
-    $form['goal_animation_files']['dosomething_campaign_animation_' . $i] = array(
-      '#type' => 'managed_file',
-      '#title' => t('Animation ' . $i),
-      '#description' => t("This animation will be played when goal progress is " . $goal_description_ranges[$i]),
-      '#default_value' => variable_get('dosomething_campaign_animation_' . $i),
-    );
-  }
-
   foreach ($goal_description_ranges as $key => $range) {
     $form['goal_animation_files']['dosomething_campaign_animation_' . $key] = array(
       '#type' => 'managed_file',


### PR DESCRIPTION
## Fixes #4443

Adds 6 file fields to the campaign config page that will hold the different goal progress animations. 

@aaronschachter I checked the status of these files after they were saved, and they did indeed have a `0` status. I can create a separate issue where we can discuss how we want to get that worked out. 

cc/ @angaither 
