### PR TITLE
First pass at language-aware finder

### DIFF
--- a/lib/modules/dosomething/dosomething_auto_translate/dosomething_auto_translate.module
+++ b/lib/modules/dosomething/dosomething_auto_translate/dosomething_auto_translate.module
@@ -9,7 +9,7 @@
  * @file dosomething_auto_translate.module
  *
  */
-function dosomething_auto_translate_campaigns($start = NULL, $limit = NULL) {
+function dosomething_auto_translate_campaigns($start = NULL, $limit = 10) {
   $query = new EntityFieldQuery();
 
   $query->entityCondition('entity_type', 'node')

--- a/lib/modules/dosomething/dosomething_auto_translate/dosomething_auto_translate.module
+++ b/lib/modules/dosomething/dosomething_auto_translate/dosomething_auto_translate.module
@@ -7,11 +7,23 @@
 
 /**
  * @file dosomething_auto_translate.module
- * TODO: This doesn't scale.
+ *
  */
-function dosomething_auto_translate_campaigns() {
-  $nodes = node_load_multiple(array(), array('type' => 'campaign'));
+function dosomething_auto_translate_campaigns($start = NULL, $limit = NULL) {
+  $query = new EntityFieldQuery();
+
+  $query->entityCondition('entity_type', 'node')
+    ->entityCondition('bundle', 'campaign')
+    ->propertyCondition('status', NODE_PUBLISHED)
+    ->range($start, $limit);
+
+  $result = $query->execute();
+
+  $nids = array_keys($result['node']);
+
+  $nodes = node_load_multiple($nids, array());
   foreach($nodes as $campaign) {
+    //Set values and overwrite any existing translations.
     dosomething_auto_translate_set_values($campaign);
   }
 }
@@ -21,9 +33,10 @@ function dosomething_auto_translate_campaigns() {
  */
 function dosomething_auto_translate_set_values($node) {
   $handler  = entity_translation_get_handler('node', $node, TRUE);
-  $translations = $handler->getTranslations();
-  foreach (array('pt-br', 'es-mx') as $lang) {
-    if ($lang !== $node->language && !isset($translations->data[$lang])) {
+
+  $languages = array_keys(variable_get('dosomething_global_language_map'));
+  foreach ($languages as $lang) {
+    if ($lang !== $node->language) {
       $translation_node = $node;
       $values = array();
       // Change translatable fields languages to trasnlation language.
@@ -34,12 +47,13 @@ function dosomething_auto_translate_set_values($node) {
           foreach ($translation_node->$field_name as $lang_key => $field) {
             if ($lang_key == $node->language) {
               if (isset($field[0]['value'])) {
-                $values[$field_name][$lang]['0']['value'] = dosomething_auto_translate_get_translation($field[0]['value'], $lang);
+                $values[$field_name][$lang][0]['value'] = dosomething_auto_translate_get_translation($field[0]['value'], $lang);
               }
             }
           }
         }
       }
+
 
       // Create a translation.
       $translation = array(

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.info
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.info
@@ -15,6 +15,7 @@ features[features_api][] = api:2
 features[language][] = en-global
 features[language][] = es-mx
 features[language][] = pt-br
+features[variable][] = dosomething_global_language_map
 features[variable][] = language_negotiation_language
 features[variable][] = language_negotiation_language_content
 mtime = 1440615612

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.strongarm.inc
@@ -13,6 +13,33 @@ function dosomething_global_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'dosomething_global_language_map';
+  $strongarm->value = array(
+    'es-mx' => array(
+      'display_name' => 'Spanish, Mexico',
+      'default_roles' => array('mexico admin'),
+      'country' => 'MX',
+    ),
+    'pt-br' => array(
+      'display_name' => 'Portuguese, Brazil',
+      'default_roles' => array('brazil admin'),
+      'country' => 'BR',
+    ),
+    'en' => array(
+      'display_name' => 'English',
+      'default_roles' => array(),
+      'country' => 'US'
+    ),
+    'en-global' => array(
+      'display_name' => 'English, Global',
+      'default_roles' => array(),
+    ),
+  );
+  $export['dosomething_global_language_map'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'language_negotiation_language';
   $strongarm->value = array(
     'locale-session' => array(

--- a/lib/modules/dosomething/dosomething_home/dosomething_home.module
+++ b/lib/modules/dosomething/dosomething_home/dosomething_home.module
@@ -46,8 +46,9 @@ function dosomething_home_preprocess_node(&$vars) {
       $tiles['title'] = $node->title;
       $tiles['tagline'] = $node->field_call_to_action[$lang_code][0]['safe_value'];
 
-      // Get the campaign cover image.
-      $image_nid = $node->field_image_campaign_cover[$lang_code][0]['target_id'];
+      // Get the campaign cover image. If there is no image for the user's language,
+      // use the image for the default language.
+      $image_nid = $node->field_image_campaign_cover[$lang_code][0]['target_id'] ?: $node->field_image_campaign_cover[language_default()->language][0]['target_id'];
       if ($key == 0) {
         $tiles['modifier_classes'] = "big";
         $tiles['image_url'] = dosomething_image_get_themed_image_url($image_nid, 'square', '720x720');

--- a/lib/modules/dosomething/dosomething_search/dosomething_search.module
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.module
@@ -28,13 +28,16 @@ function dosomething_search_menu() {
 }
 
 function dosomething_search_preprocess_page(&$vars) {
+  global $language;
+
   $solrURL = variable_get('dosomething_search_finder_url', 'https://search.dosomething.org');
   $collection = variable_get('dosomething_search_finder_collection', 'collection1');
   drupal_add_js(
     array('dosomethingSearch' =>
       array(
         'solrURL' => $solrURL,
-        'collection' => $collection
+        'collection' => $collection,
+        'language' => $language->language
       )
     ),
     'setting'

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -236,6 +236,7 @@ function paraneue_dosomething_get_node_gallery_item($nid, $source = NULL) {
  */
 function paraneue_dosomething_get_campaign_gallery($nids, $source = NULL, $show_more = FALSE) {
   $items = array();
+
   foreach ($nids as $delta => $nid) {
     $item = paraneue_dosomething_get_node_gallery_item($nid, $source);
     $items[] = paraneue_dosomething_get_gallery_item($item['content'], 'tile', TRUE);

--- a/lib/themes/dosomething/paraneue_dosomething/includes/patterns.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/patterns.inc
@@ -24,6 +24,7 @@
  * @return string
  */
 function paraneue_dosomething_get_gallery_item($content, $type = 'figure', $use_default = TRUE, $classes_array = array()) {
+
   // If no image is provided and we want to use a default, then set the default image here.
   if (empty($content['image']) && $use_default) {
     $content['image'] = theme('image', array(

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
@@ -48,7 +48,7 @@ define(function(require) {
 
     // This would be awesome with an object key:value, but Solr allows multiple of the same key
     defaultQuery: [
-      "fq=-sm_field_campaign_status:(closed) bundle:[campaign TO campaign_group]",
+      "fq=-sm_field_campaign_status:(closed) bundle:[campaign TO campaign_group] ss_language:" + setting('dosomethingSearch.language'),
       //"fq=ss_field_search_image:[* TO *]",
       "wt=json",
       "indent=false",
@@ -58,7 +58,7 @@ define(function(require) {
       "facet.field=im_field_action_type",
       // TODO: un-hard-code the rows
       "rows=8",
-      "fl=label,tid,im_vid_1,sm_vid_Action_Type,tm_vid_1_names,im_field_cause,im_vid_2,sm_vid_Cause,tm_vid_2_names,im_field_tags,im_vid_5,sm_vid_Tags,tm_vid_5_names,fs_field_active_hours,sm_field_call_to_action,bs_field_staff_pick,ss_field_search_image_400x400,ss_field_search_image_720x720,url"
+      "fl=label,tid,im_vid_1,sm_vid_Action_Type,tm_vid_1_names,im_field_cause,im_vid_2,sm_vid_Cause,tm_vid_2_names,im_field_tags,im_vid_5,sm_vid_Tags,tm_vid_5_names,fs_field_active_hours,sm_field_call_to_action,bs_field_staff_pick,ss_field_search_image_400x400,ss_field_search_image_720x720,url,ss_language"
     ],
 
     // Map the input field names to the Solr query fields


### PR DESCRIPTION
- This code will show the translated nodes in the finder
- Adding a limit and some fixes to the auto_translate module
- Fixing broken images on home page tiles
- Adding filter for language based on user's default language
- Adding Strongarm variable with rules for each language
  - Can be used by any language switching logic
