### PR TITLE
Removes metatag and revision access from regional admins

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -22,6 +22,7 @@ function dosomething_global_form_campaign_node_form_alter(&$form, &$form_state, 
         $form[$field_name]['#access'] = FALSE;
       }
     }
+    $form['revision_information']['#access'] = FALSE;
   }
 }
 

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.features.user_permission.inc
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.features.user_permission.inc
@@ -23,9 +23,7 @@ function dosomething_metatag_user_default_permissions() {
   $permissions['edit meta tags'] = array(
     'name' => 'edit meta tags',
     'roles' => array(
-      'brazil admin' => 'brazil admin',
       'editor' => 'editor',
-      'mexico admin' => 'mexico admin',
     ),
     'module' => 'metatag',
   );

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.info
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.info
@@ -9,4 +9,4 @@ features[metatag][] = global
 features[metatag][] = node:campaign
 features[user_permission][] = administer meta tags
 features[user_permission][] = edit meta tags
-mtime = 1438621037
+mtime = 1439909405


### PR DESCRIPTION
#### What's this PR do?

Removes access from editing meta tags and content revisions from regional admins
#### How should this be manually tested?

Create a new user and give them the a regional admin role (Mexico or Brazil admin) and check if this box 
![image](https://cloud.githubusercontent.com/assets/897368/9686612/ca3d68e0-52f2-11e5-8eb1-9f98ecb28b60.png)

is at the bottom of this page
/node/add/campaign
#### Any background context you want to provide?

The content revision permissions did not remove the revision form from node/add, had to manually remove access in the form alter instead. 
#### What are the relevant tickets?

Fixes #4934 
https://github.com/DoSomething/phoenix/issues/4934#issuecomment-137541461
#### Screenshots (if appropriate)

<img width="427" alt="screen shot 2015-09-04 at 10 52 12 am" src="https://cloud.githubusercontent.com/assets/897368/9686671/0f8f5dcc-52f3-11e5-83b4-73479b491941.png">

@angaither 
