### PR TITLE
Fix image_rotate compatibility issue with php 5.5

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -399,7 +399,7 @@ function dosomething_reportback_form_save_file(&$form_state) {
 function dosomething_reportback_image_edit($image, $x, $y, $width, $height, $rotate = NULL) {
   // Rotate the image and then crop it if rotation was successful.
   if ($rotate) {
-    image_rotate($image, $rotate);
+    $rotate_worked = image_rotate($image, $rotate, 0xffffff);
   }
 
   $result = image_crop($image, $x, $y, $width, $height);


### PR DESCRIPTION
## Fixes #4577

I was seeing some issues around `imagecolortransparent()` after rotating and image and saving my reportback. There are some [compatibility issues with the GD image library and PHP 5.5](https://www.drupal.org/node/2215369). By explicitly telling Drupal to use a white background color to recreate the image, we get around any of the transparency issues that are throwing errors in 5.5. 
