### PR TITLE
Who done it?

### DIFF
--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.features.field_base.inc
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.features.field_base.inc
@@ -33,6 +33,7 @@ function dosomething_fact_page_field_default_field_bases() {
     'locked' => 0,
     'module' => 'entityreference',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'handler' => 'base',
       'handler_settings' => array(
         'behaviors' => array(
@@ -69,6 +70,7 @@ function dosomething_fact_page_field_default_field_bases() {
     'locked' => 0,
     'module' => 'field_collection',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'hide_blank_items' => 1,
       'path' => '',
     ),
@@ -99,6 +101,7 @@ function dosomething_fact_page_field_default_field_bases() {
     'locked' => 0,
     'module' => 'entityreference',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'handler' => 'base',
       'handler_settings' => array(
         'behaviors' => array(

--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.features.field_instance.inc
@@ -38,6 +38,7 @@ You can use [link] to link to the Campaign selected in the Campaign field, e.g. 
     'label' => 'Copy',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -82,6 +83,7 @@ You can use [link] to link to the Campaign selected in the Campaign field, e.g. 
     'label' => 'Fact',
     'required' => 1,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -127,6 +129,7 @@ You can use [link] to link to the Campaign selected in the Campaign field, e.g. 
     'label' => 'Campaign',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -175,6 +178,7 @@ You can use [link] to link to the Campaign selected in the Campaign field, e.g. 
     'label' => 'Call to Action',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -222,6 +226,7 @@ You can use [link] to link to the Campaign selected in the Campaign field, e.g. 
     'label' => 'Cause',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -279,6 +284,7 @@ You can use [link] to link to the Campaign selected in the Campaign field, e.g. 
         'url_cutoff' => 80,
       ),
       'enable_tokens' => 1,
+      'entity_translation_sync' => FALSE,
       'rel_remove' => 'default',
       'title' => 'optional',
       'title_maxlength' => 128,
@@ -334,6 +340,7 @@ You can use [link] to link to the Campaign selected in the Campaign field, e.g. 
     'label' => 'Facts',
     'required' => 1,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -381,6 +388,7 @@ You can use [link] to link to the Campaign selected in the Campaign field, e.g. 
     'label' => 'Facts Image',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -429,6 +437,7 @@ You can use [link] to link to the Campaign selected in the Campaign field, e.g. 
     'label' => 'Primary Cause',
     'required' => 1,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -473,6 +482,7 @@ You can use [link] to link to the Campaign selected in the Campaign field, e.g. 
     'label' => 'Subtitle',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),

--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.info
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.info
@@ -49,4 +49,4 @@ features[variable][] = node_options_fact_page
 features[variable][] = node_preview_fact_page
 features[variable][] = node_submitted_fact_page
 features[variable][] = pathauto_node_fact_page_pattern
-mtime = 1415207699
+mtime = 1441386579

--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.strongarm.inc
@@ -88,7 +88,9 @@ function dosomething_fact_page_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'node_options_fact_page';
-  $strongarm->value = array();
+  $strongarm->value = array(
+    0 => 'revision',
+  );
   $export['node_options_fact_page'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
#### What's this PR do?

This PR adds revision tracking to the fact page content type. I added revision tracking by selecting `create new revision` in the content type config page and then exported to features using `drush fu dosomething_fact_page`. 
#### Where should the reviewer start?

All of these changes were introduced by drush. I believe in `dosomething_fact_page.strongarm.inc` is where the actual turning on of the revision tracking happens.
#### How should this be manually tested?

Make some changes to a fact page and the revisions tab should show up at the top of the page. Click on that and hold yourself accountable.
#### Any background context you want to provide?

Andrea and Fantini told me to do it.
#### What are the relevant tickets?

Fixes #5040 
