### PR TITLE
Campaign preprocess configs olé

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -45,7 +45,7 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#title' => t('Number of Participants Form Label'),
     '#description' => t("If a Campaign is set to collect number of participants in the Reportback form, this label is displayed."),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get($var_name)]),
+    '#default_value' => t(variable_get($var_name)),
   );
 
   // Confirmation page:
@@ -59,13 +59,13 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Confirmation Page Title'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_confirmation_page_title')]),
+    '#default_value' => t(variable_get('dosomething_campaign_confirmation_page_title')),
   );
   $form['campaign']['confirmation_page']['dosomething_campaign_confirmation_page_button_text'] = array(
     '#type' => 'textfield',
     '#title' => t('Confirmation Page Button Text'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_confirmation_page_button_text')]),
+    '#default_value' => t(variable_get('dosomething_campaign_confirmation_page_button_text')),
   );
 
   // Action page:
@@ -79,7 +79,7 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Problem Fact Share Prompt'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_problem_share_prompt')]),
+    '#default_value' => t(variable_get('dosomething_campaign_problem_share_prompt')),
   );
 
   // SMS Game variables.
@@ -93,14 +93,14 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Signup Friends Form Button Label'),
     '#description' => t("Text displayed on the Signup Friends Form. Defaults to <em>Share</em> if not set."),
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_sms_game_signup_friends_form_button_copy')]),
+    '#default_value' => t(variable_get('dosomething_campaign_sms_game_signup_friends_form_button_copy')),
   );
   $form['sms_game']['dosomething_campaign_sms_game_all_participants_copy'] = array(
     '#type' => 'textarea',
     '#required' => TRUE,
     '#title' => t('Total participants in all SMS Games copy'),
     '#description' => t("This copy is displayed in every SMS Game. e.g. <em>Join 250,000 people who have played since 2012!</em>"),
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_sms_game_all_participants_copy')]),
+    '#default_value' => t(variable_get('dosomething_campaign_sms_game_all_participants_copy')),
   );
   $form['sms_game']['confirmation_page'] = array(
     '#type' => 'fieldset',
@@ -112,21 +112,21 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Confirmation Page Title'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_sms_game_confirmation_page_title')]),
+    '#default_value' => t(variable_get('dosomething_campaign_sms_game_confirmation_page_title')),
   );
   $form['sms_game']['confirmation_page']['dosomething_campaign_confirmation_page_anon_button_text'] = array(
     '#type' => 'textfield',
     '#title' => t('Anon User: Button Text'),
     '#description' => t('Button label if an anonymous user is viewing the confirmation page -- links to the login/register modal.'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_confirmation_page_anon_button_text')]),
+    '#default_value' => t(variable_get('dosomething_campaign_confirmation_page_anon_button_text')),
   );
   $form['sms_game']['confirmation_page']['dosomething_campaign_confirmation_page_anon_cta_text'] = array(
     '#type' => 'textfield',
     '#title' => t('Anon User: Call to Action'),
     '#description' => t('Appears above the button if an anonymous user is viewing the confirmation page.'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_confirmation_page_anon_cta_text')]),
+    '#default_value' => t(variable_get('dosomething_campaign_confirmation_page_anon_cta_text')),
   );
   // Closed variables.
   $form['closed'] = array(
@@ -140,14 +140,14 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#title' => t('Presignup Form Callout Copy'),
     '#required' => TRUE,
     '#description' => t("Callout text displayed for the Presignup Form."),
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_presignup_callout_copy')]),
+    '#default_value' => t(variable_get('dosomething_campaign_presignup_callout_copy')),
   );
   // The pre-signup button text.
   $form['closed']['dosomething_campaign_run_signup_button_copy'] = array(
     '#type' => 'textfield',
     '#title' => t('Presignup Form Button Text'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_run_signup_button_copy')]),
+    '#default_value' => t(variable_get('dosomething_campaign_run_signup_button_copy')),
   );
   // If there are no total number of X collected.
   $form['closed']['dosomething_campaign_run_no_total_copy'] = array(
@@ -155,14 +155,14 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#title' => t('Waiting for total copy'),
     '#description' => t('Place [label] where you would like the label to be replaced.'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_run_no_total_copy')]),
+    '#default_value' => t(variable_get('dosomething_campaign_run_no_total_copy')),
   );
    // No winners yet copy.
   $form['closed']['dosomething_campaign_run_no_winner_copy'] = array(
     '#type' => 'textarea',
     '#title' => t('Waiting for Winner Copy'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_run_no_winner_copy')]),
+    '#default_value' => t(variable_get('dosomething_campaign_run_no_winner_copy')),
   );
   // Permalink page.
   $form['permalink'] = array(
@@ -189,49 +189,49 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#title' => t('Permalink confirmation page subtitle'),
     '#description' => t('Appears on the confirmation page above the reportback of the owner.'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_permalink_confirmation_owners_page_subtitle')]),
+    '#default_value' => t(variable_get('dosomething_campaign_permalink_confirmation_owners_page_subtitle')),
   );
   $form['permalink']['owners']['confirmation']['dosomething_campaign_permalink_confirmation_owners_scholarship'] = array(
     '#type' => 'textfield',
     '#title' => t('Permalink confirmation page scholarship addition'),
     '#description' => t('Displays scholarhship info if a campaign has it.'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_permalink_confirmation_owners_scholarship')]),
+    '#default_value' => t(variable_get('dosomething_campaign_permalink_confirmation_owners_scholarship')),
   );
   $form['permalink']['owners']['confirmation']['dosomething_campaign_permalink_confirmation_owners_important_to_you'] = array(
     '#type' => 'textfield',
     '#title' => t('Permalink confirmation page important to you header'),
     '#description' => t('Appears above the why is this important to you user copy.'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_permalink_confirmation_owners_important_to_you')]),
+    '#default_value' => t(variable_get('dosomething_campaign_permalink_confirmation_owners_important_to_you')),
   );
   $form['permalink']['owners']['confirmation']['dosomething_campaign_permalink_confirmation_owners_social_cta'] = array(
     '#type' => 'textfield',
     '#title' => t('Social cta on reportback permalink page.'),
     '#description' => t('Appears above the social share on the reportback confirmation page.'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_permalink_confirmation_owners_social_cta')]),
+    '#default_value' => t(variable_get('dosomething_campaign_permalink_confirmation_owners_social_cta')),
   );
   $form['permalink']['owners']['confirmation']['dosomething_campaign_permalink_confirmation_owners_social_network_copy'] = array(
     '#type' => 'textfield',
     '#title' => t('Social network copy.'),
     '#description' => t('Appears after share on social network.'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_permalink_confirmation_owners_social_network_copy')]),
+    '#default_value' => t(variable_get('dosomething_campaign_permalink_confirmation_owners_social_network_copy')),
   );
   $form['permalink']['owners']['dosomething_campaign_permalink_owners_page_title'] = array(
     '#type' => 'textfield',
     '#title' => t('Permalink owners title'),
     '#description' => t('Appears above the reportback if the owner user is viewing the permalink page.'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_permalink_owners_page_title')]),
+    '#default_value' => t(variable_get('dosomething_campaign_permalink_owners_page_title')),
   );
   $form['permalink']['owners']['dosomething_campaign_permalink_owners_page_subtitle'] = array(
     '#type' => 'textfield',
     '#title' => t('Permalink owners subtitle'),
     '#description' => t('Appears above the reportback if the owner user is viewing the permalink page.'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_permalink_owners_page_subtitle')]),
+    '#default_value' => t(variable_get('dosomething_campaign_permalink_owners_page_subtitle')),
   );
     // Permalink owners vars.
   $form['permalink']['nonowners'] = array(
@@ -245,21 +245,21 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#title' => t('Permalink non-owners page title'),
     '#description' => t('Appears above the reportback if an anonymous user (or a non-owner) is viewing the permalink page.'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_permalink_nonowners_page_title')]),
+    '#default_value' => t(variable_get('dosomething_campaign_permalink_nonowners_page_title')),
   );
   $form['permalink']['nonowners']['dosomething_campaign_permalink_nonowners_closed_cta'] = array(
     '#type' => 'textfield',
     '#title' => t('Permalink non-owners campaign closed CTA'),
     '#description' => t('Appears near the button that links to /campagins.'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_permalink_nonowners_closed_cta')]),
+    '#default_value' => t(variable_get('dosomething_campaign_permalink_nonowners_closed_cta')),
   );
   $form['permalink']['nonowners']['dosomething_campaign_permalink_nonowners_closed_button_copy'] = array(
     '#type' => 'textfield',
     '#title' => t('Permalink non-owners closed button copy'),
     '#description' => t('Appears in place of the sign up button when the campagin is closed.'),
     '#required' => TRUE,
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_permalink_nonowners_closed_button_copy')]),
+    '#default_value' => t(variable_get('dosomething_campaign_permalink_nonowners_closed_button_copy')),
   );
   // Goal Animations.
   $form['goals'] = array(
@@ -273,49 +273,49 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Hot module share copy'),
     '#description' => t("Sets the hot module share copy"),
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_share_copy', 'Rally your friends to crush this goal!')]),
+    '#default_value' => t(variable_get('dosomething_campaign_share_copy', 'Rally your friends to crush this goal!')),
   ];
 
   $form['goals']['progress_copy']['dosomething_campaign_0_20_progress_copy'] = [
     '#type' => 'textarea',
     '#title' => t('Hot module 0-20% progress copy'),
     '#description' => t('Sets the hot module progress copy between 0 and 20%'),
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_0_20_progress_copy', '[node:title] has just kicked off! Let’s start off with a bang! Submit photos of your work early and often to help us reach our goal of [campaign_goal] [node:field_reportback_noun] [node:field_reportback_verb]. You can add photos and update your submission as your impact increases.')]),
+    '#default_value' => t(variable_get('dosomething_campaign_0_20_progress_copy', '[node:title] has just kicked off! Let’s start off with a bang! Submit photos of your work early and often to help us reach our goal of [campaign_goal] [node:field_reportback_noun] [node:field_reportback_verb]. You can add photos and update your submission as your impact increases.')),
   ];
 
   $form['goals']['progress_copy']['dosomething_campaign_21_40_progress_copy'] = [
     '#type' => 'textarea',
     '#title' => t('Hot module 21-40% progress copy'),
     '#description' => t('Sets the hot module progress copy between 21 and 40%'),
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_21_40_progress_copy', 'We’re gaining steam! Keep spreading the word to get more friends involved so we can reach our goal of [campaign_goal] [node:field_reportback_noun] [node:field_reportback_verb]!')]),
+    '#default_value' => t(variable_get('dosomething_campaign_21_40_progress_copy', 'We’re gaining steam! Keep spreading the word to get more friends involved so we can reach our goal of [campaign_goal] [node:field_reportback_noun] [node:field_reportback_verb]!')),
   ];
 
   $form['goals']['progress_copy']['dosomething_campaign_41_60_progress_copy'] = [
     '#type' => 'textarea',
     '#title' => t('Hot module 41-60% progress copy'),
     '#description' => t('Sets the hot module progress copy between 41 and 60%'),
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_41_60_progress_copy', 'The more people we get to sign up for [node:title] the sooner we’ll reach our goal of [campaign_goal] [node:field_reportback_noun] [node:field_reportback_verb]! Be a megaphone - get your friends involved by posting on social!')]),
+    '#default_value' => t(variable_get('dosomething_campaign_41_60_progress_copy', 'The more people we get to sign up for [node:title] the sooner we’ll reach our goal of [campaign_goal] [node:field_reportback_noun] [node:field_reportback_verb]! Be a megaphone - get your friends involved by posting on social!')),
   ];
 
   $form['goals']['progress_copy']['dosomething_campaign_61_80_progress_copy'] = [
     '#type' => 'textarea',
     '#title' => t('Hot module 61-80% progress copy'),
     '#description' => t('Sets the hot module progress copy between 61 and 80%'),
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_61_80_progress_copy', 'Keep those campaign updates coming! Don’t wait to the end to submit a photo of you in action! Submit your progress early and often so we can reach our goal of [campaign_goal] [node:field_reportback_noun] [node:field_reportback_verb]. You can update your submission at any time.')]),
+    '#default_value' => t(variable_get('dosomething_campaign_61_80_progress_copy', 'Keep those campaign updates coming! Don’t wait to the end to submit a photo of you in action! Submit your progress early and often so we can reach our goal of [campaign_goal] [node:field_reportback_noun] [node:field_reportback_verb]. You can update your submission at any time.')),
   ];
 
   $form['goals']['progress_copy']['dosomething_campaign_81_99_progress_copy'] = [
     '#type' => 'textarea',
     '#title' => t('Hot module 81-99% progress copy'),
     '#description' => t('Sets the hot module progress copy between 81 and 99%'),
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_81_99_progress_copy', 'We’re almost there! Keep showing off your work. You can add photos and update your submission throughout the campaign.')]),
+    '#default_value' => t(variable_get('dosomething_campaign_81_99_progress_copy', 'We’re almost there! Keep showing off your work. You can add photos and update your submission throughout the campaign.')),
   ];
 
   $form['goals']['progress_copy']['dosomething_campaign_100_progress_copy'] = [
     '#type' => 'textarea',
     '#title' => t('Hot module 100% progress copy'),
     '#description' => t('Sets the hot module progress copy for 100%'),
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_100_progress_copy', 'Woohoo! Congratulations everyone for crushing our goal of [campaign_goal] [node:field_reportback_noun] [node:field_reportback_verb]! Can you help push us even higher!? Keep submitting photos of your work. You can update your submission with new photos/info at any time.')]),
+    '#default_value' => t(variable_get('dosomething_campaign_100_progress_copy', 'Woohoo! Congratulations everyone for crushing our goal of [campaign_goal] [node:field_reportback_noun] [node:field_reportback_verb]! Can you help push us even higher!? Keep submitting photos of your work. You can update your submission with new photos/info at any time.')),
   ];
 
   // Win module
@@ -335,13 +335,13 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Win module share copy'),
     '#description' => t("Sets the win module share copy"),
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_win_share_copy', 'show the world what we did!')]),
+    '#default_value' => t(variable_get('dosomething_campaign_win_share_copy', 'show the world what we did!')),
   ];
   $form['win']['dosomething_campaign_win_copy'] = [
     '#type' => 'textarea',
     '#title' => t('Win module copy'),
     '#description' => t("Sets the win module copy"),
-    '#default_value' => t("@value", ['@value' => variable_get('dosomething_campaign_win_copy', '[campaign_progress] [node:field_reportback_noun] [node:field_reportback_verb]! That’s amazing - thanks to everyone for rocking [node:title]. Let’s keep it up! Add your contribution in the prove it section below.')]),
+    '#default_value' => t(variable_get('dosomething_campaign_win_copy', '[campaign_progress] [node:field_reportback_noun] [node:field_reportback_verb]! That’s amazing - thanks to everyone for rocking [node:title]. Let’s keep it up! Add your contribution in the prove it section below.')),
   ];
 
   return system_settings_form($form);
@@ -386,9 +386,9 @@ function dosomething_campaign_admin_status_page() {
   foreach (dosomething_campaign_admin_status_title_query() as $record) {
     $vars['rows'][] = dosomething_campaign_admin_status_get_row_array($record);
   }
-  $output .= '<h2>Titles over 20 characters</h2>';
+  $output = '<h2>Titles over 20 characters</h2>';
   $output .= theme('table', $vars);
-  // Initalize rows as empty array.
+  // Initialize rows as empty array.
   $vars['rows'] = array();
   // Display campaigns with field_call_to_action values over recommended limit.
   foreach (dosomething_campaign_admin_status_call_to_action_query() as $record) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -228,7 +228,7 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     $label_default = t("Total # of people participated");
     // Check for the num_participants_label variable.
     $var_name = 'dosomething_reportback_num_participants_label';
-    $label = variable_get($var_name, $label_default);
+    $label = t(variable_get($var_name, $label_default));
     $form['reportback_inputs']['num_participants'] = array(
       '#type' => 'textfield',
       '#required' => TRUE,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -461,15 +461,15 @@ function _dosomething_reportback_get_permalink_copy_vars($user) {
     $user->field_first_name[LANGUAGE_NONE][0]['value'] = t('your friend');
   }
   return array(
-    'owners_rb_subtitle' => variable_get('dosomething_campaign_permalink_confirmation_owners_page_subtitle', ''),
-    'owners_rb_scholarship' => variable_get('dosomething_campaign_permalink_confirmation_owners_scholarship', ''),
-    'owners_rb_important' => variable_get('dosomething_campaign_permalink_confirmation_owners_important_to_you', ''),
-    'owners_rb_social_cta' => variable_get('dosomething_campaign_permalink_confirmation_owners_social_cta', ''),
-    'owners_title' => variable_get('dosomething_campaign_permalink_owners_page_title', ''),
-    'owners_subtitle' => variable_get('dosomething_campaign_permalink_owners_page_subtitle', ''),
-    'non_owners_title' => token_replace(variable_get('dosomething_campaign_permalink_nonowners_page_title', ''), array('user' => $user)),
-    'non_owners_closed_button' => variable_get('dosomething_campaign_permalink_nonowners_closed_button_copy', ''),
-    'non_owners_closed_cta' => variable_get('dosomething_campaign_permalink_nonowners_closed_cta', ''),
+    'owners_rb_subtitle' => t(variable_get('dosomething_campaign_permalink_confirmation_owners_page_subtitle', '')),
+    'owners_rb_scholarship' => t(variable_get('dosomething_campaign_permalink_confirmation_owners_scholarship', '')),
+    'owners_rb_important' => t(variable_get('dosomething_campaign_permalink_confirmation_owners_important_to_you', '')),
+    'owners_rb_social_cta' => t(variable_get('dosomething_campaign_permalink_confirmation_owners_social_cta', '')),
+    'owners_title' => t(variable_get('dosomething_campaign_permalink_owners_page_title', '')),
+    'owners_subtitle' => t(variable_get('dosomething_campaign_permalink_owners_page_subtitle', '')),
+    'non_owners_title' => token_replace(t(variable_get('dosomething_campaign_permalink_nonowners_page_title', '')), array('user' => $user)),
+    'non_owners_closed_cta' => t(variable_get('dosomething_campaign_permalink_nonowners_closed_cta', '')),
+    'non_owners_closed_button' => t(variable_get('dosomething_campaign_permalink_nonowners_closed_button_copy', '')),
   );
 }
 
@@ -527,7 +527,7 @@ function dosomething_reportback_view_entity($entity) {
 
     $reportback_url = url(current_path(), array('absolute' => TRUE, 'query' => array('fid' => $fid)));
 
-    $share_text = token_replace(variable_get('dosomething_campaign_permalink_confirmation_owners_social_network_copy'), array('node' => $node));
+    $share_text = token_replace(t(variable_get('dosomething_campaign_permalink_confirmation_owners_social_network_copy')), array('node' => $node));
     $share_text = str_replace('[node:issue]', strtolower($node->issue['name']), $share_text);
 
 


### PR DESCRIPTION
Refs #5147
#### What's this PR do?

This PR updates the configuration variables for the Number of Participants label and the complete Permalink Page section of variables within **DoSomething Config -> DoSomething Campaign**.
#### Where should the reviewer start?

Just confirming that the code looks correct.
#### Any background context you want to provide?

The fields are translated both on the main site page, user-facing output and within the input fields in the CMS. They have all been testing to confirm that if a translation is available, the translation is used.
#### What are the relevant tickets?
#5147

---

@angaither 
