### PR TITLE
Add a query string to bust cache on deploys.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/template.php
+++ b/lib/themes/dosomething/paraneue_dosomething/template.php
@@ -15,9 +15,9 @@ if(theme_get_setting('asset_path')) {
 
 // Determine whether to use minified stylesheets or not.
 if(theme_get_setting('use_minified_assets')) {
-  define('DS_STYLE_PATH', DS_ASSET_PATH . '/dist/app.min.css');
+  define('DS_STYLE_PATH', DS_ASSET_PATH . '/dist/app.min.css?' . variable_get('ds_version', 'latest'));
 } else {
-  define('DS_STYLE_PATH', DS_ASSET_PATH . '/dist/app.css');
+  define('DS_STYLE_PATH', DS_ASSET_PATH . '/dist/app.css?' . variable_get('ds_version', 'latest'));
 }
 
 // Define asset directory paths


### PR DESCRIPTION
# Changes

Adds a query string to CSS files (e.g. `app.css?v1.0.32`) so that they properly invalidate cache on deploys. References #4867.

For review: @sergii-tkachenko 
