### PR TITLE
Adds new functions to read fastly geo headers 

### DIFF
--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
@@ -106,3 +106,26 @@ function dosomething_settings_get_sitewide_copy() {
   }
   return $copy;
 }
+
+function dosomething_settings_get_geo_country_code() {
+  return $_SERVER['HTTP_X_FASTLY_COUNTRY_CODE'];
+}
+
+function dosomething_settings_get_geo_city() {
+  return $_SERVER['HTTP_X_FASTLY_CITY'];
+}
+
+function dosomething_settings_get_geo_country_name() {
+  return $_SERVER['HTTP_X_FASTLY_COUNTRY_NAME'];
+}
+
+function dosomething_settings_get_geo_latlong() {
+  return array(
+    'lat' => $_SERVER['HTTP_X_FASTLY_LATITUDE'],
+    'long' => $_SERVER['HTTP_X_FASTLY_LONGITUDE'],
+  );
+}
+
+function dosomething_settings_get_geo_region() {
+  return $_SERVER['HTTP_X_FASTLY_REGION'];
+}

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
@@ -71,6 +71,12 @@ function dosomething_settings_get_affiliate_code() {
  *   otherwise default: US.
  */
 function dosomething_settings_get_affiliate_country_code() {
+  // Fastly header takes priority over old affiliate logic
+  $country_code = dosomething_settings_get_geo_country_code();
+  if (isset($country_code)) {
+    return $country_code;
+  }
+
   $country_code = &drupal_static(__FUNCTION__);
   if (!isset($country_code)) {
     $mapping = array(

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
@@ -107,18 +107,38 @@ function dosomething_settings_get_sitewide_copy() {
   return $copy;
 }
 
+/**
+ * Returns the Fastly header specifying country code
+ *
+ * @return string
+ */
 function dosomething_settings_get_geo_country_code() {
   return $_SERVER['HTTP_X_FASTLY_COUNTRY_CODE'];
 }
 
+/**
+ * Returns the Fastly header specifying city
+ *
+ * @return string
+ */
 function dosomething_settings_get_geo_city() {
   return $_SERVER['HTTP_X_FASTLY_CITY'];
 }
 
+/**
+ * Returns the Fastly header specifying country name
+ *
+ * @return string
+ */
 function dosomething_settings_get_geo_country_name() {
   return $_SERVER['HTTP_X_FASTLY_COUNTRY_NAME'];
 }
 
+/**
+ * Returns the Fastly header specifying lat & long
+ *
+ * @return array
+ */
 function dosomething_settings_get_geo_latlong() {
   return array(
     'lat' => $_SERVER['HTTP_X_FASTLY_LATITUDE'],
@@ -126,6 +146,11 @@ function dosomething_settings_get_geo_latlong() {
   );
 }
 
+/**
+ * Returns the Fastly header specifying region
+ *
+ * @return string
+ */
 function dosomething_settings_get_geo_region() {
   return $_SERVER['HTTP_X_FASTLY_REGION'];
 }

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
@@ -119,7 +119,11 @@ function dosomething_settings_get_sitewide_copy() {
  * @return string
  */
 function dosomething_settings_get_geo_country_code() {
-  return $_SERVER['HTTP_X_FASTLY_COUNTRY_CODE'];
+  $name = 'HTTP_X_FASTLY_COUNTRY_CODE';
+  if (isset($_SERVER[$name])) {
+    return $_SERVER[$name];
+  }
+  return NULL;
 }
 
 /**
@@ -128,7 +132,11 @@ function dosomething_settings_get_geo_country_code() {
  * @return string
  */
 function dosomething_settings_get_geo_city() {
-  return $_SERVER['HTTP_X_FASTLY_CITY'];
+  $name = 'HTTP_X_FASTLY_CITY';
+  if (isset($_SERVER[$name])) {
+    return $_SERVER[$name];
+  }
+  return NULL;
 }
 
 /**
@@ -137,7 +145,11 @@ function dosomething_settings_get_geo_city() {
  * @return string
  */
 function dosomething_settings_get_geo_country_name() {
-  return $_SERVER['HTTP_X_FASTLY_COUNTRY_NAME'];
+  $name = 'HTTP_X_FASTLY_COUNTRY_NAME';
+  if (isset($_SERVER[$name])) {
+    return $_SERVER[$name];
+  }
+  return NULL;
 }
 
 /**
@@ -146,10 +158,15 @@ function dosomething_settings_get_geo_country_name() {
  * @return array
  */
 function dosomething_settings_get_geo_latlong() {
-  return array(
-    'lat' => $_SERVER['HTTP_X_FASTLY_LATITUDE'],
-    'long' => $_SERVER['HTTP_X_FASTLY_LONGITUDE'],
-  );
+  $lat_name = 'HTTP_X_FASTLY_LATITUDE';
+  $long_name = 'HTTP_X_FASTLY_LONGITUDE';
+  if (isset($lat_name) && isset($long_name)) {
+    return array(
+      'lat' => $_SERVER[$lat_name],
+      'long' => $_SERVER[$long_name],
+    );
+  }
+  return NULL;
 }
 
 /**
@@ -158,5 +175,9 @@ function dosomething_settings_get_geo_latlong() {
  * @return string
  */
 function dosomething_settings_get_geo_region() {
-  return $_SERVER['HTTP_X_FASTLY_REGION'];
+  $name = 'HTTP_X_FASTLY_REGION';
+  if (isset($_SERVER[$name])) {
+    return $_SERVER[$name];
+  }
+  return NULL;
 }


### PR DESCRIPTION
#### What's this PR do?
- Adds new functions to dosomething settings (outlined in more detail [here](https://github.com/DoSomething/phoenix/issues/4959#issuecomment-140189850) ) to read the Fastly headers 
- Updates the affiliate logic to prefer these headers over the old logic per Dee's request https://github.com/DoSomething/phoenix/issues/4959#issuecomment-135904328
#### Where should the reviewer start?

dosomething_settings
#### How should this be manually tested?

Tricky one. Follow this guide to get setup https://github.com/DoSomething/phoenix/wiki/Testing-global-functionality-on-your-local-environment

Then to get an output of all the functions, you can add this to the top of dosomething_settings temporarily to test,

```
function dosomething_settings_init() {
  dpm($_SERVER);
  dpm(dosomething_settings_get_geo_country_code());
  dpm(dosomething_settings_get_geo_city());
  dpm(dosomething_settings_get_geo_country_name());
  dpm(dosomething_settings_get_geo_latlong());
  dpm(dosomething_settings_get_geo_region());
  dpm(dosomething_settings_get_affiliate_country_code());
}
```
#### Any background context you want to provide?

drupal_get_http_header was giving me issues, $_SERVER worked fine so I went with that
#### What are the relevant tickets?

Fixes #4959 

@angaither 
