### PR TITLE
Adds override copy to campaign settings

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -318,13 +318,6 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#description' => t('Sets the hot module progress copy for 100%'),
   ];
 
-  $form['goals']['progress_copy']['dosomething_campaign_progress_copy_override'] = [
-    '#type' => 'textarea',
-    '#title' => t('Hot Module progress override copy'),
-    '#default_value' => variable_get('dosomething_campaign_progress_copy_override'),
-    '#description' => t('Add copy here if you’d like to override the default progress copy in the hot module. Note: The default copy changes as progress increases. Override copy is static. If you create override copy, you’ll need to either delete the copy or change it yourself for this text to update.'),
-  ];
-
   // Win module
   $form['win'] = array(
     '#type' => 'fieldset',

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -278,7 +278,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
     $rb_percent = 0;
   }
 
-  $override_copy = variable_get('dosomething_campaign_progress_copy_override', NULL);
+  $override_copy = dosomething_helpers_get_variable('node', $vars['nid'], 'progress_copy');
   if ($override_copy) {
     $progress_copy = $override_copy;
   }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -278,7 +278,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
     $rb_percent = 0;
   }
 
-  $override_copy = dosomething_helpers_get_variable('node', $vars['nid'], 'progress_copy');
+  $override_copy = dosomething_helpers_get_variable('node', $vars['nid'], 'progress_copy_override');
   if ($override_copy) {
     $progress_copy = $override_copy;
   }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -168,10 +168,10 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
       '#default_value' => $vars['mobile_signup_count'],
     );
 
-    $form['goals']['progress_copy'] = [
+    $form['goals']['progress_copy_override'] = [
       '#type' => 'textarea',
       '#title' => t('Hot Module progress override copy'),
-      '#default_value' => variable_get('progress_copy'),
+      '#default_value' => variable_get('progress_copy_override'),
       '#description' => t('Add copy here if you’d like to override the default progress copy in the hot module. Note: The default copy changes as progress increases. Override copy is static. If you create override copy, you’ll need to either delete the copy or change it yourself for this text to update.'),
     ];
   }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -167,6 +167,13 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
       '#description'=> t('The total number of signups from mobile, will be added to total web signups: '  . $web_signup_count),
       '#default_value' => $vars['mobile_signup_count'],
     );
+
+    $form['goals']['progress_copy'] = [
+      '#type' => 'textarea',
+      '#title' => t('Hot Module progress override copy'),
+      '#default_value' => variable_get('progress_copy'),
+      '#description' => t('Add copy here if you’d like to override the default progress copy in the hot module. Note: The default copy changes as progress increases. Override copy is static. If you create override copy, you’ll need to either delete the copy or change it yourself for this text to update.'),
+    ];
   }
 
   $form['actions'] = array(


### PR DESCRIPTION
Fixes #4638 
- Adds progress copy override field to campaign custom settings /node/1283/custom-settings
- Removes the old field from the campaign settings /admin/config/dosomething/dosomething_campaign
- Updates the preprocess logic to use the new field

@angaither 
