### PR TITLE
Update to fix Kudos response object.

### DIFF
--- a/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
@@ -129,13 +129,7 @@ class KudosTransformer extends Transformer {
    * @return array
    */
   protected function transform($kudos) {
-    $data = [];
-
-    $data['reportback_item'] = $kudos->reportback_item;
-
-    $data['user'] = $this->transformUser($kudos->user);
-
-    return $data;
+    return $kudos;
   }
 
 }


### PR DESCRIPTION
Fixes Kudos response object to represent the following:

```
data: {
  id: "1",
  term: {
    id: "9",
    name: "make something"
  },
  reportback_item: {
    id: "647"
  },
  user: {
    id: "12930"
  }
}
```

*Note: Currently the `transform()` method on the `KudosTransformer` isn't doing much other than passing the `$kudos` object straight through. However, this doesn't mean that transforming stuff won't be needed at a later date. Just FYI!

@jonuy 
