### PR TITLE
Updates the hot (and win) module timing logic

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -738,8 +738,10 @@ function dosomething_campaign_add_shipment_form_vars($node) {
  */
 function dosomething_campaign_is_hot_module($vars) {
   $today = new DateTime();
+  $today->setTimezone(new DateTimeZone('America/New_York'));
   $start_date = new DateTime($vars['field_high_season'][0]['value']);
   $end_date = new DateTime($vars['field_high_season'][0]['value2']);
+  $end_date->setTime(23, 59, 59);
 
   // Hot module is only enabled when variable is set, high season dates exist and there is still days left.
   if (!empty($vars['field_high_season']) && (($start_date < $today)  && ($today < $end_date))) {
@@ -824,8 +826,11 @@ function dosomething_campaign_is_active($node) {
   */
  function dosomething_campaign_is_win_module($vars) {
    $today = new DateTime();
+   $today->setTimezone(new DateTimeZone('America/New_York'));
    $end_date = new DateTime($vars['field_high_season'][0]['value2']);
+   $end_date->setTime(23, 59, 59);
    $win_module_end = date_modify(clone $end_date, '+30 days');
+   $win_module_end->setTime(23, 59, 59);
 
    // Win module is only enabled when variable is set, high season dates exist and there is still days left.
    if (variable_get('dosomething_campaign_enable_win_module', NULL) == 1 && !empty($vars['field_high_season']) && (($end_date < $today)  && ($today < $win_module_end))) {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -737,7 +737,7 @@ function dosomething_campaign_add_shipment_form_vars($node) {
  * @return bool
  */
 function dosomething_campaign_is_hot_module($vars) {
-  $today = new DateTime();
+  $today = dosomething_campaign_set_est_timezone(new DateTime());
   $today->setTimezone(new DateTimeZone('America/New_York'));
   $start_date = new DateTime($vars['field_high_season'][0]['value']);
   $end_date = new DateTime($vars['field_high_season'][0]['value2']);
@@ -825,8 +825,7 @@ function dosomething_campaign_is_active($node) {
   * @return bool
   */
  function dosomething_campaign_is_win_module($vars) {
-   $today = new DateTime();
-   $today->setTimezone(new DateTimeZone('America/New_York'));
+   $today = dosomething_campaign_set_est_timezone(new DateTime());
    $end_date = new DateTime($vars['field_high_season'][0]['value2']);
    $end_date->setTime(23, 59, 59);
    $win_module_end = date_modify(clone $end_date, '+30 days');
@@ -850,7 +849,7 @@ function dosomething_campaign_is_active($node) {
    * @return DateTime
    *  Updated time
    */
-function dosomething_campaign_format_time($date, $end_of_day = FALSE) {
+function dosomething_campaign_set_est_timezone($date) {
   $date->setTimezone(new DateTimeZone('America/New_York'));
   return $date;
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -839,6 +839,22 @@ function dosomething_campaign_is_active($node) {
    return FALSE;
  }
 
+ /**
+   * Set the given DateTime to America/New_York and end of day
+   *
+   * @param DateTime $date
+   *  DateTime to edit
+   * @param boolean $end_of_day;
+   *  Optional - set the date to end of day
+   *
+   * @return DateTime
+   *  Updated time
+   */
+function dosomething_campaign_format_time($date, $end_of_day = FALSE) {
+  $date->setTimezone(new DateTimeZone('America/New_York'));
+  return $date;
+}
+
 /**
  * Returns array of nid's of recommended campaigns for $uid.
  *


### PR DESCRIPTION
Fixes #4926 
- Sets the user timezone to America/New_York to match the campaign time zone
- Sets end dates to be at hour 23, minute 59, second 59 (current default is 00:00:00)
- Did similar updates to the win module timing as well

@angaither   
