### PR TITLE
Fix linting errors in Donate form code.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/donate/Donate.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/donate/Donate.js
@@ -1,28 +1,18 @@
-/* eslint-disable */
-
-/* ----------------------------------------------------------
- * @TODO: ^ Enable linting by removing `eslint-disable`! ^
- * ----------------------------------------------------------
- * Linting is disabled in this file. Remove this line and
- * clean this file up according to our coding standards next
- * time it is touched.
- */
-
 import $ from 'jquery';
 import StripeForm from './StripeForm';
 import setting from '../utilities/Setting';
 
-const $donateForm = $('#dosomething-payment-form');
-
 /**
  * Initialize the Stripe donation form.
+ * @param {jQuery} $donateForm - Donation form element
  */
-function init() {
-  if(!$donateForm.length) return;
+function init($donateForm = $('#dosomething-payment-form')) {
+  if (!$donateForm.length) return;
 
   try {
-    var stripeAPIPublishKey = setting('dosomethingPayment.stripeAPIPublish');
-    new StripeForm($donateForm, stripeAPIPublishKey);
+    const stripeAPIPublishKey = setting('dosomethingPayment.stripeAPIPublish');
+    const form = new StripeForm($donateForm, stripeAPIPublishKey);
+    form.init();
   } catch(e) {
     $donateForm.html(`<div class="messages">Whoops! Something's not right. Please email us!</div>`);
   }

--- a/lib/themes/dosomething/paraneue_dosomething/js/donate/StripeForm.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/donate/StripeForm.js
@@ -13,15 +13,19 @@ class StripeForm {
     if (publishKey === undefined) throw new Error('Stripe key is required.');
 
     this.$form = $(form);
-
-    Stripe.setPublishableKey(publishKey);
-
     this.onFormSubmit = this.onFormSubmit.bind(this);
 
+    Stripe.setPublishableKey(publishKey);
+  }
+
+  /**
+   * Initialize the form & hook up event listeners.
+   */
+  init() {
     // Prevent `dosomething-validation` handler from running
     this.$form.on('submit', (event) => event.preventDefault());
 
-    // attach event listener to submit button to avoid double binding
+    // Attach event listener to submit button to avoid double binding
     this.$form.find('.form-submit').on('click', this.onFormSubmit);
   }
 


### PR DESCRIPTION
# Changes

Fixed up a few minor errors in donation code so we can start linting it.
- Remove side-effects (event binding) from constructor and move into an `init()` method for the `StripeForm`. This fixes the code smell of [using the constructor without storing the result](http://eslint.org/docs/rules/no-new.html).
- Allow the selector for donation form to be overridden as a parameter to `init($donateForm)`, rather than hard-coding in this file. This follows the same convention we're using elsewhere.

For review: @DoSomething/front-end 
