### PR TITLE
Fix broken revealer galleries.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/patterns/Gallery.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/patterns/Gallery.js
@@ -7,8 +7,8 @@ import Revealer from 'utilities/Revealer';
  * Initialize galleries.
  */
 function init($galleries = $('.gallery')) {
-  const $mosaicGalleries = $galleries.find('.-mosaic');
-  const $revealGalleries = $galleries.find('[data-show-more="true"]');
+  const $mosaicGalleries = $galleries.filter('.-mosaic');
+  const $revealGalleries = $galleries.filter('[data-show-more="true"]');
 
   // The Swapper swaps low resolution images for feature tiles in the "mosaic"
   // gallery pattern with higher resolution version from tablet size up.


### PR DESCRIPTION
# Changes

Fixes #4939, by properly filtering the DOM query (rather than filtering it's children). 

For review: @weerd 
