### PR TITLE
Campaigns query

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -12,12 +12,26 @@ function _campaign_resource_definition() {
         'access arguments' => array('index'),
         'args' => array(
           array(
-            'name' => 'parameters',
+            'name' => 'is_staff_pick',
             'optional' => TRUE,
-            'type' => 'array',
-            'description' => 'Parameters',
-            'default value' => array(),
-            'source' => array('param' => 'parameters'),
+            'type' => 'int',
+            'source' => array('param' => 'is_staff_pick'),
+            'default value' => NULL,
+          ),
+          array(
+            'name' => 'on_mobile_app',
+            'optional' => TRUE,
+            'type' => 'int',
+            'source' => array('param' => 'on_mobile_app'),
+            'default value' => NULL,
+          ),
+          array(
+            'name' => 'term_ids',
+            'description' => 'Taxonomy term ids to filter by.',
+            'optional' => TRUE,
+            'type' => 'string',
+            'source' => array('param' => 'term_ids'),
+            'default value' => NULL,
           ),
         ),
       ),
@@ -153,36 +167,19 @@ function _campaign_resource_access($op = 'view', $args = array()) {
 /**
  * Callback for Campaigns index.
  */
-function _campaign_resource_index($parameters) {
-  // Initialize output.
-  $index = array();
-
-  // Get the results of the explore_campaigns view.
-  $view = views_get_view('explore_campaigns');
-  $view->execute();
-
-  $filter_staff_pick = FALSE;
-  if (isset($parameters['is_staff_pick']) && $parameters['is_staff_pick']) {
-    $filter_staff_pick = TRUE;
+function _campaign_resource_index($is_staff_pick = NULL, $on_mobile_app = NULL, $term_ids = NULL) {
+  $params = array();
+  if (isset($is_staff_pick)) {
+    $params['is_staff_pick'] = (int) $is_staff_pick;
   }
-
-  foreach ($view->result as $result) {
-    $campaign = new StdClass();
-    $campaign->title = $result->label;
-    $campaign->nid = $result->entity_id;
-    $campaign->is_staff_pick = $result->bm_field_staff_pick[0];
-    // If not filtering by staff pick:
-    if (!$filter_staff_pick) {
-      // Add this campaign to the result.
-      $index[] = $campaign;
-    }
-    // Else check if it's a staff pick:
-    if ($campaign->is_staff_pick) {
-      $index[] = $campaign;
-    }
+  if (isset($on_mobile_app)) {
+    $params['on_mobile_app'] = (int) $on_mobile_app;
   }
-
-  return $index;
+  if (isset($term_ids)) {
+    $term_ids = implode(',', $term_ids);
+    $params['term_ids'] = $term_ids;
+  }
+  return dosomething_campaign_get_campaigns_query_result($params);
 }
 
 /**
@@ -207,7 +204,7 @@ function _campaign_resource_signup($nid, $values) {
     watchdog('dosomething_api', '_campaign_resource_signup values:' . json_encode($values));
   }
   // @todo: Pass parameter into signup_create whether or not to send SMS.
-  // Since SMS campaign signups would hit this endpoint, would not want 
+  // Since SMS campaign signups would hit this endpoint, would not want
   // to send an additional "You've signed up text".
   return dosomething_signup_create($nid, $values['uid'], $values['source']);
 }

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -176,7 +176,7 @@ function _campaign_resource_index($is_staff_pick = NULL, $on_mobile_app = NULL, 
     $params['on_mobile_app'] = (int) $on_mobile_app;
   }
   if (isset($term_ids)) {
-    $term_ids = implode(',', $term_ids);
+    $term_ids = explode(',', $term_ids);
     $params['term_ids'] = $term_ids;
   }
   return dosomething_campaign_get_campaigns_query_result($params);

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -14,14 +14,14 @@ function _campaign_resource_definition() {
           array(
             'name' => 'is_staff_pick',
             'optional' => TRUE,
-            'type' => 'int',
+            'type' => 'boolean',
             'source' => array('param' => 'is_staff_pick'),
             'default value' => NULL,
           ),
           array(
             'name' => 'on_mobile_app',
             'optional' => TRUE,
-            'type' => 'int',
+            'type' => 'boolean',
             'source' => array('param' => 'on_mobile_app'),
             'default value' => NULL,
           ),
@@ -170,10 +170,10 @@ function _campaign_resource_access($op = 'view', $args = array()) {
 function _campaign_resource_index($is_staff_pick = NULL, $on_mobile_app = NULL, $term_ids = NULL) {
   $params = array();
   if (isset($is_staff_pick)) {
-    $params['is_staff_pick'] = (int) $is_staff_pick;
+    $params['is_staff_pick'] = (bool) $is_staff_pick;
   }
   if (isset($on_mobile_app)) {
-    $params['on_mobile_app'] = (int) $on_mobile_app;
+    $params['on_mobile_app'] = (bool) $on_mobile_app;
   }
   if (isset($term_ids)) {
     $term_ids = explode(',', $term_ids);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -363,15 +363,31 @@ function dosomething_campaign_reportback_confirmation_page_access($node) {
 /**
  * Returns array of published campaign nid and titles by campaign type $type.
  */
-function dosomething_campaign_get_campaigns($type = 'campaign') {
+function dosomething_campaign_get_campaigns() {
+  $query = dosomething_campaign_get_campaigns_query();
+  return $query->execute()->fetchAll();
+}
+
+/**
+ * Returns a SelectQuery object of published standard Campaigns with given $params.
+ *
+ * @param array $params
+ *   An associative array of conditions to filter by. Possible keys:
+ *   - is_staff_pick: (int)
+ *   - on_mobile_app: (int)
+ *   - term: (string) Term tid(s) to filter by.
+ *
+ * @return SelectQuery object
+ */
+function dosomething_campaign_get_campaigns_query($params = array()) {
   $query = db_select('node', 'n');
   $query->join('field_data_field_campaign_type', 't', 't.entity_id = n.nid');
   $query->condition('status', 1);
-  $query->condition('t.field_campaign_type_value', $type);
+  $query->condition('t.field_campaign_type_value', 'campaign');
   $query->condition('type', 'campaign');
   $query->fields('n', array('nid', 'title'));
   $query->orderBy('title');
-  return $query->execute()->fetchAll();
+  return $query;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -385,6 +385,10 @@ function dosomething_campaign_get_campaigns_query($params = array()) {
   $query->condition('status', 1);
   $query->condition('t.field_campaign_type_value', 'campaign');
   $query->condition('type', 'campaign');
+  if (isset($params['is_staff_pick'])) {
+    $query->join('field_data_field_staff_pick', 'sp', 'sp.entity_id = n.nid');
+    $query->condition('sp.field_staff_pick_value', (int) $params['is_staff_pick']);
+  }
   if (isset($params['term_id'])) {
     $query->join('taxonomy_index', 'terms', 'terms.nid = n.nid');
     $query->condition('terms.tid', $params['term_id']);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -375,7 +375,7 @@ function dosomething_campaign_get_campaigns() {
  *   An associative array of conditions to filter by. Possible keys:
  *   - is_staff_pick: (int)
  *   - on_mobile_app: (int)
- *   - term: (string) Term tid(s) to filter by.
+ *   - term_id: (string) Term tid(s) to filter by.
  *
  * @return SelectQuery object
  */
@@ -385,6 +385,10 @@ function dosomething_campaign_get_campaigns_query($params = array()) {
   $query->condition('status', 1);
   $query->condition('t.field_campaign_type_value', 'campaign');
   $query->condition('type', 'campaign');
+  if (isset($params['term_id'])) {
+    $query->join('taxonomy_index', 'terms', 'terms.nid = n.nid');
+    $query->condition('terms.tid', $params['term_id']);
+  }
   $query->fields('n', array('nid', 'title'));
   $query->orderBy('title');
   return $query;

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -363,8 +363,8 @@ function dosomething_campaign_reportback_confirmation_page_access($node) {
 /**
  * Returns array of published campaign nid and titles by campaign type $type.
  */
-function dosomething_campaign_get_campaigns() {
-  $query = dosomething_campaign_get_campaigns_query();
+function dosomething_campaign_get_campaigns_query_result($params = array()) {
+  $query = dosomething_campaign_get_campaigns_query($params);
   return $query->execute()->fetchAll();
 }
 
@@ -388,6 +388,10 @@ function dosomething_campaign_get_campaigns_query($params = array()) {
   if (isset($params['is_staff_pick'])) {
     $query->join('field_data_field_staff_pick', 'sp', 'sp.entity_id = n.nid');
     $query->condition('sp.field_staff_pick_value', (int) $params['is_staff_pick']);
+  }
+  if (isset($params['on_mobile_app'])) {
+    $query->join('field_data_field_on_mobile_app', 'm', 'm.entity_id = n.nid');
+    $query->condition('m.field_on_mobile_app_value', (int) $params['on_mobile_app']);
   }
   if (isset($params['term_id'])) {
     $query->join('taxonomy_index', 'terms', 'terms.nid = n.nid');

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -375,7 +375,7 @@ function dosomething_campaign_get_campaigns_query_result($params = array()) {
  *   An associative array of conditions to filter by. Possible keys:
  *   - is_staff_pick: (int)
  *   - on_mobile_app: (int)
- *   - term_id: (string) Term tid(s) to filter by.
+ *   - term_ids: (array) Taxonomy term tids to filter by.
  *
  * @return SelectQuery object
  */
@@ -393,9 +393,9 @@ function dosomething_campaign_get_campaigns_query($params = array()) {
     $query->join('field_data_field_on_mobile_app', 'm', 'm.entity_id = n.nid');
     $query->condition('m.field_on_mobile_app_value', (int) $params['on_mobile_app']);
   }
-  if (isset($params['term_id'])) {
+  if (isset($params['term_ids']) && is_array($params['term_ids'])) {
     $query->join('taxonomy_index', 'terms', 'terms.nid = n.nid');
-    $query->condition('terms.tid', $params['term_id']);
+    $query->condition('terms.tid', $params['term_ids'], 'IN');
   }
   $query->fields('n', array('nid', 'title'));
   $query->orderBy('title');

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -301,7 +301,7 @@ function dosomething_reportback_count_page() {
   $tables = array();
   $tables['node']['title'] = t("Campaigns");
   $tables['node']['url'] = 'node/';
-  $tables['node']['results'] = dosomething_campaign_get_campaigns();
+  $tables['node']['results'] = dosomething_campaign_get_campaigns_query_result();
 
   $tables['taxonomy_term']['title'] = t("Cause");
   $tables['taxonomy_term']['url'] = 'taxonomy/term/';


### PR DESCRIPTION
Refactors existing `dosomething_campaign_get_campaigns` method to `dosomething_campaign_get_campaigns_query_result($params)`, similar to the `dosomething_reportbck_get_reportbacks_query_result`.

Possible `$params` keys:
- `is_staff_pick` (int)
- `on_mobile_app` (int)
- `term_ids`: array of term id's.  Can be any field, queries the `taxonomy_index` table to lookup whether the nid is associated with the given term.

Updates existing GET `/campaigns` endpoint accordingly:

```
http://dev.dosomething.org:8888/api/v1/campaigns.json?is_staff_pick=1
http://dev.dosomething.org:8888/api/v1/campaigns.json?on_mobile_app=1
http://dev.dosomething.org:8888/api/v1/campaigns.json?term_ids=4,5
```

Closes #4110

cc @deadlybutter this will break the lobby dashboard query once pushed to prod... 
