### PR TITLE
Display Partner logos on Static Content Types

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -685,5 +685,7 @@ function paraneue_dosomething_preprocess_fact_page(&$vars) {
   if (isset($vars['promotions'])) {
     $vars['classes_array'][] = 'has-promotions';
   }
+
+  dosomething_helpers_preprocess_partners_vars($vars);
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -664,7 +664,7 @@ function paraneue_dosomething_preprocess_fact_page(&$vars) {
   }
 
   // Add class to header if promotions will be included in display.
-  if ($vars['promotions']) {
+  if (isset($vars['promotions'])) {
     $vars['classes_array'][] = 'has-promotions';
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -142,7 +142,25 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     if (isset($vars['node']->field_subtitle[LANGUAGE_NONE][0]['safe_value'])) {
       $header_vars['subtitle'] = $vars['node']->field_subtitle[LANGUAGE_NONE][0]['safe_value'];
     }
-     // Add global header.
+
+    if (isset($vars['node']->field_partners[LANGUAGE_NONE])) {
+      $vars['partners'] = dosomething_taxonomy_get_partners_data($vars['node']->field_partners[LANGUAGE_NONE]);
+      $vars['sponsor_logos'] = paraneue_dosomething_get_sponsor_logos($vars['partners']);
+
+      // Output sponsor, if it exists.
+      if ($vars['sponsor_logos']) {
+        $header_vars['promotions'] = $vars['sponsor_logos'];
+
+        $header_vars['promotions'] = '<div class="promotions">' . $header_vars['promotions'] . '</div>';
+      }
+
+      // Add class to header if promotions will be included in display.
+      if (isset($vars['promotions'])) {
+        $vars['classes_array'][] = 'has-promotions';
+      }
+    }
+
+    // Add global header.
     $vars['header'] = theme('header', $header_vars);
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
@@ -22,7 +22,7 @@
         <h2 class="header__subtitle"><?php print $subtitle; ?></h2>
       <?php endif; ?>
 
-      <?php print $promotions; ?>
+      <?php if (isset($promotions)) { print $promotions; } ?>
     </div>
   </header>
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
@@ -100,4 +100,8 @@
       </div>
     </div>
   <?php endif; ?>
+
+  <?php if ($info_bar): ?>
+    <?php print $info_bar; ?>
+  <?php endif; ?>
 </article>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/header.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/header.tpl.php
@@ -12,17 +12,6 @@
     <p class="header__subtitle"><?php if (isset($subtitle)): print $subtitle; endif; ?></p>
     <?php endif; ?>
 
-    <?php if (isset($sponsors)): ?>
-      <div class="promotion promotion--sponsor">
-        <div class="wrapper">
-          <p class="__copy"><?php print t('Powered by'); ?></p>
-          <?php foreach ($sponsors as $sponsor) :?>
-            <div class="__image">
-              <?php if (isset($sponsor['display'])): print $sponsor['display']; endif; ?>
-            </div>
-          <?php endforeach; ?>
-        </div>
-      </div>
-    <?php endif; ?>
+    <?php if (isset($promotions)) { print $promotions; } ?>
   </div>
 </header>


### PR DESCRIPTION
#### What's this PR do?
- Displays sponsor logos if they exists in the global header, which is what is used on static content pages. 
- Added some null checks for variables being sent to fact pages that were throwing error if no sponsor was set. 
- Adds the info bar to fact pages. 
#### Where should the reviewer start?

`preprocess.inc` is where variables are preprocessed and sent to the header theme function.
#### How should this be manually tested?

Add a sponsor to a static content page, and you should see the sponsor logo displayed on the page. 
#### What are the relevant tickets?

Fixes #5037 
