### PR TITLE
Adds new confirmation field & styling to form

### DIFF
--- a/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
+++ b/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
@@ -245,6 +245,12 @@ function dosomething_payment_form_submit($form, &$form_state) {
       );
     }
   }
+  else {
+    // Send stathat info.
+    if (module_exists('stathat')) {
+      stathat_send_ez_count('drupal - Donate - honeypot', 1);
+    }
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
+++ b/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
@@ -226,20 +226,24 @@ function dosomething_payment_form_submit($form, &$form_state) {
   $dollars = $values['amount'];
   // Expected amount to charge to Stripe should be in cents.
   $values['amount'] = $values['amount'] * 100;
-  // Send Payment request to Stripe API.
-  if (dosomething_payment_post_payment_stripe($values) && !isset($values['email'])) {
-    // Send stathat info.
-    if (module_exists('stathat')) {
-      stathat_send_ez_count('drupal - Donate - count', 1);
-      stathat_send_ez_value('drupal - Donate - value', $dollars);
+
+  // Check the honey pot for honey
+  if (!isset($values['email'])) {
+    // Send Payment request to Stripe API.
+    if (dosomething_payment_post_payment_stripe($values)) {
+      // Send stathat info.
+      if (module_exists('stathat')) {
+        stathat_send_ez_count('drupal - Donate - count', 1);
+        stathat_send_ez_value('drupal - Donate - value', $dollars);
+      }
+      // Redirect to current page with query string.
+      $form_state['redirect'] = array(
+        drupal_get_path_alias(),
+        array(
+          'query' => array('donated' => 1),
+        ),
+      );
     }
-    // Redirect to current page with query string.
-    $form_state['redirect'] = array(
-      drupal_get_path_alias(),
-      array(
-        'query' => array('donated' => 1),
-      ),
-    );
   }
 }
 

--- a/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
+++ b/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
@@ -93,6 +93,8 @@ function dosomething_payment_form($form, &$form_state, $config = array()) {
     ),
     'setting'
   );
+  $hide_honeypot_style = '.form-item-email { display: none }';
+  drupal_add_css($hide_honeypot_style, $option['type'] = inline);
   $form['full_name'] = array(
     '#type' => 'textfield',
     '#title' => t('Name on Card'),
@@ -103,7 +105,18 @@ function dosomething_payment_form($form, &$form_state, $config = array()) {
       'data-stripe' => 'name',
     ),
   );
+  // Honeypot. Upon submitting the form this field is removed from $form to avoid
+  // confusion in the payment processing.
   $form['email'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Email'),
+    '#required' => FALSE,
+    '#attributes' => array(
+      'data-stripe' => 'email',
+    ),
+  );
+  // Actual email field.
+  $form['email_confirmation'] = array(
     '#type' => 'textfield',
     '#title' => t('Email'),
     '#required' => TRUE,
@@ -294,7 +307,7 @@ function dosomething_payment_post_payment_stripe($values) {
       'customer' => $customer->id,
       'amount' => $values['amount'],
       'currency' => 'usd',
-      'receipt_email' => $values['email'],
+      'receipt_email' => $values['confirmation_email'],
       'description' => "Donation for DoSomething.org",
       'metadata' => $notes,
     ));

--- a/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
+++ b/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
@@ -227,7 +227,7 @@ function dosomething_payment_form_submit($form, &$form_state) {
   // Expected amount to charge to Stripe should be in cents.
   $values['amount'] = $values['amount'] * 100;
   // Send Payment request to Stripe API.
-  if (dosomething_payment_post_payment_stripe($values)) {
+  if (dosomething_payment_post_payment_stripe($values) && !isset($values['email'])) {
     // Send stathat info.
     if (module_exists('stathat')) {
       stathat_send_ez_count('drupal - Donate - count', 1);


### PR DESCRIPTION
Fixes #4838 

Adds a new email confirmation field to the form and updates the form submit logic to include this new field. Also inserts styling to correctly display the new field. 

Has been verified to work on local development and on the remote service by @namimody 

@angaither 
