### PR TITLE
Google analytics refactor

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -219,7 +219,7 @@ function dosomething_campaign_preprocess_win_module(&$vars, $wrapper) {
     )
   );
 
-  $share_bar = dosomething_helpers_share_bar($campaign_path, $share_types, 'win_share', 'js-analytics-win', 'social-share-bar -with-callout');
+  $share_bar = dosomething_helpers_share_bar($campaign_path, $share_types, 'Win Share', 'js-analytics-win', 'social-share-bar -with-callout');
 
   $win_module_variables = array(
     'share_copy' => variable_get('dosomething_campaign_win_share_copy'),
@@ -331,8 +331,6 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
   );
 
   // Share links
-  // @TODO - Possible refactor: Create a function that creates a 'share bar', programatically creating
-  // the markup and links for facebook, twitter, and tumblr buttons for us.
   $campaign_path = url(current_path(), array('absolute' => TRUE));
 
   $goal_copy = number_format($goal, 0, '', ',') . " " . strtolower($vars['reportback_noun_verb']) . " by " . $readable_end_date;
@@ -355,7 +353,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
     ),
   );
 
-  $share_bar = dosomething_helpers_share_bar($campaign_path, $share_types, 'hot_share', 'js-analytics-hot', 'social-share-bar -with-callout');
+  $share_bar = dosomething_helpers_share_bar($campaign_path, $share_types, 'Hot Share', 'js-analytics-hot', 'social-share-bar -with-callout');
 
   $hot_module_variables = array(
     'goal' => $goal,

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -219,7 +219,7 @@ function dosomething_campaign_preprocess_win_module(&$vars, $wrapper) {
     )
   );
 
-  $share_bar = dosomething_helpers_share_bar($campaign_path, $share_types, 'Win Share', 'js-analytics-win', 'social-share-bar -with-callout');
+  $share_bar = dosomething_helpers_share_bar($campaign_path, $share_types, 'Win Share', 'social-share-bar -with-callout');
 
   $win_module_variables = array(
     'share_copy' => variable_get('dosomething_campaign_win_share_copy'),
@@ -353,7 +353,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
     ),
   );
 
-  $share_bar = dosomething_helpers_share_bar($campaign_path, $share_types, 'Hot Share', 'js-analytics-hot', 'social-share-bar -with-callout');
+  $share_bar = dosomething_helpers_share_bar($campaign_path, $share_types, 'Hot Share', 'social-share-bar -with-callout');
 
   $hot_module_variables = array(
     'goal' => $goal,

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -139,22 +139,22 @@ function dosomething_helpers_share_bar($path, $share_types, $share_description, 
     switch ($type) {
       case 'facebook':
         $share_intents['facebook'] = dosomething_helpers_get_facebook_intent($share_utm_paths['facebook'], $options['type'], $options['parameters']);
-        $tracking = $analytics_class . '-fb';
+        // $tracking = $analytics_class . '-fb';
         break;
       case 'twitter':
         $share_intents['twitter'] = dosomething_helpers_get_twitter_intent($options['tweet'] . ' ' . $share_utm_paths['twitter']);
-        $tracking = $analytics_class . '-tw';
+        // $tracking = $analytics_class . '-tw';
         break;
       case 'tumblr':
         $options['caption'] = $options['caption'] . $share_utm_paths['tumblr'];
         $share_intents['tumblr'] = dosomething_helpers_get_tumblr_intent($share_utm_paths['tumblr'], $options);
-        $tracking = $analytics_class . '-tm';
+        // $tracking = $analytics_class . '-tm';
       default:
         break;
     }
 
     if ($share_intents[$type]) {
-      $share_bar .= '<li><a class="social-icon -' . $type . ' js-share-link ' . $tracking . '" href="' . $share_intents[$type] . '"><span>'. $type . '</span></a></li>';
+      $share_bar .= '<li><a class="social-icon -' . $type . ' js-share-link ga-click" href="' . $share_intents[$type] . '" data-category="Share" data-label="' . $type .'" data-action="' . $share_description .'"><span>'. $type . '</span></a></li>';
     }
   }
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -139,16 +139,13 @@ function dosomething_helpers_share_bar($path, $share_types, $share_description, 
     switch ($type) {
       case 'facebook':
         $share_intents['facebook'] = dosomething_helpers_get_facebook_intent($share_utm_paths['facebook'], $options['type'], $options['parameters']);
-        // $tracking = $analytics_class . '-fb';
         break;
       case 'twitter':
         $share_intents['twitter'] = dosomething_helpers_get_twitter_intent($options['tweet'] . ' ' . $share_utm_paths['twitter']);
-        // $tracking = $analytics_class . '-tw';
         break;
       case 'tumblr':
         $options['caption'] = $options['caption'] . $share_utm_paths['tumblr'];
         $share_intents['tumblr'] = dosomething_helpers_get_tumblr_intent($share_utm_paths['tumblr'], $options);
-        // $tracking = $analytics_class . '-tm';
       default:
         break;
     }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -130,7 +130,7 @@ function dosomething_helpers_utm_share_paths($share_types, $path, $utm_campaign)
  * @return
  *   Share bar markup.
  */
-function dosomething_helpers_share_bar($path, $share_types, $share_description, $analytics_class = NULL, $classes = NULL) {
+function dosomething_helpers_share_bar($path, $share_types, $share_description, $classes = NULL) {
   $share_utm_paths = dosomething_helpers_utm_share_paths($share_types, $path, $share_description);
   $share_bar = '<ul class="' . $classes . '">';
   $share_intents = [];

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -545,7 +545,7 @@ function dosomething_reportback_view_entity($entity) {
       ),
     );
 
-    $share_bar = dosomething_helpers_share_bar($reportback_url, $share_types, 'Confirmation Page', 'js-analytics-permalink');
+    $share_bar = dosomething_helpers_share_bar($reportback_url, $share_types, 'Confirmation Page');
 
     $share_enabled = variable_get('dosomething_reportback_display_permalink_share', '');
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -545,7 +545,7 @@ function dosomething_reportback_view_entity($entity) {
       ),
     );
 
-    $share_bar = dosomething_helpers_share_bar($reportback_url, $share_types, 'confirmation_page_share', 'js-analytics-permalink');
+    $share_bar = dosomething_helpers_share_bar($reportback_url, $share_types, 'Confirmation Page', 'js-analytics-permalink');
 
     $share_enabled = variable_get('dosomething_reportback_display_permalink_share', '');
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/app.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/app.js
@@ -25,7 +25,7 @@ import Gallery from 'patterns/Gallery';
 import Tile from 'patterns/Tile';
 
 // Utilities
-import 'utilities/Analytics';
+import Analytics from 'utilities/Analytics';
 import Share from 'utilities/Share';
 import ShowMore from 'utilities/ShowMore';
 
@@ -43,6 +43,9 @@ $(document).ready(function() {
    * Initialize feature modules. Each module is responsible for checking if
    * it exists on the page, and short-circuiting if not.
    */
+
+  // Initialize analytics.
+  Analytics.init();
 
   // Initialize the donation form on the donate page.
   Donate.init();

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -42,6 +42,17 @@ function subscribeEvents() {
   });
 }
 
+/**
+ * Google Analytics Event Tracking
+ * Requires an element with the 'ga-event' class on it
+ * and the required data attributes:
+ *   data-category
+ *   data-action
+ *   data-label
+ *
+ * TODO - Should we have default values for category, action, label
+ * so anytime we want to track a click we can just add the .ga-click class to it with nothing else?
+**/
 function clickEvents($el) {
   $el.on('click', function() {
     const category = (typeof ($(this).data('category')) !== 'undefined') ? $(this).data('category') : null;

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -8,8 +8,7 @@ import $ from 'jquery';
 import Validation from 'dosomething-validation';
 import Modal from 'dosomething-modal';
 
-// Only fire GA Custom Events if the GA object exists.
-if (typeof ga !== 'undefined' && ga !== null) {
+function subscribeEvents() {
   // Validation
   Validation.Events.subscribe('Validation:InlineError', function(topic, args) {
     ga('send', 'event', 'Form', 'Inline Validation Error', args);
@@ -41,25 +40,27 @@ if (typeof ga !== 'undefined' && ga !== null) {
     const label = args !== null ? '#' + args.attr('id') : '';
     ga('send', 'event', 'Modal', 'Close', label);
   });
+}
 
-  /******
-   * Google Analytics Event Tracking
-   * Requires an element with the 'ga-event' class on it
-   * and the required data attributes:
-   *   data-category
-   *   data-action
-   *   data-label
-   *
-   * TODO - Should we have default values for category, action, label
-   * so anytime we want to track a click we can just add the .ga-click class to it with nothing else?
-  ********/
-  if ($('.ga-click').length) {
-    $('.ga-click').on('click', function() {
-      const category = (typeof ($(this).data('category')) !== 'undefined') ? $(this).data('category') : null;
-      const action = (typeof ($(this).data('action')) !== 'undefined') ? $(this).data('action') : null;
-      const label = (typeof ($(this).data('label')) !== 'undefined') ? $(this).data('label') : null;
+function clickEvents($el) {
+  $el.on('click', function() {
+    const category = (typeof ($(this).data('category')) !== 'undefined') ? $(this).data('category') : null;
+    const action = (typeof ($(this).data('action')) !== 'undefined') ? $(this).data('action') : null;
+    const label = (typeof ($(this).data('label')) !== 'undefined') ? $(this).data('label') : null;
 
-      ga('send', 'event', category, action, label);
-    });
+    ga('send', 'event', category, action, label);
+  });
+}
+
+function init() {
+  // Only fire GA Custom Events if the GA object exists.
+  if (typeof ga !== 'undefined' && ga !== null) {
+    subscribeEvents();
+
+    if ($('.ga-click').length) {
+      clickEvents($('.ga-click'));
+    }
   }
 }
+
+export default { init };

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -31,46 +31,6 @@ if (typeof ga !== 'undefined' && ga !== null) {
     ga('send', 'event', 'Form', 'Validation Error on submit', args);
   });
 
-  // Confirmation Page Shares
-  $('.js-analytics-permalink-fb').on('click', function() {
-    ga('send', 'event', 'Share', 'Confirmation Page', 'Facebook');
-  });
-
-  $('.js-analytics-permalink-tw').on('click', function() {
-    ga('send', 'event', 'Share', 'Confirmation Page', 'Twitter');
-  });
-
-  $('.js-analytics-permalink-tm').on('click', function() {
-    ga('send', 'event', 'Share', 'Confirmation Page', 'Tumblr');
-  });
-
-
-  // Campaign problem statement shares.
-  $('.js-analytics-problem-fb').on('click', function() {
-    ga('send', 'event', 'Share', 'Problem Statement', 'Facebook');
-  });
-
-  $('.js-analytics-problem-tw').on('click', function() {
-    ga('send', 'event', 'Share', 'Problem Statement', 'Twitter');
-  });
-
-  $('.js-analytics-problem-tm').on('click', function() {
-    ga('send', 'event', 'Share', 'Problem Statement', 'Tumblr');
-  });
-
-  // Hot module goal shares.
-  $('.js-analytics-hot-fb').on('click', function() {
-    ga('send', 'event', 'Share', 'Hot Module', 'Facebook');
-  });
-
-  $('.js-analytics-hot-tw').on('click', function() {
-    ga('send', 'event', 'Share', 'Hot Module', 'Twitter');
-  });
-
-  $('.js-analytics-hot-tm').on('click', function() {
-    ga('send', 'event', 'Share', 'Hot Module', 'Tumblr');
-  });
-
   // Modals
   Modal.Events.subscribe('Modal:Open', function(topic, args) {
     const label = args !== null ? '#' + args.attr('id') : '';
@@ -81,4 +41,25 @@ if (typeof ga !== 'undefined' && ga !== null) {
     const label = args !== null ? '#' + args.attr('id') : '';
     ga('send', 'event', 'Modal', 'Close', label);
   });
+
+  /******
+   * Google Analytics Event Tracking
+   * Requires an element with the 'ga-event' class on it
+   * and the required data attributes:
+   *   data-category
+   *   data-action
+   *   data-label
+   *
+   * TODO - Should we have default values for category, action, label
+   * so anytime we want to track a click we can just add the .ga-click class to it with nothing else?
+  ********/
+  if ($('.ga-click').length) {
+    $('.ga-click').on('click', function() {
+      const category = (typeof ($(this).data('category')) !== 'undefined') ? $(this).data('category') : null;
+      const action = (typeof ($(this).data('action')) !== 'undefined') ? $(this).data('action') : null;
+      const label = (typeof ($(this).data('label')) !== 'undefined') ? $(this).data('label') : null;
+
+      ga('send', 'event', category, action, label);
+    });
+  }
 }


### PR DESCRIPTION
Resolves #4793 

Updated the analytics script to be a bit more DRY. Now, all we have to do to track custom click events is add a `ga-click` class on the element we are tracking with some data attributes that pass in the custom info that we want to track. 

@DoSomething/front-end 
