### PR TITLE
Form updates for multiplayer SMS games

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -192,7 +192,7 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
         '#attributes' => array(
           'data-validate' => 'friend_name',
           'data-validate-required' => '',
-          'placeholder' => t('(555) 555-5555'),
+          'placeholder' => t('Friend\'s Name'),
           'autocomplete' => 'off',
         ),
       );

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -145,6 +145,13 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
     '#default_value' => $num_friends,
     '#access' => FALSE,
   );
+  $form['#attributes'] = array(
+    'class' => ['sms-campaign-form'],
+  );
+  // If this is a multiplayer game, add style overrides.
+  if ($form['sms_game_type']['#default_value'] === 'multi_player') {
+    $form['#attributes']['class'][] = 'sms-campaign-form--multiplayer';
+  }
   // Load "all participants" copy.
   $all_participants_copy = variable_get('dosomething_campaign_sms_game_all_participants_copy');
   $form['all_participants_copy'] = array(
@@ -163,14 +170,7 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
       'placeholder' => t('First Name'),
     ),
   );
-  // Add fieldsets to wrappers to various mobile form elements.
-  $form['group1'] = array(
-    '#type' => 'fieldset',
-    '#attributes' => array(
-      'class' => array('campaign-sms-numbers'),
-    ),
-  );
-  $form['group1']['alpha_mobile'] = array(
+  $form['alpha_mobile'] = array(
     '#type' => 'textfield',
     '#required' => TRUE,
     '#title' => 'Your Cell Number',
@@ -183,12 +183,22 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
     ),
   );
   for ($i = 0; $i < $num_friends; $i++) {
-    $form['group1']['beta_first_name_' .$i] = array(
-      '#type' => 'hidden',
-      '#title' => 'Your Friend\'s Name',
-    );
+    // If this is a multiplayer game, add first name fields.
+    if ($form['sms_game_type']['#default_value'] === 'multi_player') {
+      $form['beta_first_name_' .$i] = array(
+        '#type' => 'textfield',
+        '#title' => 'Your Friend\'s Name',
+        '#required' => TRUE,
+        '#attributes' => array(
+          'data-validate' => 'friend_name',
+          'data-validate-required' => '',
+          'placeholder' => t('(555) 555-5555'),
+          'autocomplete' => 'off',
+        ),
+      );
+    }
 
-    $form['group1']['beta_mobile_' .$i] = array(
+    $form['beta_mobile_' .$i] = array(
       '#type' => 'textfield',
       '#required' => TRUE,
       '#title' => 'Friend\'s Cell Number',

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-sms.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-sms.scss
@@ -21,9 +21,22 @@
       }
     }
 
-    // @EXPERIMENTAL: Used for Optimizely test for first names on SMS forms.
-    .optimizely-sms-form {
+    .sms-campaign-form {
+      .form-item {
+        @include span(100%);
+
+        @include media($medium) {
+          @include span(50%);
+        }
+      }
+    }
+
+    .sms-campaign-form--multiplayer {
       padding-top: $base-spacing;
+
+      .form-item-alpha-mobile {
+        clear: none;
+      }
 
       .message-callout.-above {
         @include media($tablet) {
@@ -43,17 +56,8 @@
       }
     }
 
-    .campaign-sms-numbers {
+    .form-item-alpha-mobile {
       clear: both;
-
-      .form-item {
-        @include span(100%);
-
-        @include media($medium) {
-          @include span(50%);
-        }
-      }
-
     }
 
     .form-wrapper.-columned {

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -98,58 +98,6 @@
           <?php print render($signup_form); ?>
         <?php endif; ?>
 
-        <!-- ########## A/B Test For SMS First Names ##########  -->
-        <!-- We find the fieldset "edit-group1" in the form above, and replace  -->
-        <!-- with the below snippet. This allows us to swap out form fields -->
-        <!-- without losing CSRF tokens: -->
-
-        <!--  var $ = jQuery; var $form = $("#dosomething-signup-sms-game-form"); $form.addClass('optimizely-sms-form'); $form.find(".form-item-alpha-first-name").remove(); $form.find("#edit-group1").html($("#ab-test-sms-names").html());  -->
-
-        <div id="ab-test-sms-names" style="display: none;">
-          <div class="fieldset-wrapper">
-            <div class="form-item form-type-textfield">
-              <label class="field-label" for="edit-alpha-first-name">Your First Name <span class="form-required" title="This field is required.">*</span></label>
-              <input data-validate="fname" data-validate-required="" placeholder="First Name" type="text" id="edit-alpha-first-name" name="alpha_first_name" value="" size="60" maxlength="128" class="text-field required has-success">
-            </div>
-
-            <div class="form-item form-type-textfield form-item-alpha-mobile">
-              <label class="field-label" for="edit-alpha-mobile">Your Cell Number <span class="form-required" title="This field is required.">*</span></label>
-              <input data-validate="phone" data-validate-required="" placeholder="(555) 555-5555" autocomplete="off" type="text" id="edit-alpha-mobile" name="alpha_mobile" value="" size="60" maxlength="128" class="text-field required">
-            </div>
-
-            <div class="form-item form-type-textfield">
-              <label class="field-label" for="edit-beta-first-name-0">Your Friend's Name <span class="form-required" title="This field is required.">*</span></label>
-              <input data-validate="friend_name" data-validate-required="" placeholder="Friend's Name" type="text" id="edit-beta-first-name-0" name="beta_first_name_0" value="" size="60" maxlength="128" class="text-field required has-success">
-            </div>
-
-            <div class="form-item form-type-textfield form-item-alpha-mobile">
-              <label class="field-label" for="edit-beta-mobile-0">Friend's Cell Number <span class="form-required" title="This field is required.">*</span></label>
-              <input data-validate="phone" data-validate-required="" placeholder="(555) 555-5555" autocomplete="off" type="text" id="edit-beta-mobile-0" name="beta_mobile_0" value="" size="60" maxlength="128" class="text-field required">
-            </div>
-
-            <div class="form-item form-type-textfield ">
-              <label class="field-label" for="edit-beta-first-name-1">Your Friend's Name <span class="form-required" title="This field is required.">*</span></label>
-              <input data-validate="friend_name" data-validate-required="" placeholder="Friend's Name" type="text" id="edit-beta-first-name-1" name="beta_first_name_1" value="" size="60" maxlength="128" class="text-field required has-success">
-            </div>
-
-            <div class="form-item form-type-textfield form-item-alpha-mobile">
-              <label class="field-label" for="edit-beta-mobile-1">Friend's Cell Number <span class="form-required" title="This field is required.">*</span></label>
-              <input data-validate="phone" data-validate-required="" placeholder="(555) 555-5555" autocomplete="off" type="text" id="edit-beta-mobile-1" name="beta_mobile_1" value="" size="60" maxlength="128" class="text-field required">
-            </div>
-
-            <div class="form-item form-type-textfield">
-              <label class="field-label" for="edit-beta-first-name-2">Your Friend's Name <span class="form-required" title="This field is required.">*</span></label>
-              <input data-validate="friend_name" data-validate-required="" placeholder="Friend's Name" type="text" id="edit-beta-first-name-2" name="beta_first_name_2" value="" size="60" maxlength="128" class="text-field required has-success">
-            </div>
-
-            <div class="form-item form-type-textfield form-item-alpha-mobile">
-              <label class="field-label" for="edit-beta-mobile-2">Friend's Cell Number <span class="form-required" title="This field is required.">*</span></label>
-              <input data-validate="phone" data-validate-required="" placeholder="(555) 555-5555" autocomplete="off" type="text" id="edit-beta-mobile-2" name="beta_mobile_2" value="" size="60" maxlength="128" class="text-field required">
-            </div>
-          </div>
-        </div>
-        <!-- ########## END A/B Test For SMS First Names ########## -->
-
         <div class="container__block -narrow">
           <?php if (isset($official_rules)): ?>
             <p class="footnote">


### PR DESCRIPTION
# Step 1: Know It
- This merges in the changes that were A/B tested in #4247. All multiplayer games will now have first name fields. Closes #4499.

For review: @angaither @aaronschachter @tongxiang 
# Step 4: Prove It

For single-player games (configured with `mobilecommons_opt_in_path` and `mobilecommons_friends_opt_in_path`):
![screen shot 2015-07-21 at 3 10 12 pm](https://cloud.githubusercontent.com/assets/583202/8810096/a86a2be6-2fba-11e5-9611-5d89ece986b5.png)

For multiplayer games (configured with `ms_game_mp_story_id` and `sms_game_mp_story_type`):
![screen shot 2015-07-21 at 3 10 22 pm](https://cloud.githubusercontent.com/assets/583202/8810099/ab40ad40-2fba-11e5-9c21-26e8fb639172.png)
