### PR TITLE
Show problem shares on SMS campaigns

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -105,6 +105,43 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
   if (isset($vars['content']['zendesk_form'])) {
     $vars['zendesk_form'] = $vars['content']['zendesk_form'];
   }
+
+  // Problem shares
+  $vars['show_problem_shares'] = theme_get_setting('show_problem_shares');
+  $campaign = $vars['campaign'];
+
+  if ($vars['show_problem_shares']) {
+    $problem_share_prompt = variable_get('dosomething_campaign_problem_share_prompt');
+    if ($problem_share_prompt) {
+      $vars['problem_share_prompt'] = $problem_share_prompt;
+    }
+
+    $base_url = url(base_path(), array('absolute'=> TRUE));
+    $campaign_path = url(current_path(), array('absolute' => TRUE));
+
+    // Create the image path to the problem fact statement image generated for the node.
+    $problem_share_image = $base_url . 'profiles/dosomething/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/images/' . $vars['nid'] . '.png';
+
+    $share_types = array(
+      'facebook' => array(
+        'type' => 'feed_dialog',
+        'parameters' => array(
+          'picture' => $problem_share_image,
+        ),
+      ),
+      'twitter' => array(
+        'tweet' => (isset($campaign->fact_problem)) ? $campaign->fact_problem['fact'] : NULL,
+      ),
+      'tumblr' => array(
+        'posttype' => 'photo',
+        'content' => $problem_share_image,
+        'caption' => "This is REAL, do something about this with me: ",
+      ),
+    );
+
+    $vars['share_bar'] = dosomething_helpers_share_bar($campaign_path, $share_types, 'problem_shares', 'js-analytics-problem', 'social-share-bar -with-callout');
+  }
+
 }
 
 /**
@@ -289,43 +326,6 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $vars['campaign_progress'] = dosomething_reportback_get_reportback_total_plus_override($vars['nid']);
 
   // Know It.
-
-  // Problem shares.
-
-  // Share prompt.
-  $vars['show_problem_shares'] = theme_get_setting('show_problem_shares');
-
-  if ($vars['show_problem_shares']) {
-    $problem_share_prompt = variable_get('dosomething_campaign_problem_share_prompt');
-    if ($problem_share_prompt) {
-      $vars['problem_share_prompt'] = $problem_share_prompt;
-    }
-
-    $base_url = url(base_path(), array('absolute'=> TRUE));
-    $campaign_path = url(current_path(), array('absolute' => TRUE));
-
-    // Create the image path to the problem fact statement image generated for the node.
-    $problem_share_image = $base_url . 'profiles/dosomething/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/images/' . $vars['nid'] . '.png';
-
-    $share_types = array(
-      'facebook' => array(
-        'type' => 'feed_dialog',
-        'parameters' => array(
-          'picture' => $problem_share_image,
-        ),
-      ),
-      'twitter' => array(
-        'tweet' => (isset($campaign->fact_problem)) ? $campaign->fact_problem['fact'] : NULL,
-      ),
-      'tumblr' => array(
-        'posttype' => 'photo',
-        'content' => $problem_share_image,
-        'caption' => "This is REAL, do something about this with me: ",
-      ),
-    );
-
-    $vars['share_bar'] = dosomething_helpers_share_bar($campaign_path, $share_types, 'problem_shares', 'js-analytics-problem', 'social-share-bar -with-callout');
-  }
 
   // Plan.
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -120,7 +120,7 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
     $campaign_path = url(current_path(), array('absolute' => TRUE));
 
     // Create the image path to the problem fact statement image generated for the node.
-    $problem_share_image = $base_url . 'profiles/dosomething/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/images/' . $vars['nid'] . '.png';
+    $problem_share_image = $base_url . drupal_get_path('module', 'dosomething_campaign_problem_shares') . '/images/' . $vars['nid'] . '.png';
 
     $share_types = array(
       'facebook' => array(

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -27,17 +27,36 @@
 
         <div class="container__block -half">
           <?php if (isset($campaign->fact_problem)): ?>
-          <h3 class="inline-sponsor-color"><?php print t('The Problem'); ?></h3>
-          <p><?php print $campaign->fact_problem['fact']; ?><sup><?php print $campaign->fact_problem['footnotes']; ?></sup></p>
+            <h3 class="inline-sponsor-color"><?php print t('The Problem'); ?></h3>
+            <p><?php print $campaign->fact_problem['fact']; ?><sup><?php print $campaign->fact_problem['footnotes']; ?></sup></p>
+
+            <?php if ($show_problem_shares): ?>
+              <div class="message-callout -above-horizontal -blue">
+                <div class="message-callout__copy">
+                  <p><?php print $problem_share_prompt; ?></p>
+                </div>
+              </div>
+              <?php print $share_bar; ?>
+            <?php endif; ?>
           <?php endif; ?>
 
-          <?php if (isset($psa)): ?>
-            <p <?php if ($is_video_psa) echo 'class="media-video"'; ?>>
-              <?php print $psa; ?>
-            </p>
+          <?php if ($show_problem_shares): ?>
+            <?php // If there's a PSA image or video, output it in this column. ?>
+            <?php if (isset($psa)): ?>
+              <p <?php if ($is_video_psa) echo 'class="media-video"'; ?>>
+                <?php print $psa; ?>
+              </p>
+            <?php endif; ?>
           <?php else: ?>
-            <?php if (isset($modals)): ?>
-              <?php print $modals; ?>
+            <?php // If there's a PSA image or video, output it in this column, otherwise output the modals list if it exists. ?>
+            <?php if (isset($psa)): ?>
+              <p <?php if ($is_video_psa) echo 'class="media-video"'; ?>>
+                <?php print $psa; ?>
+              </p>
+            <?php else: ?>
+              <?php if (isset($modals)): ?>
+                <?php print $modals; ?>
+              <?php endif; ?>
             <?php endif; ?>
           <?php endif; ?>
         </div>
@@ -58,9 +77,17 @@
 
           <?php endif; ?>
 
-          <?php if (isset($psa)): ?>
+          <?php if ($show_problem_shares): ?>
+            <?php // Alway output modals in the second column. ?>
             <?php if (isset($modals)): ?>
-              <?php print $modals; ?>
+             <?php print $modals; ?>
+            <?php endif; ?>
+          <?php else: ?>
+            <?php // If there's a PSA image or video, then it was output in the first column above and thus need to output the modals in this second column instead. ?>
+            <?php if (isset($psa)): ?>
+              <?php if (isset($modals)): ?>
+                <?php print $modals; ?>
+              <?php endif; ?>
             <?php endif; ?>
           <?php endif; ?>
         </div>


### PR DESCRIPTION
Resolves #4560 . Move problem share preprocessing to `dosomething_campaign_preprocess_common_vars()` and output problem shares on the sms campaign template. 
