### PR TITLE
Updates reportback total to use override

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -134,7 +134,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
 
   $rb_percent = NULL;
   if ($goal) {
-    $rb_progress = (int) dosomething_helpers_get_variable('node', $nid, 'sum_rb_quantity_override') + (int) dosomething_reportback_get_reportback_total_by_nid($node->nid);
+    $rb_progress = dosomething_reportback_get_reportback_total_plus_override($node->nid);
     $rb_percent = ($rb_progress / $goal) * 100;
   }
 
@@ -253,7 +253,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
 
   // Progress
   if (theme_get_setting('show_campaign_progress')) {
-    $vars['campaign_progress'] = dosomething_helpers_get_variable('node', $vars['nid'], 'sum_rb_quanity');
+    $vars['campaign_progress'] = dosomething_reportback_get_reportback_total_plus_override($vars['nid']);
   }
 
   // Know It.
@@ -500,7 +500,7 @@ function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
   // Moar $tagline.
   $vars['tagline'] .= t('Any cause, anytime, anywhere.');
 
-  $campaign_progress = (int) dosomething_helpers_get_variable('node', $vars['nid'], 'sum_rb_quantity_override') + (int) dosomething_helpers_get_variable('node', $vars['nid'], 'sum_rb_quanity');
+  $campaign_progress = dosomething_reportback_get_reportback_total_plus_override($vars['nid']);
   // Get sign up total and add it to cta
   $signup_count = (int) dosomething_helpers_get_variable('node', $vars['nid'], 'web_signup_count') + (int) dosomething_helpers_get_variable('node', $vars['nid'], 'mobile_signup_count');
   $vars['signup_cta'] .= t('Join @signup_count people doing this.', array(

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -134,7 +134,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
 
   $rb_percent = NULL;
   if ($goal) {
-    $rb_progress = dosomething_reportback_get_reportback_total_by_nid($node->nid);
+    $rb_progress = (int) dosomething_helpers_get_variable('node', $nid, 'sum_rb_quantity_override') + (int) dosomething_reportback_get_reportback_total_by_nid($node->nid);
     $rb_percent = ($rb_progress / $goal) * 100;
   }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -884,15 +884,7 @@ function dosomething_reportback_get_reportback_total_by_nid($nid, $type = 'quant
  *  Sum of all reportback quantities plus the override.
  */
  function dosomething_reportback_get_reportback_total_plus_override($nid) {
-   // Select all reportbacks for given $nid.
-   $query = db_select('dosomething_reportback', 'rb')->condition('nid', $nid);
-   // Get quantity of all reportbacks
-   $query->fields('rb', array('quantity'));
-   $query->addExpression('SUM(quantity)', 'quantity');
-   $result = $query->execute()->fetchAll();
-   $quantity = $result[0]->quantity;
-   dosomething_helpers_set_variable('node', $nid, 'sum_rb_quanity', $quantity);
-   return $quantity + (int) dosomething_helpers_get_variable('node', $nid, 'sum_rb_quantity_override');
+   return dosomething_reportback_get_reportback_total_by_nid($nid) + (int) dosomething_helpers_get_variable('node', $nid, 'sum_rb_quantity_override');
  }
 
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -864,7 +864,7 @@ function dosomething_reportback_get_reportback_total_by_nid($nid, $type = 'quant
     $query->fields('rb', array('quantity'));
     $query->addExpression('SUM(quantity)', 'quantity');
     $result = $query->execute()->fetchAll();
-    $quantity = (int) dosomething_helpers_get_variable('node', $nid, 'sum_rb_quantity_override') + (int) $result[0]->quantity;
+    $quantity = $result[0]->quantity;
     dosomething_helpers_set_variable('node', $nid, 'sum_rb_quanity', $quantity);
     return $quantity;
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -864,7 +864,7 @@ function dosomething_reportback_get_reportback_total_by_nid($nid, $type = 'quant
     $query->fields('rb', array('quantity'));
     $query->addExpression('SUM(quantity)', 'quantity');
     $result = $query->execute()->fetchAll();
-    $quantity = $result[0]->quantity;
+    $quantity = (int) dosomething_helpers_get_variable('node', $nid, 'sum_rb_quantity_override') + (int) $result[0]->quantity;
     dosomething_helpers_set_variable('node', $nid, 'sum_rb_quanity', $quantity);
     return $quantity;
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -875,6 +875,28 @@ function dosomething_reportback_get_reportback_total_by_nid($nid, $type = 'quant
 }
 
 /**
+ * Returns the total number of reportbacks with the override added to it.
+ *
+ * @param int $nid
+*   A node nid.
+ *
+ * @return int $total
+ *  Sum of all reportback quantities plus the override.
+ */
+ function dosomething_reportback_get_reportback_total_plus_override($nid) {
+   // Select all reportbacks for given $nid.
+   $query = db_select('dosomething_reportback', 'rb')->condition('nid', $nid);
+   // Get quantity of all reportbacks
+   $query->fields('rb', array('quantity'));
+   $query->addExpression('SUM(quantity)', 'quantity');
+   $result = $query->execute()->fetchAll();
+   $quantity = $result[0]->quantity;
+   dosomething_helpers_set_variable('node', $nid, 'sum_rb_quanity', $quantity);
+   return $quantity + (int) dosomething_helpers_get_variable('node', $nid, 'sum_rb_quantity_override');
+ }
+
+
+/**
  * Returns total number of Reportbacks by status (promoted, approved, etc).
  *
  * @param int $nid

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -333,7 +333,7 @@ class ReportbackEntityController extends EntityAPIController {
     }
 
     parent::save($entity, $transaction);
-
+    
     // If a file fid exists:
     if (isset($entity->fid)) {
       // Add it into the reportback files.

--- a/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
+++ b/lib/modules/dosomething/dosomething_reportback/includes/dosomething_reportback.inc
@@ -333,7 +333,6 @@ class ReportbackEntityController extends EntityAPIController {
     }
 
     parent::save($entity, $transaction);
-    
     // If a file fid exists:
     if (isset($entity->fid)) {
       // Add it into the reportback files.


### PR DESCRIPTION
Fixes #4652 

Updated the `dosomething_reportback_get_reportback_total_by_nid` function to also add `sum_rb_quantity_override` to the quantity. Also re-added a blank line that I accidentally removed in a previous PR. 

@angaither 
