### PR TITLE
Add Optimizley custom event when user is signed up for campaign.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -435,8 +435,11 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $vars['reportback_form'] = $vars['content']['reportback_form'];
 
   // Add analytics custom event on action page.
-  $js = 'if(typeof(ga) !== "undefined" && ga !== null) { ga("send", "event", "Action Page View", "' . $vars['title'] . '"); }';
-  drupal_add_js($js, 'inline');
+  $google_analytics_js = 'if(typeof(ga) !== "undefined" && ga !== null) { ga("send", "event", "Action Page View", "' . $vars['title'] . '"); }';
+  drupal_add_js($google_analytics_js, 'inline');
+
+  $optimizely_js = 'window["optimizely"] = window["optimizely"] || []; window.optimizely.push(["trackEvent", "Action Page View"]);';
+  drupal_add_js($optimizely_js, 'inline');
 
 }
 


### PR DESCRIPTION
# Changes

Fixes #4617. This will let us use campaign signups (rather than just "signup attempts") as a metric for Optimizely tests. See Optimizely's help article for [implementation details](https://help.optimizely.com/hc/en-us/articles/200039925-Custom-event-goals).

For review: @DoSomething/front-end @angaither 
