### PR TITLE
Quick update to property name.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -382,7 +382,7 @@ abstract class Transformer {
     if ($data->items) {
       $items = $this->getReportbackItems($data->items);
 
-      $output['items'] = array(
+      $output['reportback_items'] = array(
         'total' => count($items),
         'data' => $this->transformCollection($items, 'transformReportbackItem'),
       );


### PR DESCRIPTION
### Fixes #4561

This fix will help give more context when `reportback-items` object is nested in other objects other than the `reportbacks`... for example, when they are nested in a `kudos` response object. See associated issue for code example.

@aaronschachter 

CC: @jonuy @angaither @DFurnes @chloealee 

PS> Will update the wiki shortly!
