### PR TITLE
Adds register & login custom events

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -435,8 +435,9 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $vars['reportback_form'] = $vars['content']['reportback_form'];
 
   // Add analytics custom event on action page.
-  $google_analytics_js = 'if(typeof(ga) !== "undefined" && ga !== null) { ga("send", "event", "Action Page View", "' . $vars['title'] . '"); }';
-  drupal_add_js($google_analytics_js, 'inline');
+  //$google_analytics_js = 'if(typeof(ga) !== "undefined" && ga !== null) { ga("send", "event", "Action Page View", "' . $vars['title'] . '"); }';
+  //drupal_add_js($google_analytics_js, 'inline');
+  dosomething_helpers_add_analytics_event("Action Page View", $vars['title']);
 
   $optimizely_js = 'window["optimizely"] = window["optimizely"] || []; window.optimizely.push(["trackEvent", "Action Page View"]);';
   drupal_add_js($optimizely_js, 'inline');

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -435,8 +435,6 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $vars['reportback_form'] = $vars['content']['reportback_form'];
 
   // Add analytics custom event on action page.
-  //$google_analytics_js = 'if(typeof(ga) !== "undefined" && ga !== null) { ga("send", "event", "Action Page View", "' . $vars['title'] . '"); }';
-  //drupal_add_js($google_analytics_js, 'inline');
   dosomething_helpers_add_analytics_event("Action Page View", $vars['title']);
 
   $optimizely_js = 'window["optimizely"] = window["optimizely"] || []; window.optimizely.push(["trackEvent", "Action Page View"]);';

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -441,3 +441,23 @@ function dosomething_helpers_text_truncate($text, $length = 100, $ending = '...'
 function dosomething_helpers_floor_decimal($value, $decimals = 1) {
   return floor($value * pow(10, $decimals)) / pow(10, $decimals);
 }
+
+/**
+ * Adds custom GA event to page
+ *
+ * @param String category The category of the event
+ * @param String action The action being performed
+ * @param String label The event label (Optional)
+ * @param String value The value to be sent (Optional)
+ */
+function dosomething_helpers_add_analytics_event($category, $action, $label, $value) {
+  $event_string = '"' . $category . '"' . ', ' . '"' . $action . '"';
+  if ($label) {
+    $event_string = $event_string . ', ' . $label;
+  }
+  if ($value) {
+    $event_string = $event_string  . ',' . $value;
+  }
+  $google_analytics_js = 'if(typeof(ga) !== "undefined" && ga !== null) { ga("send", "event", ' . $event_string . '); }';
+  drupal_add_js($google_analytics_js, 'inline');
+}

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -450,7 +450,7 @@ function dosomething_helpers_floor_decimal($value, $decimals = 1) {
  * @param String label The event label (Optional)
  * @param String value The value to be sent (Optional)
  */
-function dosomething_helpers_add_analytics_event($category, $action, $label, $value) {
+function dosomething_helpers_add_analytics_event($category, $action, $label = NULL, $value = NULL) {
   $event_string = '"' . $category . '"' . ', ' . '"' . $action . '"';
   if ($label) {
     $event_string = $event_string . ', ' . $label;

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -15,6 +15,10 @@ include_once 'dosomething_user.theme.inc';
  */
 function dosomething_user_preprocess_page(&$vars) {
   $school_api_endpoint = variable_get('dosomething_user_school_api_endpoint', 'http://lofischools.herokuapp.com/search');
+  if ($_SESSION['log_login']) {
+    dosomething_helpers_add_analytics_event("login", $_SESSION['log_login']);
+    unset($_SESSION['log_login']);
+  }
   drupal_add_js(
     array('dosomethingUser' =>
       array(
@@ -228,11 +232,12 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
       // Helper text & additional data.
       _dosomething_user_add_signup_data($form);
       $form['#submit'][] = 'dosomething_user_login_submit';
-
+      $_SESSION['log_login'] = "login";
     break;
 
     case 'user_profile_form':
     case 'user_register_form':
+      $_SESSION['log_login'] = "register";
       // Gather helper text.
       _dosomething_user_register_helper_text($form);
       // Conditionally displays certain fields based on configuration settings.
@@ -436,6 +441,7 @@ function dosomething_user_update_user($form, &$form_state) {
  * Sign user up for emails/texts.
  */
 function dosomething_user_new_user($form, &$form_state) {
+  $_SESSION['log_login'] = "register";
   if (!module_exists('dosomething_mbp') || !module_exists('dosomething_signup')) {
     return;
   }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -15,9 +15,9 @@ include_once 'dosomething_user.theme.inc';
  */
 function dosomething_user_preprocess_page(&$vars) {
   $school_api_endpoint = variable_get('dosomething_user_school_api_endpoint', 'http://lofischools.herokuapp.com/search');
-  if ($_SESSION['log_login']) {
-    dosomething_helpers_add_analytics_event("login", $_SESSION['log_login']);
-    unset($_SESSION['log_login']);
+  if ($_SESSION['dosomething_user_log_login']) {
+    dosomething_helpers_add_analytics_event("login", $_SESSION['dosomething_user_log_login']);
+    unset($_SESSION['dosomething_user_log_login']);
   }
   drupal_add_js(
     array('dosomethingUser' =>
@@ -232,7 +232,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
       // Helper text & additional data.
       _dosomething_user_add_signup_data($form);
       $form['#submit'][] = 'dosomething_user_login_submit';
-      $_SESSION['log_login'] = "login";
+      $_SESSION['dosomething_user_log_login'] = "login";
     break;
 
     case 'user_profile_form':
@@ -440,7 +440,7 @@ function dosomething_user_update_user($form, &$form_state) {
  * Sign user up for emails/texts.
  */
 function dosomething_user_new_user($form, &$form_state) {
-  $_SESSION['log_login'] = "register";
+  $_SESSION['dosomething_user_log_login'] = "register";
   if (!module_exists('dosomething_mbp') || !module_exists('dosomething_signup')) {
     return;
   }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -237,7 +237,6 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
 
     case 'user_profile_form':
     case 'user_register_form':
-      $_SESSION['log_login'] = "register";
       // Gather helper text.
       _dosomething_user_register_helper_text($form);
       // Conditionally displays certain fields based on configuration settings.


### PR DESCRIPTION
None of the signup / login functions return anything so you can't add a drupal_add_js there (also the redirects can break add_js). To workaround this I added into the user session whether they were loggin in or registering. Then in the preprocess I add the Google Analytics JS w/ the value of that session var (and unset it).

Fixes #4589 

@DFurnes @angaither 
