### PR TITLE
Updates review reportback logic to support multiple files

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -336,8 +336,8 @@ class Reportback extends Entity {
     $items = ReportbackItem::get($this->getFids());
 
     // Determine all of the reportback statuses
-    $flagged_reportbacks = false;
-    $promoted_reportbacks = false;
+    $flagged_reportbacks = FALSE;
+    $promoted_reportbacks = FALSE;
 
     foreach ($items as $item) {
       if ($item->status === "flagged") {

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -344,14 +344,16 @@ class Reportback extends Entity {
       foreach ($items as $item) {
         if ($item->status === "flagged") {
           $flaggedReportbacks = TRUE;
+
         }
         else if($item->status === "promoted") {
           $promotedReportbacks = TRUE;
+
         }
       }
 
-      // The optional conditional verifies that flagged always overrides promoted
-      // regardless if its a new or existing reportback status
+      // Verifies that reportbacks get the correct status and boolean
+      // regardless of the order they are reviewed or how many there is
       if ($flaggedReportbacks || $status === "flagged") {
         $status = "flagged";
       }
@@ -360,15 +362,28 @@ class Reportback extends Entity {
       }
     }
 
+    // Based on the logic decided above, modify the review values
     if ($status === 'flagged') {
       $this->flagged = 1;
-      $this->flagged_reason = $values['flagged_reason'] ?: NULL;
       $this->promoted = 0;
+      if (is_string($values['flagged_reason'])) {
+        if (empty($values['flagged_reason'])) {
+          $values['flagged_reason'] = $this->flagged_reason;
+        }
+        $this->flagged_reason = $values['flagged_reason'];
+      }
+      $this->promoted_reason = NULL;
     }
     elseif ($status === 'promoted') {
       $this->promoted = 1;
-      $this->promoted_reason = $values['promoted_reason'] ?: NULL;
       $this->flagged = 0;
+      if (is_string($values['promoted_reason'])) {
+        if (empty($values['promoted_reason'])) {
+          $values['promoted_reason'] = $this->promoted_reason;
+        }
+        $this->promoted_reason = $values['promoted_reason'];
+      }
+      $this->flagged_reason = NULL;
     }
     else {
       $this->flagged = 0;

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -364,9 +364,12 @@ class Reportback extends Entity {
       $this->flagged = 1;
       $this->promoted = 0;
 
-      // Make sure the reason is correct
+      // If the user doesn't select a reason for a reportback item,
+      // an array is sent instead of a string.
       if (is_string($values['flagged_reason'])) {
+        // Ensure that the string isn't empty (Occurs when you press save without changing anything)
         if (empty($values['flagged_reason'])) {
+          // If the string is empty use the existing reason
           $values['flagged_reason'] = $this->flagged_reason;
         }
         $this->flagged_reason = $values['flagged_reason'];
@@ -381,9 +384,12 @@ class Reportback extends Entity {
       $this->promoted = 1;
       $this->flagged = 0;
 
-      // Make sure the reason is correct
+      // If the user doesn't select a reason for a reportback item,
+      // an array is sent instead of a string.
       if (is_string($values['promoted_reason'])) {
+        // Ensure that the string isn't empty (Occurs when you press save without changing anything)
         if (empty($values['promoted_reason'])) {
+          // If the string is empty use the existing reason
           $values['promoted_reason'] = $this->promoted_reason;
         }
         $this->promoted_reason = $values['promoted_reason'];

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -336,26 +336,26 @@ class Reportback extends Entity {
     $items = ReportbackItem::get($this->getFids());
 
     // Determine all of the reportback statuses
-    $flaggedReportbacks = false;
-    $promotedReportbacks = false;
+    $flagged_reportbacks = false;
+    $promoted_reportbacks = false;
 
     foreach ($items as $item) {
       if ($item->status === "flagged") {
-        $flaggedReportbacks = TRUE;
+        $flagged_reportbacks = TRUE;
 
       }
       else if($item->status === "promoted") {
-        $promotedReportbacks = TRUE;
+        $promoted_reportbacks = TRUE;
       }
     }
 
     // Verifies that reportbacks get the correct status and boolean
     // regardless of the order they are reviewed or how many there is
-    if ($flaggedReportbacks || $status === "flagged") {
+    if ($flagged_reportbacks || $status === "flagged") {
       $status = "flagged";
     }
     // Promoted must be after flagged as it has second priority
-    else if($promotedReportbacks || $status === "promoted") {
+    else if($promoted_reportbacks || $status === "promoted") {
       $status = "promoted";
     }
 
@@ -376,7 +376,7 @@ class Reportback extends Entity {
       }
 
       // Set the other status reason to NULL if there isn't any left
-      if (!$promotedReportbacks) {
+      if (!$promoted_reportbacks) {
         $this->promoted_reason = NULL;
       }
     }


### PR DESCRIPTION
Rewrote a good chunk of the setFlaggedPromoted function, as a result this PR should fix the following issues, #4908 #4880 

Currently testing it, progress is being logged in a Google Sheet here: https://docs.google.com/a/dosomething.org/spreadsheets/d/1YA5QSNf5Jhs9myY-CUcY3Ca3arkDWgr4MUR7AiphniQ/edit?usp=sharing

Logic is much more clear and documented now, accounts for each reportback item before determining what the values should be. Clearly labels & separates the business logic. After this is merged I can another round of thorough testing with @namimody 

@angaither 
