### PR TITLE
Win module background image updates. Fixes #4941

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -176,11 +176,15 @@ function dosomething_campaign_preprocess_win_module(&$vars, $wrapper) {
 
   $win_module_image = '.win-module__progress {
       background-image: url("' . $background_square_url . '");
+      background-size: contain;
+      background-position: center;
     }
 
-    @media only screen and (min-width: 768px) {
+    @media only screen and (min-width: 560px) {
       .win-module__progress {
         background-image: url("' . $background_landscape_url . '");
+        background-size: contain;
+        background-position: center;
       }
     }';
   drupal_add_css($win_module_image, $option['type'] = 'inline');

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -50,6 +50,8 @@ function subscribeEvents() {
  *   data-action
  *   data-label
  *
+ * @param {jQuery} $el - The element being tracked.
+ *
  * TODO - Should we have default values for category, action, label
  * so anytime we want to track a click we can just add the .ga-click class to it with nothing else?
 **/

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_win-module.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_win-module.scss
@@ -19,12 +19,18 @@
       }
     }
 
+    // Font sizes here are hard coded because they are
+    // outlier to our regular font system. Specific to the win module.
     h2 {
       color: $black;
       font-size: 76px;
 
+      @include media($medium) {
+        font-size: 120px;
+      }
+
       @include media($large) {
-        font-size: 124px;
+        font-size: 200px;
       }
     }
 
@@ -34,8 +40,12 @@
       font-weight: $weight-normal;
       text-transform: uppercase;
 
-      @include media($large) {
+      @include media($medium) {
         font-size: $font-larger;
+      }
+
+      @include media($large) {
+        font-size: $font-medium * 2;
       }
     }
   }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_win-module.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_win-module.scss
@@ -20,7 +20,7 @@
     }
 
     // Font sizes here are hard coded because they are
-    // outlier to our regular font system. Specific to the win module.
+    // outliers to our regular font system. Specific to the win module.
     h2 {
       color: $black;
       font-size: 76px;
@@ -45,7 +45,7 @@
       }
 
       @include media($large) {
-        font-size: $font-medium * 2;
+        font-size: 48px;
       }
     }
   }


### PR DESCRIPTION
Updates the win module background image so that it works at all break points. This background image is a little funky because the pattern lies around centered text, so we needed to play around with breakpoints and font sizes a bit to get it to work at all sizes. 

@DoSomething/front-end 

Notes: 
- I will make another issue to move this image from an image node to an svg.
- This also includes a small lint error I was getting in `Analytics.js`
