### PR TITLE
Hot fix for hot module total numbers

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -899,11 +899,13 @@ function dosomething_reportback_get_reportback_total_by_nid($nid, $type = 'quant
   }
 
   if ($type == 'quantity') {
-    $query->fields('rb', array('quantity'));
+    //@TODO: temporary hotfix to get hotmodule out, need to debug why this query is broken.
+    return dosomething_helpers_get_variable('node', $nid, 'sum_rb_quantity');
+
     $query->addExpression('SUM(quantity)', 'quantity');
     $result = $query->execute()->fetchAll();
     $quantity = $result[0]->quantity;
-    dosomething_helpers_set_variable('node', $nid, 'sum_rb_quantity', $quantity);
+    // dosomething_helpers_set_variable('node', $nid, 'sum_rb_quantity', $quantity);
     return $quantity;
   }
   elseif ($type == 'count') {


### PR DESCRIPTION
This `sum_rb_quantity` value is getting set correctly on cron, but when the`dosomething_reportback_get_reportback_total_by_nid` query runs, it removes the value for some campaigns, there's a bug in the query that I will work on later, but this is just to get the hot module live now.

Refs #4748
