### PR TITLE
Enable the hot module share module.

### DIFF
--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -78,6 +78,7 @@ dependencies[] = dosomething_api
 dependencies[] = dosomething_action_guide
 dependencies[] = dosomething_campaign
 dependencies[] = dosomething_campaign_problem_shares
+dependencies[] = dosomething_campaign_hot_shares
 dependencies[] = dosomething_campaign_group
 dependencies[] = dosomething_campaign_run
 dependencies[] = dosomething_fact


### PR DESCRIPTION
# Changes

Enables the hot module share module _for real_.
For review: @angaither 

![enable hot shares module](https://cloud.githubusercontent.com/assets/583202/9608383/18b368e8-509c-11e5-83af-6da8e7845f74.gif)
