### PR TITLE
Add new permissions for editors and site admins

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.user_permission.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.user_permission.inc
@@ -50,6 +50,8 @@ function dosomething_campaign_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'creative team' => 'creative team',
+      'editor' => 'editor',
+      'site admin' => 'site admin',
     ),
     'module' => 'dosomething_campaign',
   );


### PR DESCRIPTION
Allow editors and site admins to see change custom settings on campaigns.
 Fixes #4928
