### PR TITLE
Sasslint

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/.sasslint.json
+++ b/lib/themes/dosomething/paraneue_dosomething/.sasslint.json
@@ -1,0 +1,11 @@
+{
+  "rules": {
+    "BorderZero": {
+      "enabled": true,
+      "convention": "0"
+    },
+    "SpaceAfterPropertyColon": {
+      "enabled": true
+    }
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
+++ b/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
@@ -193,12 +193,19 @@ module.exports = function(grunt) {
     },
 
     /**
+     * Lint SCSS using Sasslint.
+     */
+    sasslint: {
+      all: ["scss/**/*.scss"]
+    },
+
+    /**
      * Watch files for changes, and trigger relevant tasks.
      */
     watch: {
       sass: {
         files: ["scss/**/*.scss"],
-        tasks: ["sass:debug", "postcss:debug"]
+        tasks: ["sass:debug", "postcss:debug", "sasslint"]
       },
       js: {
         files: ["js/**/*.js"],
@@ -229,7 +236,7 @@ module.exports = function(grunt) {
 
   // > grunt test
   // Run included unit tests and linters.
-  grunt.registerTask('test', ['eslint']);
+  grunt.registerTask('test', ['eslint', 'sasslint']);
 
 };
 

--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -38,6 +38,7 @@
     "grunt-modernizr": "^0.6.0",
     "grunt-postcss": "^0.2.0",
     "grunt-sass": "^0.18.0",
+    "grunt-sasslint": "0.0.5",
     "grunt-webpack": "^1.0.8",
     "load-grunt-tasks": "^3.1.0",
     "raw-loader": "^0.5.1",

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback-permalink.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback-permalink.scss
@@ -30,7 +30,7 @@
   }
 
   .cta {
-    border-top: none;
+    border-top: 0;
 
     @include media($tablet) {
       display: table-footer-group;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
@@ -67,7 +67,7 @@
 
   .divider {
     background-color: $yellow;
-    border: 0 none;
+    border: 0;
     height: ($base_spacing / 4);
     margin: 0;
     width: 100%;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_card.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_card.scss
@@ -23,7 +23,7 @@
 
       @include media($tablet) {
         border-left: 2px solid $light-gray;
-        border-top: none;
+        border-top: 0;
       }
     }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_cta.scss
@@ -28,7 +28,7 @@
 
   &.-persistent {
     background-color: $black;
-    border: none;
+    border: 0;
     position: sticky;
     top: 0;
     z-index: 100;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_stat-card.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_stat-card.scss
@@ -39,6 +39,6 @@ $dark-blue: #0081BC;
 
   .stat-card__chart {
     border: solid 2px $light-gray;
-    border-top: none;
+    border-top: 0;
   }
 }


### PR DESCRIPTION
# Changes

Use [Sasslint](https://github.com/DFurnes/sasslint) to lint our stylesheets. Currently has two linting rules, but more to come!

For review: @DoSomething/front-end 
