### PR TITLE
Updates promoted image processing

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -196,9 +196,20 @@ function dosomething_campaign_preprocess_win_module(&$vars, $wrapper) {
     'count' => '1',
     'random' => true,
   );
-  $random_image = ReportbackItem::find($parameters)[0];
-  if (isset($random_image)) {
-    $promoted_image = $random_image->media['uri'];
+  $promoted_image = NULL;
+  try {
+    // First try and retrieve a promoted reportback
+    $promoted_image = ReportbackItem::find($parameters)[0]->media['uri'];
+  }
+  catch (Exception $error) {
+    // If that fails try and find just an approved ReportbackItem
+    try {
+      $parameters['status'] = 'approved';
+      $promoted_image = ReportbackItem::find($parameters)[0]->media['uri'];
+    }
+    catch (Exception $error) {
+      // Do nothing, the template has a null check
+    }
   }
 
   // Share bar

--- a/lib/modules/dosomething/dosomething_campaign/theme/win-module.tpl.php
+++ b/lib/modules/dosomething/dosomething_campaign/theme/win-module.tpl.php
@@ -37,7 +37,9 @@
         </div>
       </div>
       <div class="win-module__reportback show-at-large">
-        <img src="<?php print $promoted_image ?>" />
+        <?php if ($promoted_image): ?>
+          <img src="<?php print $promoted_image ?>" />
+        <?php endif; ?>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #4976 
- Adds try/catch around the ReportbackItem Find to solve the broken page error
- Adds a fallback to 'approved' status if no promoted items are found
- Adds a null check to the template in the event no approved items are also found

@angaither 
