### PR TITLE
Adds review fix

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -237,7 +237,6 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
 
     $rbf = reportback_file_load($fid);
 
-    // Set flagged or promoted reasons.
     if ($values['status'] === 'promoted') {
       dosomething_reportback_set_promote_flag_reasons($values, 'promoted_reason');
     }
@@ -247,6 +246,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
 
     // Write the review data.
     $save = $rbf->review($values);
+
     if (!$save) {
       form_set_error(t("An error has occurred."));
     }

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -346,12 +346,12 @@ class Reportback extends Entity {
     else {
       if ($this->flagged == NULL) {
         $this->flagged = 0;
+        $this->promoted_reason = NULL;
       }
       if ($this->promoted == NULL) {
         $this->promoted = 0;
+        $this->flagged_reason = NULL;
       }
-      $this->promoted_reason = NULL;
-      $this->flagged_reason = NULL;
     }
     return entity_save('reportback', $this);
   }

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -344,8 +344,12 @@ class Reportback extends Entity {
       $this->flagged = 0;
     }
     else {
-      $this->flagged = 0;
-      $this->promoted = 0;
+      if ($this->flagged == NULL) {
+        $this->flagged = 0;
+      }
+      if ($this->promoted == NULL) {
+        $this->promoted = 0;
+      }
       $this->promoted_reason = NULL;
       $this->flagged_reason = NULL;
     }

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -344,6 +344,7 @@ class Reportback extends Entity {
       $this->flagged = 0;
     }
     else {
+      // These extra if statments verify that we're not overriding existing values
       if ($this->flagged == NULL) {
         $this->flagged = 0;
         $this->promoted_reason = NULL;


### PR DESCRIPTION
Fixes #4847 

Problem was the following,
- Two reportback items call the setFlaggedPromoted option (items are looped through in the form submit)
- The second item is 'approved', which in the old setFlaggedPromoted function meant the flagged & promoted fields were set to 0, **regardless of there previous variable**. (this is why it was bugged)

Solution,
- Added a second step of verification in the 'else' (where approves are handled) to make sure a previous promoted or flagged field wasn't overridden 

@angaither 
