### PR TITLE
Upating response to clean it up and fix a bug.

### DIFF
--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -78,7 +78,7 @@ function dosomething_kudos_get_kudos_query($params = [], $count = NULL, $start =
  *
  * @return array
  */
-function dosomething_kudos_sort($data) {
+function dosomething_kudos_sort($data, $display = 'teaser') {
   // The array containing collection of kudos items passed to this function
   // consists of individual kudos items. However, within this collection
   // there could be multiple kudos items that all fall within the same
@@ -88,7 +88,7 @@ function dosomething_kudos_sort($data) {
 
   usort($data, 'dosomething_kudos_sort_by_taxonomy_term');
 
-  $data = dosomething_kudos_group_by_taxonomy_term($data);
+  $data = dosomething_kudos_group_by_taxonomy_term($data, $display);
   $data = dosomething_kudos_get_totals_by_taxonomy_term($data);
   return $data;
 }
@@ -120,7 +120,7 @@ function dosomething_kudos_sort_by_taxonomy_term($a, $b) {
  *
  * @return array
  */
-function dosomething_kudos_group_by_taxonomy_term($data) {
+function dosomething_kudos_group_by_taxonomy_term($data, $display = 'teaser') {
   $terms = [];
 
   foreach ($data as $item) {
@@ -130,11 +130,18 @@ function dosomething_kudos_group_by_taxonomy_term($data) {
       ];
     }
 
-    $terms[$item->term['id']]['kudos_items']['data'][] = [
+    $output = [
       'id' => $item->id,
       'user' => $item->user,
     ];
+
+    if ($display === 'full') {
+      $output['reportback_item'] = $item->reportback_item;
+    }
+
+    $terms[$item->term['id']]['kudos_items']['data'][] = $output;
   }
+
 
   return array_values($terms);
 }

--- a/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
@@ -29,7 +29,7 @@ class KudosTransformer extends Transformer {
     }
 
     $data = $this->transformCollection($kudos);
-    $data = dosomething_kudos_sort($data);
+    $data = dosomething_kudos_sort($data, 'full');
 
     return [
       'kudos' => [

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -35,7 +35,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
     if (!$reportbackItems) {
       return array(
         'error' => array(
-          'message' => 'These are not the reportback items you are looking for.',
+          'message' => 'There were no reportback items found.',
         ),
       );
     }
@@ -54,12 +54,19 @@ class ReportbackItemTransformer extends ReportbackTransformer {
    * @return array
    */
   public function show($id) {
-
     $params = array();
     $params['fid'] = $id;
 
     $query = dosomething_reportback_get_reportback_files_query_result($params);
     $reportbackItem = services_resource_build_index_list($query, 'reportback-items', 'fid');
+
+    if (!$reportbackItem) {
+      return array(
+        'error' => array(
+          'message' => 'There was no reportback item found.',
+        ),
+      );
+    }
 
     return array(
       'data' => $this->transform($reportbackItem[0]),


### PR DESCRIPTION
This PR updates the response to allow for specifying whether the Kudos response should include the `reportback_item` object which provides the `id` of the RB item the kudos belongs to. Normally when hitting the `/reportback-items` endpoint, the index of RB items in collection already has the RB item id, so the kudos collection doesn't need it and is thus not included to allow for a less redundant response.

However, if hitting the `/kudos` endpoint, then the index collection of kudos in response need the RB item  info, and thus this update adds it :)

Also updates the retrieve method on `/reportback-items` to now properly show an error if a non-existent RB item id is passed to the `/reportback-items/:id.json` endpoint.

@uy @aaronschachter 
