### PR TITLE
Adding "en-global" campaigns to end of finder results

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
@@ -48,7 +48,7 @@ define(function(require) {
 
     // This would be awesome with an object key:value, but Solr allows multiple of the same key
     defaultQuery: [
-      "fq=-sm_field_campaign_status:(closed) bundle:[campaign TO campaign_group] ss_language:" + setting('dosomethingSearch.language'),
+      "fq=-sm_field_campaign_status:(closed) bundle:[campaign TO campaign_group] ss_language:(" + setting('dosomethingSearch.language') + " OR en-global)",
       //"fq=ss_field_search_image:[* TO *]",
       "wt=json",
       "indent=false",
@@ -58,7 +58,8 @@ define(function(require) {
       "facet.field=im_field_action_type",
       // TODO: un-hard-code the rows
       "rows=8",
-      "fl=label,tid,im_vid_1,sm_vid_Action_Type,tm_vid_1_names,im_field_cause,im_vid_2,sm_vid_Cause,tm_vid_2_names,im_field_tags,im_vid_5,sm_vid_Tags,tm_vid_5_names,fs_field_active_hours,sm_field_call_to_action,bs_field_staff_pick,ss_field_search_image_400x400,ss_field_search_image_720x720,url,ss_language"
+      "fl=label,tid,im_vid_1,sm_vid_Action_Type,tm_vid_1_names,im_field_cause,im_vid_2,sm_vid_Cause,tm_vid_2_names,im_field_tags,im_vid_5,sm_vid_Tags,tm_vid_5_names,fs_field_active_hours,sm_field_call_to_action,bs_field_staff_pick,ss_field_search_image_400x400,ss_field_search_image_720x720,url,ss_language",
+      "bq=ss_language:" + setting('dosomethingSearch.language') + "^10"
     ],
 
     // Map the input field names to the Solr query fields


### PR DESCRIPTION
#### What's this PR do?
- Surfaces en-global content along with the user's language content in the finder
- Adds "en-global" with "OR" to finder query
- Adds a boost query to the user's langugage to prioritize those results over en-global results
#### How should this be manually tested?
- Prerequisites:
  - Translate a significant amount of campaigns, enough to populate finder results for a given set of filters
    - Note: To test this properly you must have a significant amount of campaigns that **do not** have the user's language translation but **do** have the "en-global" translation.
  - Create dummy en-global campaigns
  - Login and set your language to something other than 'en'
- Use the finder as usual.

Resolves #4886 
