### PR TITLE
Hot module tumblr

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -232,13 +232,12 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
 
   // Tumblr
   $tumblr_options = array(
-    'canonicalUrl' => $share_paths['tumblr'],
     'posttype' => 'photo',
     'content' => $vars['hero_image']['desktop'],
     'caption' => "Think you can make @dosomething reach " . $goal_copy . "? Prove it: " . $share_paths['tumblr'],
   );
 
-  $vars['hot_module_tm_link'] = dosomething_helpers_get_tumblr_intent($tumblr_options);
+  $vars['hot_module_tm_link'] = dosomething_helpers_get_tumblr_intent($share_paths['tumblr'], $tumblr_options);
 }
 
 /**
@@ -323,7 +322,6 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
 
     // Tumblr share parameters.
     $tumblr_options = array(
-      'canonicalUrl' => $campaign_path,
       'posttype' => 'photo',
       'content' => $problem_share_image,
       'caption' => "This is REAL, do something about this with me: " . $campaign_path,
@@ -332,7 +330,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     // Create the intent links
     $vars['fb_link'] = dosomething_helpers_get_facebook_intent($campaign_path, 'feed_dialog', $fb_options);
     $vars['twitter_link'] = dosomething_helpers_get_twitter_intent($tweet);
-    $vars['tumblr_link'] = dosomething_helpers_get_tumblr_intent($tumblr_options);
+    $vars['tumblr_link'] = dosomething_helpers_get_tumblr_intent($campaign_path, $tumblr_options);
   }
 
   // Plan.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -232,6 +232,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
 
   // Tumblr
   $tumblr_options = array(
+    'canonicalUrl' => $share_paths['tumblr'],
     'posttype' => 'photo',
     'content' => $vars['hero_image']['desktop'],
     'caption' => "Think you can make @dosomething reach " . $goal_copy . "? Prove it: " . $share_paths['tumblr'],
@@ -322,6 +323,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
 
     // Tumblr share parameters.
     $tumblr_options = array(
+      'canonicalUrl' => $campaign_path,
       'posttype' => 'photo',
       'content' => $problem_share_image,
       'caption' => "This is REAL, do something about this with me: " . $campaign_path,

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -73,6 +73,7 @@ function dosomething_helpers_get_twitter_intent($tweet) {
 /**
  * Returns a tumblr share url.
  *
+ * @param string $path - the canonical URL being shared (required)
  * @param  array $options
  *   - source: url of the image to share.
  *   - caption: share language.
@@ -80,7 +81,8 @@ function dosomething_helpers_get_twitter_intent($tweet) {
  * @return string
  *   The tumblr intent url to share a photo.
  */
-function dosomething_helpers_get_tumblr_intent($options) {
+function dosomething_helpers_get_tumblr_intent($path, $options) {
+  $options['canonicalUrl'] = $path;
   return url('https://www.tumblr.com/widgets/share/tool', array('query' => $options));
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -527,7 +527,6 @@ function dosomething_reportback_view_entity($entity) {
 
     // Set tumblr options
     $tumblr_options = array(
-      'canonicalUrl' => $reportback_url,
       'posttype' => 'photo',
       'content' => $file->getImageURL('480x480'),
       'caption' => $share_text . " " . $reportback_url,
@@ -536,7 +535,7 @@ function dosomething_reportback_view_entity($entity) {
     // Create share button links
     $fb_link = dosomething_helpers_get_facebook_intent($reportback_url);
     $twitter_link = dosomething_helpers_get_twitter_intent($twitter_text);
-    $tumblr_link = dosomething_helpers_get_tumblr_intent($tumblr_options);
+    $tumblr_link = dosomething_helpers_get_tumblr_intent($reportback_url, $tumblr_options);
     $share_enabled = variable_get('dosomething_reportback_display_permalink_share', '');
 
     $permalink_vars = array(

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -527,6 +527,7 @@ function dosomething_reportback_view_entity($entity) {
 
     // Set tumblr options
     $tumblr_options = array(
+      'canonicalUrl' => $reportback_url,
       'posttype' => 'photo',
       'content' => $file->getImageURL('480x480'),
       'caption' => $share_text . " " . $reportback_url,


### PR DESCRIPTION
## Fixes #4741

Tumblr made an update to it's share tool that requires a new parameter `canonicalUrl` which :bomb: 'ed tumblr shares . So this PR updates the `dosomething_helpers_get_tumblr_intent` to take in the absolute path of the page being shared, and sets the required parameter for all links. 

@angaither 
