### PR TITLE
Display partner logos on the fact page

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -658,11 +658,9 @@ function paraneue_dosomething_preprocess_search_results(&$vars) {
 function paraneue_dosomething_preprocess_fact_page(&$vars) {
   // Output sponser, if it exists.
   if ($vars['sponsor_logos']) {
-    $classes = NULL;
-
     $vars['promotions'] = $vars['sponsor_logos'];
 
-    $vars['promotions'] = '<div class="promotions' . $classes . '">' . $vars['promotions'] . '</div>';
+    $vars['promotions'] = '<div class="promotions">' . $vars['promotions'] . '</div>';
   }
 
   // Add class to header if promotions will be included in display.

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -656,7 +656,7 @@ function paraneue_dosomething_preprocess_search_results(&$vars) {
  * Preprocess variables for the fact page.
  */
 function paraneue_dosomething_preprocess_fact_page(&$vars) {
-  // Output sponser, if it exists.
+  // Output sponsor, if it exists.
   if ($vars['sponsor_logos']) {
     $vars['promotions'] = $vars['sponsor_logos'];
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -248,7 +248,8 @@ function paraneue_dosomething_preprocess_node(&$vars) {
       // Allow CTAs to be properly embedded in between.
       $vars['first_fact_group'] = array_slice($vars['facts'], 0, 5);
       $vars['second_fact_group'] = array_slice($vars['facts'], 5);
-
+      paraneue_dosomething_preprocess_field_partners($vars);
+      paraneue_dosomething_preprocess_fact_page($vars);
       break;
 
     case "home":
@@ -650,3 +651,23 @@ function paraneue_dosomething_preprocess_search_results(&$vars) {
     $vars['search_results_gallery'] = paraneue_dosomething_get_search_gallery($search_results);
   }
 }
+
+/**
+ * Preprocess variables for the fact page.
+ */
+function paraneue_dosomething_preprocess_fact_page(&$vars) {
+  // Output sponser, if it exists.
+  if ($vars['sponsor_logos']) {
+    $classes = NULL;
+
+    $vars['promotions'] = $vars['sponsor_logos'];
+
+    $vars['promotions'] = '<div class="promotions' . $classes . '">' . $vars['promotions'] . '</div>';
+  }
+
+  // Add class to header if promotions will be included in display.
+  if ($vars['promotions']) {
+    $vars['classes_array'][] = 'has-promotions';
+  }
+}
+

--- a/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
@@ -21,6 +21,8 @@
       <?php if (isset($subtitle)): ?>
         <h2 class="header__subtitle"><?php print $subtitle; ?></h2>
       <?php endif; ?>
+
+      <?php print $promotions; ?>
     </div>
   </header>
 


### PR DESCRIPTION
#### What's this PR do?

Displays sponsor logos on fact pages.
#### Where should the reviewer start?

`preprocess.inc` where the variables are processed for the template.
#### How should this be manually tested?

Add a sponsor to a fact page, and it should be displayed.
#### What are the relevant tickets?

Fixes #5038 
#### Screenshots (if appropriate)

<img width="1005" alt="screen shot 2015-09-10 at 1 06 47 pm" src="https://cloud.githubusercontent.com/assets/1700409/9795115/d7a8390a-57bc-11e5-8546-808db4ed2954.png">
