### PR TITLE
One point graph

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -322,8 +322,8 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
     array('dosomethingCampaign' =>
       array(
         'goals' => array(
-          'dates' => (isset($dates)) ? json_encode($dates) : null,
-          'quantities' => (isset($quantities)) ? json_encode($quantities) : null,
+          'dates' => (isset($dates)) ? $dates : null,
+          'quantities' => (isset($quantities)) ? $quantities : null,
           'highSeason' => array(
             'start' => $start_date->format($date_format),
             'end' => $end_date->format($date_format)

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -311,6 +311,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
                                FROM dosomething_reportback_progress_log
                                WHERE nid = :nid
                                GROUP BY date(from_unixtime(timestamp));", array(':nid' => $vars['nid']))->fetchAll();
+
   foreach($quantity_by_date as $date) {
     $maxdate = new DateTime($date->maxdate);
     $dates[] = $maxdate->format($date_format);
@@ -321,8 +322,8 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
     array('dosomethingCampaign' =>
       array(
         'goals' => array(
-          'dates' => json_encode($dates),
-          'quantities' => json_encode($quantities),
+          'dates' => (isset($dates)) ? json_encode($dates) : null,
+          'quantities' => (isset($quantities)) ? json_encode($quantities) : null,
           'highSeason' => array(
             'start' => $start_date->format($date_format),
             'end' => $end_date->format($date_format)

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
@@ -106,7 +106,7 @@ const createQuantityArray = function(dates, dateLabels, quantities) {
  * Checks to see if we only have one point of data.
  */
 const hasOnePoint = function(data) {
-  return (JSON.parse(data.quantities) && JSON.parse(data.quantities).length === 1) ? true : false;
+  return ((data.quantities) && data.quantities.length === 1) ? true : false;
 };
 
 /*
@@ -122,11 +122,11 @@ const createDataObj = function(data) {
 
   // Turn the dates we recieve from the backend, and the array of all dates in the high season
   // to readable labels, so we can use them for display and comparison.
-  const dates = createDateLabels(JSON.parse(data.dates));
+  const dates = createDateLabels(data.dates);
   const dateLabels = createDateLabels(getDays(startDate, endDate));
 
   // Build out the quantities array.
-  const quantities = createQuantityArray(dates, dateLabels, JSON.parse(data.quantities));
+  const quantities = createQuantityArray(dates, dateLabels, data.quantities);
 
   // Use the highSeason start and end dates to determine the
   // four highlighed dates on the graph and turn those dates into labels.

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
@@ -103,6 +103,13 @@ const createQuantityArray = function(dates, dateLabels, quantities) {
 };
 
 /*
+ * Checks to see if we only have one point of data.
+ */
+const hasOnePoint = function(data) {
+  return (JSON.parse(data.quantities) && JSON.parse(data.quantities).length === 1) ? true : false;
+};
+
+/*
  * Creates the data object that needs to be passed to the graph
  * and adds a property that has an array of 4 dates to be highlighted in the graph.
  */
@@ -146,6 +153,7 @@ const createDataObj = function(data) {
 const lineGraph = function($el, progressData) {
   const goal = $el.data('goal');
   const data = createDataObj(progressData);
+  const onePoint = hasOnePoint(progressData);
 
   // Extend the line graph to create a new chart type that
   // draws a goal line across the chart and highlights certain points
@@ -245,8 +253,7 @@ const lineGraph = function($el, progressData) {
       this.scale.xScalePaddingRight = 30;
 
       Chart.types.Line.prototype.draw.apply(this, arguments);
-      // console.log(data);
-      console.log(data.datasets[0]);
+
       // Place the goal number on the graph as a string.
       this.chart.ctx.textAlign = 'center';
       this.chart.ctx.fillStyle = lineColor;
@@ -288,6 +295,26 @@ const lineGraph = function($el, progressData) {
           ctx.strokeStyle = this.scale.lineColor;
         }
       }, this);
+
+      // If we only have one point, then just draw that point on the graph.
+      if (onePoint) {
+        Chart.helpers.each(this.datasets[0].points, function(point) {
+          if (point.value !== null) {
+            ctx.beginPath();
+
+            ctx.arc(point.x, point.y, point.radius, 0, Math.PI * 2);
+            ctx.closePath();
+
+            ctx.strokeStyle = point.strokeColor;
+            ctx.lineWidth = point.strokeWidth;
+
+            ctx.fillStyle = point.fillColor;
+
+            ctx.fill();
+            ctx.stroke();
+          }
+        }, this);
+      }
     },
   });
 
@@ -328,29 +355,8 @@ function init($chart = $('.js-progress-chart')) {
   if (!$chart.length) return;
 
   const progressData = setting('dosomethingCampaign.goals');
-  console.log(progressData);
 
-  // const progressData2 = {
-  //   dates: '["09\/02\/2015","09\/03\/2015"]',
-  //   quantities: '["4", "25"]',
-  //   highSeason: {
-  //     end: '09/30/2015',
-  //     start: '09/01/2015',
-  //   },
-  // };
-  // console.log(progressData2);
-
-  const onePointData = {
-    dates: '["09\/02\/2015"]',
-    quantities: '["25"]',
-    highSeason: {
-      end: '09/30/2015',
-      start: '09/01/2015',
-    },
-  };
-  console.log(onePointData);
-
-  lineGraph($chart, onePointData);
+  lineGraph($chart, progressData);
 }
 
 export default { lineGraph, init };

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/HotModule.js
@@ -245,7 +245,8 @@ const lineGraph = function($el, progressData) {
       this.scale.xScalePaddingRight = 30;
 
       Chart.types.Line.prototype.draw.apply(this, arguments);
-
+      // console.log(data);
+      console.log(data.datasets[0]);
       // Place the goal number on the graph as a string.
       this.chart.ctx.textAlign = 'center';
       this.chart.ctx.fillStyle = lineColor;
@@ -327,7 +328,29 @@ function init($chart = $('.js-progress-chart')) {
   if (!$chart.length) return;
 
   const progressData = setting('dosomethingCampaign.goals');
-  lineGraph($chart, progressData);
+  console.log(progressData);
+
+  // const progressData2 = {
+  //   dates: '["09\/02\/2015","09\/03\/2015"]',
+  //   quantities: '["4", "25"]',
+  //   highSeason: {
+  //     end: '09/30/2015',
+  //     start: '09/01/2015',
+  //   },
+  // };
+  // console.log(progressData2);
+
+  const onePointData = {
+    dates: '["09\/02\/2015"]',
+    quantities: '["25"]',
+    highSeason: {
+      end: '09/30/2015',
+      start: '09/01/2015',
+    },
+  };
+  console.log(onePointData);
+
+  lineGraph($chart, onePointData);
 }
 
 export default { lineGraph, init };


### PR DESCRIPTION
#### What's this PR do?

In this PR I check to see if we only have one point of data, and if so explicitly draws that point on the graph. I also added some sanity checks on the backend side of things to see make sure we even have data to pass to the frontend. I was seeing errors in the drupal log when we were trying to send variables in the json that weren't defined because the there was no data for that campaign.
#### Where should the reviewer start?

I suggest starting in `HotModule.js`. The `hasOnePoint()` function does the testing and then on line 300, we do the actual drawing of the point.
#### How should this be manually tested?

Create new campaign and launch it in the hot phase, then generate some reportbacks on it and run cron. Then check to see if the graph shows just the one progress point. Compare that to another campaign with more data to make sure we see the pretty line graph.
#### Any background context you want to provide?

This PR solves an issue we were seeing with the hot module graph when there was only one point of data. This would pop up, for example, when a new campaign is launch in the hot phase and starts getting reportbacks that day. It seems that issue is that the graph is a line graph, and it expects at least two points on the graph to draw a line between. 
#### What are the relevant tickets?

Fixes #4925 
#### Screenshots (if appropriate)

ONE POINT!

<img width="325" alt="screen shot 2015-09-04 at 12 52 50 pm" src="https://cloud.githubusercontent.com/assets/1700409/9689449/145d55d2-5304-11e5-899a-c8cae73a155b.png">
#### Questions:
- Is there a blog post? Nope 
- Does the knowledge base need an update? NOOOOPPE
- Does this add new (Python) dependencies which need to be added to chef? Python? What's that?

@DoSomething/front-end 
