### PR TITLE
Hides non translatable fields from Mexico and Brazil admins

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -10,17 +10,32 @@ include_once 'dosomething_global.features.inc';
  * Implements hook_form_alter().
  */
 function dosomething_global_form_campaign_node_form_alter(&$form, &$form_state, $form_id) {
-  global $user;
   // Check if the user is a mexico or brazil admin
-  if (in_array('brazil admin', $user->roles) || in_array('mexico admin', $user->roles)) {
+  if (dosomething_global_is_regional_admin()) {
     // Get translatable fields.
     $fields = $form_state['field'];
     foreach ($fields as $field) {
-      $translatable = $field['en']['field']['translatable'];
-      // If the field is not translatable disable access 
-      if (!$translatable) {
-        $form[$field[LANGUAGE_NONE]['field']['field_name']]['#access'] = FALSE;
+      $field_name = $field[LANGUAGE_NONE]['field']['field_name'];
+      $field_info = field_info_field($field_name);
+      // If the field is not translatable disable access
+      if (!$field_info['translatable']) {
+        $form[$field_name]['#access'] = FALSE;
       }
     }
   }
+}
+
+/**
+ * Returns if the user is a regional admin
+ *
+ * @param Object $user
+ *   Optional - A specified user to check
+ *
+ * @return SelectQuery object
+ */
+function dosomething_global_is_regional_admin($user = NULL) {
+  if (!isset($user)) {
+    global $user;
+  }
+  return (in_array('brazil admin', $user->roles) || in_array('mexico admin', $user->roles));
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -10,13 +10,17 @@ include_once 'dosomething_global.features.inc';
  * Implements hook_form_alter().
  */
 function dosomething_global_form_campaign_node_form_alter(&$form, &$form_state, $form_id) {
-  // Get translatable fields.
-  $fields = $form_state['field'];
-  $tfields = array();
-  foreach ($fields as $field) {
-    $translatable = $field['en']['field']['translatable'];
-    if ($translatable) {
-      $form[$field['en']['field']['field_name']]['#access'] = FALSE;
+  global $user;
+  // Check if the user is a mexico or brazil admin
+  if (in_array('brazil admin', $user->roles) || in_array('mexico admin', $user->roles)) {
+    // Get translatable fields.
+    $fields = $form_state['field'];
+    foreach ($fields as $field) {
+      $translatable = $field['en']['field']['translatable'];
+      // If the field is not translatable disable access 
+      if (!$translatable) {
+        $form[$field[LANGUAGE_NONE]['field']['field_name']]['#access'] = FALSE;
+      }
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -37,6 +37,11 @@ function dosomething_global_is_regional_admin($user = NULL) {
   if (!isset($user)) {
     global $user;
   }
-  $roles = explode(",", GLOBAL_ADMIN_ROLES);
-  return in_array('brazil admin', $roles);
+  $regional_roles = explode(",", GLOBAL_ADMIN_ROLES);
+  foreach ($user->roles as $role) {
+    if (in_array($role, $regional_roles)) {
+      return TRUE;
+    }
+  }
+  return FALSE;
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -5,3 +5,17 @@
  */
 
 include_once 'dosomething_global.features.inc';
+
+/**
+ * Implements hook_form_alter().
+ */
+function dosomething_global_form_campaign_node_form_alter(&$form, &$form_state, $form_id) {
+  // Get translatable fields.
+  $fields = $form_state['field'];
+  foreach ($fields as $field) {
+    $translatable = $field[LANGUAGE_NONE]['field']['translatable']);
+    if ($field[LANGUAGE_NONE]['field']['translatable']) {
+      $translatable_fields[] = $field;
+    }
+  }
+}

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -5,7 +5,7 @@
  */
 
 include_once 'dosomething_global.features.inc';
-define('GLOBAL_ADMIN_ROLES', 'mexio admin,brazil admin');
+define('GLOBAL_ADMIN_ROLES', 'mexico admin,brazil admin');
 
 /**
  * Implements hook_form_alter().

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -5,7 +5,7 @@
  */
 
 include_once 'dosomething_global.features.inc';
-define(GLOBAL_ADMIN_ROLES, ['mexio admin, brazil admin]');
+define('GLOBAL_ADMIN_ROLES', 'mexio admin,brazil admin');
 
 /**
  * Implements hook_form_alter().
@@ -37,5 +37,6 @@ function dosomething_global_is_regional_admin($user = NULL) {
   if (!isset($user)) {
     global $user;
   }
-  return in_array('brazil admin', GLOBAL_ADMIN_ROLES);
+  $roles = explode(",", GLOBAL_ADMIN_ROLES);
+  return in_array('brazil admin', $roles);
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -5,6 +5,7 @@
  */
 
 include_once 'dosomething_global.features.inc';
+define(GLOBAL_ADMIN_ROLES, ['mexio admin, brazil admin]');
 
 /**
  * Implements hook_form_alter().
@@ -14,8 +15,7 @@ function dosomething_global_form_campaign_node_form_alter(&$form, &$form_state, 
   if (dosomething_global_is_regional_admin()) {
     // Get translatable fields.
     $fields = $form_state['field'];
-    foreach ($fields as $field) {
-      $field_name = $field[LANGUAGE_NONE]['field']['field_name'];
+    foreach ($fields as $field_name => $field) {
       $field_info = field_info_field($field_name);
       // If the field is not translatable disable access
       if (!$field_info['translatable']) {
@@ -37,5 +37,5 @@ function dosomething_global_is_regional_admin($user = NULL) {
   if (!isset($user)) {
     global $user;
   }
-  return (in_array('brazil admin', $user->roles) || in_array('mexico admin', $user->roles));
+  return in_array('brazil admin', GLOBAL_ADMIN_ROLES);
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -12,10 +12,11 @@ include_once 'dosomething_global.features.inc';
 function dosomething_global_form_campaign_node_form_alter(&$form, &$form_state, $form_id) {
   // Get translatable fields.
   $fields = $form_state['field'];
+  $tfields = array();
   foreach ($fields as $field) {
-    $translatable = $field[LANGUAGE_NONE]['field']['translatable']);
-    if ($field[LANGUAGE_NONE]['field']['translatable']) {
-      $translatable_fields[] = $field;
+    $translatable = $field['en']['field']['translatable'];
+    if ($translatable) {
+      $form[$field['en']['field']['field_name']]['#access'] = FALSE;
     }
   }
 }


### PR DESCRIPTION
Fixes #4934 

_Side note, first function in dosomething global module_ :tada: :boom: :tada: 

Adds a node_form_alter and removes access from non translatable fields for brazil and mexico admins 

Do I send these to @blisteringherb or @angaither ? 
