### PR TITLE
Fix lists and spacing on partner modal.

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/modal-links.tpl.php
+++ b/lib/modules/dosomething/dosomething_helpers/modal-links.tpl.php
@@ -67,11 +67,15 @@
   <?php foreach ($modals['partner_info'] as $delta => $partner): ?>
     <div data-modal id="modal-partner-<?php print $delta; ?>" role="dialog">
       <h2 class="heading -banner"><?php print t('We &lt;3 @partner', array('@partner' => $partner['name'])); ?></h2>
-      <div class="modal__block">
+      <div class="modal__block with-lists">
         <?php print $partner['copy']; ?>
-        <?php if (isset($partner['video'])): print $partner['video']; ?>
-        <?php elseif (isset($partner['image'])): print $partner['image']; endif; ?>
       </div>
+      <?php if (isset($partner['video']) || isset($partner['image'])): ?>
+        <div class="modal__block">
+          <?php if (isset($partner['video'])): print $partner['video']; ?>
+          <?php elseif (isset($partner['image'])): print $partner['image']; endif; ?>
+        </div>
+      <?php endif; ?>
       <div class="modal__block">
         <div class="form-actions">
           <a href="#" class="js-close-modal"><?php print t('Back to main page'); ?></a>


### PR DESCRIPTION
#### Changes

Fixes #5101. The partner modal copy container was missing `.with-lists` so Markdown lists were not being styled correctly. The image/video was also not being placed in it's own `.container__block`, so it didn't get the proper spacing applied.
#### Screenshot

<img width="366" alt="screen shot 2015-09-14 at 10 46 59 am" src="https://cloud.githubusercontent.com/assets/583202/9852922/d153661e-5ace-11e5-94b7-3d3c1c144fa2.png">

---

@DoSomething/front-end 
