### PR TITLE
Hot Module: Social Stuff

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -221,7 +221,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
     'picture' => $vars['hero_image']['desktop'],
     'caption' => $goal_copy . "? Let's make it happen!",
   );
-  $vars['hot_module_fb_link'] = dosomething_helpers_get_facebook_intent('feed_dialog', $share_paths['facebook'], $fb_options);
+  $vars['hot_module_fb_link'] = dosomething_helpers_get_facebook_intent($share_paths['facebook'], 'feed_dialog', $fb_options);
 
   // Twitter
   $tweet = "Be a part of @dosomething reaching " . $goal_copy . "- who's ready to rumble?! " . $share_paths['twitter'];

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -204,27 +204,34 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
   $vars['author_name']  = $first_name . ' ' . $last_name;
   $vars['author_title'] = check_plain($wrapper->author->field_job_title->value());
   if($author->picture) {
-      $vars['author_image'] = dosomething_image_get_themed_image_by_fid($author->picture->fid, '300x300'); 
+    $vars['author_image'] = dosomething_image_get_themed_image_by_fid($author->picture->fid, '300x300');
   }
 
   // Share links
+  // @TODO - Possible refactor: Create a function that creates a 'share bar', programatically creating
+  // the markup and links for facebook, twitter, and tumblr buttons for us.
   $campaign_path = url(current_path(), array('absolute' => TRUE));
+
   $goal_copy = number_format($goal, 0, '', ',') . " " . strtolower($vars['reportback_noun_verb']) . " by " . $readable_end_date;
+
+  $share_types = array('facebook', 'twitter', 'tumblr');
+  $share_paths = dosomething_helpers_utm_share_paths($share_types, $campaign_path, 'hot_share');
 
   $fb_options = array(
     'picture' => $vars['hero_image']['desktop'],
     'caption' => $goal_copy . "? Let's make it happen!",
   );
-  $vars['hot_module_fb_link'] = dosomething_helpers_get_facebook_intent($campaign_path, 'feed_dialog', $fb_options);
+  $vars['hot_module_fb_link'] = dosomething_helpers_get_facebook_intent('feed_dialog', $share_paths['facebook'], $fb_options);
 
-  $tweet = "Be a part of @dosomething reaching " . $goal_copy . "- who's ready to rumble?! " . $campaign_path;
+  // Twitter
+  $tweet = "Be a part of @dosomething reaching " . $goal_copy . "- who's ready to rumble?! " . $share_paths['twitter'];
   $vars['hot_module_tw_link'] = dosomething_helpers_get_twitter_intent($tweet);
 
-  // Tumblr share parameters.
+  // Tumblr
   $tumblr_options = array(
     'posttype' => 'photo',
     'content' => $vars['hero_image']['desktop'],
-    'caption' => "Think you can make @dosomething reach " . $goal_copy . "? Prove it: " . $campaign_path,
+    'caption' => "Think you can make @dosomething reach " . $goal_copy . "? Prove it: " . $share_paths['tumblr'],
   );
 
   $vars['hot_module_tm_link'] = dosomething_helpers_get_tumblr_intent($tumblr_options);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -117,9 +117,10 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
   $end_date = new DateTime($node->field_high_season[LANGUAGE_NONE][0]['value2']);
   $difference = $today->diff($end_date, true);
   $days_left = $difference->d;
+  $readable_end_date = $end_date->format('F') . ' ' . $end_date->format('j') . $end_date->format('S');
 
   if ($days_left >= 8) {
-    $vars['time_left'] = t('Ends ' . $end_date->format('F') . ' ' . $end_date->format('j') . $end_date->format('S'));
+    $vars['time_left'] = t('Ends ' . $readable_end_date);
   }
   elseif ($days_left >= 3) {
     $vars['time_left'] = t($end_date->format('j') . ' days left');
@@ -205,6 +206,28 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
   if($author->picture) {
       $vars['author_image'] = dosomething_image_get_themed_image_by_fid($author->picture->fid, '300x300'); 
   }
+
+  // Share links
+  $campaign_path = url(current_path(), array('absolute' => TRUE));
+  $goal_copy = number_format($goal, 0, '', ',') . " " . strtolower($vars['reportback_noun_verb']) . " by " . $readable_end_date;
+
+  $fb_options = array(
+    'picture' => $vars['hero_image']['desktop'],
+    'caption' => $goal_copy . "? Let's make it happen!",
+  );
+  $vars['hot_module_fb_link'] = dosomething_helpers_get_facebook_intent($campaign_path, 'feed_dialog', $fb_options);
+
+  $tweet = "Be a part of @dosomething reaching " . $goal_copy . "- who's ready to rumble?! " . $campaign_path;
+  $vars['hot_module_tw_link'] = dosomething_helpers_get_twitter_intent($tweet);
+
+  // Tumblr share parameters.
+  $tumblr_options = array(
+    'posttype' => 'photo',
+    'content' => $vars['hero_image']['desktop'],
+    'caption' => "Think you can make @dosomething reach " . $goal_copy . "? Prove it: " . $campaign_path,
+  );
+
+  $vars['hot_module_tm_link'] = dosomething_helpers_get_tumblr_intent($tumblr_options);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -479,3 +479,22 @@ function dosomething_helpers_add_analytics_event($category, $action, $label = NU
   $google_analytics_js = 'if(typeof(ga) !== "undefined" && ga !== null) { ga("send", "event", ' . $event_string . '); }';
   drupal_add_js($google_analytics_js, 'inline');
 }
+
+/**
+ * Creates a simple query encoded string with basic or customized UTM params
+ * that can be added to any url.
+ * @param  $nid
+ * @param  array $options - custom utm values to use.
+ */
+function dosomething_helpers_utm_parameters($nid, $options = NULL) {
+  // Use the node id for 'utm_campaign', if it is given, otherwise use the custom value in $options
+  $utm_campaign = ($nid) ? $nid : ($options['utm_campaign']) ? $options['utm_campaign'] : NULL;
+
+  $utm_params = array(
+    'utm_source' => ($options['utm_source']) ? $options['utm_source'] : 'dosomething',
+    'utm_medium' => ($options['utm_medium']) ? $options['utm_medium'] : 'site',
+    'utm_campaign' => $utm_campaign,
+  );
+
+  return '?' . http_build_query($utm_params, '', '&');
+}

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -26,7 +26,7 @@ function dosomething_helpers_share_redirect() {
  *
  * @return string   The facebook intent url.
  */
-function dosomething_helpers_get_facebook_intent($link, $type = NULL, $custom_options = NULL) {
+function dosomething_helpers_get_facebook_intent($type = NULL, $link, $custom_options = NULL) {
   switch ($type) {
     // Used to create a facebook share link that uses a custom image,
     // different from what is set in the metatags.
@@ -82,4 +82,32 @@ function dosomething_helpers_get_twitter_intent($tweet) {
  */
 function dosomething_helpers_get_tumblr_intent($options) {
   return url('https://www.tumblr.com/widgets/share/tool', array('query' => $options));
+}
+
+/**
+ * Returns an array of paths to share on each social network with the
+ * correct utm parameters attached.
+ *
+ * @param  array $share_types
+ *   - array of social networks to create paths for.
+ *     i.e ['facebook', 'twitter', 'tumblr']
+ * @param string $path
+ *   The absolute path of the page being shared.
+ * @param string $utm_campaign
+ *   A custom value to use for 'utm_campaign'.
+ * @return
+ *   An array of paths, indexed by type.
+ */
+function dosomething_helpers_utm_share_paths($share_types, $path, $utm_campaign) {
+  foreach ($share_types as $type) {
+    $utm_params = dosomething_helpers_utm_parameters(NULL,
+      array(
+        'utm_medium' => $type,
+        'utm_campaign' => $utm_campaign,
+      )
+    );
+    $share_paths[$type] = $path . $utm_params;
+  }
+
+  return $share_paths;
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -26,7 +26,7 @@ function dosomething_helpers_share_redirect() {
  *
  * @return string   The facebook intent url.
  */
-function dosomething_helpers_get_facebook_intent($type = NULL, $link, $custom_options = NULL) {
+function dosomething_helpers_get_facebook_intent($link, $type = NULL, $custom_options = NULL) {
   switch ($type) {
     // Used to create a facebook share link that uses a custom image,
     // different from what is set in the metatags.

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -264,5 +264,4 @@ function dosomething_helpers_add_inline_css(&$vars) {
 
     drupal_add_css($style_alt_background, $option['type'] = 'inline');
   }
-  
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_author-callout.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_author-callout.scss
@@ -30,6 +30,10 @@
     }
   }
 
+  .figure {
+    margin-bottom: $base-spacing;
+  }
+
   .author-callout__first-name {
     font-size: $font-medium;
     font-weight: $weight-sbold;

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -91,9 +91,9 @@
               </div>
             </div>
             <ul class="social-share-bar -with-callout">
-              <li><a class="social-icon -facebook js-share-link js-analytics-problem-fb" href="<?php print $hot_module_fb_link; ?>"><span>Facebook</span></a></li>
-              <li><a class="social-icon -twitter js-share-link js-analytics-problem-tw" href="<?php print $hot_module_tw_link; ?>"><span>Twitter</span></a></li>
-              <li><a class="social-icon -tumblr js-share-link js-analytics-problem-tm" href="<?php print $hot_module_tm_link; ?>"><span>Tumblr</span></a></li>
+              <li><a class="social-icon -facebook js-share-link" href="<?php print $hot_module_fb_link; ?>"><span>Facebook</span></a></li>
+              <li><a class="social-icon -twitter js-share-link" href="<?php print $hot_module_tw_link; ?>"><span>Twitter</span></a></li>
+              <li><a class="social-icon -tumblr js-share-link" href="<?php print $hot_module_tm_link; ?>"><span>Tumblr</span></a></li>
             </ul>
           </div>
         </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -56,7 +56,9 @@
               <?php endif; ?>
             </div>
             <div class="stat-card__timing">
-              <p><?php print $time_left ?></p>
+              <?php if(isset($time_left)): ?>
+                <p><?php print $time_left ?></p>
+              <?php endif; ?>
             </div>
             <div class="stat-card__chart">
               <canvas class="js-progress-chart" width="280" height="200" data-goal="<?php print $goal; ?>"></canvas>
@@ -65,13 +67,17 @@
 
           <div class="author-callout">
             <div class="author-callout__copy">
-              <?php print $progress_copy; ?>
+              <?php if(isset($progress_copy)): ?>
+                <?php print $progress_copy; ?>
+              <?php endif; ?>
             </div>
 
             <article class="figure -left -center">
               <div class="figure__media">
                 <div class="avatar">
-                  <?php print $author_image ?>
+                  <?php if(isset($author_image)): ?>
+                    <?php print $author_image ?>
+                  <?php endif; ?>
                 </div>
               </div>
               <div class="figure__body">
@@ -79,6 +85,16 @@
                   <p class="author-callout__last-name"><?php print $author_title ?></p>
               </div>
             </article>
+            <div class="message-callout -above-horizontal -blue">
+              <div class="message-callout__copy">
+                <p><?php print $hot_module_share_copy; ?></p>
+              </div>
+            </div>
+            <ul class="social-share-bar -with-callout">
+              <li><a class="social-icon -facebook js-share-link js-analytics-problem-fb" href="<?php print $hot_module_fb_link; ?>"><span>Facebook</span></a></li>
+              <li><a class="social-icon -twitter js-share-link js-analytics-problem-tw" href="<?php print $hot_module_tw_link; ?>"><span>Twitter</span></a></li>
+              <li><a class="social-icon -tumblr js-share-link js-analytics-problem-tm" href="<?php print $hot_module_tm_link; ?>"><span>Tumblr</span></a></li>
+            </ul>
           </div>
         </div>
 


### PR DESCRIPTION
This PR fixes #4447 and addresses #4610.
- Adds goal share buttons to the hot module with a message callout. 
- Adds a helper function `dosomething_helpers_utm_parameters` that creates a query string of utm parameters that can be customized that can then be attached to any url.
- Addes a helper function `dosomething_helpers_utm_share_paths` that creates an array of paths to be shared that have the correct UTM parameters attached for each desired social network.
- Creates the intent links for the facebook, twitter, and tumblr buttons and passes them as variables to the template (NOTE: added a todo to move this work into another helper function since we now are doing it in a couple of places

@angaither @DoSomething/front-end 
