### PR TITLE
Exporting langugage detection settings to strongarm

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.info
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.info
@@ -18,4 +18,6 @@ features[language][] = pt-br
 features[variable][] = dosomething_global_language_map
 features[variable][] = language_negotiation_language
 features[variable][] = language_negotiation_language_content
-mtime = 1440615612
+features[variable][] = locale_language_providers_weight_language
+features[variable][] = locale_language_providers_weight_language_content
+mtime = 1442243431

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.strongarm.inc
@@ -17,18 +17,22 @@ function dosomething_global_strongarm() {
   $strongarm->value = array(
     'es-mx' => array(
       'display_name' => 'Spanish, Mexico',
-      'default_roles' => array('mexico admin'),
+      'default_roles' => array(
+        0 => 'mexico admin',
+      ),
       'country' => 'MX',
     ),
     'pt-br' => array(
       'display_name' => 'Portuguese, Brazil',
-      'default_roles' => array('brazil admin'),
+      'default_roles' => array(
+        0 => 'brazil admin',
+      ),
       'country' => 'BR',
     ),
     'en' => array(
       'display_name' => 'English',
       'default_roles' => array(),
-      'country' => 'US'
+      'country' => 'US',
     ),
     'en-global' => array(
       'display_name' => 'English, Global',
@@ -42,6 +46,12 @@ function dosomething_global_strongarm() {
   $strongarm->api_version = 1;
   $strongarm->name = 'language_negotiation_language';
   $strongarm->value = array(
+    'locale-user' => array(
+      'callbacks' => array(
+        'language' => 'locale_language_from_user',
+      ),
+      'file' => 'includes/locale.inc',
+    ),
     'locale-session' => array(
       'callbacks' => array(
         'language' => 'locale_language_from_session',
@@ -63,6 +73,12 @@ function dosomething_global_strongarm() {
   $strongarm->api_version = 1;
   $strongarm->name = 'language_negotiation_language_content';
   $strongarm->value = array(
+    'locale-user' => array(
+      'callbacks' => array(
+        'language' => 'locale_language_from_user',
+      ),
+      'file' => 'includes/locale.inc',
+    ),
     'locale-session' => array(
       'callbacks' => array(
         'language' => 'locale_language_from_session',
@@ -84,6 +100,33 @@ function dosomething_global_strongarm() {
     ),
   );
   $export['language_negotiation_language_content'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'locale_language_providers_weight_language';
+  $strongarm->value = array(
+    'locale-url' => '-9',
+    'locale-session' => '-8',
+    'locale-user' => '-10',
+    'locale-browser' => '-7',
+    'language-default' => '-6',
+  );
+  $export['locale_language_providers_weight_language'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'locale_language_providers_weight_language_content';
+  $strongarm->value = array(
+    'locale-url' => '-10',
+    'locale-session' => '-8',
+    'locale-user' => '-9',
+    'locale-browser' => '-7',
+    'locale-interface' => '-6',
+    'language-default' => '-5',
+  );
+  $export['locale_language_providers_weight_language_content'] = $strongarm;
 
   return $export;
 }


### PR DESCRIPTION
- Enabling language detection based on user's preferences
- For the interface the hierarchy is:
  - User
  - URL
  - Session
  - Browser
  - Default
- For the content the hierarchy is:
  - URL (URL is not enabled in this commit)
  - User
  - Session
  - Browser
  - Interface
  - Default

Resolves #5000 
