### PR TITLE
User config translateable olé

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
@@ -66,7 +66,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
     '#rows' => 2,
     '#title' => t('Login Form copy'),
     '#description' => t("Copy displayed below the Login Form header. Optional."),
-    '#default_value' => variable_get($var_name),
+    '#default_value' => t(variable_get($var_name)),
   );
 
   // Display Forgot Password.
@@ -85,7 +85,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
     '#rows' => 2,
     '#title' => t('Forgot Password copy'),
     '#description' => t('Password reset neutral copy displayed both on fail and success.'),
-    '#default_value' => variable_get($var_name),
+    '#default_value' => t(variable_get($var_name)),
   );
 
   // Registration form settings.
@@ -144,7 +144,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
     '#title' => t('Subtitle'),
     '#required' => TRUE,
     '#description' => t("Displayed below the Profile main page title."),
-    '#default_value' => variable_get($var_name),
+    '#default_value' => t(variable_get($var_name)),
   );
 
   // No Signups header.
@@ -152,7 +152,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
   $form['profile'][$var_name] = array(
     '#type' => 'textfield',
     '#title' => t('No Signups Header'),
-    '#default_value' => variable_get($var_name),
+    '#default_value' => t(variable_get($var_name)),
   );
 
   // No Signups copy.
@@ -160,7 +160,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
   $form['profile'][$var_name] = array(
     '#type' => 'textarea',
     '#title' => t('No Signups Copy'),
-    '#default_value' => variable_get($var_name),
+    '#default_value' => t(variable_get($var_name)),
   );
 
   // School settings.
@@ -181,13 +181,13 @@ function dosomething_user_admin_config_form($form, &$form_state) {
     '#default_value' => variable_get($var_name),
   );
 
-  // School API endpoint.
+  // School Finder Help text.
   $var_name = 'dosomething_user_school_finder_help_text';
   $form['school'][$var_name] = array(
     '#type' => 'textarea',
     '#title' => t('School Finder Help Text'),
     '#description' => t("Text displayed if User needs help finding school.  Markdown supported."),
-    '#default_value' => variable_get($var_name),
+    '#default_value' => t(variable_get($var_name)),
   );
 
   // Development settings.

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -658,11 +658,9 @@ function paraneue_dosomething_preprocess_search_results(&$vars) {
 function paraneue_dosomething_preprocess_fact_page(&$vars) {
   // Output sponser, if it exists.
   if ($vars['sponsor_logos']) {
-    $classes = NULL;
-
     $vars['promotions'] = $vars['sponsor_logos'];
 
-    $vars['promotions'] = '<div class="promotions' . $classes . '">' . $vars['promotions'] . '</div>';
+    $vars['promotions'] = '<div class="promotions">' . $vars['promotions'] . '</div>';
   }
 
   // Add class to header if promotions will be included in display.

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -656,7 +656,7 @@ function paraneue_dosomething_preprocess_search_results(&$vars) {
  * Preprocess variables for the fact page.
  */
 function paraneue_dosomething_preprocess_fact_page(&$vars) {
-  // Output sponser, if it exists.
+  // Output sponsor, if it exists.
   if ($vars['sponsor_logos']) {
     $vars['promotions'] = $vars['sponsor_logos'];
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -248,7 +248,8 @@ function paraneue_dosomething_preprocess_node(&$vars) {
       // Allow CTAs to be properly embedded in between.
       $vars['first_fact_group'] = array_slice($vars['facts'], 0, 5);
       $vars['second_fact_group'] = array_slice($vars['facts'], 5);
-
+      paraneue_dosomething_preprocess_field_partners($vars);
+      paraneue_dosomething_preprocess_fact_page($vars);
       break;
 
     case "home":
@@ -650,3 +651,23 @@ function paraneue_dosomething_preprocess_search_results(&$vars) {
     $vars['search_results_gallery'] = paraneue_dosomething_get_search_gallery($search_results);
   }
 }
+
+/**
+ * Preprocess variables for the fact page.
+ */
+function paraneue_dosomething_preprocess_fact_page(&$vars) {
+  // Output sponser, if it exists.
+  if ($vars['sponsor_logos']) {
+    $classes = NULL;
+
+    $vars['promotions'] = $vars['sponsor_logos'];
+
+    $vars['promotions'] = '<div class="promotions' . $classes . '">' . $vars['promotions'] . '</div>';
+  }
+
+  // Add class to header if promotions will be included in display.
+  if ($vars['promotions']) {
+    $vars['classes_array'][] = 'has-promotions';
+  }
+}
+

--- a/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
@@ -21,6 +21,8 @@
       <?php if (isset($subtitle)): ?>
         <h2 class="header__subtitle"><?php print $subtitle; ?></h2>
       <?php endif; ?>
+
+      <?php print $promotions; ?>
     </div>
   </header>
 


### PR DESCRIPTION
#### What's this PR do?

This PR wraps translatable content around Drupal's `t()` to allow for later adding translations for these items. This specifically addresses strings in the configuration interface for Usres in the admin view.
#### Where should the reviewer start?

In the main **dosomething_user.admin.inc** file and just review that the wrapped content looks correct.
#### What are the relevant tickets?

Fixes #4997

---

@angaither 
