### PR TITLE
Fixes #4894: campaign images on search results.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -108,7 +108,8 @@ function paraneue_dosomething_get_search_vars($results) {
         $image = $result_node->field_image_campaign_cover;
         // Make it available as a variable, if it exists. Otherwise, leave it empty.
         if (!empty($image)) {
-          $value['display_image'] = dosomething_image_get_themed_image($image['und'][0]['target_id'], 'square', '300x300');
+          $clc = dosomething_helpers_get_current_language_code();
+          $value['display_image'] = dosomething_image_get_themed_image($image[$clc][0]['target_id'], 'square', '300x300');
         }
         else {
           $value['display_image'] = '';


### PR DESCRIPTION
The campaign images are language-dependent now, so current language code is used instead of `LANGUAGE_NONE`.

![image](https://cloud.githubusercontent.com/assets/672669/9501807/1751f196-4c36-11e5-98fa-7ab2e3ca6623.png)
