### PR TITLE
Kudos response fix

### DIFF
--- a/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
@@ -28,6 +28,8 @@ class KudosTransformer extends Transformer {
       $kudos[] = Kudos::get($id);
     }
 
+//    die(print_r($kudos));
+
     return [
       'data' => $this->transformCollection($kudos),
     ];
@@ -129,13 +131,7 @@ class KudosTransformer extends Transformer {
    * @return array
    */
   protected function transform($kudos) {
-    $data = [];
-
-    $data['reportback_item'] = $kudos->reportback_item;
-
-    $data['user'] = $this->transformUser($kudos->user);
-
-    return $data;
+    return $kudos;
   }
 
 }

--- a/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
@@ -28,8 +28,6 @@ class KudosTransformer extends Transformer {
       $kudos[] = Kudos::get($id);
     }
 
-//    die(print_r($kudos));
-
     return [
       'data' => $this->transformCollection($kudos),
     ];

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1130,7 +1130,7 @@ function dosomething_reportback_get_reportback_files_query_result($params = arra
   if ($count && $count !== 'all') {
     $query->range($start, $count);
   }
-  $result = $query->execute();
+  $result = $query->execute()->fetchAll();
   return $result;
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1038,6 +1038,18 @@ function dosomething_reportback_get_reportback_files_query($params = array()) {
   $query->join('node', 'n', 'rb.nid = n.nid');
   $query->join('file_managed', 'f', 'rbf.fid = f.fid');
 
+  // @NOTE: So the below join will correctly grab Kudos id for a reportback item if there is one
+  // otherwise it's null or something.
+  // Only issue is that it should ideally grab all kudos ids for a given reportback item.
+  $query->leftJoin('dosomething_kudos', 'k', 'k.fid = rbf.fid');
+
+  // @NOTE: One potential solution could be doing a Group Concat type thing, but need to figure out how
+  // to do it for each reportback item instead of what I see it doing now, and grabbing all and
+  // popping them into a single item... so maybe Group Concat won't work but something to try
+  // along these lines.
+  //
+  // $query->addExpression('GROUP_CONCAT(DISTINCT k.kid)', 'stuff');
+
   if (isset($params['tid'])) {
     $query->join('field_data_field_primary_cause', 't', 't.entity_id = n.nid');
     $query->condition('t.field_primary_cause_tid', $params['tid']);
@@ -1085,6 +1097,8 @@ function dosomething_reportback_get_reportback_files_query($params = array()) {
   $query->fields('rb', $rb_fields);
   $query->fields('n', array('nid', 'title'));
   $query->fields('f', array('timestamp'));
+  // Will be empty/false/null? if no kudos on reportback item
+  $query->fields('k', array('kid'));
 
   if (isset($params['random'])) {
     $query->orderRandom();

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1097,7 +1097,7 @@ function dosomething_reportback_get_reportback_files_query($params = array()) {
   $query->fields('rb', $rb_fields);
   $query->fields('n', array('nid', 'title'));
   $query->fields('f', array('timestamp'));
-  // Will be empty/false/null? if no kudos on reportback item
+  // @NOTE: Will be empty/false/null? if no kudos on reportback item.
   $query->fields('k', array('kid'));
 
   if (isset($params['random'])) {
@@ -1130,7 +1130,7 @@ function dosomething_reportback_get_reportback_files_query_result($params = arra
   if ($count && $count !== 'all') {
     $query->range($start, $count);
   }
-  $result = $query->execute()->fetchAll();
+  $result = $query->execute();
   return $result;
 }
 


### PR DESCRIPTION
Fixes Kudos response object to represent the following:

```
data: {
  id: "1",
  term: {
    id: "9",
    name: "make something"
  },
  reportback_item: {
    id: "647"
  },
  user: {
    id: "12930"
  }
}
```
