### PR TITLE
Updates cron script to run script from the correct directory

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/dosomething_campaign_problem_shares.cron.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/dosomething_campaign_problem_shares.cron.inc
@@ -27,7 +27,8 @@ function dosomething_campaign_problem_shares_cron() {
     $nid = escapeshellarg($result->nid);
     $problem = escapeshellarg($problem);
     // Call shell script to create the image.
-    shell_exec("/bin/bash /var/www/dev.dosomething.org/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/create-images.sh $nid $problem");
+    $module_path = shell_exec("/usr/bin/find /var/www -type d -name dosomething_campaign_problem_shares");
+    shell_exec("cd $module_path /bin/bash create-images.sh $nid $problem");
   }
 
 }


### PR DESCRIPTION
Made an update to the cron job to run the image magic script from the correct directory. We were hardcoding the path to the script before so it couldn't be run in different environments. Fixes #4504 
