### PR TITLE
Share Bar

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -236,7 +236,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
     ),
   );
 
-  $vars['hot_module_share_bar'] = dosomething_helpers_share_bar($campaign_path, $share_types, 'hot_share', 'js-analytics-hot');
+  $vars['hot_module_share_bar'] = dosomething_helpers_share_bar($campaign_path, $share_types, 'hot_share', 'js-analytics-hot', 'social-share-bar -with-callout');
 }
 
 /**
@@ -324,7 +324,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
       ),
     );
 
-    $vars['share_bar'] = dosomething_helpers_share_bar($campaign_path, $share_types, 'problem_shares', 'js-analytics-problem');
+    $vars['share_bar'] = dosomething_helpers_share_bar($campaign_path, $share_types, 'problem_shares', 'js-analytics-problem', 'social-share-bar -with-callout');
   }
 
   // Plan.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -314,35 +314,10 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
       $tweet = $campaign->fact_problem['fact'];
     }
 
-    // // Facebook feed dialog parameters, using the problem share image instead of the image set in the metatag.
-    // $fb_options = array(
-    //   'picture' => $problem_share_image,
-    // );
-
-    // // Tumblr share parameters.
-    // $tumblr_options = array(
-    //   'posttype' => 'photo',
-    //   'content' => $problem_share_image,
-    //   'caption' => "This is REAL, do something about this with me: " . $campaign_path,
-    // );
-
-    // $fb_options = array(
-    //   'type' => 'feed_dialog',
-    //   'options' => array(
-    //     'picture' => $problem_share_image,
-    //   ),
-    // );
-
-    // $tumblr_options = array(
-    //   'posttype' => 'photo',
-    //   'content' => $problem_share_image,
-    //   'caption' => "This is REAL, do something about this with me: ",
-    // );
-
-    $share_options = array(
+    $share_types = array(
       'facebook' => array(
         'type' => 'feed_dialog',
-        'options' => array(
+        'parameters' => array(
           'picture' => $problem_share_image,
         ),
       ),
@@ -356,13 +331,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
       ),
     );
 
-    // Create the intent links
-    // $vars['fb_link'] = dosomething_helpers_get_facebook_intent($campaign_path, 'feed_dialog', $fb_options);
-    // $vars['twitter_link'] = dosomething_helpers_get_twitter_intent($tweet);
-    // $vars['tumblr_link'] = dosomething_helpers_get_tumblr_intent($campaign_path, $tumblr_options);
-
-    // $vars['share_bar'] = dosomething_helpers_share_links($campaign_path, 'problem_shares', $tweet, $tumblr_options, $fb_options);
-    $vars['share_bar'] = dosomething_helpers_share_links($campaign_path, $share_options, 'problem_shares');
+    $vars['share_bar'] = dosomething_helpers_share_bar($campaign_path, $share_types, 'problem_shares', 'js-analytics-problem');
   }
 
   // Plan.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -218,27 +218,25 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
 
   $goal_copy = number_format($goal, 0, '', ',') . " " . strtolower($vars['reportback_noun_verb']) . " by " . $readable_end_date;
 
-  $share_types = array('facebook', 'twitter', 'tumblr');
-  $share_paths = dosomething_helpers_utm_share_paths($share_types, $campaign_path, 'hot_share');
-
-  $fb_options = array(
-    'picture' => $vars['hero_image']['desktop'],
-    'caption' => $goal_copy . "? Let's make it happen!",
-  );
-  $vars['hot_module_fb_link'] = dosomething_helpers_get_facebook_intent($share_paths['facebook'], 'feed_dialog', $fb_options);
-
-  // Twitter
-  $tweet = "Be a part of @dosomething reaching " . $goal_copy . "- who's ready to rumble?! " . $share_paths['twitter'];
-  $vars['hot_module_tw_link'] = dosomething_helpers_get_twitter_intent($tweet);
-
-  // Tumblr
-  $tumblr_options = array(
-    'posttype' => 'photo',
-    'content' => $vars['hero_image']['desktop'],
-    'caption' => "Think you can make @dosomething reach " . $goal_copy . "? Prove it: " . $share_paths['tumblr'],
+  $share_types = array(
+    'facebook' => array(
+      'type' => 'feed_dialog',
+      'parameters' => array(
+        'picture' => $vars['hero_image']['desktop'],
+        'caption' => $goal_copy . "? Let's make it happen!",
+      ),
+    ),
+    'twitter' => array(
+      'tweet' => "Be a part of @dosomething reaching " . $goal_copy . "- who's ready to rumble?! ",
+    ),
+    'tumblr' => array(
+      'posttype' => 'photo',
+      'content' => $vars['hero_image']['desktop'],
+      'caption' => "Think you can make @dosomething reach " . $goal_copy . "? Prove it: ",
+    ),
   );
 
-  $vars['hot_module_tm_link'] = dosomething_helpers_get_tumblr_intent($share_paths['tumblr'], $tumblr_options);
+  $vars['hot_module_share_bar'] = dosomething_helpers_share_bar($campaign_path, $share_types, 'hot_share', 'js-analytics-hot');
 }
 
 /**
@@ -308,11 +306,6 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
 
     // Create the image path to the problem fact statement image generated for the node.
     $problem_share_image = $base_url . 'profiles/dosomething/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/images/' . $vars['nid'] . '.png';
-
-    // Create the tweet for twitter.
-    if (isset($campaign->fact_problem)) {
-      $tweet = $campaign->fact_problem['fact'];
-    }
 
     $share_types = array(
       'facebook' => array(

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -311,25 +311,58 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
 
     // Create the tweet for twitter.
     if (isset($campaign->fact_problem)) {
-      $tweet = $campaign->fact_problem['fact'] . " " . $campaign_path;
+      $tweet = $campaign->fact_problem['fact'];
     }
 
-    // Facebook feed dialog parameters, using the problem share image instead of the image set in the metatag.
-    $fb_options = array(
-      'picture' => $problem_share_image,
-    );
+    // // Facebook feed dialog parameters, using the problem share image instead of the image set in the metatag.
+    // $fb_options = array(
+    //   'picture' => $problem_share_image,
+    // );
 
-    // Tumblr share parameters.
-    $tumblr_options = array(
-      'posttype' => 'photo',
-      'content' => $problem_share_image,
-      'caption' => "This is REAL, do something about this with me: " . $campaign_path,
+    // // Tumblr share parameters.
+    // $tumblr_options = array(
+    //   'posttype' => 'photo',
+    //   'content' => $problem_share_image,
+    //   'caption' => "This is REAL, do something about this with me: " . $campaign_path,
+    // );
+
+    // $fb_options = array(
+    //   'type' => 'feed_dialog',
+    //   'options' => array(
+    //     'picture' => $problem_share_image,
+    //   ),
+    // );
+
+    // $tumblr_options = array(
+    //   'posttype' => 'photo',
+    //   'content' => $problem_share_image,
+    //   'caption' => "This is REAL, do something about this with me: ",
+    // );
+
+    $share_options = array(
+      'facebook' => array(
+        'type' => 'feed_dialog',
+        'options' => array(
+          'picture' => $problem_share_image,
+        ),
+      ),
+      'twitter' => array(
+        'tweet' => (isset($campaign->fact_problem)) ? $campaign->fact_problem['fact'] : NULL,
+      ),
+      'tumblr' => array(
+        'posttype' => 'photo',
+        'content' => $problem_share_image,
+        'caption' => "This is REAL, do something about this with me: ",
+      ),
     );
 
     // Create the intent links
-    $vars['fb_link'] = dosomething_helpers_get_facebook_intent($campaign_path, 'feed_dialog', $fb_options);
-    $vars['twitter_link'] = dosomething_helpers_get_twitter_intent($tweet);
-    $vars['tumblr_link'] = dosomething_helpers_get_tumblr_intent($campaign_path, $tumblr_options);
+    // $vars['fb_link'] = dosomething_helpers_get_facebook_intent($campaign_path, 'feed_dialog', $fb_options);
+    // $vars['twitter_link'] = dosomething_helpers_get_twitter_intent($tweet);
+    // $vars['tumblr_link'] = dosomething_helpers_get_tumblr_intent($campaign_path, $tumblr_options);
+
+    // $vars['share_bar'] = dosomething_helpers_share_links($campaign_path, 'problem_shares', $tweet, $tumblr_options, $fb_options);
+    $vars['share_bar'] = dosomething_helpers_share_links($campaign_path, $share_options, 'problem_shares');
   }
 
   // Plan.

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -114,7 +114,23 @@ function dosomething_helpers_utm_share_paths($share_types, $path, $utm_campaign)
   return $share_paths;
 }
 
-function dosomething_helpers_share_links($path, $share_types, $share_description) {
+/**
+ * Return the markup for share button.
+ *
+ * @param string $path
+ *   The absolute path of the page being shared.
+ * @param  array $share_types
+ *   - array of social networks to create paths for.
+ *     including the relevant parameters needed to create the custom intents.
+ * @param string $share_description
+ *   A custom value to use for 'utm_campaign'.
+ * @param string $analytics_class
+ *   A base class to use for Google Analytics tracking. @TODO - This implementation is temporary. We will be refactoring
+ *   how google analtyics tracking is implemented. Discussion happening in issue #4793
+ * @return
+ *   Share bar markup.
+ */
+function dosomething_helpers_share_bar($path, $share_types, $share_description, $analytics_class = NULL) {
   $share_utm_paths = dosomething_helpers_utm_share_paths($share_types, $path, $share_description);
   $share_bar = '';
   $share_intents = [];
@@ -122,19 +138,23 @@ function dosomething_helpers_share_links($path, $share_types, $share_description
   foreach ($share_types as $type => $options) {
     switch ($type) {
       case 'facebook':
-        $share_intents['facebook'] = dosomething_helpers_get_facebook_intent($share_utm_paths['facebook'], $options['type'], $options['options']);
+        $share_intents['facebook'] = dosomething_helpers_get_facebook_intent($share_utm_paths['facebook'], $options['type'], $options['parameters']);
+        $tracking = $analytics_class . '-fb';
         break;
       case 'twitter':
         $share_intents['twitter'] = dosomething_helpers_get_twitter_intent($options['tweet'] . ' ' . $share_utm_paths['twitter']);
+        $tracking = $analytics_class . '-tw';
         break;
       case 'tumblr':
         $options['caption'] = $options['caption'] . $share_utm_paths['tumblr'];
         $share_intents['tumblr'] = dosomething_helpers_get_tumblr_intent($share_utm_paths['tumblr'], $options);
+        $tracking = $analytics_class . '-tm';
       default:
         break;
     }
+
     if ($share_intents[$type]) {
-      $share_bar .= '<li><a class="social-icon -' . $type . ' js-share-link js-analytics" href="' . $share_intents[$type] . '"><span>'. $type . '</span></a></li>';
+      $share_bar .= '<li><a class="social-icon -' . $type . ' js-share-link ' . $tracking . '" href="' . $share_intents[$type] . '"><span>'. $type . '</span></a></li>';
     }
   }
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -130,9 +130,9 @@ function dosomething_helpers_utm_share_paths($share_types, $path, $utm_campaign)
  * @return
  *   Share bar markup.
  */
-function dosomething_helpers_share_bar($path, $share_types, $share_description, $analytics_class = NULL) {
+function dosomething_helpers_share_bar($path, $share_types, $share_description, $analytics_class = NULL, $classes = NULL) {
   $share_utm_paths = dosomething_helpers_utm_share_paths($share_types, $path, $share_description);
-  $share_bar = '';
+  $share_bar = '<ul class="' . $classes . '">';
   $share_intents = [];
 
   foreach ($share_types as $type => $options) {
@@ -158,5 +158,5 @@ function dosomething_helpers_share_bar($path, $share_types, $share_description, 
     }
   }
 
-  return $share_bar;
+  return $share_bar . "</ul>";
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -101,7 +101,7 @@ function dosomething_helpers_get_tumblr_intent($path, $options) {
  *   An array of paths, indexed by type.
  */
 function dosomething_helpers_utm_share_paths($share_types, $path, $utm_campaign) {
-  foreach ($share_types as $type) {
+  foreach ($share_types as $type => $options) {
     $utm_params = dosomething_helpers_utm_parameters(NULL,
       array(
         'utm_medium' => $type,
@@ -112,4 +112,31 @@ function dosomething_helpers_utm_share_paths($share_types, $path, $utm_campaign)
   }
 
   return $share_paths;
+}
+
+function dosomething_helpers_share_links($path, $share_types, $share_description) {
+  $share_utm_paths = dosomething_helpers_utm_share_paths($share_types, $path, $share_description);
+  $share_bar = '';
+  $share_intents = [];
+
+  foreach ($share_types as $type => $options) {
+    switch ($type) {
+      case 'facebook':
+        $share_intents['facebook'] = dosomething_helpers_get_facebook_intent($share_utm_paths['facebook'], $options['type'], $options['options']);
+        break;
+      case 'twitter':
+        $share_intents['twitter'] = dosomething_helpers_get_twitter_intent($options['tweet'] . ' ' . $share_utm_paths['twitter']);
+        break;
+      case 'tumblr':
+        $options['caption'] = $options['caption'] . $share_utm_paths['tumblr'];
+        $share_intents['tumblr'] = dosomething_helpers_get_tumblr_intent($share_utm_paths['tumblr'], $options);
+      default:
+        break;
+    }
+    if ($share_intents[$type]) {
+      $share_bar .= '<li><a class="social-icon -' . $type . ' js-share-link js-analytics" href="' . $share_intents[$type] . '"><span>'. $type . '</span></a></li>';
+    }
+  }
+
+  return $share_bar;
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -522,20 +522,23 @@ function dosomething_reportback_view_entity($entity) {
     $share_text = token_replace(variable_get('dosomething_campaign_permalink_confirmation_owners_social_network_copy'), array('node' => $node));
     $share_text = str_replace('[node:issue]', strtolower($node->issue['name']), $share_text);
 
-    // Set twitter text.
-    $twitter_text = htmlspecialchars_decode($share_text, ENT_QUOTES) . " " . $reportback_url;
 
-    // Set tumblr options
-    $tumblr_options = array(
-      'posttype' => 'photo',
-      'content' => $file->getImageURL('480x480'),
-      'caption' => $share_text . " " . $reportback_url,
+    $share_types = array(
+      'facebook' => array(
+        'type' => 'default',
+      ),
+      'twitter' => array(
+        'tweet' => htmlspecialchars_decode($share_text, ENT_QUOTES) . " ",
+      ),
+      'tumblr' => array(
+        'posttype' => 'photo',
+        'content' => $file->getImageURL('480x480'),
+        'caption' => $share_text . " ",
+      ),
     );
 
-    // Create share button links
-    $fb_link = dosomething_helpers_get_facebook_intent($reportback_url);
-    $twitter_link = dosomething_helpers_get_twitter_intent($twitter_text);
-    $tumblr_link = dosomething_helpers_get_tumblr_intent($reportback_url, $tumblr_options);
+    $share_bar = dosomething_helpers_share_bar($reportback_url, $share_types, 'confirmation_page_share', 'js-analytics-permalink');
+
     $share_enabled = variable_get('dosomething_reportback_display_permalink_share', '');
 
     $permalink_vars = array(
@@ -547,9 +550,7 @@ function dosomething_reportback_view_entity($entity) {
       'copy_vars' => $copy_vars,
       'title' => $title,
       'subtitle' => $subtitle,
-      'fb_link' => $fb_link,
-      'twitter_link' => $twitter_link,
-      'tumblr_link' => $tumblr_link,
+      'share_bar' => $share_bar,
       'share_enabled' => $share_enabled,
       'why_participated_short' => $why_participated_short,
     );

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -32,15 +32,15 @@ if (typeof ga !== 'undefined' && ga !== null) {
   });
 
   // Confirmation Page Shares
-  $('.js-analytics-fb-share').on('click', function() {
+  $('.js-analytics-permalink-fb').on('click', function() {
     ga('send', 'event', 'Share', 'Confirmation Page', 'Facebook');
   });
 
-  $('.js-analytics-tw-share').on('click', function() {
+  $('.js-analytics-permalink-tw').on('click', function() {
     ga('send', 'event', 'Share', 'Confirmation Page', 'Twitter');
   });
 
-  $('.js-analytics-tm-share').on('click', function() {
+  $('.js-analytics-permalink-tm').on('click', function() {
     ga('send', 'event', 'Share', 'Confirmation Page', 'Tumblr');
   });
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -117,9 +117,10 @@
               </div>
             </div>
             <ul class="social-share-bar -with-callout">
-              <li><a class="social-icon -facebook js-share-link js-analytics-problem-fb" href="<?php print $fb_link; ?>"><span>Facebook</span></a></li>
-              <li><a class="social-icon -twitter js-share-link js-analytics-problem-tw" href="<?php print $twitter_link; ?>"><span>Twitter</span></a></li>
-              <li><a class="social-icon -tumblr js-share-link js-analytics-problem-tm" href="<?php print $tumblr_link; ?>"><span>Tumblr</span></a></li>
+              <?php print $share_bar; ?>
+              <!-- <li><a class="social-icon -facebook js-share-link js-analytics-problem-fb" href="<?php print $fb_link; ?>"><span>Facebook</span></a></li> -->
+              <!-- <li><a class="social-icon -twitter js-share-link js-analytics-problem-tw" href="<?php print $twitter_link; ?>"><span>Twitter</span></a></li> -->
+              <!-- <li><a class="social-icon -tumblr js-share-link js-analytics-problem-tm" href="<?php print $tumblr_link; ?>"><span>Tumblr</span></a></li> -->
             </ul>
           <?php endif; ?>
         <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -89,9 +89,7 @@
               </div>
             </div>
             <ul class="social-share-bar -with-callout">
-              <li><a class="social-icon -facebook js-share-link js-analytics-hot-fb" href="<?php print $hot_module_fb_link; ?>"><span>Facebook</span></a></li>
-              <li><a class="social-icon -twitter js-share-link js-analytics-hot-tw" href="<?php print $hot_module_tw_link; ?>"><span>Twitter</span></a></li>
-              <li><a class="social-icon -tumblr js-share-link js-analytics-hot-tm" href="<?php print $hot_module_tm_link; ?>"><span>Tumblr</span></a></li>
+              <?php print $hot_module_share_bar; ?>
             </ul>
           </div>
         </div>
@@ -118,9 +116,6 @@
             </div>
             <ul class="social-share-bar -with-callout">
               <?php print $share_bar; ?>
-              <!-- <li><a class="social-icon -facebook js-share-link js-analytics-problem-fb" href="<?php print $fb_link; ?>"><span>Facebook</span></a></li> -->
-              <!-- <li><a class="social-icon -twitter js-share-link js-analytics-problem-tw" href="<?php print $twitter_link; ?>"><span>Twitter</span></a></li> -->
-              <!-- <li><a class="social-icon -tumblr js-share-link js-analytics-problem-tm" href="<?php print $tumblr_link; ?>"><span>Tumblr</span></a></li> -->
             </ul>
           <?php endif; ?>
         <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -88,9 +88,7 @@
                 <p><?php print $hot_module_share_copy; ?></p>
               </div>
             </div>
-            <ul class="social-share-bar -with-callout">
-              <?php print $hot_module_share_bar; ?>
-            </ul>
+            <?php print $hot_module_share_bar; ?>
           </div>
         </div>
 
@@ -114,9 +112,7 @@
                 <p><?php print $problem_share_prompt; ?></p>
               </div>
             </div>
-            <ul class="social-share-bar -with-callout">
-              <?php print $share_bar; ?>
-            </ul>
+            <?php print $share_bar; ?>
           <?php endif; ?>
         <?php endif; ?>
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
@@ -49,11 +49,7 @@
                 <div class="wrapper">
                   <p class="cta__message"><?php print $copy_vars['owners_rb_social_cta']; ?></p>
                 </div>
-                <ul>
-                  <li><a class="social-icon -facebook js-share-link js-analytics-fb-share" href="<?php print $fb_link; ?>"><span>Facebook</span></a></li>
-                  <li><a class="social-icon -twitter js-share-link js-analytics-tw-share" href="<?php print $twitter_link; ?>"><span>Twitter</span></a></li>
-                  <li><a class="social-icon -tumblr js-share-link js-analytics-tm-share" href="<?php print $tumblr_link; ?>"><span>Tumblr</span></a></li>
-                </ul>
+                <?php print $share_bar; ?>
               </div>
             <?php endif; ?>
             <div class="card__copy">


### PR DESCRIPTION
This PR refactors how I was implementing share buttons on the campaign page (problem statement and hot module) and the permalink page. 

Adds a function `dosomething_helpers_share_bar()` that spits out the markup needed for a standard facebook, twitter, tumblr share buttons, a pattern that we use at least three places on the site. This function also takes care of adding the necessary google analytics tracking classes and UTM parameters to the share links (resolves #4575 and #4611 )

@DoSomething/front-end 
