### PR TITLE
Hot module cross browser

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -114,6 +114,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
   $node = node_load($vars['nid']);
   //Calculate days left
   $today = new DateTime();
+  $start_date = new DateTime($node->field_high_season[LANGUAGE_NONE][0]['value']);
   $end_date = new DateTime($node->field_high_season[LANGUAGE_NONE][0]['value2']);
   $difference = $today->diff($end_date, true);
   $days_left = $difference->d;
@@ -176,7 +177,8 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
                                WHERE nid = :nid
                                GROUP BY date(from_unixtime(timestamp));", array(':nid' => $vars['nid']))->fetchAll();
   foreach($quantity_by_date as $date) {
-    $dates[] = $date->maxdate;
+    $maxdate = new DateTime($date->maxdate);
+    $dates[] = $maxdate->format('m/d/Y');
     $quantities[] = $date->quantity;
   }
 
@@ -187,8 +189,8 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
           'dates' => json_encode($dates),
           'quantities' => json_encode($quantities),
           'highSeason' => array(
-            'start' => new DateTime($node->field_high_season[LANGUAGE_NONE][0]['value']),
-            'end' => new DateTime($node->field_high_season[LANGUAGE_NONE][0]['value2']),
+            'start' => $start_date->format('m/d/Y'),
+            'end' => $end_date->format('m/d/Y')
           )
         ),
       ),

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -113,6 +113,7 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
 function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
   $node = node_load($vars['nid']);
   //Calculate days left
+  $date_format = 'm/d/Y';
   $today = new DateTime();
   $start_date = new DateTime($node->field_high_season[LANGUAGE_NONE][0]['value']);
   $end_date = new DateTime($node->field_high_season[LANGUAGE_NONE][0]['value2']);
@@ -178,7 +179,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
                                GROUP BY date(from_unixtime(timestamp));", array(':nid' => $vars['nid']))->fetchAll();
   foreach($quantity_by_date as $date) {
     $maxdate = new DateTime($date->maxdate);
-    $dates[] = $maxdate->format('m/d/Y');
+    $dates[] = $maxdate->format($date_format);
     $quantities[] = $date->quantity;
   }
 
@@ -189,8 +190,8 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
           'dates' => json_encode($dates),
           'quantities' => json_encode($quantities),
           'highSeason' => array(
-            'start' => $start_date->format('m/d/Y'),
-            'end' => $end_date->format('m/d/Y')
+            'start' => $start_date->format($date_format),
+            'end' => $end_date->format($date_format)
           )
         ),
       ),

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
@@ -114,16 +114,18 @@ var createQuantityArray = function(dates, dateLabels, quantities) {
  * and adds a property that has an array of 4 dates to be highlighted in the graph.
  */
 var createDataObj = function(data) {
+
   var yellow = "#fcd116";
   var darkYellow = "#E5BC09";
   var white = "#FFFFFF";
 
   // Use the highSeason start and end dates to determine the
   // four highlighed dates on the graph and turn those dates into labels.
-  var startDate = new Date(data.highSeason.start.date);
-  var endDate = new Date(data.highSeason.end.date);
+  var startDate = new Date(data.highSeason.start);
+  var endDate = new Date(data.highSeason.end);
   var highlightDates = getFourDates(startDate, endDate);
   highlightDates = createDateLabels(highlightDates);
+
 
   // Turn the dates we recieve from the backend, and the array of all dates in the high season
   // to readable labels, so we can use them for display and comparison.

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
@@ -268,11 +268,15 @@ var LineGraph = function($el, progressData) {
       this.chart.ctx.lineTo(scale.width - this.scale.xScalePaddingRight, goalPoint);
       this.chart.ctx.strokeStyle = lineColor;
       this.chart.ctx.lineWidth = 1;
-      this.chart.ctx.setLineDash([5, 15]);
+      if (this.chart.ctx.setLineDash) {
+        this.chart.ctx.setLineDash([5, 15]);
+      }
       this.chart.ctx.stroke();
 
       // clear dashes.
-      this.chart.ctx.setLineDash([]);
+      if (this.chart.ctx.setLineDash) {
+        this.chart.ctx.setLineDash([]);
+      }
 
       // Draw a grid line at each of the highlighted data points.
       Chart.helpers.each(this.scale.xLabels, function(label, index) {


### PR DESCRIPTION
## Addresses #4695
- Updated the format of the dates passed to the front end because the The pattern `yyyy-MM-dd` that being returned from PHP isn't an officially supported format for Date constructor in JS. This was causing some `Invalid Date` errors in Safari and IE9 that was stopping the graph from being rendered.
- Added a check for the support of the `setLineDash()` HTML5 Canvas function which is only supported in IE10+. So now in IE9 the goal line will be solid, not dashed. 

@DoSomething/front-end 
