### PR TITLE
Fixing bug with helper isset function

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -347,8 +347,8 @@ class Campaign {
    */
   protected function getMailChimpData() {
     return [
-      'grouping_id' => $this->variables['mailchimp_grouping_id'],
-      'group_name' => $this->variables['mailchimp_group_name'],
+      'grouping_id' => dosomething_helpers_isset($this->variables, 'mailchimp_grouping_id'),
+      'group_name' => dosomething_helpers_isset($this->variables, 'mailchimp_group_name'),
     ];
   }
 
@@ -359,8 +359,8 @@ class Campaign {
    */
   protected function getMobileCommonsData() {
     return [
-      'opt_in_path_id' => $this->variables['mobilecommons_opt_in_path'],
-      'friends_opt_in_path_id' => $this->variables['mobilecommons_friends_opt_in_path'],
+      'opt_in_path_id' => dosomething_helpers_isset($this->variables, 'mobilecommons_opt_in_path'),
+      'friends_opt_in_path_id' => dosomething_helpers_isset($this->variables, 'mobilecommons_friends_opt_in_path'),
     ];
   }
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -14,15 +14,26 @@ include_once('dosomething_helpers.share.inc');
 
 /**
  * Utility function to check if a variable is set, and return it
- * if it is, otherwise return a default value.
+ * if it is, otherwise return a default value. If the variable is
+ * an array or object, then a $key is passed to select the specific
+ * variable that may or may not exist.
  *
- * @param $var
- * @param null $default
+ * @param string|array|object $var  Variable to check.
+ * @param string $key  If $var is an array or object, key to check.
+ * @param null $value  Set a default value to assign if $var not set.
  *
  * @return array|object|string|integer|null
  */
-function dosomething_helpers_isset($var, $default = NULL) {
-  return isset($var) ? $var : $default;
+function dosomething_helpers_isset($var, $key = NULL, $value = NULL) {
+  if (is_array($var) && $key) {
+    return isset($var[$key]) ? $var[$key] : $value;
+  }
+
+  if (is_object($var) && $key) {
+    return isset($var->$key) ? $var->$key : $value;
+  }
+
+  return isset($var) ? $var : $value;
 }
 
 


### PR DESCRIPTION
### Fixes #4759

There was a bug where if the variables for the `mailchimp` and `mobile_commons` data don't exist in the `$variables` array, then PHP will throw a few notices for an _undefined index_.

This PR updates to use the `dosomething_helpers_isset()` function to pass the data in and output it or `null`.

It also updates the `dosomething_helpers_isset()` function to accept either a string or an array, or object, with optional parameter (`$key`) to pass to specify which item in array or property in object to test.

@DFurnes @angaither @aaronschachter 

CC: @chloealee 
