### PR TITLE
This value was set to approved above, but since that's commented out,…

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -194,7 +194,7 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
         '#title' => t('Status'),
         '#required' => TRUE,
         '#options' => $status_options,
-        '#default_value' => $status,
+        // '#default_value' => $status,
       ),
       'promoted_reason' => array(
         '#type' => 'checkboxes',


### PR DESCRIPTION
… this shouldn't be set.

Refs #4797 

for now, let's leave things required, and not pre-selected as approved. 
