### PR TITLE
Making fields for Not Found config translateable.

### DIFF
--- a/lib/modules/dosomething/dosomething_notfound/dosomething_notfound.admin.inc
+++ b/lib/modules/dosomething/dosomething_notfound/dosomething_notfound.admin.inc
@@ -5,31 +5,31 @@ function dosomething_notfound_admin_config_form($form, &$form_state) {
   $form['dosomething_notfound_disable_results'] = array(
     '#type' => 'checkbox',
     '#title' => t('Disable relevant results'),
-    '#default_value' => variable_get('dosomething_notfound_disable_results'),
+    '#default_value' => t("@value", ['@value' => variable_get('dosomething_notfound_disable_results')]),
     );
   $form['dosomething_notfound_copy_projects'] = array(
     '#type' => 'textarea',
-    '#title' => 'Projects copy',
-    '#default_value' => variable_get('dosomething_notfound_copy_projects'),
+    '#title' => t('Projects copy'),
+    '#default_value' => t("@value", ['@value' => variable_get('dosomething_notfound_copy_projects')]),
     '#required' => TRUE,
     );
   $form['dosomething_notfound_copy_grants'] = array(
     '#type' => 'textarea',
-    '#title' => 'Grants copy',
-    '#default_value' => variable_get('dosomething_notfound_copy_grants'),
+    '#title' => t('Grants copy'),
+    '#default_value' => t("@value", ['@value' => variable_get('dosomething_notfound_copy_grants')]),
     '#required' => TRUE,
     );
   $form['dosomething_notfound_copy_search_results'] = array(
     '#type' => 'textarea',
-    '#title' => 'Search Copy',
-    '#default_value' => variable_get('dosomething_notfound_copy_search_results'),
+    '#title' => t('Search Copy'),
+    '#default_value' => t("@value", ['@value' => variable_get('dosomething_notfound_copy_search_results')]),
     '#required' => TRUE,
     );
   $form['dosomething_notfound_search_filter'] = array(
     '#type' => 'textarea',
-    '#title' => 'Search filter words',
-    '#description' => 'Comma separated list of all words to exclude from the search string (e.g. blog, actnow)',
-    '#default_value' => variable_get('dosomething_notfound_search_filter'),
+    '#title' => t('Search filter words'),
+    '#description' => t('Comma separated list of all words to exclude from the search string (e.g. blog, actnow)'),
+    '#default_value' => t("@value", ['@value' => variable_get('dosomething_notfound_search_filter')]),
     );
   return system_settings_form($form);
 }


### PR DESCRIPTION
#### What's this PR do?

This PR wraps translatable content around Drupal's `t()` to allow for later adding translations for these items. This specifically addresses strings in the configuration interface for DoSomething Config -> Search in the admin view.
#### Where should the reviewer start?

In the main **dosomething_search.admin.inc** file and just review that the wrapped content looks correct.
#### What are the relevant tickets?

Fixes #4993 

---

@angaither 
