### PR TITLE
Display and style promoted reportback image

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -175,18 +175,6 @@ function dosomething_campaign_preprocess_win_module(&$vars, $wrapper) {
   $background_landscape_url = dosomething_image_get_themed_image_url($background_nid, 'landscape', '1440x810');
   $background_square_url = dosomething_image_get_themed_image_url($background_nid, 'square', '768x768');
 
-  // Get random promoted image
-  $parameters = array(
-    'campaigns' => $vars['nid'],
-    'status' => 'promoted',
-    'count' => '1',
-    'random' => true,
-  );
-  $random_image = ReportbackItem::find($parameters)[0];
-  if (isset($random_image)) {
-    $promoted_image = $random_image->media['uri'];
-  }
-
   $win_module_image = '.win-module__progress {
       background-image: url("' . $background_square_url . '");
     }
@@ -197,6 +185,18 @@ function dosomething_campaign_preprocess_win_module(&$vars, $wrapper) {
       }
     }';
   drupal_add_css($win_module_image, $option['type'] = 'inline');
+
+  // Get random promoted reportback image
+  $parameters = array(
+    'campaigns' => $vars['nid'],
+    'status' => 'promoted',
+    'count' => '1',
+    'random' => true,
+  );
+  $random_image = ReportbackItem::find($parameters)[0];
+  if (isset($random_image)) {
+    $promoted_image = $random_image->media['uri'];
+  }
 
   // Share bar
   // @TODO - Copy is placeholder

--- a/lib/modules/dosomething/dosomething_campaign/theme/win-module.tpl.php
+++ b/lib/modules/dosomething/dosomething_campaign/theme/win-module.tpl.php
@@ -36,6 +36,9 @@
           <?php print $share_bar; ?>
         </div>
       </div>
+      <div class="win-module__reportback show-at-large">
+        <img src="<?php print $promoted_image ?>" />
+      </div>
     </div>
   </div>
 </section>

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_win-module.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_win-module.scss
@@ -60,4 +60,11 @@
       padding-left: $base-spacing;
     }
   }
+
+  .win-module__reportback {
+    @include media($large) {
+      @include span(5);
+      margin-bottom: $base-spacing;
+    }
+  }
 }


### PR DESCRIPTION
Fixes #4812 

Shows the promoted reportback image next to the author callout in the win module. 

@DoSomething/front-end 
