### PR TITLE
Adds promoted/flagged reasons to the reportback log

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
@@ -40,7 +40,7 @@ function dosomething_reportback_cron() {
    * @see https://github.com/DoSomething/dosomething/issues/4529
    */
 
-  $results = db_query("UPDATE dosomething_reportback as rb
+  db_query("UPDATE dosomething_reportback as rb
                        INNER JOIN dosomething_reportback_file as rbf on rb.rbid = rbf.rbid
                        INNER JOIN dosomething_reportback_log as rbl on rb.rbid = rbl.rbid
                        SET rb.flagged = 1, rb.flagged_reason = rbl.reason
@@ -48,7 +48,7 @@ function dosomething_reportback_cron() {
                        AND rbl.op = 'flagged'
                        AND (rb.flagged = 0 or rb.flagged is null);");
 
-  $results = db_query("UPDATE dosomething_reportback as rb
+  db_query("UPDATE dosomething_reportback as rb
                       INNER JOIN dosomething_reportback_file as rbf on rb.rbid = rbf.rbid
                       INNER JOIN dosomething_reportback_log as rbl on rb.rbid = rbl.rbid
                       SET rb.promoted = 1, rb.promoted_reason = rbl.reason

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
@@ -42,8 +42,18 @@ function dosomething_reportback_cron() {
 
   $results = db_query("UPDATE dosomething_reportback as rb
                        INNER JOIN dosomething_reportback_file as rbf on rb.rbid = rbf.rbid
-                       SET rb.flagged = 1
+                       INNER JOIN dosomething_reportback_log as rbl on rb.rbid = rbl.rbid
+                       SET rb.flagged = 1, rb.flagged_reason = rbl.reason
                        WHERE rbf.status = 'flagged'
+                       AND rbl.op = 'flagged'
                        AND (rb.flagged = 0 or rb.flagged is null);");
+
+  $results = db_query("UPDATE dosomething_reportback as rb
+                      INNER JOIN dosomething_reportback_file as rbf on rb.rbid = rbf.rbid
+                      INNER JOIN dosomething_reportback_log as rbl on rb.rbid = rbl.rbid
+                      SET rb.promoted = 1, rb.promoted_reason = rbl.reason
+                      WHERE rbf.status = 'promoted'
+                      AND rbl.op = 'promoted'
+                      AND (rb.promoted = 0 or rb.promoted is null);");
 
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -155,6 +155,12 @@ function dosomething_reportback_schema() {
         'length' => '2048',
         'not null' => FALSE,
       ),
+      'reason' => array(
+        'description' => 'The reason the reoportback item was flagged/promoted',
+        'type' => 'text',
+        'length' => '2048',
+        'not null' => FALSE,
+      ),
     ),
     'primary key' => array('id'),
   );
@@ -771,4 +777,14 @@ function dosomething_reportback_update_7027(&$sandbox) {
   $table_name = 'dosomething_reportback_progress_log';
   $schema = dosomething_reportback_schema();
   db_create_table($table_name, $schema[$table_name]);
+}
+
+/**
+ * Adds the operation reason to the reportback log table
+ */
+function dosomething_reportback_update_7028(&$sandbox) {
+  $table_name = 'dosomething_reportback_log';
+  $schema = dosomething_reportback_schema();
+  $field_name = "reason";
+  db_add_field($table_name, $field_name, $schema[$table_name]['fields'][$field_name]);
 }

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -277,6 +277,7 @@ class Reportback extends Entity {
           'files' => implode(',', $fids),
           'num_files' => count($fids),
           'remote_addr' => dosomething_helpers_ip_address(),
+          'reason' => 'test',
         ))
         ->execute();
     }

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -277,7 +277,7 @@ class Reportback extends Entity {
           'files' => implode(',', $fids),
           'num_files' => count($fids),
           'remote_addr' => dosomething_helpers_ip_address(),
-          'reason' => 'test',
+          'reason' => $this->flagged_reason == NULL ? $this->promoted_reason : $this->flagged_reason,
         ))
         ->execute();
     }
@@ -337,6 +337,8 @@ class Reportback extends Entity {
     else {
       $this->flagged = 0;
       $this->promoted = 0;
+      $this->promoted_reason = NULL;
+      $this->flagged_reason = NULL;
     }
     return entity_save('reportback', $this);
   }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackController.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackController.php
@@ -88,6 +88,12 @@ public function save($entity, DatabaseTransaction $transaction = NULL) {
     $entity->created = $now;
     $op = 'insert';
   }
+  if ($entity->promoted) {
+    $op = 'promoted';
+  }
+  elseif ($entity->flagged) {
+    $op = 'flagged';
+  }
   $entity->updated = $now;
   if (DOSOMETHING_REPORTBACK_LOG) {
     watchdog('dosomething_reportback', 'save:' . json_encode($entity));

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackController.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackController.php
@@ -81,56 +81,56 @@ return $build;
 * Populates created and uid automatically.
 */
 public function save($entity, DatabaseTransaction $transaction = NULL) {
-global $user;
-$now = REQUEST_TIME;
-$op = 'update';
-if (isset($entity->is_new)) {
-$entity->created = $now;
-$op = 'insert';
-}
-$entity->updated = $now;
-if (DOSOMETHING_REPORTBACK_LOG) {
-watchdog('dosomething_reportback', 'save:' . json_encode($entity));
-}
+  global $user;
+  $now = REQUEST_TIME;
+  $op = 'update';
+  if (isset($entity->is_new)) {
+    $entity->created = $now;
+    $op = 'insert';
+  }
+  $entity->updated = $now;
+  if (DOSOMETHING_REPORTBACK_LOG) {
+    watchdog('dosomething_reportback', 'save:' . json_encode($entity));
+  }
 
-// Make sure a uid exists.
-if (!isset($entity->uid)) {
-return FALSE;
-}
-// If the entity uid doesn't belong to current user:
-if ($entity->uid != $user->uid) {
-// And current user can't edit any reportback:
-if (!user_access('edit any reportback') && !drupal_is_cli()) {
-watchdog('dosomething_reportback', "Attempted uid override for @reportback by User @uid",
-array(
-'@reportback' => json_encode($entity),
-'@uid' => $user->uid,
-), WATCHDOG_WARNING);
-return FALSE;
-}
-}
+  // Make sure a uid exists.
+  if (!isset($entity->uid)) {
+    return FALSE;
+  }
+  // If the entity uid doesn't belong to current user:
+  if ($entity->uid != $user->uid) {
+    // And current user can't edit any reportback:
+    if (!user_access('edit any reportback') && !drupal_is_cli()) {
+      watchdog('dosomething_reportback', "Attempted uid override for @reportback by User @uid",
+      array(
+      '@reportback' => json_encode($entity),
+      '@uid' => $user->uid,
+      ), WATCHDOG_WARNING);
+      return FALSE;
+    }
+  }
 
-parent::save($entity, $transaction);
+  parent::save($entity, $transaction);
 
-// If a file fid exists:
-if (isset($entity->fid)) {
-// Add it into the reportback files.
-$entity->createReportbackFile($entity);
-}
-// Log the write operation.
-$entity->insertLog($op);
+  // If a file fid exists:
+  if (isset($entity->fid)) {
+    // Add it into the reportback files.
+    $entity->createReportbackFile($entity);
+  }
+  // Log the write operation.
+  $entity->insertLog($op);
 
-// If this was an insert:
-if ($op == 'insert') {
-// Send Message Broker request.
-if (module_exists('dosomething_mbp')) {
-dosomething_reportback_mbp_request($entity);
-}
-if (module_exists('dosomething_reward')) {
-// Check for Reportback Count Reward.
-dosomething_reward_reportback_count($entity);
-}
-}
+  // If this was an insert:
+  if ($op == 'insert') {
+    // Send Message Broker request.
+    if (module_exists('dosomething_mbp')) {
+      dosomething_reportback_mbp_request($entity);
+    }
+    if (module_exists('dosomething_reward')) {
+      // Check for Reportback Count Reward.
+      dosomething_reward_reportback_count($entity);
+    }
+  }
 
 }
 


### PR DESCRIPTION
Fixes #4658 
- Adds new column to the table 
- Adds the flagged or promoted reason
- Also fixes a bug that was partially still remaining from #4621 where the reason stays in the reportback after you change it to approved

This is what the DB looks like in my dev for reference 

![screen shot 2015-07-23 at 11 29 02 am](https://cloud.githubusercontent.com/assets/897368/8854474/0f5ec310-312e-11e5-8763-e73e3e7c5c06.png)

@angaither 
