### PR TITLE
Updating translateable config settings for Standard Campaigns and SMS Games.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
@@ -34,16 +34,16 @@ function dosomething_campaign_reportback_confirmation_page($node) {
 
   // Set variables for anonymous user:
   if (!user_is_logged_in()) {
-    $button_text = variable_get('dosomething_campaign_confirmation_page_anon_button_text');
-    $vars['call_to_action'] = variable_get('dosomething_campaign_confirmation_page_anon_cta_text');
+    $button_text = t(variable_get('dosomething_campaign_confirmation_page_anon_button_text'));
+    $vars['call_to_action'] = t(variable_get('dosomething_campaign_confirmation_page_anon_cta_text'));
     // The button should open the login/register form.
     $vars['more_campaigns_link'] = dosomething_user_get_login_modal_link_markup($button_text, 'large');
   }
   // Else set variables for authenticated user:
   else {
-    $button_text = variable_get('dosomething_campaign_confirmation_page_button_text');
+    $button_text = t(variable_get('dosomething_campaign_confirmation_page_button_text'));
     // Set button to link to /campaigns.
-    $vars['more_campaigns_link'] = l(t($button_text), 'campaigns', array(
+    $vars['more_campaigns_link'] = l($button_text, 'campaigns', array(
       'attributes' => array('class' =>
         array('button')
       ))

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -116,7 +116,7 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
   $campaign = $vars['campaign'];
 
   if ($vars['show_problem_shares']) {
-    $problem_share_prompt = variable_get('dosomething_campaign_problem_share_prompt');
+    $problem_share_prompt = t(variable_get('dosomething_campaign_problem_share_prompt'));
     if ($problem_share_prompt) {
       $vars['problem_share_prompt'] = $problem_share_prompt;
     }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -153,7 +153,7 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
     $form['#attributes']['class'][] = 'sms-campaign-form--multiplayer';
   }
   // Load "all participants" copy.
-  $all_participants_copy = variable_get('dosomething_campaign_sms_game_all_participants_copy');
+  $all_participants_copy = t(variable_get('dosomething_campaign_sms_game_all_participants_copy'));
   $form['all_participants_copy'] = array(
     '#prefix' => '<div class="message-callout -above"><div class="message-callout__copy"><p>',
     '#markup' => $all_participants_copy,
@@ -210,8 +210,8 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
       ),
     );
   }
-  // Check if varaible is set for the Friends Form submit button label.
-  $label = variable_get('dosomething_campaign_sms_game_signup_friends_form_button_copy', t('Share'));
+  // Check if variable is set for the Friends Form submit button label.
+  $label = t(variable_get('dosomething_campaign_sms_game_signup_friends_form_button_copy', 'Share'));
 
   // Get scholarship amount.
   $amount = dosomething_campaign_get_scholarship($node->nid);


### PR DESCRIPTION
Refs #5147
#### What's this PR do?

This PR updates the configuration variables for Standard Campaigns and SMS Games section of variables within **DoSomething Config -> DoSomething Campaign**.
#### Where should the reviewer start?

Just confirming that the code looks correct.
#### Any background context you want to provide?

The fields are translated both on the main site page, user-facing output and within the input fields in the CMS. They have all been testing to confirm that if a translation is available, the translation is used.
#### What are the relevant tickets?
#5147

---

@angaither 
