### PR TITLE
Allow admins to rotate reportback images

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -103,6 +103,14 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
     'impact' => t('High impact')
   );
 
+  // Provide options to update the rotation of the image.
+  $rotate_options = array(
+    '90' => 90,
+    '180' => 180,
+    '270' => 270,
+    '360' => 360,
+  );
+
   $params = array(
     'status' => $status,
   );
@@ -196,6 +204,11 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
         '#type' => 'checkbox',
         '#title' => t("Delete this image"),
       ),
+      // Provide an option to rotate the image.
+      'rotate' => array(
+        '#type' => 'radios',
+        '#options' => $rotate_options,
+      )
     );
   }
   $form['actions'] = array('#type' => 'actions');
@@ -231,6 +244,16 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
     $save = $rbf->review($values);
     if (!$save) {
       form_set_error(t("An error has occurred."));
+    }
+
+    // Rotate the original image if a rotation option was selected.
+    if ($values['rotate']) {
+      $file = file_load($fid);
+      $image = image_load($file->uri);
+      image_rotate($image, $values['rotate'], 0xffffff);
+      image_save($image);
+      // Flush the image style cache for this image.
+      image_path_flush($image->source);
     }
   }
 
@@ -291,6 +314,7 @@ function theme_dosomething_reportback_files_form($variables) {
         drupal_render($form['rb_files'][$fid]['quantity']),
         drupal_render($form['rb_files'][$fid]['node']),
         drupal_render($form['rb_files'][$fid]['status']) . '<div class="flag-form"><hr />' . $flag_form . '</div>' .  drupal_render($form['rb_files'][$fid]['status']) . '<div class="promote-form"><hr />' . $promote_form . '</div>',
+        drupal_render($form['rb_files'][$fid]['rotate']),
 
       ),
     );
@@ -301,6 +325,7 @@ function theme_dosomething_reportback_files_form($variables) {
     t('Quantity'),
     t('Campaign'),
     t('Op'),
+    t('Rotate (CW)'),
   );
 
   $output = '';

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -207,6 +207,7 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
       // Provide an option to rotate the image.
       'rotate' => array(
         '#type' => 'radios',
+        '#title' => t('Rotate (CW)'),
         '#options' => $rotate_options,
       )
     );
@@ -246,13 +247,17 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
       form_set_error(t("An error has occurred."));
     }
 
-    // Rotate the original image if a rotation option was selected.
+    // Rotate the original image, if a rotation option was selected.
     if ($values['rotate']) {
+      // Load the file.
       $file = file_load($fid);
+      // Create an image object.
       $image = image_load($file->uri);
+      // Rotate the image.
       image_rotate($image, $values['rotate'], 0xffffff);
+      // Save.
       image_save($image);
-      // Flush the image style cache for this image.
+      // Flush the image style cache for this image so they update with the new image.
       image_path_flush($image->source);
     }
   }


### PR DESCRIPTION
## Fixes #4512

Adds a `Rotate` column to the reportback admin page that allows an admin to select a rotation amount. Then rotates the image by that amount using `image_rotate()` in the submit callback. 

@aaronschachter cc @angaither 
