### PR TITLE
Re-pre-approved reportbacks, don't required status.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -169,9 +169,7 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
 
   foreach ($result as $record) {
     $rb_path = 'admin/reportback/' . $record->rbid;
-    // @TODO: temporarily disable pre-approved to unblock campaigns team from reviewing reportbacks.
-    // Refs #4797
-    // $status = 'approved';
+    $status = 'approved';
     if (isset($record->status) && $record->status != 'pending') {
       $status = $record->status;
     }
@@ -192,7 +190,6 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
       'status' => array(
         '#type' => 'radios',
         '#title' => t('Status'),
-        '#required' => TRUE,
         '#options' => $status_options,
         '#default_value' => $status,
       ),


### PR DESCRIPTION
Fixes #4797

@weerd is also a goddamn champion. 

When a status was required on reportbacks, it was causing drupal's default validation hook to run, which re-checks all the data to see that an option was selected 
This was causing two things: 
- the 'an illegal choice was made' error 
- the get the latest reportbacks query to run and causing rbs to be approved without a member of the campaigns team reviewing the reportback
### TO TEST
1. View a campaign with many reportbacks in the inbox and review/approve those
2. Submit a reportback while the Save method on the inbox is still running

The reportback that was submitted should NOT have been reviewed. 
This was previously fixed by disabling the `approved` radio button. This PR adds that back in and doesn't cause incorrect reportbacks to be approved. 
