### PR TITLE
Update to fix bug with URI in usage of RB when not instance of class.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -370,13 +370,21 @@ abstract class Transformer {
    * @return array
    */
   protected function transformReportback($data) {
+
+
     $output = [
       'id' => $data->id,
       'created_at' => $data->created_at,
       'updated_at' => $data->updated_at,
       'quantity' => $data->quantity,
-      'uri' => $data->uri . '.json',
     ];
+
+    if (!isset($data->uri)) {
+      $output['uri'] = services_resource_uri(['reportback', $data->id]) . '.json';
+    }
+    else {
+      $output['uri'] = $data->uri . '.json';
+    }
 
     if ($data instanceof Reportback) {
       $output['why_participated'] = $data->why_participated;

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -370,8 +370,6 @@ abstract class Transformer {
    * @return array
    */
   protected function transformReportback($data) {
-
-
     $output = [
       'id' => $data->id,
       'created_at' => $data->created_at,


### PR DESCRIPTION
### Fixes #4977

This PR fixes a bug where Reportback object in ReportbackItem response is not an instance of Reportback class, so it doesn't contain the `uri` property. This update addresses adding `uri` property if it doesn't exist.

---

@angaither 
