### PR TITLE
Card font color

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/modal-links.tpl.php
+++ b/lib/modules/dosomething/dosomething_helpers/modal-links.tpl.php
@@ -67,11 +67,15 @@
   <?php foreach ($modals['partner_info'] as $delta => $partner): ?>
     <div data-modal id="modal-partner-<?php print $delta; ?>" role="dialog">
       <h2 class="heading -banner"><?php print t('We &lt;3 @partner', array('@partner' => $partner['name'])); ?></h2>
-      <div class="modal__block">
+      <div class="modal__block with-lists">
         <?php print $partner['copy']; ?>
-        <?php if (isset($partner['video'])): print $partner['video']; ?>
-        <?php elseif (isset($partner['image'])): print $partner['image']; endif; ?>
       </div>
+      <?php if (isset($partner['video']) || isset($partner['image'])): ?>
+        <div class="modal__block">
+          <?php if (isset($partner['video'])): print $partner['video']; ?>
+          <?php elseif (isset($partner['image'])): print $partner['image']; endif; ?>
+        </div>
+      <?php endif; ?>
       <div class="modal__block">
         <div class="form-actions">
           <a href="#" class="js-close-modal"><?php print t('Back to main page'); ?></a>

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_card.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_card.scss
@@ -1,5 +1,6 @@
 .card {
   background: $white;
+  color: $base-font-color;
   margin: 0 $base-spacing / 2;
 
   @include media($tablet) {


### PR DESCRIPTION
Fixes #5132. The new `.container.-dark` pattern was setting white font color (because that's a sane default for that pattern), but the `.card` pattern was inheriting that and making text appear invisible.
#### Before

<img width="1231" alt="screen shot 2015-09-16 at 1 42 59 pm" src="https://cloud.githubusercontent.com/assets/583202/9913106/052269bc-5c79-11e5-8694-be2bed791959.png">
#### After

<img width="1231" alt="screen shot 2015-09-16 at 1 42 33 pm" src="https://cloud.githubusercontent.com/assets/583202/9913110/08bd262a-5c79-11e5-9206-1860aae0ab10.png">

---

@DoSomething/front-end 
