### PR TITLE
Fixes logic flow that allowed fatal error during parner image render.

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -107,6 +107,10 @@ function dosomething_helpers_preprocess_partners_vars(&$vars) {
       if (!empty($image_node->field_image_landscape)) {
         $img = dosomething_image_get_themed_image($image_node->nid, 'landscape', '550x300');
         $vars['partner_info'][$delta]['image'] = $img;
+      } else {
+        // Must be overridden: partner image is unrendered object by default,
+        // but rendered string is expected in the template.
+        $vars['partner_info'][$delta]['image'] = dosomething_image_get_themed_no_image();
       }
     }
   }

--- a/lib/modules/dosomething/dosomething_image/dosomething_image.module
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.module
@@ -167,6 +167,8 @@ function dosomething_image_get_themed_image_by_fid($fid, $style, $alt = '') {
  *   Img tag of no-image-found.png
  */
 function dosomething_image_get_themed_no_image() {
+  // The function output is always the same, so static caching used.
+  // See drupal_static() documentation.
   $img = &drupal_static(__FUNCTION__);
   if (!isset($img)) {
     $args = [

--- a/lib/modules/dosomething/dosomething_image/dosomething_image.module
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.module
@@ -142,13 +142,7 @@ function dosomething_image_get_themed_image_by_fid($fid, $style, $alt = '') {
 
   $image = image_load($file->uri);
   if (!$image) {
-    $args = array(
-      'path' => DS_ASSET_PATH .'/dist/images/no-image-found.png',
-      'alt' => 'No image found placeholder',
-      'title' => 'No Image Found',
-      'attributes' => NULL,
-    );
-    return theme_image($args);
+    return dosomething_image_get_themed_no_image();
   }
   else {
     $content = array(
@@ -162,6 +156,28 @@ function dosomething_image_get_themed_image_by_fid($fid, $style, $alt = '') {
 
     return drupal_render($content);
   }
+}
+
+/**
+ * Returns no image tag.
+ *
+ * Uses static cache to speed up the output.
+ *
+ * @return string
+ *   Img tag of no-image-found.png
+ */
+function dosomething_image_get_themed_no_image() {
+  $img = &drupal_static(__FUNCTION__);
+  if (!isset($img)) {
+    $args = [
+      'path' => DS_ASSET_PATH .'/dist/images/no-image-found.png',
+      'alt' => 'No image found placeholder',
+      'title' => 'No Image Found',
+      'attributes' => NULL,
+    ];
+    $img = theme_image($args);
+  }
+  return $img;
 }
 
 /**


### PR DESCRIPTION
Fixes #4916.
Plus, a helper function created for rendering no-image-found.png tag.

cc @mikefantini 
