### PR TITLE
[hold off on reviewing] Goal animation logic

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -251,6 +251,9 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
   $form['goal_animation_files'] = array(
     '#type' => 'fieldset',
     '#title' => t('Goal Animation Files'),
+    '#description' => t("Insert the !link to use for each goal animation", array(
+      '!link' => l("file fid", 'admin/content/files'),
+    )),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
@@ -259,8 +262,8 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
 
   foreach ($goal_description_ranges as $key => $range) {
     $form['goal_animation_files']['dosomething_campaign_animation_' . $key] = array(
-      '#type' => 'managed_file',
-      '#title' => t('Animation ' . $range),
+      '#type' => 'textfield',
+      '#title' => t('FID for Animation ' . $range),
       '#description' => t("This animation will be played when goal progress is " . $range),
       '#default_value' => variable_get('dosomething_campaign_animation_' . $key),
     );

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -607,3 +607,70 @@ function dosomething_campaign_get_scholarship($nid) {
   $wrapper = entity_metadata_wrapper('node', $nid);
   return $wrapper->field_scholarship_amount->value();
 }
+
+/**
+ * Returns the animation file to use based on goal progress.
+ *
+ * @return Image.
+ *  The animation image (gif).
+ */
+function dosomething_campaign_get_animation($nid) {
+  // Get progress range.
+  $range = dosomething_campaign_get_progress_range($nid);
+
+  // Get the fid of the correct animation.
+  $var_name = 'dosomething_campaign_animation_' . $range;
+  $fid = variable_get($var_name);
+
+  if (!is_null($fid)) {
+    $animation = dosomething_image_get_themed_image_by_fid((int) $fid, '300x300');
+  }
+
+  return $animation;
+}
+
+/**
+ * Checks if a goal is complete, otherwise breaks goal progress into 5 ranges,
+ * and returns where the current progress lands.
+ * Used to determine which goal animation file to use.
+ *
+ * 0 - Between 0 and 20%
+ * 1 - Between 20% and 40%
+ * 2 - Between 40% and 60%
+ * 3 - Between 60% and 80%
+ * 4 - Between 80% and 100%
+ * 5 - Progress is 100% or over, goal is complete.
+ *
+ * @return int
+ *  An integer repersenting a goal progress range.
+ */
+function dosomething_campaign_get_progress_range($nid) {
+  // Get current progress and goal.
+  $campaign_progress = (int) dosomething_helpers_get_variable('node', $nid, 'sum_rb_quanity');
+  $campaign_goal = (int) dosomething_helpers_get_variable('node', $nid, 'goal');
+
+  // Calculate current progress in relation to the goal.
+  $progress_percentage = floor(($campaign_progress / $campaign_goal) * 100);
+
+  // Set initial loop values.
+  $num_ranges = 5;
+  $interval = 100 / $num_ranges;
+  $range_start = 0;
+  $range_end = $interval;
+
+  // Loop through each of the ranges and check where the progress lands.
+  for ($range = 0; $range <= $num_ranges; $range++) {
+    // If progress, is at 100% or over, goal is complete.
+    if ($range_start == 100 && $progress_percentage >= $range_start) {
+      return $range;
+    }
+    // Otherwise, check if current progress lands in this range.
+    else if ($progress_percentage >= $range_start && $progress_percentage < $range_end) {
+      return $range;
+    }
+
+    // Iterate to the next range.
+    $range_start = $range_end;
+    $range_end = $range_end + $interval;
+  }
+}

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -622,6 +622,8 @@ function dosomething_campaign_get_animation($nid) {
   $var_name = 'dosomething_campaign_animation_' . $range;
   $fid = variable_get($var_name);
 
+  // @TODO - The file should be an animated gif image, but we might
+  // need to change the file size once designs are locked down.
   if (!is_null($fid)) {
     $animation = dosomething_image_get_themed_image_by_fid((int) $fid, '300x300');
   }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -152,6 +152,11 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     $vars['campaign_progress'] = dosomething_helpers_get_variable('node', $vars['nid'], 'sum_rb_quanity');
   }
 
+  // Progress animation
+  if (dosomething_campaign_get_animation($vars['nid'])) {
+    $vars['goal_animation'] = dosomething_campaign_get_animation($vars['nid']);
+  }
+
   // Plan.
 
   // 1) Materials
@@ -355,7 +360,6 @@ function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
   $vars['tagline'] .= t('Any cause, anytime, anywhere.');
 
   // Get sign up total and add it to cta
-  $campaign_progress = dosomething_helpers_get_variable('node', $vars['nid'], 'sum_rb_quanity');
   $signup_count = (int) dosomething_helpers_get_variable('node', $vars['nid'], 'web_signup_count') + (int) dosomething_helpers_get_variable('node', $vars['nid'], 'mobile_signup_count');
   $vars['signup_cta'] .= t('Join @signup_count people doing this.', array(
       '@signup_count' => number_format($signup_count, 0, '', ','),


### PR DESCRIPTION
## Fixes #4461 and #4445
- Changes goal animation config fields to be text fields that take in FID values as discussed in #4461 
- Creates two helper functions - one that gets the current range of progress, and one that gets the animation file that corresponds with that progress range.
- Creates a variable that the template can use to print the correct animation file. 

@angaither @aaronschachter 
