### PR TITLE
Bump Vagrant box version to 1.0.4. Update box name.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,8 @@
 Vagrant.configure("2") do |config|
 
   ## Choose your base box
-  config.vm.box = "dosomething/drupal"
-  config.vm.box_version = "1.0.3"
+  config.vm.box = "dosomething/phoenix"
+  config.vm.box_version = "1.0.4"
 
   config.vm.provider "virtualbox" do |v|
     v.customize ["modifyvm", :id, "--memory", 3072]


### PR DESCRIPTION
Vagrant 1.0.4 changelog:
https://github.com/DoSomething/tower/releases/tag/v1.0.4

Box name is updated to `dosomething/phoenix`.
