### PR TITLE
No more first names

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -148,10 +148,6 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
   $form['#attributes'] = array(
     'class' => ['sms-campaign-form'],
   );
-  // If this is a multiplayer game, add style overrides.
-  if ($form['sms_game_type']['#default_value'] === 'multi_player') {
-    $form['#attributes']['class'][] = 'sms-campaign-form--multiplayer';
-  }
   // Load "all participants" copy.
   $all_participants_copy = variable_get('dosomething_campaign_sms_game_all_participants_copy');
   $form['all_participants_copy'] = array(
@@ -183,21 +179,6 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
     ),
   );
   for ($i = 0; $i < $num_friends; $i++) {
-    // If this is a multiplayer game, add first name fields.
-    if ($form['sms_game_type']['#default_value'] === 'multi_player') {
-      $form['beta_first_name_' .$i] = array(
-        '#type' => 'textfield',
-        '#title' => 'Your Friend\'s Name',
-        '#required' => TRUE,
-        '#attributes' => array(
-          'data-validate' => 'friend_name',
-          'data-validate-required' => '',
-          'placeholder' => t('Friend\'s Name'),
-          'autocomplete' => 'off',
-        ),
-      );
-    }
-
     $form['beta_mobile_' .$i] = array(
       '#type' => 'textfield',
       '#required' => TRUE,

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -884,9 +884,6 @@ function dosomething_signup_sms_game_multi_player_signup_request($values) {
     'beta_mobile_0',
     'beta_mobile_1',
     'beta_mobile_2',
-    'beta_first_name_0',
-    'beta_first_name_1',
-    'beta_first_name_2',
     'story_id',
     'story_type',
   );

--- a/lib/themes/dosomething/paraneue_dosomething/js/validators/auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validators/auth.js
@@ -63,13 +63,6 @@ define(function(require) {
     );
   });
 
-  Validation.registerValidationFunction("friend_name", function(string, done) {
-    validateNotBlank(string, done,
-      Drupal.t("Got it!", {"@name": string}),
-      Drupal.t("We need your friend's name.")
-    );
-  });
-
   Validation.registerValidationFunction("last_name", function(string, done) {
     validateNotBlank(string, done,
       Drupal.t("Got it, @name!", {"@name": string}),

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-sms.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign-sms.scss
@@ -31,23 +31,6 @@
       }
     }
 
-    .sms-campaign-form--multiplayer {
-      padding-top: $base-spacing;
-
-      .form-item-alpha-mobile {
-        clear: none;
-      }
-
-      .message-callout.-above {
-        @include media($tablet) {
-          position: absolute;
-          top: -60px;
-          right: 20px;
-          margin: 0;
-        }
-      }
-    }
-
     .form-item-alpha-first-name {
       @include span(100%);
 


### PR DESCRIPTION
### Changes

Closes #5157. This removes first name fields from the multiplayer SMS game form & associated styles and validation rules, since we are [no longer interested in collecting them](https://cloud.githubusercontent.com/assets/583202/9967116/9e000cfc-5e0e-11e5-8cae-a81529349475.png).
### How should I test this?

Feel free to pull down to your local and test, although changes should be fairly easy to follow... (it's basically just removing conditional logic that was added in the two referenced PRs).
### Screenshots

The SMS game form (configured for a multiplayer game) on staging:
![screen shot 2015-09-18 at 1 56 57 pm](https://cloud.githubusercontent.com/assets/583202/9967049/54bc2850-5e0e-11e5-97b3-4a1133cd18b2.png)

The SMS game form (configured for a multiplayer game) on this branch:
![screen shot 2015-09-18 at 1 57 25 pm](https://cloud.githubusercontent.com/assets/583202/9967060/5e283910-5e0e-11e5-8f00-ff11caa395bd.png)

---

@DoSomething/front-end 
