### PR TITLE
Don't preprocess hot/win vars for sms campaigns.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -31,16 +31,6 @@ function dosomething_campaign_preprocess_node(&$vars) {
   // Preprocess common vars between all campaign types for non-pitch templates.
   dosomething_campaign_preprocess_common_vars($vars, $wrapper);
 
-  // If the win module is enabled
-  if (dosomething_campaign_is_win_module($vars)) {
-    dosomething_campaign_preprocess_win_module($vars, $wrapper);
-  }
-
-  // If the hot module is enabled and the high season is set on a campaign.
-  if (dosomething_campaign_is_hot_module($vars)) {
-    dosomething_campaign_preprocess_hot_module($vars, $wrapper);
-  }
-
   $pitch_path = 'node/' . $node->nid . '/pitch';
   if ($pitch_path == $current_path || dosomething_campaign_is_pitch_page($node)) {
     // Gather vars for pitch page.
@@ -70,6 +60,16 @@ function dosomething_campaign_preprocess_node(&$vars) {
   if (dosomething_campaign_get_campaign_type($node) == 'sms_game') {
     dosomething_campaign_preprocess_sms_game($vars, $wrapper);
     return;
+  }
+
+  // If the hot module is enabled and the high season is set on a campaign.
+  if (dosomething_campaign_is_hot_module($vars)) {
+    dosomething_campaign_preprocess_hot_module($vars, $wrapper);
+  }
+
+  // If the win module is enabled
+  if (dosomething_campaign_is_win_module($vars)) {
+    dosomething_campaign_preprocess_win_module($vars, $wrapper);
   }
 
   // Preprocess the vars for the campaign action page.


### PR DESCRIPTION
moved the call to test if campaigns are in a hot/win state after the check for sms campaigns. 
Fixes #4982
