### PR TITLE
Provides temporary solution for API output of translatable fields.

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -105,6 +105,19 @@ function dosomething_helpers_delete_test_nodes() {
 function dosomething_helpers_extract_field_data($field, $language = LANGUAGE_NONE) {
   if (isset($field) && !empty($field)) {
 
+    // ---
+    // Temporary fix for translatable fields.
+    // If no specific language requested, attempt to return English value first.
+    //
+    // In future the API will be extended with functionally that controls
+    // output language with a URL parameter.
+    if ($language === LANGUAGE_NONE) {
+      if (!empty($field['en'])) {
+        $language = 'en';
+      }
+    }
+    // ---
+
     $data = $field[$language];
 
     $values = array();


### PR DESCRIPTION
Solution 1 for #4922:
Temporary fix for translatable fields.
If no specific language requested, attempt return English value first.

![image](https://cloud.githubusercontent.com/assets/672669/9504281/7374ddea-4c44-11e5-87c6-0106f8d909bb.png)
