### PR TITLE
Pull HTML5Shiv from Github because of NPM package issues.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -18,7 +18,7 @@
     "dotty": "0.0.2",
     "es5-shim": "^4.1.1",
     "fixed-sticky": "DFurnes/fixed-sticky#umd",
-    "html5shiv": "~3.7.2",
+    "html5shiv": "aFarkas/html5shiv.git#3.7.2",
     "jquery": "~1.11.0",
     "jquery-once": "~2.0.0",
     "jquery.iecors": "DFurnes/jquery.iecors#umd",


### PR DESCRIPTION
# Changes
- Fixes the build because the `html5shiv` NPM package has gone missing! In the meantime, we'll pull the `3.7.2` tag from Github.

For review: @sheydari-ds @DoSomething/front-end 
