### PR TITLE
Fixes dosomething_reportback dependencies.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -4,7 +4,6 @@ package = DoSomething
 dependencies[] = ctools
 dependencies[] = services
 dependencies[] = dosomething_image
-dependencies[] = dosomething_reportback
 features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
@@ -3,6 +3,7 @@ description = Provides Reportback entity and functionality.
 core = 7.x
 package = DoSomething
 version = 7.x-1.0
+dependencies[] = dosomething_api
 dependencies[] = dosomething_helpers
 dependencies[] = dosomething_static_content
 dependencies[] = features


### PR DESCRIPTION
Fixes an error during `build --install`:

> `Error: Class 'Transformer' not found in /var/www/dev.dosomething.org/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php, line 6`
