### PR TITLE
Give '' as default status.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -194,7 +194,7 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
         '#title' => t('Status'),
         '#required' => TRUE,
         '#options' => $status_options,
-        // '#default_value' => $status,
+        '#default_value' => $status ?: '',
       ),
       'promoted_reason' => array(
         '#type' => 'checkboxes',


### PR DESCRIPTION
This way after a reportback has been reviewed the status that was selected will show.
Refs #4797
