### PR TITLE
Fix hot module share bar

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_win-module.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_win-module.scss
@@ -63,6 +63,10 @@
       @include media($large) {
         @include span(8 of 12);
       }
+
+      .figure {
+        float: left;
+      }
     }
 
     .win-module__share-bar {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_author-callout.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_author-callout.scss
@@ -31,7 +31,6 @@
 
   .figure {
     margin-bottom: $base-spacing;
-    float: left;
   }
 
   .author-callout__first-name {


### PR DESCRIPTION
Fixes #4918 

I made an update the caused the author information to float left on both the win and hot module, but we only needed that for the win module so that the share bar can sit next to it. 

@DoSomething/front-end 
