### PR TITLE
Updates campaign form script

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -19,7 +19,6 @@ define('DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER', 'Snap a Pic');
  */
 function dosomething_campaign_form_campaign_node_form_alter(&$form, &$form_state, $form_id) {
   unset($form['field_active_hours'][LANGUAGE_NONE]['#options']['_none']);
-  $form['title']['#description'] = t('Title - i.e. "Protect your Pills", "Birthday Mail", or "Teens for Jeans" <br/><strong> Limit: 20 characters. </strong>');
   // Add in campaign close info.
   dosomething_campaign_run_add_campaign_run_info($form, $form_state);
   // Use #after_build to add JS even on validation errors: https://drupal.org/node/1253520#comment-4881588

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -19,6 +19,7 @@ define('DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER', 'Snap a Pic');
  */
 function dosomething_campaign_form_campaign_node_form_alter(&$form, &$form_state, $form_id) {
   unset($form['field_active_hours'][LANGUAGE_NONE]['#options']['_none']);
+  $form['title']['#description'] = t('Title - i.e. "Protect your Pills", "Birthday Mail", or "Teens for Jeans" <br/><strong> Limit: 20 characters. </strong>');
   // Add in campaign close info.
   dosomething_campaign_run_add_campaign_run_info($form, $form_state);
   // Use #after_build to add JS even on validation errors: https://drupal.org/node/1253520#comment-4881588

--- a/lib/modules/dosomething/dosomething_campaign/js/campaign_node_form.js
+++ b/lib/modules/dosomething/dosomething_campaign/js/campaign_node_form.js
@@ -1,33 +1,61 @@
 (function ($) {
   $(document).ready(function(){
 
-    // List all id's that should only display when Campaign type == 'campaign'.
-    var campaignSections = [];
-    campaignSections.push("#node_campaign_form_group_prep_it");
-    campaignSections.push("#node_campaign_form_group_do_it");
-    campaignSections.push("#node_campaign_form_group_report_back");
-    campaignSections.push("#node_campaign_form_group_pitch_additional_info");
+    // Titles of all elements that should only display when Campaign type == 'campaign'.
+    var campaignTitles = ["Know It", "Plan It", "Prove It"];
 
-    // If SMS Game, hide the campaignSections.
-    if ($('#edit-field-campaign-type-und-sms-game').is(':checked')) { 
-      for (var i = 0; i < campaignSections.length; i++) {
-        $(campaignSections[i]).hide();
-      }
-    }
-    
-    // Listen for changes to the campaign type field.
-    $('#edit-field-campaign-type-und-campaign, #edit-field-campaign-type-und-sms-game').click(function() {
-      if ($('#edit-field-campaign-type-und-campaign').is(':checked')) { 
-        for (var i = 0; i < campaignSections.length; i++) {
-          $(campaignSections[i]).show();
-        }
-      }
-      if ($('#edit-field-campaign-type-und-sms-game').is(':checked')) { 
-        for (var i = 0; i < campaignSections.length; i++) {
-          $(campaignSections[i]).hide();
-        }
+    // List all elements that should only display when Campaign type == 'campaign'.
+    var campaignSections = [];
+    // campaignSections.push("#node_campaign_form_group_prep_it");
+    // campaignSections.push("#node_campaign_form_group_do_it");
+    // campaignSections.push("#node_campaign_form_group_report_back");
+    // campaignSections.push("#node_campaign_form_group_pitch_additional_info");
+
+    $('.fieldset-title').each(function(index, value) {
+      // Get the title of the fieldset and strip out unneeded text
+      var title = $(value).text().replace("Show", "").trim();
+      //Check if it's a campaign only title
+      if (campaignTitles.indexOf(title) != -1) {
+        campaignSections.push($(value).closest('.form-wrapper'));
+        console.log(campaignSections);
       }
     });
+
+    // If SMS Game, hide the campaignSections.
+    if ($('#edit-field-campaign-type-und-sms-game').is(':checked')) {
+      // for (var i = 0; i < campaignSections.length; i++) {
+      //   $(campaignSections[i]).hide();
+      // }
+      toggleSections(false);
+    }
+
+    // Listen for changes to the campaign type field.
+    $('#edit-field-campaign-type-und-campaign, #edit-field-campaign-type-und-sms-game').click(function() {
+      if ($('#edit-field-campaign-type-und-campaign').is(':checked')) {
+        // for (var i = 0; i < campaignSections.length; i++) {
+        //   $(campaignSections[i]).show();
+        // }
+        toggleSections(true);
+      }
+      if ($('#edit-field-campaign-type-und-sms-game').is(':checked')) {
+        // for (var i = 0; i < campaignSections.length; i++) {
+        //   $(campaignSections[i]).hide();
+        // }
+        toggleSections(false);
+      }
+    });
+
+    function toggleSections(show) {
+      campaignSections.forEach(function($element, index, array) {
+        console.log($element);
+        if (show) {
+          $element.show();
+        }
+        else {
+          $element.hide();
+        }
+      });
+    }
 
   });
 }(jQuery));

--- a/lib/modules/dosomething/dosomething_campaign/js/campaign_node_form.js
+++ b/lib/modules/dosomething/dosomething_campaign/js/campaign_node_form.js
@@ -6,10 +6,6 @@
 
     // List all elements that should only display when Campaign type == 'campaign'.
     var campaignSections = [];
-    // campaignSections.push("#node_campaign_form_group_prep_it");
-    // campaignSections.push("#node_campaign_form_group_do_it");
-    // campaignSections.push("#node_campaign_form_group_report_back");
-    // campaignSections.push("#node_campaign_form_group_pitch_additional_info");
 
     $('.fieldset-title').each(function(index, value) {
       // Get the title of the fieldset and strip out unneeded text
@@ -17,37 +13,27 @@
       //Check if it's a campaign only title
       if (campaignTitles.indexOf(title) != -1) {
         campaignSections.push($(value).closest('.form-wrapper'));
-        console.log(campaignSections);
       }
     });
 
     // If SMS Game, hide the campaignSections.
     if ($('#edit-field-campaign-type-und-sms-game').is(':checked')) {
-      // for (var i = 0; i < campaignSections.length; i++) {
-      //   $(campaignSections[i]).hide();
-      // }
       toggleSections(false);
     }
 
     // Listen for changes to the campaign type field.
     $('#edit-field-campaign-type-und-campaign, #edit-field-campaign-type-und-sms-game').click(function() {
       if ($('#edit-field-campaign-type-und-campaign').is(':checked')) {
-        // for (var i = 0; i < campaignSections.length; i++) {
-        //   $(campaignSections[i]).show();
-        // }
         toggleSections(true);
       }
       if ($('#edit-field-campaign-type-und-sms-game').is(':checked')) {
-        // for (var i = 0; i < campaignSections.length; i++) {
-        //   $(campaignSections[i]).hide();
-        // }
         toggleSections(false);
       }
     });
 
+    // Toggle the visibility of field sets in campaignSelections
     function toggleSections(show) {
       campaignSections.forEach(function($element, index, array) {
-        console.log($element);
         if (show) {
           $element.show();
         }


### PR DESCRIPTION
Fixes #4319 

Updated the script to no longer be ID based like it previously was (cause of it breaking). New method is sort of hacky but was the best solution me & @DFurnes could come too. Currently we find the title for each field group, if it matches a 'campaign only' the code traverses up the DOM until it finds a form-wrapper class and adds that to an array. 

@DFurnes 
