### PR TITLE
Update to pass correct data type to entity func to avoid php warnings.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -432,8 +432,9 @@ abstract class Transformer {
       'created_at' => $data->created_at,
     ];
 
+    $kudos = $data->kudos ?: [];
     try {
-      $kudos = Kudos::get($data->kudos);
+      $kudos = Kudos::get($kudos);
       $kudos = dosomething_kudos_sort($kudos);
     }
     catch (Exception $error) {

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -155,7 +155,7 @@ function dosomething_kudos_group_by_taxonomy_term($data, $display = 'teaser') {
       $output['reportback_item'] = $item->reportback_item;
     }
 
-    if ($item->uri) {
+    if (isset($item->uri)) {
       $output['uri'] = $item->uri;
     }
 


### PR DESCRIPTION
### Fixes #5013

Within the `transformReportbackItem()` method, when no **kudos** on an item, `null` was being passed to the `array_flip()` function as the data got passed to the `EntityAPIController`, since it only checks for if the variable is `!empty`. This fixes it by setting the variable to an empty array if item has no kudos data.

---

@angaither 
