### PR TITLE
Fix style bug on problem shares

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -143,7 +143,7 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
       ),
     );
 
-    $vars['share_bar'] = dosomething_helpers_share_bar($campaign_path, $share_types, 'problem_shares', 'js-analytics-problem', 'social-share-bar -with-callout');
+    $vars['share_bar'] = dosomething_helpers_share_bar($campaign_path, $share_types, 'problem_shares', 'social-share-bar -with-callout');
   }
 
   // Hot and win module variables.


### PR DESCRIPTION
Fixes #4899 

I updated the share bar function to not take in an analytics class parameter anymore, but I was still passing it when generating the problem share bar. The function was then not applying share bar classes I passed to it, because the ordering was off. 
