### PR TITLE
Hides language tabs from regional admins

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.install
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.install
@@ -3,3 +3,21 @@
  * @file
  * Installation and updates for dosomething_global.module.
  */
+
+ /**
+  * Update module weight to be greater than entity translation
+  */
+ function dosomething_global_update_7001(&$sandbox) {
+   // Get the weight of the module we want to compare against
+   $weight = db_select('system', 's')
+               ->fields('s', array('weight'))
+               ->condition('name', 'entity_translation', '=')
+               ->execute()
+               ->fetchField();
+
+   // Set our module to a weight 1 heavier, so ours moves lower in execution order
+   db_update('system')
+     ->fields(array('weight' => $weight + 1))
+     ->condition('name', 'dosomething_global', '=')
+     ->execute();
+ }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -64,6 +64,9 @@ function dosomething_global_form_campaign_node_form_alter(&$form, &$form_state, 
       }
     }
     $form['revision_information']['#access'] = FALSE;
+
+    $hide_tabs_style = 'ul.tabs.secondary { display: none }';
+    drupal_add_css($hide_tabs_style, $option['type'] = inline);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -64,9 +64,6 @@ function dosomething_global_form_campaign_node_form_alter(&$form, &$form_state, 
       }
     }
     $form['revision_information']['#access'] = FALSE;
-
-    $hide_tabs_style = 'ul.tabs.secondary { display: none }';
-    drupal_add_css($hide_tabs_style, $option['type'] = inline);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -68,10 +68,13 @@ function dosomething_global_form_campaign_node_form_alter(&$form, &$form_state, 
 }
 
 function dosomething_global_menu_local_tasks_alter(&$data, $route_name) {
+  // Verify we're operating on a node edit page
   if ($route_name['path'] != 'node/%/edit') {
       return;
   }
+  // Only perform this for regional admins
   if (dosomething_global_is_regional_admin()) {
+    // Remove tabs from the edit page
     unset($data['tabs'][1]['output']);
   }
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -67,6 +67,9 @@ function dosomething_global_form_campaign_node_form_alter(&$form, &$form_state, 
   }
 }
 
+/**
+ * Implements hook_meny_local_tasks_alter
+ */
 function dosomething_global_menu_local_tasks_alter(&$data, $route_name) {
   // Verify we're operating on a node edit page
   if ($route_name['path'] != 'node/%/edit') {

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -67,6 +67,15 @@ function dosomething_global_form_campaign_node_form_alter(&$form, &$form_state, 
   }
 }
 
+function dosomething_global_menu_local_tasks_alter(&$data, $route_name) {
+  if ($route_name['path'] != 'node/%/edit') {
+      return;
+  }
+  if (dosomething_global_is_regional_admin()) {
+    unset($data['tabs'][1]['output']);
+  }
+}
+
 /**
  * Returns if the user is a regional admin
  *


### PR DESCRIPTION
#### What's this PR do?

Hides the language tabs at the top of /node/edit/ from regional admins
#### How should this be manually tested?

Edit a node as a regional admin and verify the tabs aren't there.
#### Any background context you want to provide?

Looked in both menu_alter $items and the node_form alter $form and couldnt find them set in either. Figured this was an easier solution.
#### What are the relevant tickets?

Fixes #5113 
