### PR TITLE
Updates Ctools to 1.8.

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -32,7 +32,7 @@ projects[cdn][version] = "2.6"
 projects[cdn][subdir] = "contrib"
 
 ; Ctools
-projects[ctools][version] = "1.7"
+projects[ctools][version] = "1.8"
 projects[ctools][subdir] = "contrib"
 
 ; Date


### PR DESCRIPTION
See https://www.drupal.org/node/2554145.
Fixes #4873.
