### PR TITLE
Using user's account language to set campaign params

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -12,7 +12,7 @@ include_once 'includes/Campaign.php';
 include_once 'includes/CampaignController.php';
 include_once 'includes/CampaignTransformer.php';
 include_once 'dosomething_campaign.theme.inc';
-define('DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER', 'Snap a Pic');
+define('DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER', t('Snap a Pic'));
 
 /**
  * Implements hook_form_alter().

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -221,6 +221,7 @@ function dosomething_global_convert_country_to_language($country) {
     }
   }
   return 'en';
+}
 
 /*
  * Get the appropriate language for the application.

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -232,7 +232,7 @@ function dosomething_global_convert_country_to_language($country) {
  *
  */
 function dosomething_global_get_language($account, stdClass $node = NULL) {
-  if ($node = $options['node']) {
+  if ($node) {
     // If there is a published translation for the node in the user's language, use it.
     if ($node->translations->data['$account->language']['status']) {
       $language = $account->language;

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -221,4 +221,37 @@ function dosomething_global_convert_country_to_language($country) {
     }
   }
   return 'en';
+
+/*
+ * Get the appropriate language for the application.
+ *
+ * @param $account
+ *   The user's account
+ * @param  $node
+ *   Optional node.
+ *
+ */
+function dosomething_global_get_language($account, stdClass $node = NULL) {
+  if ($node = $options['node']) {
+    // If there is a published translation for the node in the user's language, use it.
+    if ($node->translations->data['$account->language']['status']) {
+      $language = $account->language;
+    }
+    // If there's no published translation in their language try 'en-global'.
+    elseif ($node->translations->data['en-global']['status']) {
+      $language = 'en-global';
+    }
+    // Default to node language if there's no translation in their language and no 'en-global'.
+    else {
+      $language = $node->language;
+    }
+  }
+  elseif ($language = $account->language) {
+    return $language;
+  }
+  else {
+    $language = dosomething_global_get_user_language($account);
+  }
+
+  return $language;
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -592,3 +592,38 @@ function dosomething_helpers_get_current_language_code() {
 function dosomething_helpers_application_path($path = '') {
   return realpath(DRUPAL_ROOT . '/../' . $path);
 }
+
+/**
+ * Get the appropriate language for the application.
+ *
+ * @param $account
+ *   The user's account
+ * @param  $node
+ *   Optional node.
+ *
+ */
+
+function dosomething_helpers_get_language($account, stdClass $node = NULL) {
+  if ($node = $options['node']) {
+    // If there is a published translation for the node in the user's language, use it.
+    if ($node->translations->data['$account->language']['status']) {
+      $language = $account->language;
+    }
+    // If there's no published translation in their language try 'en-global'.
+    elseif ($node->translations->data['en-global']['status']) {
+      $language = 'en-global';
+    }
+    // Default to node language if there's no translation in their language and no 'en-global'.
+    else {
+      $language = $node->language;
+    }
+  }
+  elseif ($language = $account->language) {
+    return $language;
+  }
+  else {
+    $language = dosomething_global_get_user_language($account);
+  }
+
+  return $language;
+}

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -592,38 +592,3 @@ function dosomething_helpers_get_current_language_code() {
 function dosomething_helpers_application_path($path = '') {
   return realpath(DRUPAL_ROOT . '/../' . $path);
 }
-
-/**
- * Get the appropriate language for the application.
- *
- * @param $account
- *   The user's account
- * @param  $node
- *   Optional node.
- *
- */
-
-function dosomething_helpers_get_language($account, stdClass $node = NULL) {
-  if ($node = $options['node']) {
-    // If there is a published translation for the node in the user's language, use it.
-    if ($node->translations->data['$account->language']['status']) {
-      $language = $account->language;
-    }
-    // If there's no published translation in their language try 'en-global'.
-    elseif ($node->translations->data['en-global']['status']) {
-      $language = 'en-global';
-    }
-    // Default to node language if there's no translation in their language and no 'en-global'.
-    else {
-      $language = $node->language;
-    }
-  }
-  elseif ($language = $account->language) {
-    return $language;
-  }
-  else {
-    $language = dosomething_global_get_user_language($account);
-  }
-
-  return $language;
-}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -489,10 +489,8 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL) {
   if ($sid = dosomething_signup_create($nid, $account->uid, $source)) {
     $node = node_load($nid);
 
-    // Check if a field_signup_confirm_msg field is set.
-    if (isset($node->field_signup_confirm_msg[LANGUAGE_NONE][0]['value'])) {
-      // Store that message.
-      $msg = $node->field_signup_confirm_msg[LANGUAGE_NONE][0]['value'];
+    // Check if a field_signup_confirm_msg field is set and store the msg.
+    if ($msg = $node->field_signup_confirm_msg[$account->language][0]['value']) {
       // Display that message.
       drupal_set_message($msg);
       // Exit out of function.
@@ -558,14 +556,16 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
   if (!($node->type == 'campaign' || $node->type == 'campaign_group')) {
     return FALSE;
   }
+  $wrapper = entity_metadata_wrapper('node', $node);
   $params = array(
     'email' => $account->mail,
     'uid' => $account->uid,
     'first_name' => dosomething_user_get_field('field_first_name', $account),
     'mobile' => dosomething_user_get_field('field_mobile', $account),
     'event_id' => $node->nid,
-    'campaign_title' => $node->title,
+    'campaign_title' => $wrapper->language($account->language)->title_field->value(),
     'campaign_link' => url(drupal_get_path_alias('node/' . $node->nid), array('absolute' => TRUE)),
+    'language' => $account->language,
   );
 
   // Don't subscribe 26+ yo users for Mobile Commons.
@@ -575,8 +575,8 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
   }
 
   // Add additional values to $params based on campaign / campaign_group
-  dosomething_signup_get_mbp_params_campaign($params, $node);
-  dosomething_signup_get_mbp_params_campaign_group($params, $node);
+  dosomething_signup_get_mbp_params_campaign($params, $wrapper);
+  dosomething_signup_get_mbp_params_campaign_group($params, $wrapper);
   // Add any mailchimp params if needed.
   dosomething_signup_get_mbp_params_mailchimp($params, $node);
   return $params;
@@ -590,13 +590,13 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
  * @param object $node
  *   Details about the node that the signup was made on.
  */
-function dosomething_signup_get_mbp_params_campaign(&$params, $node) {
-  if ($node->type == 'campaign') {
-    $wrapper = entity_metadata_wrapper('node', $node);
-    $params['call_to_action'] = $wrapper->field_call_to_action->value();
-    $params['step_one'] = $wrapper->field_pre_step_header->value();
+function dosomething_signup_get_mbp_params_campaign(&$params, $wrapper) {
+  if ($wrapper->type->value() == 'campaign') {
+    $content = $wrapper->language($params['language']);
+    $params['call_to_action'] = $content->field_call_to_action->value();
+    $params['step_one'] = $content->field_pre_step_header->value();
     $params['step_two'] = DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER;
-    $params['step_three'] = $wrapper->field_post_step_header->value();
+    $params['step_three'] = $content->field_post_step_header->value();
   }
 }
 
@@ -611,8 +611,8 @@ function dosomething_signup_get_mbp_params_campaign(&$params, $node) {
 function dosomething_signup_get_mbp_params_campaign_group(&$params, $node) {
   if ($node->type == 'campaign_group') {
     $copy = '';
-    if (isset($node->field_transactional_email_copy[LANGUAGE_NONE][0]['safe_value'])) {
-      $copy = $node->field_transactional_email_copy[LANGUAGE_NONE][0]['safe_value'];
+    if (isset($node->field_transactional_email_copy[$params['language']][0]['safe_value'])) {
+      $copy = $node->field_transactional_email_copy[$params['language']][0]['safe_value'];
     }
     $params['transactional_email_copy'] = $copy;
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -558,7 +558,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     return FALSE;
   }
   $wrapper = entity_metadata_wrapper('node', $node);
-  $language = dosomething_helpers_get_language($account, $node);
+  $language = dosomething_global_get_language($account, $node);
 
   $params = array(
     'email' => $account->mail,
@@ -568,7 +568,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     'event_id' => $node->nid,
     'campaign_title' => $wrapper->language($language)->title_field->value(),
     'campaign_link' => url(drupal_get_path_alias('node/' . $node->nid, $language), array('absolute' => TRUE)),
-    'language' => $language,
+    'user_language' => $language,
   );
 
   // Don't subscribe 26+ yo users for Mobile Commons.
@@ -595,7 +595,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
  */
 function dosomething_signup_get_mbp_params_campaign(&$params, $wrapper) {
   if ($wrapper->type->value() == 'campaign') {
-    $content = $wrapper->language($params['language']);
+    $content = $wrapper->language($params['user_language']);
     $params['call_to_action'] = $content->field_call_to_action->value();
     $params['step_one'] = $content->field_pre_step_header->value();
     $params['step_two'] = DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER;
@@ -614,8 +614,8 @@ function dosomething_signup_get_mbp_params_campaign(&$params, $wrapper) {
 function dosomething_signup_get_mbp_params_campaign_group(&$params, $node) {
   if ($node->type == 'campaign_group') {
     $copy = '';
-    if (isset($node->field_transactional_email_copy[$params['language']][0]['safe_value'])) {
-      $copy = $node->field_transactional_email_copy[$params['language']][0]['safe_value'];
+    if (isset($node->field_transactional_email_copy[$params['user_language']][0]['safe_value'])) {
+      $copy = $node->field_transactional_email_copy[$params['user_language']][0]['safe_value'];
     }
     $params['transactional_email_copy'] = $copy;
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -530,6 +530,7 @@ function dosomething_signup_mbp_request($account, $node, $opt_in) {
 
   // Gather mbp params for the signup.
   $params = dosomething_signup_get_mbp_params($account, $node, $opt_in);
+
   // Send campaign mbp request.
   if ($node->type == 'campaign') {
     dosomething_mbp_request('campaign_signup', $params);
@@ -557,15 +558,17 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     return FALSE;
   }
   $wrapper = entity_metadata_wrapper('node', $node);
+  $language = dosomething_helpers_get_language($account, $node);
+
   $params = array(
     'email' => $account->mail,
     'uid' => $account->uid,
     'first_name' => dosomething_user_get_field('field_first_name', $account),
     'mobile' => dosomething_user_get_field('field_mobile', $account),
     'event_id' => $node->nid,
-    'campaign_title' => $wrapper->language($account->language)->title_field->value(),
-    'campaign_link' => url(drupal_get_path_alias('node/' . $node->nid), array('absolute' => TRUE)),
-    'language' => $account->language,
+    'campaign_title' => $wrapper->language($language)->title_field->value(),
+    'campaign_link' => url(drupal_get_path_alias('node/' . $node->nid, $language), array('absolute' => TRUE)),
+    'language' => $language,
   );
 
   // Don't subscribe 26+ yo users for Mobile Commons.

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -109,13 +109,13 @@ function paraneue_dosomething_get_search_vars($results) {
         // Make it available as a variable, if it exists. Otherwise, leave it empty.
         if (!empty($image)) {
           $clc = dosomething_helpers_get_current_language_code();
-          if ($image[$clc][0]['target_id']) {
+          if ($image[$clc]) {
             $value['display_image'] = dosomething_image_get_themed_image($image[$clc][0]['target_id'], 'square', '300x300');
           }
           //If the current language doesn't have an image, use the node's default langauge image.
           else {
             $default_language = $result_node->language;
-           $value['display_image'] = dosomething_image_get_themed_image($image[$default_language][0]['target_id'], 'square', '300x300');
+            $value['display_image'] = dosomething_image_get_themed_image($image[$default_language][0]['target_id'], 'square', '300x300');
           }
         }
         else {


### PR DESCRIPTION
- When user's sign up for a campaign, they will now receive their signup
  emails with copy in their language of choice.
- The user's language should always be set appropriately either when they create an account or when they change their own language settings.

Fixes #5091 and #4956 
