### PR TITLE
Campaign class bug fix

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -28,9 +28,10 @@ class Campaign {
 
 
   /**
+   * Convenience method to retrieve a single campaign from supplied id.
+   *
    * @param $id
    * @param $display
-   *
    * @return static
    * @throws Exception
    */
@@ -43,9 +44,10 @@ class Campaign {
 
 
   /**
+   * Build out the instantiated Campaign class object with supplied data.
+   *
    * @param $id
    * @param $display
-   *
    * @throws Exception
    */
   public function load($id, $display = 'teaser') {
@@ -335,7 +337,7 @@ class Campaign {
     $data = array();
 
     $tag_ids = dosomething_helpers_extract_field_data($this->node->field_tags);
-    
+
     if ($tag_ids) {
       foreach ((array) $tag_ids as $id) {
         $data[] = $this->getTaxonomyTerm($id);
@@ -415,6 +417,7 @@ class Campaign {
 
   /**
    * Get the Scholarship amount for campaign if available.
+   *
    * @return array|null
    */
   protected function getScholarship() {

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -335,9 +335,9 @@ class Campaign {
     $data = array();
 
     $tag_ids = dosomething_helpers_extract_field_data($this->node->field_tags);
-
+    
     if ($tag_ids) {
-      foreach ($tag_ids as $id) {
+      foreach ((array) $tag_ids as $id) {
         $data[] = $this->getTaxonomyTerm($id);
       }
 


### PR DESCRIPTION
Quickie fix based on a warning in Drupal error logs. If only 1 tag assigned to a campaign, the `foreach` would crap out because it was not an array and simply a string. So the returned data is now cast to an array to allow foreach to run fine even if a single item.

Also some comment cleanup and updates.

@aaronschachter 
