### PR TITLE
Custom GA events for hot module shares

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -58,6 +58,19 @@ if (typeof ga !== 'undefined' && ga !== null) {
     ga('send', 'event', 'Share', 'Problem Statement', 'Tumblr');
   });
 
+  // Hot module goal shares.
+  $('.js-analytics-hot-fb').on('click', function() {
+    ga('send', 'event', 'Share', 'Hot Module', 'Facebook');
+  });
+
+  $('.js-analytics-hot-tw').on('click', function() {
+    ga('send', 'event', 'Share', 'Hot Module', 'Twitter');
+  });
+
+  $('.js-analytics-hot-tm').on('click', function() {
+    ga('send', 'event', 'Share', 'Hot Module', 'Tumblr');
+  });
+
   // Modals
   Modal.Events.subscribe('Modal:Open', function(topic, args) {
     const label = args !== null ? '#' + args.attr('id') : '';

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -91,9 +91,9 @@
               </div>
             </div>
             <ul class="social-share-bar -with-callout">
-              <li><a class="social-icon -facebook js-share-link" href="<?php print $hot_module_fb_link; ?>"><span>Facebook</span></a></li>
-              <li><a class="social-icon -twitter js-share-link" href="<?php print $hot_module_tw_link; ?>"><span>Twitter</span></a></li>
-              <li><a class="social-icon -tumblr js-share-link" href="<?php print $hot_module_tm_link; ?>"><span>Tumblr</span></a></li>
+              <li><a class="social-icon -facebook js-share-link js-analytics-hot-fb" href="<?php print $hot_module_fb_link; ?>"><span>Facebook</span></a></li>
+              <li><a class="social-icon -twitter js-share-link js-analytics-hot-tw" href="<?php print $hot_module_tw_link; ?>"><span>Twitter</span></a></li>
+              <li><a class="social-icon -tumblr js-share-link js-analytics-hot-tm" href="<?php print $hot_module_tm_link; ?>"><span>Tumblr</span></a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Fixes #4644 - Add custom click events for Hot module shares. 

@DoSomething/front-end - Also, wondering if it is worth discussing potential refactoring of how analytics is implemented. It seems weird that every new thing we want to track needs it's own hard coded event. This file could potentially end up growing bigger and bigger. One idea could be coming up with some standard class names and data attributes to use and then creating a function that sends listens to click events on that class and sends different info to GA based on what data attributes it has?
