### PR TITLE
Notes on how to tackle collection kudos for each reportback item.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1038,6 +1038,18 @@ function dosomething_reportback_get_reportback_files_query($params = array()) {
   $query->join('node', 'n', 'rb.nid = n.nid');
   $query->join('file_managed', 'f', 'rbf.fid = f.fid');
 
+  // @NOTE: So the below join will correctly grab Kudos id for a reportback item if there is one
+  // otherwise it's null or something.
+  // Only issue is that it should ideally grab all kudos ids for a given reportback item.
+  $query->leftJoin('dosomething_kudos', 'k', 'k.fid = rbf.fid');
+
+  // @NOTE: One potential solution could be doing a Group Concat type thing, but need to figure out how
+  // to do it for each reportback item instead of what I see it doing now, and grabbing all and
+  // popping them into a single item... so maybe Group Concat won't work but something to try
+  // along these lines.
+  //
+  // $query->addExpression('GROUP_CONCAT(DISTINCT k.kid)', 'stuff');
+
   if (isset($params['tid'])) {
     $query->join('field_data_field_primary_cause', 't', 't.entity_id = n.nid');
     $query->condition('t.field_primary_cause_tid', $params['tid']);
@@ -1085,6 +1097,8 @@ function dosomething_reportback_get_reportback_files_query($params = array()) {
   $query->fields('rb', $rb_fields);
   $query->fields('n', array('nid', 'title'));
   $query->fields('f', array('timestamp'));
+  // Will be empty/false/null? if no kudos on reportback item
+  $query->fields('k', array('kid'));
 
   if (isset($params['random'])) {
     $query->orderRandom();
@@ -1116,7 +1130,7 @@ function dosomething_reportback_get_reportback_files_query_result($params = arra
   if ($count && $count !== 'all') {
     $query->range($start, $count);
   }
-  $result = $query->execute();
+  $result = $query->execute()->fetchAll();
   return $result;
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1097,7 +1097,7 @@ function dosomething_reportback_get_reportback_files_query($params = array()) {
   $query->fields('rb', $rb_fields);
   $query->fields('n', array('nid', 'title'));
   $query->fields('f', array('timestamp'));
-  // Will be empty/false/null? if no kudos on reportback item
+  // @NOTE: Will be empty/false/null? if no kudos on reportback item.
   $query->fields('k', array('kid'));
 
   if (isset($params['random'])) {
@@ -1130,7 +1130,7 @@ function dosomething_reportback_get_reportback_files_query_result($params = arra
   if ($count && $count !== 'all') {
     $query->range($start, $count);
   }
-  $result = $query->execute()->fetchAll();
+  $result = $query->execute();
   return $result;
 }
 


### PR DESCRIPTION
## Notes on progress for collecting Kudos for each Reportback Item

So I feel there's 2 potential solutions for this:
1. One solution would probably be gathering the collections of Kudos ids for each reportback when the initial DB query is called to collect all reportback items; collect them into a single CSV. Then in the transformer, when transforming each RB item. If desired you could iterate through each RB item during the transforming and collect further info iterating through the collection of Kudos ids (after exploding the CSV).
2. Alternatively, ignore grabbing the Kudos from the DB on initial query. Instead, in the transforming step for a RB item, you'll have the ID for the RB item when iterating through and transforming each RB item, so maybe in that step go run a function to go and query the DB for Kudos IDs for that RB item id. You could potentially add the Kudos module as a dependency, and harness the `dosomething_kudos_get_kudos_query()` function to build out and execute the query (Note, that the passing of a reportback item id is possible, the params are there, but the `dosomething_kudos_build_kudos_query()` function doesn't take it into account currently. There's a TODO for that; but this solution would require that working.

In code below, you can see that I started on the path of approach #1, but I'm thinking approach #2 would be better since you always have an ID for the RB item when running `transformReportbackItem()` from the `Transformer.php` class (found in **dosomething_api module**). So in any scenario where you have RB items and the API, they go through the `transformReportbackItem()` method and thus would always have an opportunity to grab and spit out the Kudos data in it.

Hope this helps!

@jonuy 
