### PR TITLE
Fly away little droops users

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -51,17 +51,51 @@ function dosomething_northstar_register_user($form_state) {
   // Build a user that Northstar expects.
   $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
   // Send that to NS.
-  $northstar = new Northstar();
-  try {
-    $response = $northstar->updateUser($ns_user);
-    if ($response->getStatusCode() === '200' && module_exists('stathat')) {
-      stathat_send_ez_count('drupal - Northstar - user migrated - count', 1);
-    }
-  }
-  catch (Exception $e) {
-    watchdog('dosomething_northstar', 'User not migrated', NULL, WATCHDOG_ERROR);
+  // $northstar = new Northstar();
+  // try {
+  //   $response = $northstar->updateUser($ns_user);
+  //   if ($response->getStatusCode() === '200' && module_exists('stathat')) {
+  //     stathat_send_ez_count('drupal - Northstar - user migrated - count', 1);
+  //   }
+  // }
+  // catch (Exception $e) {
+
+  //   watchdog('dosomething_northstar', 'User not migrated : ' . $e, NULL, WATCHDOG_ERROR);
+  // }
+  $client = _dosomething_northstar_build_http_client();
+  $response = drupal_http_request($client['base_url'] . '/users', array(
+    'headers' => $client['headers'],
+    'method' => 'POST',
+    'data' => json_encode($ns_user),
+    ));
+  if ($response->getStatusCode() === '200' && module_exists('stathat')) {
+    stathat_send_ez_count('drupal - Northstar - user migrated - count', 1);
   }
 
+}
+
+/**
+ * Build the drupal_http_request object for nothstar calls.
+ * This will be depricated once guzzle is fixed...
+ */
+function _dosomething_northstar_build_http_client() {
+  $base_url = NORTHSTAR_URL;
+  if (getenv('DS_ENVIRONMENT') === 'local') {
+      $base_url .=  ":" . NORTHSTAR_PORT;
+    }
+  $base_url .= '/' . NORTHSTAR_VERSION;
+
+  $client = array(
+    'base_url' => $base_url,
+    'headers' => array(
+      'X-DS-Application-Id' => NORTHSTAR_APP_ID,
+      'X-DS-REST-API-Key' => NORTHSTAR_APP_KEY,
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json',
+      ),
+    );
+
+  return $client;
 }
 
 /**
@@ -71,15 +105,15 @@ function dosomething_northstar_update_user($form_state) {
   $user = $form_state['user'];
   $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
 
-  $northstar = new Northstar();
-  try {
-    $response = $northstar->updateUser($ns_user);
-    if ($response->getStatusCode() === '200' && module_exists('stathat')) {
-      stathat_send_ez_count('drupal - Northstar - user updated - count', 1);
-    }
-  }
-  catch (Exception $e) {
-    watchdog('dosomething_northstar', 'User not updated', NULL, WATCHDOG_ERROR);
+  // $northstar = new Northstar();
+  $client = _dosomething_northstar_build_http_client();
+  $response = drupal_http_request($client['base_url'] . '/users', array(
+    'headers' => $client['headers'],
+    'method' => 'POST',
+    'data' => json_encode($ns_user),
+    ));
+  if ($response->getStatusCode() === '200' && module_exists('stathat')) {
+    stathat_send_ez_count('drupal - Northstar - user updated - count', 1);
   }
 }
 
@@ -139,38 +173,41 @@ function dosomething_northstar_build_ns_user($user, $form_state) {
 
 class Northstar {
 
-  protected $client;
+  // protected $client;
 
-  public function __construct() {
+  // public function __construct() {
 
-    $base_url = NORTHSTAR_URL;
-    if (getenv('DS_ENVIRONMENT') === 'local') {
-      $base_url .=  ":" . NORTHSTAR_PORT;
-    }
-    $version = NORTHSTAR_VERSION;
+  //   $base_url = NORTHSTAR_URL;
+  //   if (getenv('DS_ENVIRONMENT') === 'local') {
+  //     $base_url .=  ":" . NORTHSTAR_PORT;
+  //   }
+  //   $version = NORTHSTAR_VERSION;
 
-    if (libraries_load('guzzle') == TRUE) {
-      $client = new GuzzleHttp\Client(array(
-        'base_url' => array($base_url . '/{version}/', array('version' => $version)),
-        'defaults' => array(
-          'headers' => array(
-            'X-DS-Application-Id' => NORTHSTAR_APP_ID,
-            'X-DS-REST-API-Key' => NORTHSTAR_APP_KEY,
-            'Content-Type' => 'application/json',
-            'Accept' => 'application/json'
-            ),
-          ),
-      ));
-      $this->client = $client;
+  //   if (libraries_load('guzzle') == TRUE) {
+  //     $client = new GuzzleHttp\Client(array(
+  //       'base_url' => array($base_url . '/{version}/', array('version' => $version)),
+  //       'defaults' => array(
+  //         'headers' => array(
+  //           'X-DS-Application-Id' => NORTHSTAR_APP_ID,
+  //           'X-DS-REST-API-Key' => NORTHSTAR_APP_KEY,
+  //           'Content-Type' => 'application/json',
+  //           'Accept' => 'application/json'
+  //           ),
+  //         ),
+  //     ));
+  //     $this->client = $client;
 
-    }
-  }
+  //   }
+  // }
 
-  public function updateUser($user) {
-    $response = $this->client->post('users', array(
-      'body' => json_encode($user),
-      ));
-    return $response;
-  }
+  // public function updateUser($user) {
+  //   // return $this->client->getUrl();
+  //   $response = $this->client->post('users', array(
+  //     'body' => json_encode($user),
+  //     ));
+
+  //   // watchdog('dosomething_northstar', 'full url' . $response->getUrl(), NULL, WATCHDOG_ERROR);
+  //   return $response;
+  // }
 
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -71,6 +71,9 @@ function dosomething_northstar_register_user($form_state) {
   if ($response->getStatusCode() === '200' && module_exists('stathat')) {
     stathat_send_ez_count('drupal - Northstar - user migrated - count', 1);
   }
+  elseif ($response->getStatusCode() !== '200') {
+    watchdog('dosomething_northstar', 'User not migrated : ' . $response->getStatusCode(), NULL, WATCHDOG_ERROR);
+  }
 
 }
 
@@ -115,6 +118,10 @@ function dosomething_northstar_update_user($form_state) {
   if ($response->getStatusCode() === '200' && module_exists('stathat')) {
     stathat_send_ez_count('drupal - Northstar - user updated - count', 1);
   }
+  elseif ($response->getStatusCode() !== '200') {
+    watchdog('dosomething_northstar', 'User not updated : ' . $response->getStatusCode(), NULL, WATCHDOG_ERROR);
+  }
+
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -68,11 +68,11 @@ function dosomething_northstar_register_user($form_state) {
     'method' => 'POST',
     'data' => json_encode($ns_user),
     ));
-  if ($response->getStatusCode() === '200' && module_exists('stathat')) {
+  if ($response->code === '200' && module_exists('stathat')) {
     stathat_send_ez_count('drupal - Northstar - user migrated - count', 1);
   }
-  elseif ($response->getStatusCode() !== '200') {
-    watchdog('dosomething_northstar', 'User not migrated : ' . $response->getStatusCode(), NULL, WATCHDOG_ERROR);
+  elseif ($response->code !== '200') {
+    watchdog('dosomething_northstar', 'User not migrated : ' . $response->code, NULL, WATCHDOG_ERROR);
   }
 
 }
@@ -115,11 +115,11 @@ function dosomething_northstar_update_user($form_state) {
     'method' => 'POST',
     'data' => json_encode($ns_user),
     ));
-  if ($response->getStatusCode() === '200' && module_exists('stathat')) {
+  if ($response->code === '200' && module_exists('stathat')) {
     stathat_send_ez_count('drupal - Northstar - user updated - count', 1);
   }
-  elseif ($response->getStatusCode() !== '200') {
-    watchdog('dosomething_northstar', 'User not updated : ' . $response->getStatusCode(), NULL, WATCHDOG_ERROR);
+  elseif ($response->code !== '200') {
+    watchdog('dosomething_northstar', 'User not updated : ' . $response->code, NULL, WATCHDOG_ERROR);
   }
 
 }

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -46,6 +46,7 @@ function build_northstar_user($user) {
     'mobile'       => 'field_mobile',
     'birthdate'    => 'field_birthdate',
     'first_name'   => 'field_first_name',
+    'last_name'    => 'field_last_name',
     'source'       => 'field_user_registration_source',
     'school_id'    => 'field_school_id',
   ];

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -20,9 +20,9 @@ else {
                    FROM users u');
 }
 
-foreach ($users as $whatever) {
+foreach ($users as $user) {
   // Create json object
-  $user = user_load($whatever->uid);
+  $user = user_load($user->uid);
   $ns_user = build_northstar_user($user);
 
   // Use old drupal_http_request method.

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -64,6 +64,7 @@ function build_northstar_user($user) {
     'email'            => $user->mail,
     'drupal_id'        => $user->uid,
     'drupal_password'  => $user->pass,
+    'created_at'       => $user->created,
   ];
 
   // Set values in ns_user if they are set.

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Script to export user information from drupal into Northstar.
+ *
+ * to run:
+ * drush --script-path=../scripts/ php-script export-users-to-northstar.php
+ */
+
+include_once('../lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module');
+
+// Get all the users, with all the things!
+$users = db_query('SELECT u.uid
+                   FROM users u
+                   LIMIT 3 OFFSET 1');
+
+foreach ($users as $whatever) {
+  // Create json object
+  $user = user_load($whatever->uid);
+  $ns_user = build_northstar_user($user);
+  print_r($ns_user);
+  $ns = new Northstar();
+  $response = $ns->updateUser($ns_user);
+}
+
+/**
+ *
+ */
+function build_northstar_user($user) {
+  // Optional fields
+  $optional = [
+    'mobile'       => 'field_mobile',
+    'birthdate'    => 'field_birthdate',
+    'first_name'   => 'field_first_name',
+    'source'       => 'field_user_registration_source',
+    'school_id'    => 'field_school_id',
+  ];
+
+  // Address fields
+  $address = [
+    'country'        => 'country',
+    'addr_street1'   => 'thoroughfare',
+    'addr_street2'   => 'premise',
+    'addr_city'      => 'locality',
+    'addr_state'     => 'administrative_area',
+    'addr_zip'       => 'postal_code',
+  ];
+
+  $ns_user = [
+    'email'            => $user->mail,
+    'drupal_id'        => $user->uid,
+    'drupal_password'  => $user->pass,
+  ];
+
+  // Set values in ns_user if they are set.
+  foreach ($optional as $ns_key => $drupal_key) {
+   $field = $user->$drupal_key;
+    if (!empty($field[LANGUAGE_NONE][0]['value'])) {
+      $ns_user[$ns_key] = $field[LANGUAGE_NONE][0]['value'];
+    }
+  }
+  // Set address values.
+  foreach ($address as $ns_key => $drupal_key) {
+    $field = $user->field_address[LANGUAGE_NONE][0];
+    if (!empty($field[$drupal_key]['value'])) {
+      $ns_user[$ns_key] = $field[$drupal_key]['value'];
+    }
+  }
+  return $ns_user;
+}


### PR DESCRIPTION
This little scipty guy will migrate drooopal users into northstar. 
It worked locally with no issues and we can test this on stage droopal -> stage NS. 
There's a fallback variable/query incase the script fails and we need to restart the script.

ALSO, guzzle requests were failing for some reason, and I figured in the interest of time, it's easier to switch these Northstar requests back to `drupal_http_request`.
I know there is some duplicate code that should be refactored, but I just added back in what was here originally. 

Fixes #4631 
