### PR TITLE
Passing the -l param to drush to fix cron

### DIFF
--- a/bin/drush-intl
+++ b/bin/drush-intl
@@ -23,7 +23,7 @@ WEB_PATH=$BASE_PATH/$WEB_DIR
 for SITE in botswana canada ghana kenya indonesia nigeria training uk
 do
   echo -e "\e[38;5;071mRunning drush on \e[4m$SITE\e[24m...\e[0m"
-  cd "$WEB_PATH/sites/$SITE" && drush "$@"
+  cd "$WEB_PATH/sites/$SITE" && drush "-l http://$SITE.dosomething.org $@"
 done
 
 # ==============================================================================

--- a/bin/drush-intl
+++ b/bin/drush-intl
@@ -23,7 +23,7 @@ WEB_PATH=$BASE_PATH/$WEB_DIR
 for SITE in botswana canada ghana kenya indonesia nigeria training uk
 do
   echo -e "\e[38;5;071mRunning drush on \e[4m$SITE\e[24m...\e[0m"
-  cd "$WEB_PATH/sites/$SITE" && drush "-l http://$SITE.dosomething.org $@"
+  cd "$WEB_PATH/sites/$SITE" && drush "-l https://$SITE.dosomething.org $@"
 done
 
 # ==============================================================================


### PR DESCRIPTION
In order for links and image paths to be correctly indexed by search, drush needs the -l or --uri params. 
