### PR TITLE
Campaign api update

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -232,102 +232,115 @@ abstract class Transformer {
    *
    * @return array
    */
-  protected function transformCampaign($data, $display = 'teaser') {
+  protected function transformCampaign($data) {
     $output = array(
       'id' => isset($data->id) ? $data->id : $data->nid,
       'title' => $data->title,
     );
 
+
     if ($data instanceof Campaign) {
-      if ($display === 'full') {
 
+      if (isset($data->tagline)) {
         $output['tagline'] = $data->tagline;
+      }
+
+      if (isset($data->created_at)) {
         $output['created_at'] = $data->created_at;
+      }
+
+      if (isset($data->updated_at)) {
         $output['updated_at'] = $data->updated_at;
+      }
+
+      if (isset($data->time_commitment)) {
         $output['time_commitment'] = $data->time_commitment;
-        // $output['type'] = $data->type; //@TODO: Should type be included? Consider there is an SMS Campaign type...
+      }
 
-        if ($data->status) {
-          // @TODO: Should the status default to "active"?
-          $output['status'] = $data->status;
-        }
+      // $output['type'] = $data->type; //@TODO: Should type be included? Consider there is an SMS Campaign type...
 
-        if ($data->cover_image) {
-          foreach ($data->cover_image as $key => $image) {
-            if (!is_null($image)) {
-              $output['cover_image'][$key] = $this->transformMedia($image, 'square');
-            }
+      if (isset($data->status)) {
+        // @TODO: Should the status default to "active"?
+        $output['status'] = $data->status;
+      }
+
+      if (isset($data->cover_image)) {
+        foreach ($data->cover_image as $key => $image) {
+          if (!is_null($image)) {
+            $output['cover_image'][$key] = $this->transformMedia($image, 'square');
           }
-        }
-
-        $output['staff_pick'] = $data->staff_pick;
-
-        if ($data->facts['problem']) {
-          $output['facts']['problem'] = $data->facts['problem']['fact'];
-        }
-
-        if ($data->facts['solution']) {
-          $output['facts']['solution'] = $data->facts['solution']['fact'];
-        }
-
-        if ($data->facts['sources']) {
-          $output['facts']['sources'] = $data->facts['sources'];
-        }
-
-        if ($data->solutions['copy']) {
-          $output['solutions']['copy'] = $data->solutions['copy'];
-        }
-
-        if ($data->solutions['support_copy']) {
-          $output['solutions']['support_copy'] = $data->solutions['support_copy'];
-        }
-
-        if ($data->causes['primary']) {
-          $output['causes']['primary'] = $data->causes['primary'];
-        }
-
-        if ($data->causes['secondary']) {
-          $output['causes']['secondary'] = $data->causes['secondary'];
-        }
-
-        if ($data->action_types['primary']) {
-          $output['action_types']['primary'] = $data->action_types['primary'];
-        }
-
-        if ($data->action_types['secondary']) {
-          $output['action_types']['secondary'] = $data->action_types['secondary'];
-        }
-
-        if ($data->issue) {
-          $output['issue'] = $data->issue;
-        }
-
-        if ($data->tags) {
-          $output['tags'] = $data->tags;
-        }
-
-        if ($data->timing['high_season']) {
-          $output['timing']['high_season'] = $data->timing['high_season'];
-        }
-
-        if ($data->timing['low_season']) {
-          $output['timing']['low_season'] = $data->timing['low_season'];
         }
       }
 
-      if ($data->reportback_info['copy']) {
+      if (isset($data->staff_pick)) {
+        $output['staff_pick'] = $data->staff_pick;
+      }
+
+      if (isset($data->facts['problem'])) {
+        $output['facts']['problem'] = $data->facts['problem']['fact'];
+      }
+
+      if (isset($data->facts['solution'])) {
+        $output['facts']['solution'] = $data->facts['solution']['fact'];
+      }
+
+      if (isset($data->facts['sources'])) {
+        $output['facts']['sources'] = $data->facts['sources'];
+      }
+
+      if (isset($data->solutions['copy'])) {
+        $output['solutions']['copy'] = $data->solutions['copy'];
+      }
+
+      if (isset($data->solutions['support_copy'])) {
+        $output['solutions']['support_copy'] = $data->solutions['support_copy'];
+      }
+
+      if (isset($data->causes['primary'])) {
+        $output['causes']['primary'] = $data->causes['primary'];
+      }
+
+      if (isset($data->causes['secondary'])) {
+        $output['causes']['secondary'] = $data->causes['secondary'];
+      }
+
+      if (isset($data->action_types['primary'])) {
+        $output['action_types']['primary'] = $data->action_types['primary'];
+      }
+
+      if (isset($data->action_types['secondary'])) {
+        $output['action_types']['secondary'] = $data->action_types['secondary'];
+      }
+
+      if (isset($data->issue)) {
+        $output['issue'] = $data->issue;
+      }
+
+      if (isset($data->tags)) {
+        $output['tags'] = $data->tags;
+      }
+
+      if (isset($data->timing['high_season'])) {
+        $output['timing']['high_season'] = $data->timing['high_season'];
+      }
+
+      if (isset($data->timing['low_season'])) {
+        $output['timing']['low_season'] = $data->timing['low_season'];
+      }
+
+      if (isset($data->reportback_info['copy'])) {
         $output['reportback_info']['copy'] = $data->reportback_info['copy'];
       }
 
-      if ($data->reportback_info['confirmation_message']) {
+      if (isset($data->reportback_info['confirmation_message'])) {
         $output['reportback_info']['confirmation_message'] = $data->reportback_info['confirmation_message'];
       }
 
-      if ($data->reportback_info['noun']) {
+      if (isset($data->reportback_info['noun'])) {
         $output['reportback_info']['noun'] = $data->reportback_info['noun'];
       }
 
-      if ($data->reportback_info['verb']) {
+      if (isset($data->reportback_info['verb'])) {
         $output['reportback_info']['verb'] = $data->reportback_info['verb'];
       }
 
@@ -406,7 +419,7 @@ abstract class Transformer {
     }
 
     // Reportback Child Item data
-    if ($data->items) {
+    if (isset($data->items)) {
       $items = $this->getReportbackItems($data->items);
 
       $output['reportback_items'] = array(

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -238,7 +238,8 @@ abstract class Transformer {
       'title' => $data->title,
     );
 
-
+    // If an instance of Campaign class, then there is much
+    // more information that can be obtained.
     if ($data instanceof Campaign) {
 
       if (isset($data->tagline)) {

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -232,76 +232,103 @@ abstract class Transformer {
    *
    * @return array
    */
-  protected function transformCampaign($data) {
+  protected function transformCampaign($data, $display = 'teaser') {
     $output = array(
       'id' => isset($data->id) ? $data->id : $data->nid,
       'title' => $data->title,
     );
 
     if ($data instanceof Campaign) {
-      $output['tagline'] = $data->tagline;
-      $output['created_at'] = $data->created_at;
-      $output['updated_at'] = $data->updated_at;
-      $output['time_commitment'] = $data->time_commitment;
-      // $output['type'] = $data->type; //@TODO: Should type be included? Consider there is an SMS Campaign type...
+      if ($display === 'full') {
 
-      if ($data->status) {
-        // @TODO: Should the status default to "active"?
-        $output['status'] = $data->status;
-      }
+        $output['tagline'] = $data->tagline;
+        $output['created_at'] = $data->created_at;
+        $output['updated_at'] = $data->updated_at;
+        $output['time_commitment'] = $data->time_commitment;
+        // $output['type'] = $data->type; //@TODO: Should type be included? Consider there is an SMS Campaign type...
 
-      if ($data->cover_image) {
-        foreach ($data->cover_image as $key => $image) {
-          if (!is_null($image)) {
-            $output['cover_image'][$key] = $this->transformMedia($image, 'square');
+        if ($data->status) {
+          // @TODO: Should the status default to "active"?
+          $output['status'] = $data->status;
+        }
+
+        if ($data->cover_image) {
+          foreach ($data->cover_image as $key => $image) {
+            if (!is_null($image)) {
+              $output['cover_image'][$key] = $this->transformMedia($image, 'square');
+            }
           }
+        }
+
+        $output['staff_pick'] = $data->staff_pick;
+
+        if ($data->facts['problem']) {
+          $output['facts']['problem'] = $data->facts['problem']['fact'];
+        }
+
+        if ($data->facts['solution']) {
+          $output['facts']['solution'] = $data->facts['solution']['fact'];
+        }
+
+        if ($data->facts['sources']) {
+          $output['facts']['sources'] = $data->facts['sources'];
+        }
+
+        if ($data->solutions['copy']) {
+          $output['solutions']['copy'] = $data->solutions['copy'];
+        }
+
+        if ($data->solutions['support_copy']) {
+          $output['solutions']['support_copy'] = $data->solutions['support_copy'];
+        }
+
+        if ($data->causes['primary']) {
+          $output['causes']['primary'] = $data->causes['primary'];
+        }
+
+        if ($data->causes['secondary']) {
+          $output['causes']['secondary'] = $data->causes['secondary'];
+        }
+
+        if ($data->action_types['primary']) {
+          $output['action_types']['primary'] = $data->action_types['primary'];
+        }
+
+        if ($data->action_types['secondary']) {
+          $output['action_types']['secondary'] = $data->action_types['secondary'];
+        }
+
+        if ($data->issue) {
+          $output['issue'] = $data->issue;
+        }
+
+        if ($data->tags) {
+          $output['tags'] = $data->tags;
+        }
+
+        if ($data->timing['high_season']) {
+          $output['timing']['high_season'] = $data->timing['high_season'];
+        }
+
+        if ($data->timing['low_season']) {
+          $output['timing']['low_season'] = $data->timing['low_season'];
         }
       }
 
-      $output['staff_pick'] = $data->staff_pick;
-
-      if ($data->facts['problem']) {
-        $output['facts']['problem'] = $data->facts['problem']['fact'];
+      if ($data->reportback_info['copy']) {
+        $output['reportback_info']['copy'] = $data->reportback_info['copy'];
       }
 
-      if ($data->facts['solution']) {
-        $output['facts']['solution'] = $data->facts['solution']['fact'];
+      if ($data->reportback_info['confirmation_message']) {
+        $output['reportback_info']['confirmation_message'] = $data->reportback_info['confirmation_message'];
       }
 
-      if ($data->facts['sources']) {
-        $output['facts']['sources'] = $data->facts['sources'];
+      if ($data->reportback_info['noun']) {
+        $output['reportback_info']['noun'] = $data->reportback_info['noun'];
       }
 
-      if ($data->solutions['copy']) {
-        $output['solutions']['copy'] = $data->solutions['copy'];
-      }
-
-      if ($data->solutions['support_copy']) {
-        $output['solutions']['support_copy'] = $data->solutions['support_copy'];
-      }
-
-      if ($data->causes['primary']) {
-        $output['causes']['primary'] = $data->causes['primary'];
-      }
-
-      if ($data->causes['secondary']) {
-        $output['causes']['secondary'] = $data->causes['secondary'];
-      }
-
-      if ($data->action_types['primary']) {
-        $output['action_types']['primary'] = $data->action_types['primary'];
-      }
-
-      if ($data->action_types['secondary']) {
-        $output['action_types']['secondary'] = $data->action_types['secondary'];
-      }
-
-      if ($data->issue) {
-        $output['issue'] = $data->issue;
-      }
-
-      if ($data->tags) {
-        $output['tags'] = $data->tags;
+      if ($data->reportback_info['verb']) {
+        $output['reportback_info']['verb'] = $data->reportback_info['verb'];
       }
 
     }

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -2,7 +2,7 @@
 
 class Campaign {
 
-  public $node;
+  protected $node;
   protected $variables;
   public $id;
 
@@ -35,48 +35,51 @@ class Campaign {
     if ($this->node && $this->node->type === 'campaign') {
       $this->variables = dosomething_helpers_get_variables('node', $this->id);
       $this->title = $this->node->title;
-      $this->tagline = $this->getTagline();
-      $this->created_at = $this->node->created;
-      $this->updated_at = $this->node->changed;
-      $this->status = $this->getStatus();
-      $this->type = $this->getType();
-      $this->time_commitment = $this->getTimeCommitment();
 
-      $this->cover_image = [
-        'default' => $this->getCoverImage(),
-        'alternate' => $this->getCoverImageAlt(),
-      ];
+      if ($display === 'full') {
+        $this->tagline = $this->getTagline();
+        $this->created_at = $this->node->created;
+        $this->updated_at = $this->node->changed;
+        $this->status = $this->getStatus();
+        $this->type = $this->getType();
+        $this->time_commitment = $this->getTimeCommitment();
 
-      $this->scholarship = $this->getScholarship();
-      $this->staff_pick = $this->getStaffPickStatus();
+        $this->cover_image = [
+          'default' => $this->getCoverImage(),
+          'alternate' => $this->getCoverImageAlt(),
+        ];
 
-      $fact_data = $this->getFactData();
-      $this->facts = [
-        'problem' => $fact_data['fact_problem'],
-        'solution' => $fact_data['fact_solution'],
-        'sources' => $fact_data['sources'],
-      ];
+        $this->scholarship = $this->getScholarship();
+        $this->staff_pick = $this->getStaffPickStatus();
 
-      $solution_data = $this->getSolutionData();
-      $this->solutions = $solution_data;
+        $fact_data = $this->getFactData();
+        $this->facts = [
+          'problem' => $fact_data['fact_problem'],
+          'solution' => $fact_data['fact_solution'],
+          'sources' => $fact_data['sources'],
+        ];
 
-      $cause_data = $this->getCauses();
-      $this->causes = [
-        'primary' => $cause_data['primary'],
-        'secondary' => $cause_data['secondary'],
-      ];
+        $solution_data = $this->getSolutionData();
+        $this->solutions = $solution_data;
 
-      $action_types_data = $this->getActionTypes();
-      $this->action_types = [
-        'primary' => $action_types_data['primary'],
-        'secondary' => $action_types_data['secondary'],
-      ];
+        $cause_data = $this->getCauses();
+        $this->causes = [
+          'primary' => $cause_data['primary'],
+          'secondary' => $cause_data['secondary'],
+        ];
 
-      $this->issue = $this->getIssue();
-      $this->tags = $this->getTags();
+        $action_types_data = $this->getActionTypes();
+        $this->action_types = [
+          'primary' => $action_types_data['primary'],
+          'secondary' => $action_types_data['secondary'],
+        ];
 
-      $timing = $this->getTiming();
-      $this->timing = $timing;
+        $this->issue = $this->getIssue();
+        $this->tags = $this->getTags();
+
+        $timing = $this->getTiming();
+        $this->timing = $timing;
+      }
 
       $reportback_info = $this->getReportbackInfo();
       $this->reportback_info = [

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -2,7 +2,7 @@
 
 class Campaign {
 
-  protected $node;
+  public $node;
   protected $variables;
   public $id;
 
@@ -70,6 +70,17 @@ class Campaign {
 
       $this->issue = $this->getIssue();
       $this->tags = $this->getTags();
+
+      $timing = $this->getTiming();
+      $this->timing = $timing;
+
+      $reportback_info = $this->getReportbackInfo();
+      $this->reportback_info = [
+        'copy' => $reportback_info['copy'],
+        'confirmation_message' => $reportback_info['confirmation_message'],
+        'noun' => $reportback_info['noun'],
+        'verb' => $reportback_info['verb'],
+      ];
     }
     else {
       throw new Exception('Campaign does not exist!');
@@ -267,6 +278,43 @@ class Campaign {
 
 
   /**
+   * Get Reportback content info used in the campaign.
+   *
+   * @ return array
+   */
+  protected function getReportbackInfo() {
+    $data = [];
+    $data['copy'] = NULL;
+    $data['confirmation_message'] = NULL;
+    $data['noun'] = NULL;
+    $data['verb'] = NULL;
+
+    $copy = dosomething_helpers_extract_field_data($this->node->field_reportback_copy);
+    $confirmation_message = dosomething_helpers_extract_field_data($this->node->field_reportback_confirm_msg);
+    $noun = dosomething_helpers_extract_field_data($this->node->field_reportback_noun);
+    $verb = dosomething_helpers_extract_field_data($this->node->field_reportback_verb);
+
+    if ($copy) {
+      $data['copy'] = $copy;
+    }
+
+    if ($confirmation_message) {
+      $data['confirmation_message'] = $confirmation_message;
+    }
+
+    if ($noun) {
+      $data['noun'] = $noun;
+    }
+
+    if ($verb) {
+      $data['verb'] = $verb;
+    }
+
+    return $data;
+  }
+
+
+  /**
    * Get Tags assigned to campaign if available.
    *
    * @return array|null
@@ -324,6 +372,32 @@ class Campaign {
   protected function getTimeCommitment() {
     // @TODO: I've renamed "active_hours" to "time_commitment" because it sounds more straightforward; but appreciate feedback.
     return (float) dosomething_helpers_extract_field_data($this->node->field_active_hours);
+  }
+
+
+  /**
+   * Get the timing for high and low seasons for campaign if available.
+   * Dates formatted as ISO-8601 datetime.
+   *
+   * @return array
+   */
+  protected function getTiming() {
+    $timezone = new DateTimeZone('UTC');
+
+    $timing = [];
+    $timing['high_season'] = dosomething_helpers_extract_field_data($this->node->field_high_season);
+    $timing['low_season'] = dosomething_helpers_extract_field_data($this->node->field_low_season);
+
+    foreach ($timing as $season => $dates) {
+      if ($timing[$season]) {
+        foreach ($timing[$season] as $key => $date) {
+          $date = new DateTime($date, $timezone);
+          $timing[$season][$key] = $date->format(DateTime::ISO8601);
+        }
+      }
+    }
+
+    return $timing;
   }
 
 

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -9,12 +9,14 @@ class Campaign {
 
   /**
    * @param $id
+   * @param $display
+   *
    * @return static
    * @throws Exception
    */
-  public static function get($id) {
+  public static function get($id, $display = 'teaser') {
     $campaign = new static();
-    $campaign->load($id);
+    $campaign->load($id, $display);
 
     return $campaign;
   }
@@ -22,9 +24,11 @@ class Campaign {
 
   /**
    * @param $id
+   * @param $display
+   *
    * @throws Exception
    */
-  public function load($id) {
+  public function load($id, $display = 'teaser') {
     $this->id = $id;
     $this->node = node_load($id);
 
@@ -109,7 +113,7 @@ class Campaign {
     if ($secondary_action_type_ids) {
       $secondary_action_types = array();
 
-      foreach($secondary_action_type_ids as $tid) {
+      foreach((array) $secondary_action_type_ids as $tid) {
         $secondary_action_types[] = $this->getTaxonomyTerm($tid);
       }
 

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -62,17 +62,9 @@ class Campaign {
         $solution_data = $this->getSolutionData();
         $this->solutions = $solution_data;
 
-        $cause_data = $this->getCauses();
-        $this->causes = [
-          'primary' => $cause_data['primary'],
-          'secondary' => $cause_data['secondary'],
-        ];
+        $this->causes = $this->getCauses();
 
-        $action_types_data = $this->getActionTypes();
-        $this->action_types = [
-          'primary' => $action_types_data['primary'],
-          'secondary' => $action_types_data['secondary'],
-        ];
+        $this->action_types = $this->getActionTypes();
 
         $this->issue = $this->getIssue();
         $this->tags = $this->getTags();
@@ -81,13 +73,7 @@ class Campaign {
         $this->timing = $timing;
       }
 
-      $reportback_info = $this->getReportbackInfo();
-      $this->reportback_info = [
-        'copy' => $reportback_info['copy'],
-        'confirmation_message' => $reportback_info['confirmation_message'],
-        'noun' => $reportback_info['noun'],
-        'verb' => $reportback_info['verb'],
-      ];
+      $this->reportback_info = $this->getReportbackInfo();
     }
     else {
       throw new Exception('Campaign does not exist!');
@@ -254,8 +240,6 @@ class Campaign {
       foreach ($sources as $index => $source) {
         $data['sources'][$index]['formatted'] = $source;
       }
-
-
 
       return $data;
     }

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -37,7 +37,7 @@ class CampaignTransformer extends Transformer {
 
     $campaigns = [];
     foreach ($query as $item) {
-      $campaigns[] = Campaign::get($item->nid);
+      $campaigns[] = Campaign::get($item->nid, 'full');
     }
     $campaigns = services_resource_build_index_list($campaigns, 'campaigns', 'id');
     $total = dosomething_campaign_get_campaign_query_count($filters);
@@ -60,7 +60,7 @@ class CampaignTransformer extends Transformer {
     $params['nid'] = $id;
 
     try {
-      $campaign = Campaign::get($id);
+      $campaign = Campaign::get($id, 'full');
     }
     catch (Exception $error) {
       return array(
@@ -84,7 +84,7 @@ class CampaignTransformer extends Transformer {
   protected function transform($campaign) {
     $data = array();
 
-    $data += $this->transformCampaign($campaign, 'full');
+    $data += $this->transformCampaign($campaign);
 
     return $data;
   }

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -84,7 +84,7 @@ class CampaignTransformer extends Transformer {
   protected function transform($campaign) {
     $data = array();
 
-    $data += $this->transformCampaign($campaign);
+    $data += $this->transformCampaign($campaign, 'full');
 
     return $data;
   }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -89,7 +89,11 @@ function dosomething_helpers_extract_field_data($field, $language = LANGUAGE_NON
     foreach ($data as $item => $content) {
       $keys = array_keys($content);
 
-      if ($keys[0] === 'value') {
+      if (in_array('date_type', $keys)) {
+        // Date values, so need to extract using custom method.
+        $values[] = dosomething_helpers_extract_field_dates($content);
+      }
+      elseif ($keys[0] === 'value') {
         // Text value, so need to extract using custom method.
         $values[] = dosomething_helpers_extract_field_text($content);
       }
@@ -107,6 +111,21 @@ function dosomething_helpers_extract_field_data($field, $language = LANGUAGE_NON
   }
 
   return NULL;
+}
+
+
+function dosomething_helpers_extract_field_dates($data) {
+  $values = [];
+
+  if (isset($data['value'])) {
+    $values['start'] = $data['value'];
+  }
+
+  if (isset($data['value2'])) {
+    $values['end'] = $data['value2'];
+  }
+
+  return $values;
 }
 
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -80,7 +80,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
 
     $data['reportback'] = $this->transformReportback($item);
 
-    $data['campaign'] = $this->transformCampaign($item);
+    $data['campaign'] = $this->transformCampaign(Campaign::get($item->nid));
 
     $data['user'] = $this->transformUser($item);
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -102,7 +102,7 @@ class ReportbackTransformer extends Transformer {
 
     $data += $this->transformReportback($reportback);
 
-    $data['campaign'] = $this->transformCampaign($reportback);
+    $data['campaign'] = $this->transformCampaign(Campaign::get($reportback->nid));
 
     $data['user'] = $this->transformUser($reportback);
 


### PR DESCRIPTION
### Fixes #4554
### Fixes #4564

Also provides some clean up and fixes some warnings that were being reported in the \* Recent log messages\* in Drupal Admin.

The `timing` output includes both `high_season` and `low_season` if available and all are output as ISO-8601, which is the [recommended standard](http://apiux.com/2013/03/20/5-laws-api-dates-and-times/) for APIs.
This also provides a way to request either a _teaser_ or _full_ (more could be added) extent of data returned for the campaign object response. This helps keep the response trimmed down if all the campaign info is technically not needed. Could be fine-tuned further if needed.

@aaronschachter @sbsmith86 

CC: @jonuy @angaither @DFurnes 
