### PR TITLE
Remove `show_campaign_progress` flag

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -288,9 +288,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $campaign = $vars['campaign'];
 
   // Progress
-  if (theme_get_setting('show_campaign_progress')) {
-    $vars['campaign_progress'] = dosomething_reportback_get_reportback_total_plus_override($vars['nid']);
-  }
+  $vars['campaign_progress'] = dosomething_reportback_get_reportback_total_plus_override($vars['nid']);
 
   // Know It.
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -49,11 +49,9 @@
         <div class="container__block">
           <div class="stat-card">
             <div class="stat-card__totals">
-              <?php if(isset($campaign_progress)): ?>
-                <h4 class="stat-card__verbs"><?php print $reportback_noun_verb ?></h4>
-                <p class="stat-card__progress"><?php print number_format($campaign_progress, 0, '', ','); ?></p>
-                <p class="stat-card__goal">Out of <?php print number_format($goal, 0, '', ','); ?></p>
-              <?php endif; ?>
+              <h4 class="stat-card__verbs"><?php print $reportback_noun_verb ?></h4>
+              <p class="stat-card__progress"><?php print number_format($campaign_progress, 0, '', ','); ?></p>
+              <p class="stat-card__goal">Out of <?php print number_format($goal, 0, '', ','); ?></p>
             </div>
             <div class="stat-card__timing">
               <?php if(isset($time_left)): ?>

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -47,10 +47,6 @@ function paraneue_dosomething_form_system_theme_settings_alter(&$form, &$form_st
       '#title' => t('Show sponsors'),
       '#description' => t('Toggles the sponsors block on the home page when finder is enabled.')
     ),
-    'show_campaign_progress' => array(
-      '#title' => t('Show campaign progress'),
-      '#description' => t('Toggles the display of campaign progress on the action page')
-    ),
     'show_problem_shares' => array(
       '#title' => t('Show problem statement share buttons'),
       '#description' => t('Toggles the display of problem statement share buttons on the action page.')


### PR DESCRIPTION
Fixes #4771 - Removes the `show_campaign_progress` feature flag and any checks for it. 
