### PR TITLE
Win Module Share Bar Style Update

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_win-module.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_win-module.scss
@@ -65,13 +65,21 @@
       }
 
       .figure {
-        float: left;
+        width: 100%;
+
+        @include media($larger) {
+          @include span(6 of 12);
+        }
       }
     }
 
     .win-module__share-bar {
-      float: left;
+      width: 100%;
       padding-left: $base-spacing;
+
+      @include media($larger) {
+        @include span(6 of 12);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #4987

Set a width on the campaign author info and the share bar so that longer campaign author titles will wrap and they will always stay next to each other at larger breakpoints.

@DoSomething/front-end 
