### PR TITLE
Add override for reportback delete page.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/overrides/_drupal.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/overrides/_drupal.scss
@@ -2,15 +2,13 @@
 // Styles to make sense of Drupal's stock markup:
 // ----------------------------------------------
 
-// Quick and dirty fix for "Remove Signup" form being hidden
-// behind nav. @TODO Remove me when we fix "non-themed" template
-#dosomething-signup-node-unsignup-form {
+// Quick and dirty fix for "Remove Signup" form being hidden behind nav.
+#dosomething-signup-node-unsignup-form, #dosomething-reportback-delete-form {
   padding-top: 144px;
   padding-bottom: 36px;
   max-width: 600px;
   margin: 0 auto;
 }
-
 
 // Make Krumo look okay when it's in the ".messages" module
 .messages .krumo-root {


### PR DESCRIPTION
# Changes

Fixes #4623. Sadly, I don't think we can use default page template on this page without some kind of individual override, since it's technically a type `page__reportback` which we override to the "full-width" page template for.

For review: @DoSomething/front-end 
