### PR TITLE
Moving images to sites/default directory

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -125,7 +125,7 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
     $campaign_path = url(current_path(), array('absolute' => TRUE));
 
     // Create the image path to the problem fact statement image generated for the node.
-    $problem_share_image = $base_url . drupal_get_path('module', 'dosomething_campaign_problem_shares') . '/images/' . $vars['nid'] . '.png';
+    $problem_share_image = $base_url . 'sites/default/files/images/' . $vars['nid'] . '.png';
 
     $share_types = array(
       'facebook' => array(

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/create-images.sh
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/create-images.sh
@@ -4,7 +4,7 @@ TEMP_FILE_1=tmp1.png
 TEMP_FILE_2=tmp2.png
 BOLD_FONT_PATH="$1/fonts/ProximaNova-Bold.otf"
 REG_FONT_PATH="$1/fonts/ProximaNova-Reg.otf"
-FINAL_FILE=$1/images/$2.png
+FINAL_FILE=$2/images/$3.png
 
 convert \
   -size 471x248 \
@@ -21,7 +21,7 @@ convert \
   -fill white \
   -font $REG_FONT_PATH \
   -pointsize 24 \
-  caption:"$3" \
+  caption:"$4" \
   $TEMP_FILE_2 \
 
 composite \

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/dosomething_campaign_problem_shares.cron.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/dosomething_campaign_problem_shares.cron.inc
@@ -24,6 +24,7 @@ function dosomething_campaign_problem_shares_cron() {
   array_pop($working_directory);
   $working_directory  = implode('/', $working_directory );
   $path = $working_directory . "/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares";
+  $image_location = $working_directory . "/html/sites/default/files";
 
   // Each active campaign, call shell script to create problem share images.
   foreach($results as $result) {
@@ -35,7 +36,7 @@ function dosomething_campaign_problem_shares_cron() {
     $nid = escapeshellarg($result->nid);
     $problem = escapeshellarg($problem);
     // Call shell script to create the image.
-    shell_exec("/bin/bash $path/create-images.sh $path $nid $problem");
+    shell_exec("/bin/bash $path/create-images.sh $path $image_location $nid $problem");
   }
 
 }


### PR DESCRIPTION
Updating the problem shares image magic script to place the generated images in `/sites/default/files/images` directory. This seems to be a more standard path used across all instances and it is shared across all web heads. 

Should fix #4837 

@angaither @sheydari-ds 
