### PR TITLE
Fix campaign saves dying

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
@@ -181,4 +181,4 @@ features[variable][] = node_preview_campaign
 features[variable][] = node_submitted_campaign
 features[variable][] = pathauto_node_campaign_pattern
 features[views_view][] = campaigns_by_term
-mtime = 1441287453
+mtime = 1441806696

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.strongarm.inc
@@ -15,7 +15,7 @@ function dosomething_campaign_strongarm() {
   $strongarm->api_version = 1;
   $strongarm->name = 'entity_translation_settings_node__campaign';
   $strongarm->value = array(
-    'default_language' => 'xx-et-author',
+    'default_language' => 'xx-et-default',
     'hide_language_selector' => 1,
     'exclude_language_none' => 1,
     'lock_language' => 0,

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -6,6 +6,19 @@
 
 include_once 'dosomething_global.features.inc';
 define('GLOBAL_ADMIN_ROLES', 'mexico admin,brazil admin');
+define('GLOBAL_ADMIN_LANGUANGES', serialize(['es-mx' => 'mexico admin', 'pt-br' => 'brazil admin']));
+
+/**
+ * Implements hook_node_presave().
+ */
+function dosomething_global_node_presave($node) {
+  $user = user_load($node->uid);
+  // If we are saving a campaign and the user is a global admin.
+  if ($node->type == 'campaign' && dosomething_global_is_regional_admin($user)) {
+    // Set the node language to the author's lang.
+    $node->language = dosomething_global_get_user_language($user);
+  }
+}
 
 /**
  * Implements hook_form_alter().
@@ -45,4 +58,28 @@ function dosomething_global_is_regional_admin($user = NULL) {
     }
   }
   return FALSE;
+}
+
+/**
+ * Returns the user's langauge based on the role.
+ *
+ * @param Object $user
+ *   Optional - A specified user to check
+ *
+ * @return string
+ *   The language key.
+ */
+function dosomething_global_get_user_language($user = NULL) {
+  if (!isset($user)) {
+    global $user;
+  }
+  $lang_map = unserialize(GLOBAL_ADMIN_LANGUANGES);
+  foreach ($user->roles as $role) {
+    // If the array search returns a lang key, return that.
+    if (is_string($key = array_search($role, $lang_map))) {
+      return $key;
+    }
+  }
+  // If we didn't find a user role return english default.
+  return 'en';
 }


### PR DESCRIPTION
#### What's this PR do?

Sets the default language of campagin nodes to the site's default language (english)
Checks campaign nodes on save, and set's the language to the correct role of the user.
#### How should this be manually tested?

Create a campaign node as a brazil/mexico admin and check the lang after save.
Also create a campaign node ad a regular editor and check the language is english (and the page doesn't die!) 
#### Any background context you want to provide?

Campaign node saves were dying in a fire. 
#### What are the relevant tickets?

Fixes #5042 
