### PR TITLE
Adds global mailchimp settings

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -134,3 +134,24 @@ function dosomething_global_get_user_language($user = NULL) {
   // If we didn't find a user role return english default.
   return 'en';
 }
+
+/*
+ * Returns a list of all the countries defined in the strongarm
+ *
+ * @return array
+ *  All of the supported countries
+ */
+ function dosomething_global_get_countries() {
+   $lang_map = variable_get('dosomething_global_language_map', '');
+   $countries = array();
+   foreach ($lang_map as $lang) {
+     $country = $lang['country'];
+
+     // Prevents global english from slipping through
+     if ($country != NULL) {
+       array_push($countries, $country);
+     }
+   }
+   array_push($countries, "global");
+   return $countries;
+ }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -155,3 +155,8 @@ function dosomething_global_get_user_language($user = NULL) {
    array_push($countries, "global");
    return $countries;
  }
+
+function dosomething_global_convert_language_to_country($language) {
+    $lang_map = variable_get('dosomething_global_language_map', '');
+    return $lang_map[$language]['country'];
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -18,6 +18,7 @@ function dosomething_signup_opt_in_config_form($form, &$form_state) {
     '#collapsed' => TRUE,
   );
 
+  $field_prefix = "dosomething_signup_";
   $countries = dosomething_global_get_countries();
   foreach ($countries as $country) {
     $country_form = $form['general']['dosomething_signup'][$country] = array(
@@ -27,38 +28,35 @@ function dosomething_signup_opt_in_config_form($form, &$form_state) {
       '#collapsed' => TRUE,
     );
 
-    $country_form = $form['general']['dosomething_signup'][$country]['mail_list_id'] = array(
+    $form['general']['dosomething_signup'][$country][$field_prefix . 'mail_list_id'] = array(
       '#type' => 'textfield',
       '#required' => TRUE,
       '#title' => 'Mail List ID',
-      '#default_value' => variable_get('mail_list_id'),
+      '#default_value' => variable_get('mail_list_id_' . $country),
       '#description' => "General MailChimp List ID used in registrations and signups.",
     );
 
     //TEMPORARY -- Remove the IF statement to fix #5121
     if ($country == "US") {
-      $name = 'mobile_opt_in_campaign';
-      $country_form = $form['general']['dosomething_signup'][$country][$name] = array(
+      $name = $field_prefix . 'mobile_opt_in_campaign';
+      $form['general']['dosomething_signup'][$country][$name] = array(
         '#type' => 'textfield',
         '#required' => TRUE,
         '#title' => 'Mobile Opt-In path for Campaigns',
-        '#default_value' => variable_get($name),
+        '#default_value' => variable_get($name . '_' . $country),
         '#description' => 'Numeric Mobile Commons opt-in path for general campaign signup.',
       );
 
-      $name = 'mobile_opt_in_path_user_register';
-      $country_form = $form['general']['dosomething_signup'][$country][$name] = array(
+      $name = $field_prefix . 'mobile_opt_in_path_user_register';
+      $form['general']['dosomething_signup'][$country][$name] = array(
         '#type' => 'textfield',
         '#required' => TRUE,
         '#title' => 'Mobile Opt-In path for User Registration',
-        '#default_value' => variable_get($name),
+        '#default_value' => variable_get($name . '_' . $country),
         '#description' => 'Numeric Mobile Commons opt-in path when user registers for site.',
       );
     }
   }
-
-  //OLD START
-  //OLD END
 
   // 26 Club.
   $form['26plusclub'] = array(

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -17,35 +17,48 @@ function dosomething_signup_opt_in_config_form($form, &$form_state) {
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $name = 'dosomething_signup_mailchimp_general_list_id';
-  $desc = t("General MailChimp List ID used in registrations and signups.");
-  $form['general'][$name] = array(
-    '#type' => 'textfield',
-    '#required' => TRUE,
-    '#title' => 'MailChimp | mailchimp_list_id',
-    '#default_value' => variable_get($name),
-    '#description' => $desc,
-  );
 
-  $name = 'dosomething_signup_mobilecommons_opt_in_path_general_campaign';
-  $desc = t("Numeric Mobile Commons opt-in path for general campaign signup.");
-  $form['general'][$name] = array(
-    '#type' => 'textfield',
-    '#required' => TRUE,
-    '#title' => t('Mobile Commons | General campaign | mobilecommons_opt_in_path'),
-    '#default_value' => variable_get($name),
-    '#description' => $desc,
-  );
+  $countries = dosomething_global_get_countries();
+  foreach ($countries as $country) {
+    $country_form = $form['general']['dosomething_signup'][$country] = array(
+      '#type' => 'fieldset',
+      '#title' => $country,
+      '#collapsible' => TRUE,
+      '#collapsed' => TRUE,
+    );
 
-  $name = 'dosomething_signup_mobilecommons_opt_in_path_user_register';
-  $desc = t("Numeric Mobile Commons opt-in path when user registers for site.");
-  $form['general'][$name] = array(
-    '#type' => 'textfield',
-    '#required' => TRUE,
-    '#title' => t('Mobile Commons | User registration | mobilecommons_opt_in_path'),
-    '#default_value' => variable_get($name),
-    '#description' => $desc,
-  );
+    $country_form = $form['general']['dosomething_signup'][$country]['mail_list_id'] = array(
+      '#type' => 'textfield',
+      '#required' => TRUE,
+      '#title' => 'Mail List ID',
+      '#default_value' => variable_get('mail_list_id'),
+      '#description' => "General MailChimp List ID used in registrations and signups.",
+    );
+
+    //TEMPORARY -- Remove the IF statement to fix #5121
+    if ($country == "US") {
+      $name = 'mobile_opt_in_campaign';
+      $country_form = $form['general']['dosomething_signup'][$country][$name] = array(
+        '#type' => 'textfield',
+        '#required' => TRUE,
+        '#title' => 'Mobile Opt-In path for Campaigns',
+        '#default_value' => variable_get($name),
+        '#description' => 'Numeric Mobile Commons opt-in path for general campaign signup.',
+      );
+
+      $name = 'mobile_opt_in_path_user_register';
+      $country_form = $form['general']['dosomething_signup'][$country][$name] = array(
+        '#type' => 'textfield',
+        '#required' => TRUE,
+        '#title' => 'Mobile Opt-In path for User Registration',
+        '#default_value' => variable_get($name),
+        '#description' => 'Numeric Mobile Commons opt-in path when user registers for site.',
+      );
+    }
+  }
+
+  //OLD START
+  //OLD END
 
   // 26 Club.
   $form['26plusclub'] = array(
@@ -316,4 +329,3 @@ function dosomething_signup_admin_config_form($form, &$form_state) {
   );
   return system_settings_form($form);
 }
-

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -21,38 +21,40 @@ function dosomething_signup_opt_in_config_form($form, &$form_state) {
   $field_prefix = "dosomething_signup_";
   $countries = dosomething_global_get_countries();
   foreach ($countries as $country) {
-    $country_form = $form['general']['dosomething_signup'][$country] = array(
+    $country = strtolower($country);
+    $form['general']['dosomething_signup'][$country] = array(
       '#type' => 'fieldset',
       '#title' => $country,
       '#collapsible' => TRUE,
       '#collapsed' => TRUE,
     );
 
-    $form['general']['dosomething_signup'][$country][$field_prefix . 'mail_list_id'] = array(
+    $name = $field_prefix . $country . '_mail_list_id';
+    $form['general']['dosomething_signup'][$country][$name] = array(
       '#type' => 'textfield',
       '#required' => TRUE,
       '#title' => 'Mail List ID',
-      '#default_value' => variable_get('mail_list_id_' . $country),
+      '#default_value' => variable_get($name),
       '#description' => "General MailChimp List ID used in registrations and signups.",
     );
 
     //TEMPORARY -- Remove the IF statement to fix #5121
-    if ($country == "US") {
-      $name = $field_prefix . 'mobile_opt_in_campaign';
+    if ($country == "us") {
+      $name = $field_prefix . $country . '_mobile_opt_in_campaign';
       $form['general']['dosomething_signup'][$country][$name] = array(
         '#type' => 'textfield',
         '#required' => TRUE,
         '#title' => 'Mobile Opt-In path for Campaigns',
-        '#default_value' => variable_get($name . '_' . $country),
+        '#default_value' => variable_get($name),
         '#description' => 'Numeric Mobile Commons opt-in path for general campaign signup.',
       );
 
-      $name = $field_prefix . 'mobile_opt_in_path_user_register';
+      $name = $field_prefix . $country . '_mobile_opt_in_path_user_register';
       $form['general']['dosomething_signup'][$country][$name] = array(
         '#type' => 'textfield',
         '#required' => TRUE,
         '#title' => 'Mobile Opt-In path for User Registration',
-        '#default_value' => variable_get($name . '_' . $country),
+        '#default_value' => variable_get($name),
         '#description' => 'Numeric Mobile Commons opt-in path when user registers for site.',
       );
     }
@@ -158,15 +160,30 @@ function dosomething_signup_opt_in_config_form($form, &$form_state) {
 function dosomething_signup_opt_in_config_form_submit($form, &$form_state) {
   $values = $form_state['values'];
 
-  // Save general Drupal variables.
-  $config_variables = array(
-    'dosomething_signup_mailchimp_general_list_id',
-    'dosomething_signup_mobilecommons_opt_in_path_general_campaign',
-    'dosomething_signup_mobilecommons_opt_in_path_user_register',
-    'dosomething_signup_26plusclub_enabled',
-  );
-  foreach ($config_variables as $var_name) {
-    variable_set($var_name, $values[$var_name]);
+  // Grabs all country fieldsets within dosomething_signup
+  foreach ($form['general']['dosomething_signup'] as $field_name => $field) {
+
+    // Get a list of all the countries we support
+    $countries = dosomething_global_get_countries();
+    foreach ($countries as $country) {
+      $country = strtolower($country);
+
+      // Verify the field name is a country and not something like #parents
+      if ($field_name == $country) {
+
+        // Go through each field within the country fieldset
+        foreach ($field as $sub_field_name => $sub_field) {
+
+          // Verify the field contains dosomething_signup
+          if (strpos($sub_field_name, 'dosomething_signup') !== FALSE) {
+
+            // Set the field in the DB
+            variable_set($sub_field_name, $values[$sub_field_name]);
+          }
+        }
+        break;
+      }
+    }
   }
 
   // 26+ Club.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -560,3 +560,23 @@ function dosomething_signup_update_7019() {
   }
 
 }
+
+/**
+ * Moves old mailchimp variables into global variables.
+ */
+function dosomething_signup_update_7020() {
+  $old_name = 'dosomething_signup_mailchimp_general_list_id';
+  $new_name = 'dosomething_signup_us_mail_list_id';
+  variable_set($new_name, variable_get($old_name));
+  variable_del($old_name);
+
+  $old_name = 'dosomething_signup_mobilecommons_opt_in_path_general_campaign';
+  $new_name = 'dosomething_signup_us_mobile_opt_in_campaign';
+  variable_set($new_name, variable_get($old_name));
+  variable_del($old_name);
+
+  $old_name = 'dosomething_signup_mobilecommons_opt_in_path_user_register';
+  $new_name = 'dosomething_signup_us_mobile_opt_in_path_user_register';
+  variable_set($new_name, variable_get($old_name));
+  variable_del($old_name);
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -660,8 +660,7 @@ function dosomething_signup_get_mailchimp_list_id() {
   global $user;
   $user_language = $user->language;
   $country_code = dosomething_global_convert_language_to_country($user_language);
-  $field_name = "dosomething_signup_" . $country . '_mail_list_id';
-
+  $field_name = "dosomething_signup_" . strtolower($country_code) . '_mail_list_id';
   return variable_get($field_name);
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -657,7 +657,7 @@ function dosomething_signup_get_mailchimp_list_id() {
       return $mli;
     }
   }
-
+  
   return variable_get('dosomething_signup_mailchimp_general_list_id');
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -657,8 +657,12 @@ function dosomething_signup_get_mailchimp_list_id() {
       return $mli;
     }
   }
-  
-  return variable_get('dosomething_signup_mailchimp_general_list_id');
+  global $user;
+  $user_language = $user->language;
+  $country_code = dosomething_global_convert_language_to_country($user_language);
+  $field_name = "dosomething_signup_" . $country . '_mail_list_id';
+
+  return variable_get($field_name);
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?

This PR adds mailchimp settings for each country registered. It also maintains the existing mobile opt-in settings for the US but it's clearly labeled how to make it not US specific (For #5121). 

Also adds new helper functions to dosomething_global for retrieving a list of countries and getting a countries language. 
#### Where should the reviewer start?

dosomething_signup.admin is where a bulk of the work takes place
#### How should this be manually tested?

Visit /admin/config/dosomething/opt_in
#### Any background context you want to provide?

This logic is _not_ fastly based because the user language should have already been setup before this step based on the fastly headers. See #global where I made sure this was :ok: 
#### What are the relevant tickets?

Fixes #5072 
#### Screenshots (if appropriate)

This is what the admin UI looks like,
<img width="506" alt="screen shot 2015-09-15 at 2 12 03 pm" src="https://cloud.githubusercontent.com/assets/897368/9936349/85f05a76-5d29-11e5-9b07-0fb1e8683419.png">

This is logging the mailchimp list field name for a US/EN user after registering (to prove the logic is able to build it correctly in dosomething_signup) 
![en register](https://cloud.githubusercontent.com/assets/897368/9936362/977ac628-5d29-11e5-8c5e-4af4b0a55c3d.png)
#### Don't merge yet!

Still need to write an install hook which imports the old vars into the new one
