### PR TITLE
Using the default language image for search results

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -109,7 +109,14 @@ function paraneue_dosomething_get_search_vars($results) {
         // Make it available as a variable, if it exists. Otherwise, leave it empty.
         if (!empty($image)) {
           $clc = dosomething_helpers_get_current_language_code();
-          $value['display_image'] = dosomething_image_get_themed_image($image[$clc][0]['target_id'], 'square', '300x300');
+          if ($image[$clc][0]['target_id']) {
+            $value['display_image'] = dosomething_image_get_themed_image($image[$clc][0]['target_id'], 'square', '300x300');
+          }
+          //If the current language doesn't have an image, use the node's default langauge image.
+          else {
+            $default_language = $result_node->language;
+           $value['display_image'] = dosomething_image_get_themed_image($image[$default_language][0]['target_id'], 'square', '300x300');
+          }
         }
         else {
           $value['display_image'] = '';


### PR DESCRIPTION
- Translated nodes might not always have a unique cover image,
  so this code will use the node's default language image if
  the current langugage does not have a cover image.
- This construct probably appears in multiple places, and we could
  eventually refactor this with a helper like dosomething_helpers_get_cover_image()

Resolves #5059 
