### PR TITLE
Settings config translateable olé

### DIFF
--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.admin.inc
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.admin.inc
@@ -19,21 +19,21 @@ function dosomething_settings_admin_config_form($form, &$form_state) {
   $form['copy'][$var_name] = array(
     '#type' => 'textarea',
     '#title' => t('About DoSomething'),
-    '#default_value' => variable_get($var_name),
+    '#default_value' => t("@value", ['@value' => variable_get($var_name)]),
   );
 
   $var_name = 'dosomething_settings_copy_scholarships';
   $form['copy'][$var_name] = array(
     '#type' => 'textarea',
     '#title' => t('Scholarships'),
-    '#default_value' => variable_get($var_name),
+    '#default_value' => t("@value", ['@value' => variable_get($var_name)]),
   );
 
   $var_name = 'dosomething_settings_copy_campaign_value_proposition';
   $form['copy'][$var_name] = array(
     '#type' => 'textarea',
     '#title' => t('What You Get'),
-    '#default_value' => variable_get($var_name),
+    '#default_value' => t("@value", ['@value' => variable_get($var_name)]),
   );
    $form['share'] = array(
     '#type' => 'fieldset',


### PR DESCRIPTION
#### What's this PR do?

This PR wraps translatable content around Drupal's `t()` to allow for later adding translations for these items. This specifically addresses strings in the configuration interface for Settings in the admin view.
#### Where should the reviewer start?

In the main **dosomething_settings.admin.inc** file and just review that the wrapped content looks correct.
#### What are the relevant tickets?

Fixes #4995

---

@angaither 
