### PR TITLE
Graph: Scale math

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
@@ -304,8 +304,20 @@ var LineGraph = function($el, progressData) {
   // Actually instantiate the new graph and add it to the DOM.
   var ctx = $el.get(0).getContext("2d");
 
+  // Calculate the point to scaled the graph around.
+  // If we are pass the goal, then we want to scale based on the highest data point i.e the peak of the graph.
+  // If we are under the goal, then we want to scale based on the goal.
+  var maxDataPoint = Math.max.apply(null, data.datasets[0].data);
+  var scaleMax = (goal > maxDataPoint) ? goal : maxDataPoint;
+
   new Chart(ctx).LineWithGoal(data, {
     showScale: true,
+    scaleOverride: true,
+    // Y-axis scale configuration.
+    scaleSteps: 10,
+    scaleStepWidth: scaleMax / 10,
+    scaleStartValue: 0,
+    scaleLineWidth: 1,
     scaleShowLabels: false,
     scaleFontFamily: "'Proxima Nova', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif",
     scaleFontStyle: "Bold",

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
@@ -304,9 +304,7 @@ var LineGraph = function($el, progressData) {
   // Actually instantiate the new graph and add it to the DOM.
   var ctx = $el.get(0).getContext("2d");
 
-  // Calculate the point to scaled the graph around.
-  // If we are pass the goal, then we want to scale based on the highest data point i.e the peak of the graph.
-  // If we are under the goal, then we want to scale based on the goal.
+  // Calculate the point to scale the graph around.
   var maxDataPoint = Math.max.apply(null, data.datasets[0].data);
   var scaleMax = (goal > maxDataPoint) ? goal : maxDataPoint;
 


### PR DESCRIPTION
So, I removed the scale math in a previous pull request, but this caused the graph to not scale correctly when the goal was way higher than the highest quantity amount. 

This PR updates the logic around building the y-axis scale so that, if we are pass the goal, we should scale the goal based on the highest data point. But, if we aren't at the goal, the goal point is the highest point on the graph and we should scale around that instead. Fixes #4727 

@DoSomething/front-end 
