### PR TITLE
Update to allow fields in Search config to be translateable.

### DIFF
--- a/lib/modules/dosomething/dosomething_search/dosomething_search.admin.inc
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.admin.inc
@@ -5,7 +5,7 @@ function dosomething_search_admin_config_form($form, &$form_state) {
   $form['dosomething_search_copy_no_results'] = array(
     '#type' => 'textarea',
     '#title' => 'No Results Found Copy',
-    '#default_value' => variable_get('dosomething_search_copy_no_results'),
+    '#default_value' => t("@value", ['@value' => variable_get('dosomething_search_copy_no_results')]),
     '#required' => TRUE,
     );
   return system_settings_form($form);


### PR DESCRIPTION
#### What's this PR do?

This PR wraps translatable content around Drupal's `t()` to allow for later adding translations for these items. This specifically addresses strings in the configuration interface for DoSomething Config -> Search in the admin view.
#### Where should the reviewer start?

In the main **dosomething_search.admin.inc** file and just review that the wrapped content looks correct.
#### What are the relevant tickets?

Fixes #4994

---

@angaither 
