### PR TITLE
Fixes hot&win module timing issue

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -618,8 +618,8 @@ function dosomething_campaign_get_scholarship($nid) {
  *  Formatted time (e.g. "4 days left")
  */
 function dosomething_campaign_get_hot_time_left($node) {
-  $today = new DateTime();
-  $end_date = new DateTime($node->field_high_season[LANGUAGE_NONE][0]['value2']);
+  $today = dosomething_campaign_set_est_timezone(new DateTime());
+  $end_date = dosomething_campaign_set_est_timezone(new DateTime($node->field_high_season[LANGUAGE_NONE][0]['value2']), TRUE, TRUE);
   $difference = $today->diff($end_date, true);
   $days_left = $difference->d;
   $hours_left = $difference->h + ($days_left * 24);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -738,8 +738,9 @@ function dosomething_campaign_add_shipment_form_vars($node) {
  */
 function dosomething_campaign_is_hot_module($vars) {
   $today = dosomething_campaign_set_est_timezone(new DateTime());
-  $start_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value']), TRUE);
-  $end_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value2']), TRUE, TRUE);
+  $start_date = new DateTime($vars['field_high_season'][0]['value']);
+  $end_date = new DateTime($vars['field_high_season'][0]['value2']);
+  $end_date->setTime(23, 59, 59);
 
   // Hot module is only enabled when variable is set, high season dates exist and there is still days left.
   if (!empty($vars['field_high_season']) && (($start_date < $today)  && ($today < $end_date))) {
@@ -824,7 +825,7 @@ function dosomething_campaign_is_active($node) {
   */
  function dosomething_campaign_is_win_module($vars) {
    $today = dosomething_campaign_set_est_timezone(new DateTime());
-   $end_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value2']), TRUE, TRUE);
+   $end_date = dosomething_campaign_set_est_timezone(new DateTime($node->field_high_season[LANGUAGE_NONE][0]['value2']), TRUE, TRUE);
    $win_module_end = dosomething_campaign_set_est_timezone(date_modify(clone $end_date, '+30 days'), TRUE, TRUE);
 
    // Win module is only enabled when variable is set, high season dates exist and there is still days left.
@@ -840,7 +841,8 @@ function dosomething_campaign_is_active($node) {
    * @param DateTime $date
    *  DateTime to edit
    * @param boolean $add_four
-   *  Optional - prevents default EST datetime conversion from becoming previous day
+   *  Optional - prevents default EST datetime conversion from becoming previous day,
+   *  occurs when converting node times (Do not use for users)
    * @param boolean $end_of_day;
    *  Optional - set the date to end of day
    *
@@ -848,6 +850,7 @@ function dosomething_campaign_is_active($node) {
    *  Updated time
    */
 function dosomething_campaign_set_est_timezone($date, $add_four = FALSE, $end_of_day = FALSE) {
+  // Please see the doc block for why this exists and how to use it properly
   if ($add_four) {
     $date->add(new DateInterval('PT4H'));
   }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -738,10 +738,8 @@ function dosomething_campaign_add_shipment_form_vars($node) {
  */
 function dosomething_campaign_is_hot_module($vars) {
   $today = dosomething_campaign_set_est_timezone(new DateTime());
-  $today->setTimezone(new DateTimeZone('America/New_York'));
-  $start_date = new DateTime($vars['field_high_season'][0]['value']);
-  $end_date = new DateTime($vars['field_high_season'][0]['value2']);
-  $end_date->setTime(23, 59, 59);
+  $start_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value']), TRUE);
+  $end_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value2']), TRUE, TRUE);
 
   // Hot module is only enabled when variable is set, high season dates exist and there is still days left.
   if (!empty($vars['field_high_season']) && (($start_date < $today)  && ($today < $end_date))) {
@@ -826,10 +824,8 @@ function dosomething_campaign_is_active($node) {
   */
  function dosomething_campaign_is_win_module($vars) {
    $today = dosomething_campaign_set_est_timezone(new DateTime());
-   $end_date = new DateTime($vars['field_high_season'][0]['value2']);
-   $end_date->setTime(23, 59, 59);
-   $win_module_end = date_modify(clone $end_date, '+30 days');
-   $win_module_end->setTime(23, 59, 59);
+   $end_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value2']), TRUE, TRUE);
+   $win_module_end = dosomething_campaign_set_est_timezone(date_modify(clone $end_date, '+30 days'), TRUE, TRUE);
 
    // Win module is only enabled when variable is set, high season dates exist and there is still days left.
    if (variable_get('dosomething_campaign_enable_win_module', NULL) == 1 && !empty($vars['field_high_season']) && (($end_date < $today)  && ($today < $win_module_end))) {
@@ -843,14 +839,22 @@ function dosomething_campaign_is_active($node) {
    *
    * @param DateTime $date
    *  DateTime to edit
+   * @param boolean $add_four
+   *  Optional - prevents default EST datetime conversion from becoming previous day
    * @param boolean $end_of_day;
    *  Optional - set the date to end of day
    *
    * @return DateTime
    *  Updated time
    */
-function dosomething_campaign_set_est_timezone($date) {
+function dosomething_campaign_set_est_timezone($date, $add_four = FALSE, $end_of_day = FALSE) {
+  if ($add_four) {
+    $date->add(new DateInterval('PT4H'));
+  }
   $date->setTimezone(new DateTimeZone('America/New_York'));
+  if ($end_of_day) {
+    $date->setTime(23, 59, 59);
+  }
   return $date;
 }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -738,8 +738,8 @@ function dosomething_campaign_add_shipment_form_vars($node) {
  */
 function dosomething_campaign_is_hot_module($vars) {
   $today = dosomething_campaign_set_est_timezone(new DateTime());
-  $start_date = new DateTime($vars['field_high_season'][0]['value']);
-  $end_date = new DateTime($vars['field_high_season'][0]['value2']);
+  $start_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value']), TRUE);
+  $end_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value2']), TRUE, TRUE);
   $end_date->setTime(23, 59, 59);
 
   // Hot module is only enabled when variable is set, high season dates exist and there is still days left.
@@ -825,7 +825,7 @@ function dosomething_campaign_is_active($node) {
   */
  function dosomething_campaign_is_win_module($vars) {
    $today = dosomething_campaign_set_est_timezone(new DateTime());
-   $end_date = dosomething_campaign_set_est_timezone(new DateTime($node->field_high_season[LANGUAGE_NONE][0]['value2']), TRUE, TRUE);
+   $end_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value2']), TRUE, TRUE);
    $win_module_end = dosomething_campaign_set_est_timezone(date_modify(clone $end_date, '+30 days'), TRUE, TRUE);
 
    // Win module is only enabled when variable is set, high season dates exist and there is still days left.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -247,8 +247,8 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
   $node = node_load($vars['nid']);
   $date_format = 'm/d/Y';
 
-  $start_date = new DateTime($node->field_high_season[LANGUAGE_NONE][0]['value']);
-  $end_date = new DateTime($node->field_high_season[LANGUAGE_NONE][0]['value2']);
+  $start_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value']), TRUE);
+  $end_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value2']), TRUE, TRUE);
   $readable_end_date = $end_date->format('F') . ' ' . $end_date->format('j') . $end_date->format('S');
   $time_left = dosomething_campaign_get_hot_time_left($node);
 


### PR DESCRIPTION
Fixes #4926

Updates all logic to be "New York" time based. All user times and campaign times are converted into this.

Updated relevant helper functions to reflect this along with all the instances where we're creating start and end dates. Also made code DRY in several places.

@angaither 
