### PR TITLE
Fingerprint stylesheet assets with Webpack

### DIFF
--- a/lib/modules/dosomething/dosomething_image/dosomething_image.module
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.module
@@ -143,7 +143,7 @@ function dosomething_image_get_themed_image_by_fid($fid, $style, $alt = '') {
   $image = image_load($file->uri);
   if (!$image) {
     $args = array(
-      'path' => DS_ASSET_PATH .'/dist/images/no-image-found.png',
+      'path' => DS_ASSET_PATH .'/images/no-image-found.png',
       'alt' => 'No image found placeholder',
       'title' => 'No Image Found',
       'attributes' => NULL,

--- a/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
+++ b/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
@@ -18,16 +18,6 @@ module.exports = function(grunt) {
     },
 
     /**
-     * Copy assets into `dist/` directory.
-     */
-    copy: {
-      assets: {
-        files: [
-          {expand: true, src: ["images/**"], dest: "dist/"}
-        ]
-      }
-    },
-
     /**
      * Pre-process CSS with LibSass.
      */

--- a/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
+++ b/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
@@ -2,6 +2,7 @@
 "use strict";
 
 var webpack = require('webpack');
+var ExtractTextPlugin = require("extract-text-webpack-plugin");
 
 module.exports = function(grunt) {
   // Load tasks & measure timing
@@ -18,64 +19,12 @@ module.exports = function(grunt) {
     },
 
     /**
-    /**
-     * Pre-process CSS with LibSass.
-     */
-    sass: {
-      // On production builds, minify and remove comments.
-      prod: {
-        files: {
-          'dist/app.css': 'scss/app.scss'
-        },
-        options: {
-          outputStyle: 'compressed'
-        }
-      },
-
-      // On development builds, include source maps & do not minify.
-      debug: {
-        files: {
-          'dist/app.css': 'scss/app.scss'
-        },
-        options: {
-          sourceMap: true
-        }
-      }
-    },
-
-    /**
-     * Post-process CSS with PostCSS.
+     * Build assets with Webpack. Bundle scripts and transpile JavaScript using
+     * Babel, and pre-process CSS with LibSass.
      *
-     * We use Autoprefixer to automatically add vendor-prefixes for appropriate
-     * browsers. We use CSS-MQPacker to concatenate all media queries at the
-     * end of our built stylesheets.
-     */
-    postcss: {
-      options: {
-        processors: [
-          require('autoprefixer-core')({
-            browsers: ['last 4 versions', 'Firefox ESR', 'Opera 12.1']
-          }).postcss,
-          require('css-mqpacker').postcss
-        ]
-      },
-
-      // On production builds, omit source maps.
-      prod: {
-        src: ['dist/app.css'],
-        options: {
-          map: false
-        }
-      },
-
-      // On development builds, include source maps.
-      debug: {
-        src: ['dist/app.css']
-      }
-    },
-
-    /**
-     * Build JavaScript with Webpack.
+     * We also post-process CSS with PostCSS. We use Autoprefixer to automatically
+     * add vendor-prefixes for appropriate browsers. We use CSS-MQPacker to
+     * concatenate all media queries at the end of our built stylesheets.
      */
     webpack: {
       options: {
@@ -84,7 +33,8 @@ module.exports = function(grunt) {
           lib: './js/lib.js'
         },
         output: {
-          filename: 'dist/app.js'
+          path: 'dist',
+          filename: '[name].js'
         },
         resolve: {
           root: require('path').resolve(__dirname, './js')
@@ -92,8 +42,21 @@ module.exports = function(grunt) {
         module: {
           loaders: [
             { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader'},
-            { test: /\.html$/, exclude: /node_modules/, loader: 'raw-loader'}
+            { test: /\.html$/, exclude: /node_modules/, loader: 'raw-loader'},
+            { test: /\.(png|jpg|gif|eot|woff|svg|ttf)$/, loader: 'url-loader?limit=4096' },
+            {
+              test: /\.scss$/,
+              loader: ExtractTextPlugin.extract('css-loader?sourceMap!postcss-loader!sass-loader?sourceMap')
+            },
           ]
+        },
+        postcss: function() {
+          return [
+            require('autoprefixer-core')({
+              browsers: ['last 4 versions', 'Firefox ESR', 'Opera 12.1']
+            }),
+            require('css-mqpacker').postcss
+          ];
         }
       },
 
@@ -106,7 +69,7 @@ module.exports = function(grunt) {
           }),
           new webpack.optimize.CommonsChunkPlugin({
             name: "lib",
-            filename: "dist/lib.js"
+            filename: "lib.js"
           }),
           new webpack.optimize.UglifyJsPlugin({
             compress: {
@@ -115,13 +78,14 @@ module.exports = function(grunt) {
               drop_debugger: true,
               dead_code: true
             }
-          })
+          }),
+          new ExtractTextPlugin('app.min.css')
         ]
       },
 
       // On development builds, include source maps & set debug flags
       debug: {
-        devtool: '#inline-source-map',
+        devtool: 'eval-cheap-module-source-map',
         plugins: [
           new webpack.DefinePlugin({
             DEBUG: true,
@@ -129,9 +93,15 @@ module.exports = function(grunt) {
           }),
           new webpack.optimize.CommonsChunkPlugin({
             name: "lib",
-            filename: "dist/lib.js"
-          })
-        ]
+            filename: "lib.js"
+          }),
+          new ExtractTextPlugin('app.min.css')
+        ],
+
+        // Keep Webpack task running & watch for changes.
+        keepalive: true,
+        watch: true,
+        cache: true
       }
     },
 
@@ -179,7 +149,7 @@ module.exports = function(grunt) {
      * Lint JavaScript using ESLint.
      */
     eslint: {
-      target: ["js/**/*.js"]
+      all: ["js/**/*.js"]
     },
 
     /**
@@ -188,24 +158,6 @@ module.exports = function(grunt) {
     sasslint: {
       all: ["scss/**/*.scss"]
     },
-
-    /**
-     * Watch files for changes, and trigger relevant tasks.
-     */
-    watch: {
-      sass: {
-        files: ["scss/**/*.scss"],
-        tasks: ["sass:debug", "postcss:debug", "sasslint"]
-      },
-      js: {
-        files: ["js/**/*.js"],
-        tasks: ["webpack:debug", "eslint"]
-      },
-      assets: {
-        files: ["images/**/*"],
-        tasks: ["copy:assets"]
-      }
-    }
   });
 
   /**
@@ -214,15 +166,15 @@ module.exports = function(grunt) {
 
   // > grunt
   // Build for development & watch for changes.
-  grunt.registerTask('default', ['build:debug', 'test', 'watch']);
+  grunt.registerTask('default', ['build:debug']);
 
   // > grunt build
   // Build for production.
-  grunt.registerTask('build', ['clean:dist', 'copy:assets', 'sass:prod', 'postcss:prod', 'webpack:prod', 'modernizr:all']);
+  grunt.registerTask('build', ['clean:dist', 'modernizr:all', 'webpack:prod']);
 
   // > grunt build:debug
   // Build for development.
-  grunt.registerTask('build:debug', ['clean:dist', 'copy:assets', 'sass:debug', 'postcss:debug', 'webpack:debug', 'modernizr:all']);
+  grunt.registerTask('build:debug', ['clean:dist', 'modernizr:all', 'webpack:debug']);
 
   // > grunt test
   // Run included unit tests and linters.

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -362,7 +362,7 @@ function paraneue_dosomething_get_themed_placeholder_reportbacks($count = 6) {
   if (!$placeholder_urls) {
     $placeholder_urls = array();
     for ($i = 1; $i <= $count; $i++) {
-      $placeholder_urls[] = DS_ASSET_PATH . '/dist/images/gallery-placeholder-' . $i . '.jpg';
+      $placeholder_urls[] = DS_ASSET_PATH . '/images/gallery-placeholder-' . $i . '.jpg';
     }
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/app.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/app.js
@@ -36,6 +36,13 @@ import 'validators/address';
 import 'validators/donate';
 
 /**
+ * Load styles. We use Forge (http://forge.dosomething.org) as a foundation
+ * for building our interface, and preprocess our styles using SCSS. Any
+ * imported stylesheets will be built into `app.min.css`.
+ */
+import '../scss/app.scss';
+
+/**
  * Let's go!
  */
 $(document).ready(function() {

--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -2,6 +2,8 @@
   "private": true,
   "scripts": {
     "start": "grunt",
+    "build": "grunt build",
+    "test": "grunt test",
     "postinstall": "find node_modules/ -name '*.info' -type f -delete"
   },
   "dependencies": {
@@ -23,14 +25,17 @@
     "unveil": "DFurnes/unveil.git#umd"
   },
   "devDependencies": {
-    "autoprefixer-core": "^4.0.2",
+    "autoprefixer-core": "^5.2.0",
     "babel": "^5.0.0",
     "babel-core": "^5.0.0",
     "babel-eslint": "^3.1.23",
     "babel-loader": "^5.0.0",
-    "css-mqpacker": "^2.0.0",
+    "css-loader": "^0.16.0",
+    "css-mqpacker": "^3.1.0",
     "eslint": "^0.24.1",
     "eslint-plugin-react": "^2.7.0",
+    "extract-text-webpack-plugin": "^0.8.2",
+    "file-loader": "^0.8.4",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-copy": "^0.7.0",
@@ -38,13 +43,16 @@
     "grunt-eslint": "^16.0.0",
     "grunt-modernizr": "metaloha/grunt-modernizr#d6657bf302bd9288e25a513197fb0e30c64ce677",
     "grunt-postcss": "^0.2.0",
-    "grunt-sass": "^0.18.0",
     "grunt-sasslint": "0.0.5",
     "grunt-webpack": "^1.0.8",
     "load-grunt-tasks": "^3.1.0",
+    "node-sass": "^3.2.0",
+    "postcss-loader": "^0.6.0",
     "raw-loader": "^0.5.1",
+    "sass-loader": "^2.0.1",
     "time-grunt": "^1.0.0",
-    "webpack": "^1.4.5",
-    "webpack-dev-server": "^1.8.0"
+    "url-loader": "^0.5.6",
+    "webpack": "^1.9.11",
+    "webpack-dev-server": "^1.9.0"
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_finder.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_finder.scss
@@ -212,8 +212,7 @@
   }
 
   .no-result {
-    background: $off-black asset-url("images/placeholder.png") center center;
-    background-size: cover;
+    background: $off-black;
     text-align: center;
     min-height: 300px;
     width: 100%;


### PR DESCRIPTION
# Changes

Process stylesheets and assets using Webpack. This allows us to "fingerprint" assets in the `dist` folder so that they break cache only if they change. It also allows Webpack to handle whether to inline assets as data URLs based on their file size: for now, it's configured to inline any files that are less than 4kb.

<img width="339" alt="screen shot 2015-08-27 at 12 21 52 pm" src="https://cloud.githubusercontent.com/assets/583202/9526253/3e036718-4cb6-11e5-9068-62b3696ae156.png">

References #4867.

For review/discussion: @DoSomething/front-end 
