### PR TITLE
Sets the user language based on fastly header when registering

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -155,6 +155,7 @@ function dosomething_global_get_user_language($user = NULL) {
    array_push($countries, "global");
    return $countries;
  }
+
 /**
  * Gets the country from a given language.
  *
@@ -165,6 +166,25 @@ function dosomething_global_get_user_language($user = NULL) {
  *  The country that maps to the language passed in.
  */
 function dosomething_global_convert_language_to_country($language) {
-    $lang_map = variable_get('dosomething_global_language_map', '');
-    return $lang_map[$language]['country'];
+  $lang_map = variable_get('dosomething_global_language_map', '');
+  return $lang_map[$language]['country'];
+}
+
+/**
+ * Converts the given country into its assigned language
+ *
+ * @param string country
+ *  The country Code
+ *
+ * @return
+ *  The language mapped to this country
+ */
+function dosomething_global_convert_country_to_language($country) {
+  $lang_map = variable_get('dosomething_global_language_map', '');
+  foreach ($lang_map as $lang_key => $lang) {
+    if ($lang['country'] == $country) {
+      return $lang_key;
+    }
+  }
+  return 'en';
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -457,11 +457,6 @@ function dosomething_user_new_user($form, &$form_state) {
     return;
   }
 
-  // Should we sign this kid up for messages?
-  if (dosomething_user_is_under_thirteen()) {
-    return;
-  }
-
   global $user;
   $account = $user;
 
@@ -470,6 +465,11 @@ function dosomething_user_new_user($form, &$form_state) {
     $user_country_code = dosomething_settings_get_geo_country_code();
     $language = dosomething_global_convert_country_to_language($user_country_code);
     user_save($account, ['language' => $language]);
+  }
+
+  // Should we sign this kid up for messages?
+  if (dosomething_user_is_under_thirteen()) {
+    return;
   }
 
   // Send external message request.

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -465,6 +465,11 @@ function dosomething_user_new_user($form, &$form_state) {
   global $user;
   $account = $user;
 
+  // Adjust language based on location
+  $user_country_code = dosomething_settings_get_geo_country_code();
+  $language = dosomething_global_convert_country_to_language($user_country_code);
+  user_save($account, array('language' => $language));
+
   // Send external message request.
   $params = array(
     'mailchimp_list_id' => dosomething_signup_get_mailchimp_list_id(),

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -465,10 +465,12 @@ function dosomething_user_new_user($form, &$form_state) {
   global $user;
   $account = $user;
 
-  // Adjust language based on location
-  $user_country_code = dosomething_settings_get_geo_country_code();
-  $language = dosomething_global_convert_country_to_language($user_country_code);
-  user_save($account, array('language' => $language));
+  if (module_exists('dosomething_global') {
+    // Adjust language based on location
+    $user_country_code = dosomething_settings_get_geo_country_code();
+    $language = dosomething_global_convert_country_to_language($user_country_code);
+    user_save($account, ['language' => $language]);
+  }
 
   // Send external message request.
   $params = array(


### PR DESCRIPTION
#### What's this PR do?

When a user registers on the site this pulls in there country code supplied by Fastly and converts it into the matching language. 
#### Where should the reviewer start?

dosomething_user_module changes
#### How should this be manually tested?

Create a new account (use [this](https://github.com/DoSomething/phoenix/wiki/Testing-global-functionality-on-your-local-environment) to make sure you can fake being in another country), then in an administrator account verify that the account has the correct lang set. 
#### Any background context you want to provide?

Default lang is 'en' per @mikefantini 's message in #global https://dosomething.slack.com/archives/global/p1442858847000084
#### What are the relevant tickets?

Fixes #5168 

@angaither 
