### PR TITLE
Fixes PHP Fatal error: Class 'Transformer' not found during ds install

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
@@ -5,6 +5,7 @@ package = DoSomething
 version = 7.x-1.0
 project = dosomething_campaign
 dependencies[] = date
+dependencies[] = dosomething_api
 dependencies[] = dosomething_helpers
 dependencies[] = dosomething_image
 dependencies[] = dosomething_signup

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -4,6 +4,8 @@
  * Code for the dosomething_campaign feature.
  */
 
+module_load_include('php', 'dosomething_api', 'includes/Transformer');
+
 include_once 'dosomething_campaign.features.inc';
 include_once 'dosomething_campaign.helpers.inc';
 include_once 'includes/Campaign.php';


### PR DESCRIPTION
The error caused by incorrect dependencies.
