### PR TITLE
Fix issue with columns disappearing in Chrome 45.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_finder.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_finder.scss
@@ -29,8 +29,7 @@
     }
 
     li {
-      display: block;
-      overflow: hidden;
+      display: inline;
       position: relative;
       margin: 0;
       break-inside: avoid;
@@ -130,9 +129,11 @@
   }
 
   input[type="checkbox"] {
-    left: -40px;
     position: absolute;
     top: 0;
+    left: 0;
+    opacity: 0;
+    z-index: -1;
   }
 
   label {


### PR DESCRIPTION
See #5044. Chrome 45 includes a new CSS column implementation, which seems to break with block elements. Since overflow only affects block and inline-block elements, I also had to switch how we were hiding checkboxes.

Tested in Chrome 45, Chrome Canary, Firefox latest, Safari latest, IE8, IE9, IE10, IE11.

For review: @DoSomething/front-end 
