### PR TITLE
Add setting helper.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
@@ -1,5 +1,6 @@
 import Chart from 'chart.js';
 import $ from 'jquery';
+import setting from '../utilities/Setting';
 
 /*
  * Number formatter so we can display the goal as a number with commas.
@@ -315,7 +316,7 @@ var LineGraph = function($el, progressData) {
 function init($chart = $(".js-progress-chart")) {
   if (!$chart.length) return;
 
-  var progressData = Drupal.settings.dosomethingCampaign.goals;
+  var progressData = setting('dosomethingCampaign.goals');
   new LineGraph($chart, progressData);
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/SchoolFinder.js
@@ -4,6 +4,7 @@ var template = require("lodash/string/template");
 var isEmpty = require("lodash/lang/isEmpty");
 var forEach = require("lodash/collection/forEach");
 var throttle = require("lodash/function/throttle");
+var setting = require('../utilities/Setting');
 
 var Validation = require("dosomething-validation");
 
@@ -11,15 +12,9 @@ var shouldValidateForm = true;
 var resultTpl = template("<li><a class='js-schoolfinder-result' data-gsid='<%- gsid %>' href='#'><span><%- name %></span> <em><%- city %>, <%- state %></em></a></li>");
 
 function getResults(state, query, limit, callback) {
-  var endpoint;
   if(isEmpty(query) || isEmpty(state)) return callback([]);
 
-  try {
-    // Use Drupal dateFormat validation format if available
-    endpoint = Drupal.settings.dosomethingUser.schoolFinderAPIEndpoint;
-  } catch(e) {
-    endpoint = "http://lofischools.herokuapp.com/search";
-  }
+  var endpoint = setting('dosomethingUser.schoolFinderAPIEndpoint', 'http://lofischools.herokuapp.com/search');
 
   $.ajax({
     dataType: "json",

--- a/lib/themes/dosomething/paraneue_dosomething/js/donate/Donate.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/donate/Donate.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import StripeForm from './StripeForm';
+import setting from '../utilities/Setting';
 
 const $donateForm = $('#dosomething-payment-form');
 
@@ -10,7 +11,7 @@ function init() {
   if(!$donateForm.length) return;
 
   try {
-    var stripeAPIPublishKey = Drupal.settings.dosomethingPayment.stripeAPIPublish;
+    var stripeAPIPublishKey = setting('dosomethingPayment.stripeAPIPublish');
     new StripeForm($donateForm, stripeAPIPublishKey);
   } catch(e) {
     $donateForm.html(`<div class="messages">Whoops! Something's not right. Please email us!</div>`);

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
@@ -6,6 +6,7 @@ define(function(require) {
   var forOwn = require("lodash/object/forOwn");
   var clone = require("lodash/lang/clone");
   var isEmpty = require("lodash/lang/isEmpty");
+  var setting = require('../utilities/Setting');
 
   // Create a callback function for caching the jsonp response.
   /* jshint ignore:start */
@@ -29,8 +30,8 @@ define(function(require) {
      * Configure this too. What's the base URL of the Solr server that you want
      * the browser pinging? And what collection?
      **/
-    baseURL: Drupal.settings.dosomethingSearch.solrURL,
-    collection: Drupal.settings.dosomethingSearch.collection,
+    baseURL: setting('dosomethingSearch.solrURL'),
+    collection: setting('dosomethingSearch.collection'),
 
     // The current throttle timeout identifier
     throttle: null,

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/setting.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/setting.js
@@ -1,0 +1,7 @@
+import dotty from 'dotty';
+
+function setting(key, defaultValue) {
+  return dotty.get(Drupal.settings, key) || defaultValue;
+}
+
+export default setting;

--- a/lib/themes/dosomething/paraneue_dosomething/js/validators/auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validators/auth.js
@@ -3,6 +3,7 @@ define(function(require) {
 
   var Validation= require("dosomething-validation");
   var mailcheck = require("mailcheck");
+  var setting = require('../utilities/Setting');
 
   // # Helpers
   // Basic sanity check used by email validation.
@@ -71,12 +72,8 @@ define(function(require) {
   Validation.registerValidationFunction("birthday", function(string, done) {
     var birthday, birthMonth, birthDay, birthYear, format;
 
-    try {
-      // Use Drupal dateFormat validation format if available
-      format = Drupal.settings.dsValidation.dateFormat;
-    } catch(e) {
-      format = "MM/DD/YYYY";
-    }
+    // Use Drupal dateFormat validation format if available
+    format = setting('dsValidation.dateFormat', 'MM/DD/YYYY');
 
     // parse date from string
     if( format === "MM/DD/YYYY" && /^\d{1,2}\/\d{1,2}\/\d{4}$/.test(string) ) {


### PR DESCRIPTION
# Changes
- Adds `setting()` helper method, which gracefully handles failure if key does not exist & allows easy
  fallback to a default value. Example usage:

``` js
   import setting from './utilities/setting';

   $url = setting('dosomethingSearch.solrURL', 'http://search.dosomething.org');
```

For review: @DoSomething/front-end 
