### PR TITLE
Allows access to tabs

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -289,8 +289,8 @@ function _dosomething_campaign_pitch_page_access($node) {
     if (dosomething_campaign_get_campaign_type($node) == 'sms_game') {
       return FALSE;
     }
-    // Is the user a DS admin or editor?
-    if (dosomething_user_is_staff()) {
+    // Is the user a DS admin, regional admin or editor?
+    if (dosomething_user_is_staff() || dosomething_global_is_regional_admin()) {
       return TRUE;
     }
   }
@@ -782,7 +782,7 @@ function dosomething_campaign_is_pitch_page($node) {
     return TRUE;
   }
   // Staff can always bypass pitch page to view full action page.
-  elseif (dosomething_user_is_staff()) {
+  elseif (dosomething_user_is_staff() || dosomething_global_is_regional_admin()) {
     return FALSE;
   }
   // The $node is a pitch page if you haven't signed up yet.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -289,7 +289,7 @@ function _dosomething_campaign_pitch_page_access($node) {
     if (dosomething_campaign_get_campaign_type($node) == 'sms_game') {
       return FALSE;
     }
-    // Is the user a DS admin, regional admin or editor?
+    // Is the user a DS staff or regional admin
     if (dosomething_user_is_staff() || dosomething_global_is_regional_admin()) {
       return TRUE;
     }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -80,7 +80,7 @@ function paraneue_dosomething_preprocess_page(&$vars) {
   $vars['navigation'] = theme('navigation', $navigation_vars);
 
   // Only display tabs for Staff.
-  if (isset($vars['tabs']) && !dosomething_user_is_staff()) {
+  if (isset($vars['tabs']) && !dosomething_user_is_staff() && !dosomething_global_is_regional_admin()) {
     unset($vars['tabs']);
   }
 


### PR DESCRIPTION
#### What's this PR do?

Gives regional admins access to tabs and allows them to skip over the pitch page 
#### How should this be manually tested?

Create a MX or BR account and visit any campaign content _that user creates_. Edit will not show up for all other content and will be addressed in https://github.com/DoSomething/phoenix/issues/5020
#### What are the relevant tickets?

Fixes #4951 
#### Screenshots (if appropriate)

![screen shot 2015-09-09 at 10 02 08 am](https://cloud.githubusercontent.com/assets/897368/9763881/eaf836ec-56d9-11e5-803a-ace8d510cad4.png)

@angaither 
