### PR TITLE
Hot Module - Display progress copy and author info

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -190,9 +190,15 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
     ),
     'setting'
   );
-  // campaign author information
+
+  // Campaign author information
   $author = user_load($vars['uid']);
-  // Add this to vars array.
+  $first_name = check_plain($wrapper->author->field_first_name->value());
+  $last_name = check_plain($wrapper->author->field_last_name->value());
+
+  $vars['author_name']  = $first_name . ' ' . $last_name;
+  $vars['author_title'] = check_plain($wrapper->author->field_job_title->value());
+  $vars['author_image'] = dosomething_image_get_themed_image_by_fid($author->picture->fid, '300x300');
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -30,6 +30,7 @@ function dosomething_campaign_preprocess_node(&$vars) {
 
   // If the hot module is enabled and the high season is set on a campaign.
   if (dosomething_campaign_is_hot_module($vars)) {
+    $vars['hot_module_enabled'] = TRUE;
     dosomething_campaign_preprocess_hot_module($vars, $wrapper);
   }
 
@@ -129,6 +130,8 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
 
   //Calculate progress goal & copy
   $goal = dosomething_helpers_get_variable('node', $vars['nid'], 'goal');
+  $vars['goal'] = $goal;
+
   $rb_percent = NULL;
   if ($goal) {
     $rb_progress = dosomething_reportback_get_reportback_total_by_nid($node->nid);
@@ -160,6 +163,10 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
 
   $vars['progress_copy'] = token_replace($vars['progress_copy'], array('node' => $node));
   $vars['progress_copy'] = str_replace('[campaign_goal]', $goal, $vars['progress_copy']);
+
+  $vars['reportback_noun_verb'] = $wrapper->field_reportback_noun->value() . " " . $wrapper->field_reportback_verb->value();
+
+  $vars['hot_module_share_copy'] = variable_get('dosomething_campaign_share_copy', t('Rally your friends to crush this goal!'));
 
 
   // json file of reportback quantity
@@ -238,14 +245,6 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   if (theme_get_setting('show_campaign_progress')) {
     $vars['campaign_progress'] = dosomething_helpers_get_variable('node', $vars['nid'], 'sum_rb_quanity');
   }
-  // Hot Module - @TODO - Move to it's own preprocess function when this starts to use it's own template.
-  $vars['hot_module_enabled'] = variable_get('dosomething_campaign_enable_hot_module', FALSE);
-
-  $vars['goal'] = dosomething_helpers_get_variable('node', $vars['nid'], 'goal');
-
-  $vars['reportback_noun_verb'] = $wrapper->field_reportback_noun->value() . " " . $wrapper->field_reportback_verb->value();
-
-  $vars['hot_module_share_copy'] = variable_get('dosomething_campaign_share_copy', t('Rally your friends to crush this goal!'));
 
   // Know It.
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -245,6 +245,8 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
 
   $vars['reportback_noun_verb'] = $wrapper->field_reportback_noun->value() . " " . $wrapper->field_reportback_verb->value();
 
+  $vars['hot_module_share_copy'] = variable_get('dosomething_campaign_share_copy', t('Rally your friends to crush this goal!'));
+
   // Know It.
 
   // Problem shares.
@@ -286,11 +288,6 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     $vars['twitter_link'] = dosomething_helpers_get_twitter_intent($tweet);
     $vars['tumblr_link'] = dosomething_helpers_get_tumblr_intent($tumblr_options);
   }
-
-  $vars['hot_module_enabled'] = variable_get('dosomething_campaign_enable_hot_module', FALSE);
-  $vars['hot_module_share_copy'] = variable_get('dosomething_campaign_share_copy', t('Rally your friends to crush this goal!'));
-
-  $vars['goal'] = dosomething_helpers_get_variable('node', $vars['nid'], 'goal');
 
   // Plan.
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -25,6 +25,7 @@ $asset-path: "";
 @import "overrides/drupal";
 
 // Local patterns
+@import "patterns/author-callout"; // @TODO: Move to Neue!
 @import "patterns/container"; // @TODO: Move to Neue!
 @import "patterns/photo"; // @TODO: Move to Neue!
 @import "patterns/gallery"; // @TODO: Move to Neue!
@@ -36,7 +37,7 @@ $asset-path: "";
 @import "patterns/admin-edit"; // @TODO: Move to Neue!
 @import "patterns/social-share-bar"; // @TODO: Move to Neue!
 @import "patterns/stat-card"; // @TODO: Move to Neue!
-@import "patterns/author-callout"; // @TODO: Move to Neue!
+
 
 // Content styles by section
 @import "content/affiliate";

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -36,6 +36,7 @@ $asset-path: "";
 @import "patterns/admin-edit"; // @TODO: Move to Neue!
 @import "patterns/social-share-bar"; // @TODO: Move to Neue!
 @import "patterns/stat-card"; // @TODO: Move to Neue!
+@import "patterns/author-callout"; // @TODO: Move to Neue!
 
 // Content styles by section
 @import "content/affiliate";

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_author-callout.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_author-callout.scss
@@ -1,0 +1,30 @@
+.author-callout {
+
+  @include media($large) {
+    @include push(1);
+    @include span(7 of 12);
+  }
+
+  .text {
+    position: relative;
+    width: 100%;
+    // height: 100px;
+    text-align: center;
+    background-color: $light-gray;
+    border-radius: 10px;
+    padding: $base-spacing;
+    text-align: left;
+    font-size: $font-small;
+
+    &:before {
+      position: absolute;
+      content: '';
+      width: 0;
+      height: 0;
+      left: 50px;
+      top: 100px;
+      border: 20px solid;
+      border-color: $light-gray transparent transparent $light-gray;
+    }
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_author-callout.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_author-callout.scss
@@ -1,30 +1,41 @@
 .author-callout {
+  margin-top: $base-spacing;
 
   @include media($large) {
     @include push(1);
     @include span(7 of 12);
+    margin-top: 0px;
   }
 
-  .text {
+  .author-callout__copy {
     position: relative;
     width: 100%;
-    // height: 100px;
     text-align: center;
     background-color: $light-gray;
     border-radius: 10px;
     padding: $base-spacing;
     text-align: left;
     font-size: $font-small;
+    margin-bottom: $base-spacing * 2;
 
     &:before {
       position: absolute;
       content: '';
       width: 0;
       height: 0;
-      left: 50px;
-      top: 100px;
-      border: 20px solid;
+      left: 15%;
+      top: 100%;
+      border: 10px solid;
       border-color: $light-gray transparent transparent $light-gray;
     }
+  }
+
+  .author-callout__first-name {
+    font-size: $font-medium;
+    font-weight: $weight-sbold;
+  }
+
+  .author-callout__last-name {
+    margin-top: 0px;
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_stat-card.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_stat-card.scss
@@ -5,31 +5,31 @@ $dark-blue: #0081BC;
     @include span(4 of 12);
   }
 
-  .totals {
+  .stat-card__totals {
     background: $blue;
     color: $white;
     padding: $base-spacing / 2;
 
-    .verbs {
+    .stat-card__verbs {
       text-transform: uppercase;
       color: $dark-blue;
       font-size: $font-regular;
     }
 
-    .progress {
+    .stat-card__progress {
       font-size: $font-hero;
       font-weight: $weight-bold;
       line-height: 1;
     }
 
-    .goal {
+    .stat-card__goal {
       margin-top: 0px;
       text-transform: uppercase;
       font-size: $font-regular;
     }
   }
 
-  .timing {
+  .stat-card__timing {
     background: $dark-blue;
     padding: $base-spacing / 2;
     color: $white;
@@ -37,7 +37,7 @@ $dark-blue: #0081BC;
     font-weight: $weight-bold;
   }
 
-  .chart {
+  .stat-card__chart {
     border: solid 2px $light-gray;
     border-top: none;
   }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_stat-card.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_stat-card.scss
@@ -1,14 +1,10 @@
 $dark-blue: #0081BC;
 
 .stat-card {
-
-  @include media($medium) {
-    @include span(6 of 6);
-  }
-
   @include media($large) {
-    @include span(4 of 6);
+    @include span(4 of 12);
   }
+
   .totals {
     background: $blue;
     color: $white;

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -65,7 +65,7 @@
 
           <div class="author-callout">
             <div class="author-callout__copy">
-              The more people we get to sign up for Give A Spit About Cancer the sooner we'll reach our goal of 10,000 cheeks swabbed! Be a megaphone - get your friends involved!
+              <?php print $progress_copy; ?>
             </div>
 
             <article class="figure -left -center">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -48,17 +48,17 @@
       <div class="wrapper">
         <div class="container__block">
           <div class="stat-card">
-            <div class="totals">
+            <div class="stat-card__totals">
               <?php if(isset($campaign_progress)): ?>
-                <h4 class="verbs"><?php print $reportback_noun_verb ?></h4>
-                <p class="progress"><?php print number_format($campaign_progress, 0, '', ','); ?></p>
-                <p class="goal">Out of <?php print number_format($goal, 0, '', ','); ?></p>
+                <h4 class="stat-card__verbs"><?php print $reportback_noun_verb ?></h4>
+                <p class="stat-card__progress"><?php print number_format($campaign_progress, 0, '', ','); ?></p>
+                <p class="stat-card__goal">Out of <?php print number_format($goal, 0, '', ','); ?></p>
               <?php endif; ?>
             </div>
-            <div class="timing">
-              <p class="time-left"><?php print $time_left ?></p>
+            <div class="stat-card__timing">
+              <p><?php print $time_left ?></p>
             </div>
-            <div class="chart">
+            <div class="stat-card__chart">
               <canvas class="js-progress-chart" width="280" height="200" data-goal="<?php print $goal ?>"></canvas>
             </div>
           </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -64,16 +64,24 @@
           </div>
 
           <div class="author-callout">
-            <div class="text">
+            <div class="author-callout__copy">
               The more people we get to sign up for Give A Spit About Cancer the sooner we'll reach our goal of 10,000 cheeks swabbed! Be a megaphone - get your friends involved!
             </div>
-<!--             <div class="author">
-              <img src="http://dev.dosomething.org:8888/sites/default/files/styles/300x300/public/user/picture-1702694-1436211515.jpg?itok=hVW8d2Hv" />
-              <p>Shae Smith</p>
-              <p>Software Engineer</p>
-            </div> -->
+
+            <article class="figure -left -center">
+              <div class="figure__media">
+                <div class="avatar">
+                  <?php print $author_image ?>
+                </div>
+              </div>
+              <div class="figure__body">
+                  <p class="author-callout__first-name"><?php print $author_name ?></p>
+                  <p class="author-callout__last-name"><?php print $author_title ?></p>
+              </div>
+            </article>
           </div>
         </div>
+
       </div>
     </section>
   <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -46,7 +46,7 @@
   <?php if ($hot_module_enabled): ?>
     <section id="hot-module" class="container">
       <div class="wrapper">
-        <div class="container__block -half">
+        <div class="container__block">
           <div class="stat-card">
             <div class="totals">
               <?php if(isset($campaign_progress)): ?>
@@ -61,6 +61,17 @@
             <div class="chart">
               <canvas class="js-progress-chart" width="280" height="200" data-goal="<?php print $goal ?>"></canvas>
             </div>
+          </div>
+
+          <div class="author-callout">
+            <div class="text">
+              The more people we get to sign up for Give A Spit About Cancer the sooner we'll reach our goal of 10,000 cheeks swabbed! Be a megaphone - get your friends involved!
+            </div>
+<!--             <div class="author">
+              <img src="http://dev.dosomething.org:8888/sites/default/files/styles/300x300/public/user/picture-1702694-1436211515.jpg?itok=hVW8d2Hv" />
+              <p>Shae Smith</p>
+              <p>Software Engineer</p>
+            </div> -->
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Fixes #4602 & #4446

Builds out the progress copy and campaign author portion of the hot module page: 

![screen shot 2015-07-07 at 5 09 26 pm](https://cloud.githubusercontent.com/assets/1700409/8557389/ffcb8614-24ca-11e5-80e0-9015afca33b5.png)

Also, made some small updates to the stat-card pattern that wasn't using the BEM convention for naming. 

Speaking of naming. I was thinking of the speech bubble and author avatar/title as one contained module, which I called `author-callout` no idea if this makes sense, so I am open to suggestions.

@DoSomething/front-end 
