### PR TITLE
Fixes node_save() error

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -59,7 +59,7 @@ function dosomething_global_form_campaign_node_form_alter(&$form, &$form_state, 
     foreach ($fields as $field_name => $field) {
       $field_info = field_info_field($field_name);
       // If the field is not translatable disable access
-      if (!$field_info['translatable']) {
+      if (!$field_info['translatable'] && strpos($field_name, '#') === FALSE) {
         $form[$field_name]['#access'] = FALSE;
       }
     }


### PR DESCRIPTION
#### What's this PR do?

Fixes the node save error regional admins experience in #5048 and consequently also fixes #5061  
#### How should this be manually tested?

Edit a campaign as a regional admin and save it. Verify 
1. This error does not popup,  `
   Warning: array_key_exists(): The first argument should be either a string or an integer in drupal_array_get_nested_value() (line 6774 of /var/www/dev.dosomething.org/html/includes/common.inc).`
2. The content is actually saved 
#### Any background context you want to provide?

The code used to hide non translatable fields was also targeting #parent and this caused the error. It was discovered earlier, and further tested after making this change that the failures occurring here were the reason translations didn't save in #5061 
#### What are the relevant tickets?

Fixes #5048 
Fixes #5061 
