### PR TITLE
Fixing small bug when generating URI for single resource and adding URI property to other resources.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -293,6 +293,30 @@ abstract class Transformer {
 
 
   /**
+   * Transform Kudos data and prepare for API response.
+   *
+   * @param object $data A Kudos object containing the following properties:
+   *  - id: (string)
+   *  - term: (array)
+   *  - reportback_item: (array)
+   *  - user: (array)
+   *  - uri: (string)
+   * @return array
+   */
+  protected function transformKudos($data) {
+    $output = [
+      'id' => $data->id,
+      'term' => $data->term,
+      'reportback_item' => $data->reportback_item,
+      'user' => $data->user,
+      'uri' => $data->uri . '.json',
+    ];
+
+    return $output;
+  }
+
+
+  /**
    * Transform Media data and prepare for API response.
    *
    * @param array $data
@@ -345,6 +369,7 @@ abstract class Transformer {
       'created_at' => $data->created_at,
       'updated_at' => $data->updated_at,
       'quantity' => $data->quantity,
+      'uri' => $data->uri . '.json',
     ];
 
     if ($data instanceof Reportback) {

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -232,7 +232,6 @@ abstract class Transformer {
     $output = array(
       'id' => isset($data->id) ? $data->id : $data->nid,
       'title' => $data->title,
-      'reportback_info' => $data->reportback_info,
     );
 
     // If an instance of Campaign class, then there is much
@@ -279,6 +278,12 @@ abstract class Transformer {
 
         $output['timing']['high_season'] = $data->timing['high_season'];
         $output['timing']['low_season'] = $data->timing['low_season'];
+      }
+
+      $output['reportback_info'] = $data->reportback_info;
+
+      if ($data->uri) {
+        $output['uri'] = $data->uri . '.json';
       }
 
     }

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -60,6 +60,7 @@ class CampaignTransformer extends Transformer {
   public function show($id) {
     try {
       $campaign = Campaign::get($id, 'full');
+      $campaign = services_resource_build_index_list($campaign, 'campaigns', 'id');
     }
     catch (Exception $error) {
       return array(
@@ -76,13 +77,15 @@ class CampaignTransformer extends Transformer {
 
 
   /**
-   * @param object $campaign
+   * Transform data and build out response.
+   *
+   * @param object $item Single Campaign object of retrieved data.
    * @return array
    */
-  protected function transform($campaign) {
+  protected function transform($item) {
     $data = array();
 
-    $data += $this->transformCampaign($campaign);
+    $data += $this->transformCampaign($item);
 
     return $data;
   }

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -86,7 +86,6 @@ function dosomething_kudos_get_kudos_query($params = []) {
  * Sort kudos collection based on taxonomy term and then group them by term.
  *
  * @param array $data Collection of individual kudos items.
- *
  * @param string $display
  * @return array
  */
@@ -109,12 +108,14 @@ function dosomething_kudos_sort($data, $display = 'teaser') {
 /**
  * Sort kudos collection by taxonomy term id using a value comparison function.
  *
- * @param array $a Instance of Kudos class object.
- * @param array $b Instance of Kudos class object.
- *
+ * @param array|object $a Array of Kudos data or instance of Kudos class object.
+ * @param array|object $b Array of Kudos data or instance of Kudos class object.
  * @return mixed
  */
 function dosomething_kudos_sort_by_taxonomy_term($a, $b) {
+  $a = (object) $a;
+  $b = (object) $b;
+
   // Sort by taxonomy term id.
   $result = $a->term['id'] - $b->term['id'];
 
@@ -128,14 +129,17 @@ function dosomething_kudos_sort_by_taxonomy_term($a, $b) {
 /**
  * Group all kudos in collection and organize them by taxonomy term.
  *
- * @param array $data
- *
+ * @param array $data Array containing Kudos items.
  * @return array
  */
 function dosomething_kudos_group_by_taxonomy_term($data, $display = 'teaser') {
   $terms = [];
 
   foreach ($data as $item) {
+    if (!($item instanceof Kudos)) {
+      $item = (object) $item;
+    }
+
     if (!array_key_exists($item->term['id'], $terms)) {
       $terms[$item->term['id']] = [
         'term' => $item->term,
@@ -151,6 +155,10 @@ function dosomething_kudos_group_by_taxonomy_term($data, $display = 'teaser') {
       $output['reportback_item'] = $item->reportback_item;
     }
 
+    if ($item->uri) {
+      $output['uri'] = $item->uri;
+    }
+
     $terms[$item->term['id']]['kudos_items']['data'][] = $output;
   }
 
@@ -163,7 +171,6 @@ function dosomething_kudos_group_by_taxonomy_term($data, $display = 'teaser') {
  * Calculate total kudos per taxonomy term for a collection of kudos.
  *
  * @param array $data
- *
  * @return array
  */
 function dosomething_kudos_get_totals_by_taxonomy_term($data) {

--- a/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
@@ -18,6 +18,7 @@ class KudosTransformer extends Transformer {
 
     try {
       $kudos = Kudos::find($filters);
+      $kudos = services_resource_build_index_list($kudos, 'kudos', 'id');
     }
     catch (Exception $error) {
       return [
@@ -47,6 +48,7 @@ class KudosTransformer extends Transformer {
   public function show($id) {
     try {
       $kudos = Kudos::get($id);
+      $kudos = services_resource_build_index_list($kudos, 'kudos', 'id');
     }
     catch (Exception $error) {
       return [
@@ -127,11 +129,17 @@ class KudosTransformer extends Transformer {
 
 
   /**
-   * @param object $kudos
+   * Transform data and build out response.
+   *
+   * @param object $item Single Kudos object of retrieved data.
    * @return array
    */
-  protected function transform($kudos) {
-    return $kudos;
+  protected function transform($item) {
+    $data = [];
+
+    $data += $this->transformKudos($item);
+
+    return $data;
   }
 
 }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackController.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackController.php
@@ -1,155 +1,153 @@
 <?php
 
-/**
-* Our custom controller for the dosomething_reportback type.
-*/
 class ReportbackController extends EntityAPIController {
 
-/**
-* Overrides buildContent() method.
-*
-* Adds Reportback properties into Reportback entity's render.
-*/
-public function buildContent($entity, $view_mode = 'full', $langcode = NULL, $content = array()) {
-$build = parent::buildContent($entity, $view_mode, $langcode, $content);
+  /**
+   * Overrides buildContent() method.
+   *
+   * Adds Reportback properties into Reportback entity's render.
+   */
+  public function buildContent($entity, $view_mode = 'full', $langcode = NULL, $content = array()) {
+    $build = parent::buildContent($entity, $view_mode, $langcode, $content);
 
-// Load review form for the Reportback.
-module_load_include('inc', 'dosomething_reportback', 'dosomething_reportback.admin');
-$review_form = drupal_get_form('dosomething_reportback_files_form', NULL, $entity);
+    // Load review form for the Reportback.
+    module_load_include('inc', 'dosomething_reportback', 'dosomething_reportback.admin');
+    $review_form = drupal_get_form('dosomething_reportback_files_form', NULL, $entity);
 
-// If this reportback has been flagged:
-if ($entity->flagged) {
-$flagged_copy = 'Flagged as ' . $entity->flagged_reason . '.';
-drupal_set_message($flagged_copy, 'warning');
-}
+    // If this reportback has been flagged:
+    if ($entity->flagged) {
+      $flagged_copy = 'Flagged as ' . $entity->flagged_reason . '.';
+      drupal_set_message($flagged_copy, 'warning');
+    }
 
-// Load user to get username.
-$account = user_load($entity->uid);
-$build['username'] = array(
-'#prefix' => '<p>',
-  '#markup' => l($account->mail, 'user/' . $account->uid),
-  '#suffix' => '</p>',
-);
-$build['node_title'] = array(
-'#prefix' => '<p>',
-  '#markup' => l($entity->node_title, 'node/' . $entity->nid),
-  '#suffix' => '</p>',
-);
-$quantity_label = $entity->noun . ' ' . $entity->verb;
-$build['quantity_count'] = array(
-'#prefix' => '<p>',
-  '#markup' => 'Quantity: <strong>' . check_plain($entity->quantity) . '</strong> ' . $quantity_label,
-  '#suffix' => '</p>',
-);
-if ($entity->num_participants) {
-$build['num_participants'] = array(
-'#prefix' => '<p>',
-  '#markup' => '# of Participants: <strong>' . $entity->num_participants . '</strong> ',
-  '#suffix' => '</p>',
-);
-}
-$build['why_participated'] = array(
-'#prefix' => '<p>',
-  '#markup' => 'Why participated:<br />' . check_plain($entity->why_participated),
-  '#suffix' => '</p>',
-);
+    // Load user to get username.
+    $account = user_load($entity->uid);
+    $build['username'] = array(
+      '#prefix' => '<p>',
+      '#markup' => l($account->mail, 'user/' . $account->uid),
+      '#suffix' => '</p>',
+    );
+    $build['node_title'] = array(
+      '#prefix' => '<p>',
+      '#markup' => l($entity->node_title, 'node/' . $entity->nid),
+      '#suffix' => '</p>',
+    );
+    $quantity_label = $entity->noun . ' ' . $entity->verb;
+    $build['quantity_count'] = array(
+      '#prefix' => '<p>',
+      '#markup' => 'Quantity: <strong>' . check_plain($entity->quantity) . '</strong> ' . $quantity_label,
+      '#suffix' => '</p>',
+    );
+    if ($entity->num_participants) {
+      $build['num_participants'] = array(
+        '#prefix' => '<p>',
+        '#markup' => '# of Participants: <strong>' . $entity->num_participants . '</strong> ',
+        '#suffix' => '</p>',
+      );
+    }
+    $build['why_participated'] = array(
+      '#prefix' => '<p>',
+      '#markup' => 'Why participated:<br />' . check_plain($entity->why_participated),
+      '#suffix' => '</p>',
+    );
 
-$build['reportback_files'] = array(
-'#markup' => drupal_render($review_form),
-);
+    $build['reportback_files'] = array(
+      '#markup' => drupal_render($review_form),
+    );
 
-// Output Reportback Log.
-$rows = array();
-$header = array('Submitted', 'Op', 'Uid', 'Files', 'IP', 'Quantity', 'Why Participated');
-foreach ($entity->getReportbackLog() as $delta => $record) {
-$submitted = format_date($record->timestamp, 'short');
-$why = check_plain($record->why_participated);
-$rows[] = array($submitted, $record->op, $record->uid, $record->files, $record->remote_addr, $record->quantity, $why);
-}
-$build['reportback_log'] = array(
-'#theme' => 'table',
-'#prefix' => '<h3>Change Log</h3>',
-'#header' => $header,
-'#rows' => $rows,
-);
-return $build;
-}
-
-/**
-* Overrides save() method.
-*
-* Populates created and uid automatically.
-*/
-public function save($entity, DatabaseTransaction $transaction = NULL) {
-  global $user;
-  $now = REQUEST_TIME;
-  $op = 'update';
-  if (isset($entity->is_new)) {
-    $entity->created = $now;
-    $op = 'insert';
-  }
-  if ($entity->promoted) {
-    $op = 'promoted';
-  }
-  elseif ($entity->flagged) {
-    $op = 'flagged';
-  }
-  $entity->updated = $now;
-  if (DOSOMETHING_REPORTBACK_LOG) {
-    watchdog('dosomething_reportback', 'save:' . json_encode($entity));
+    // Output Reportback Log.
+    $rows = array();
+    $header = array('Submitted', 'Op', 'Uid', 'Files', 'IP', 'Quantity', 'Why Participated');
+    foreach ($entity->getReportbackLog() as $delta => $record) {
+      $submitted = format_date($record->timestamp, 'short');
+      $why = check_plain($record->why_participated);
+      $rows[] = array($submitted, $record->op, $record->uid, $record->files, $record->remote_addr, $record->quantity, $why);
+    }
+    $build['reportback_log'] = array(
+      '#theme' => 'table',
+      '#prefix' => '<h3>Change Log</h3>',
+      '#header' => $header,
+      '#rows' => $rows,
+    );
+    return $build;
   }
 
-  // Make sure a uid exists.
-  if (!isset($entity->uid)) {
-    return FALSE;
-  }
-  // If the entity uid doesn't belong to current user:
-  if ($entity->uid != $user->uid) {
-    // And current user can't edit any reportback:
-    if (!user_access('edit any reportback') && !drupal_is_cli()) {
-      watchdog('dosomething_reportback', "Attempted uid override for @reportback by User @uid",
-      array(
-      '@reportback' => json_encode($entity),
-      '@uid' => $user->uid,
-      ), WATCHDOG_WARNING);
+  /**
+   * Overrides save() method.
+   *
+   * Populates created and uid automatically.
+   */
+  public function save($entity, DatabaseTransaction $transaction = NULL) {
+    global $user;
+    $now = REQUEST_TIME;
+    $op = 'update';
+    if (isset($entity->is_new)) {
+      $entity->created = $now;
+      $op = 'insert';
+    }
+    if ($entity->promoted) {
+      $op = 'promoted';
+    }
+    elseif ($entity->flagged) {
+      $op = 'flagged';
+    }
+    $entity->updated = $now;
+    if (DOSOMETHING_REPORTBACK_LOG) {
+      watchdog('dosomething_reportback', 'save:' . json_encode($entity));
+    }
+
+    // Make sure a uid exists.
+    if (!isset($entity->uid)) {
       return FALSE;
     }
-  }
-
-  parent::save($entity, $transaction);
-
-  // If a file fid exists:
-  if (isset($entity->fid)) {
-    // Add it into the reportback files.
-    $entity->createReportbackFile($entity);
-  }
-  // Log the write operation.
-  $entity->insertLog($op);
-
-  // If this was an insert:
-  if ($op == 'insert') {
-    // Send Message Broker request.
-    if (module_exists('dosomething_mbp')) {
-      dosomething_reportback_mbp_request($entity);
+    // If the entity uid doesn't belong to current user:
+    if ($entity->uid != $user->uid) {
+      // And current user can't edit any reportback:
+      if (!user_access('edit any reportback') && !drupal_is_cli()) {
+        watchdog('dosomething_reportback', "Attempted uid override for @reportback by User @uid",
+          array(
+            '@reportback' => json_encode($entity),
+            '@uid' => $user->uid,
+          ), WATCHDOG_WARNING);
+        return FALSE;
+      }
     }
-    if (module_exists('dosomething_reward')) {
-      // Check for Reportback Count Reward.
-      dosomething_reward_reportback_count($entity);
+
+    parent::save($entity, $transaction);
+
+    // If a file fid exists:
+    if (isset($entity->fid)) {
+      // Add it into the reportback files.
+      $entity->createReportbackFile($entity);
     }
+    // Log the write operation.
+    $entity->insertLog($op);
+
+    // If this was an insert:
+    if ($op == 'insert') {
+      // Send Message Broker request.
+      if (module_exists('dosomething_mbp')) {
+        dosomething_reportback_mbp_request($entity);
+      }
+      if (module_exists('dosomething_reward')) {
+        // Check for Reportback Count Reward.
+        dosomething_reward_reportback_count($entity);
+      }
+    }
+
   }
 
-}
+  /**
+   * Overrides delete() method.
+   */
+  public function delete($ids, DatabaseTransaction $transaction = NULL) {
+    // Log deletions.
+    foreach ($ids as $rbid) {
+      $rb = reportback_load($rbid);
+      $rb->insertLog('delete');
+      $rb->deleteFiles();
+    }
+    parent::delete($ids, $transaction);
+  }
 
-/**
-* Overrides delete() method.
-*/
-public function delete($ids, DatabaseTransaction $transaction = NULL) {
-// Log deletions.
-foreach ($ids as $rbid) {
-$rb = reportback_load($rbid);
-$rb->insertLog('delete');
-$rb->deleteFiles();
-}
-parent::delete($ids, $transaction);
-}
 }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -23,7 +23,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
 
     try {
       $reportbackItems = ReportbackItem::find($filters);
-      $reportbackItems = services_resource_build_index_list($reportbackItems, 'reportback-items', 'fid');
+      $reportbackItems = services_resource_build_index_list($reportbackItems, 'reportback-items', 'id');
       $total = $this->getTotalCount($filters);
     }
     catch (Exception $error) {
@@ -51,7 +51,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
   public function show($id) {
     try {
       $reportbackItem = ReportbackItem::get($id);
-      $reportbackItem = services_resource_build_index_list($reportbackItem, 'reportback-items', 'fid');
+      $reportbackItem = services_resource_build_index_list($reportbackItem, 'reportback-items', 'id');
     }
     catch (Exception $error) {
       return [

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -46,6 +46,7 @@ class ReportbackTransformer extends Transformer {
 
     try {
       $reportbacks = Reportback::find($filters);
+      $reportbacks = services_resource_build_index_list($reportbacks, 'reportbacks', 'id');
     }
     catch (Exception $error) {
       return [
@@ -70,6 +71,7 @@ class ReportbackTransformer extends Transformer {
   public function show($id) {
     try {
       $reportback = Reportback::get($id);
+      $reportback = services_resource_build_index_list($reportback, 'reportbacks', 'id');
     }
     catch (Exception $error) {
       return [


### PR DESCRIPTION
# Update

This PR fixes a bug with how the `uri` property on some resources was being output. There was a wrong reference to the `id` and thus the `uri` value was not being generated correctly. This PR also adds the `uri` property to the rest of the `Campaigns, Kudos, Reportbacks, ReportbackItems` resources so all have data regarding how to access them via their respective individual URIs.

The PR also does some extra cleanup and adds some indentation formatting to the _ReportbackController.php_ file which somehow was lost before.

@aaronschachter @DFurnes 
