### PR TITLE
Fix tip appearance on mobile.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -294,11 +294,17 @@
 
               <div data-modal id="modal-tips-<?php print $key; ?>" class="modal--tips" role="dialog">
                 <h2 class="heading -banner">Tips</h2>
-                <?php foreach ($content['tips'] as $delta => $tip): ?>
-                  <h4 class="inline-sponsor-color"><?php print $tip['header']; ?></h4>
-                  <?php print $tip['copy']; ?>
-                <?php endforeach; ?>
-                <a href="#" class="js-close-modal"><?php print t('Back to main page'); ?></a>
+                <div class="modal__block">
+                  <?php foreach ($content['tips'] as $delta => $tip): ?>
+                    <h4 class="inline-sponsor-color"><?php print $tip['header']; ?></h4>
+                    <?php print $tip['copy']; ?>
+                  <?php endforeach; ?>
+                </div>
+                <div class="modal__block">
+                  <div class="form-actions">
+                    <a href="#" class="js-close-modal"><?php print t('Back to main page'); ?></a>
+                  </div>
+                </div>
               </div>
             <?php endif; ?>
           </div>


### PR DESCRIPTION
# Changes
- Fixes #4517. The modal being used for the "tabs" pattern fallback didn't have updated Neue 6 markup, so things looked all wonky and meh. They look better now.

For review: @DoSomething/front-end 
