### PR TITLE
Fix for small bug.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -234,7 +234,7 @@ abstract class Transformer {
    */
   protected function transformCampaign($data) {
     $output = array(
-      'id' => $data->id,
+      'id' => $data->id ?: $data->nid,
       'title' => $data->title,
     );
 


### PR DESCRIPTION
Really quick fix for retrieving the id, since `Reportbacks` & `ReportbackItem` classes not updated with new approach, and returning `null` for campaign `id`.

@aaronschachter 
