### PR TITLE
Rotate Reportback image when reviewing.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/js/reportback_review_form.js
+++ b/lib/modules/dosomething/dosomething_reportback/js/reportback_review_form.js
@@ -40,5 +40,14 @@
       }
     });
 
+    $('.form-radio:input[name*="rotate"]').click(function() {
+      var degrees = $(this).val();
+      var $img  = $(this).closest('tr').find('img');
+
+      $img.css({
+        "transform" : "rotate("+ degrees + "deg)"
+      });
+    });
+
   });
 }(jQuery));


### PR DESCRIPTION
#### What's this PR do?

Adds a little JS Flare to the admin interface when reviewing reportbacks. When an admin selects to rotate an image some number of degrees, the image will rotate to reflect that. BOOM. 
#### Where should the reviewer start?

`reportback_review_form.js` is where the magic happens.
#### How should this be manually tested?

Go to review reportbacks on any campaign and in the inbox, when you select to rotate, the image should rotate with it. 
#### What are the relevant tickets?

Fixes #4556 . An old ticket I've been meaning to get to when I got the chance. 
#### Screenshots (if appropriate)

![5780a9bc7d4](https://cloud.githubusercontent.com/assets/1700409/9824342/19a2f312-589a-11e5-9c28-f5a52f1f367a.gif)

@DoSomething/front-end 
