### PR TITLE
Fix Modernizr build.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -36,7 +36,7 @@
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-eslint": "^16.0.0",
-    "grunt-modernizr": "^0.6.0",
+    "grunt-modernizr": "metaloha/grunt-modernizr#d6657bf302bd9288e25a513197fb0e30c64ce677",
     "grunt-postcss": "^0.2.0",
     "grunt-sass": "^0.18.0",
     "grunt-sasslint": "0.0.5",


### PR DESCRIPTION
### What's this?

Fixes #5127. The current latest release of the Modernizr team's grunt-modernizr plugin was broken with the release of Modernizr v3. This broke our build process, so we're using a patched version until an official fix is released.

For some additional context, check out [this issue](https://goo.gl/tLPr46) on the grunt-modernizr repo.
### How do I test it?

If you want to manually test, pull this branch and run `npm install && grunt build`. You shouldn't see any errors (specifically, it shouldn't 404 when trying to download the Modernizr source code).
### But, did _you_ test it?

Here it is not working:
![screen shot 2015-09-15 at 4 14 16 pm](https://cloud.githubusercontent.com/assets/583202/9888866/751d91a6-5bc5-11e5-8822-786483204635.png)

And here it is working again:
![screen shot 2015-09-15 at 4 15 05 pm](https://cloud.githubusercontent.com/assets/583202/9888865/73586a94-5bc5-11e5-9d36-64e13a4e6a0d.png)

---

@DoSomething/front-end 
