### PR TITLE
Update to include unpublished mobile app campaigns in index collection.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -429,7 +429,10 @@ function dosomething_campaign_build_campaigns_query($params = array()) {
   $query = db_select('node', 'n');
   $query->join('field_data_field_campaign_type', 't', 't.entity_id = n.nid');
 
-  $query->condition('n.status', 1);
+  // @TODO: this is a temporary fix to address the need to allow unpublished mobile_app campaigns to be retrieved, only for the mobile app.
+  if (!$params['mobile_app']) {
+    $query->condition('n.status', 1);
+  }
 
   $query->condition('t.field_campaign_type_value', $params['type']);
   $query->condition('n.type', $params['type']);


### PR DESCRIPTION
Refs #5174 
#### What's this PR do?

This PR updates the query used to collect an index listing of campaigns for the `/campaigns` endpoint to temporarily allow the retrieval of unpublished campaigns that are also marked as being on the `mobile_app`.
#### Where should the reviewer start?

Just confirming that the code looks correct and consider if there's any potential conflicts.
#### Any background context you want to provide?

Prior PR #4986 only allowed retrieval of unpublished single campaigns, however the mobile team also needs to be able to access unpublished collections of campaigns.
#### What are the relevant tickets?
#5174

---

@angaither @jonuy @chloealee 
