### PR TITLE
Updating User config page to make certain fields translateable.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
@@ -66,7 +66,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
     '#rows' => 2,
     '#title' => t('Login Form copy'),
     '#description' => t("Copy displayed below the Login Form header. Optional."),
-    '#default_value' => t(variable_get($var_name)),
+    '#default_value' => t("@value", ['@value' => variable_get($var_name)]),
   );
 
   // Display Forgot Password.
@@ -85,7 +85,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
     '#rows' => 2,
     '#title' => t('Forgot Password copy'),
     '#description' => t('Password reset neutral copy displayed both on fail and success.'),
-    '#default_value' => t(variable_get($var_name)),
+    '#default_value' => t("@value", ['@value' => variable_get($var_name)]),
   );
 
   // Registration form settings.
@@ -144,7 +144,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
     '#title' => t('Subtitle'),
     '#required' => TRUE,
     '#description' => t("Displayed below the Profile main page title."),
-    '#default_value' => t(variable_get($var_name)),
+    '#default_value' => t("@value", ['@value' => variable_get($var_name)]),
   );
 
   // No Signups header.
@@ -152,7 +152,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
   $form['profile'][$var_name] = array(
     '#type' => 'textfield',
     '#title' => t('No Signups Header'),
-    '#default_value' => t(variable_get($var_name)),
+    '#default_value' => t("@value", ['@value' => variable_get($var_name)]),
   );
 
   // No Signups copy.
@@ -160,7 +160,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
   $form['profile'][$var_name] = array(
     '#type' => 'textarea',
     '#title' => t('No Signups Copy'),
-    '#default_value' => t(variable_get($var_name)),
+    '#default_value' => t("@value", ['@value' => variable_get($var_name)]),
   );
 
   // School settings.
@@ -187,7 +187,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
     '#type' => 'textarea',
     '#title' => t('School Finder Help Text'),
     '#description' => t("Text displayed if User needs help finding school.  Markdown supported."),
-    '#default_value' => t(variable_get($var_name)),
+    '#default_value' => t("@value", ['@value' => variable_get($var_name)]),
   );
 
   // Development settings.

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.admin.inc
@@ -66,7 +66,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
     '#rows' => 2,
     '#title' => t('Login Form copy'),
     '#description' => t("Copy displayed below the Login Form header. Optional."),
-    '#default_value' => variable_get($var_name),
+    '#default_value' => t(variable_get($var_name)),
   );
 
   // Display Forgot Password.
@@ -85,7 +85,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
     '#rows' => 2,
     '#title' => t('Forgot Password copy'),
     '#description' => t('Password reset neutral copy displayed both on fail and success.'),
-    '#default_value' => variable_get($var_name),
+    '#default_value' => t(variable_get($var_name)),
   );
 
   // Registration form settings.
@@ -144,7 +144,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
     '#title' => t('Subtitle'),
     '#required' => TRUE,
     '#description' => t("Displayed below the Profile main page title."),
-    '#default_value' => variable_get($var_name),
+    '#default_value' => t(variable_get($var_name)),
   );
 
   // No Signups header.
@@ -152,7 +152,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
   $form['profile'][$var_name] = array(
     '#type' => 'textfield',
     '#title' => t('No Signups Header'),
-    '#default_value' => variable_get($var_name),
+    '#default_value' => t(variable_get($var_name)),
   );
 
   // No Signups copy.
@@ -160,7 +160,7 @@ function dosomething_user_admin_config_form($form, &$form_state) {
   $form['profile'][$var_name] = array(
     '#type' => 'textarea',
     '#title' => t('No Signups Copy'),
-    '#default_value' => variable_get($var_name),
+    '#default_value' => t(variable_get($var_name)),
   );
 
   // School settings.
@@ -181,13 +181,13 @@ function dosomething_user_admin_config_form($form, &$form_state) {
     '#default_value' => variable_get($var_name),
   );
 
-  // School API endpoint.
+  // School Finder Help text.
   $var_name = 'dosomething_user_school_finder_help_text';
   $form['school'][$var_name] = array(
     '#type' => 'textarea',
     '#title' => t('School Finder Help Text'),
     '#description' => t("Text displayed if User needs help finding school.  Markdown supported."),
-    '#default_value' => variable_get($var_name),
+    '#default_value' => t(variable_get($var_name)),
   );
 
   // Development settings.


### PR DESCRIPTION
#### What's this PR do?

This PR wraps translatable content around Drupal's `t()` to allow for later adding translations for these items. This specifically addresses strings in the configuration interface for Users in the admin view.
#### Where should the reviewer start?

In the main **dosomething_user.admin.inc** file and just review that the wrapped content looks correct.
#### What are the relevant tickets?

Fixes #4997

---

@angaither 
