### PR TITLE
Remove scale steps from graph

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
@@ -306,11 +306,6 @@ var LineGraph = function($el, progressData) {
 
   new Chart(ctx).LineWithGoal(data, {
     showScale: true,
-    scaleOverride: true,
-    scaleSteps: 10,
-    scaleStepWidth: goal / 10,
-    scaleStartValue: 0,
-    scaleLineWidth: 1,
     scaleShowLabels: false,
     scaleFontFamily: "'Proxima Nova', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif",
     scaleFontStyle: "Bold",


### PR DESCRIPTION
Remove the scale configuration from the graph so that the graph scales with the highest data point, even if it surpasses the goal line. Fixes #4696 

so this....

![screen shot 2015-07-22 at 11 29 07 am](https://cloud.githubusercontent.com/assets/1700409/8829553/3b45b0f2-3065-11e5-8b7c-b5156451a788.png)

Instead of this...

![screen shot 2015-07-22 at 11 32 51 am](https://cloud.githubusercontent.com/assets/1700409/8829575/5d448cdc-3065-11e5-9018-4b02a9856533.png)

Jammin...

![7375e1db283](https://cloud.githubusercontent.com/assets/1700409/8829581/654d6566-3065-11e5-99d9-527aa7a548f6.gif)

@DoSomething/front-end 
