### PR TITLE
Issue4955 user registration emails

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -100,6 +100,7 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
     'activity' => $origin,
     'email' => $params['email'],
     'uid' => $params['uid'],
+    'user_language' =>  $params['user_language'],
     'merge_vars' => array(
       'MEMBER_COUNT' => dosomething_user_get_member_count(TRUE),
     ),
@@ -109,7 +110,7 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
   if (!empty($params['email_template'])) {
     $payload['email_template'] = $params['email_template'];
   } else {
-    $payload['email_template'] = dosomething_mbp_get_template_name($origin);
+    $payload['email_template'] = dosomething_mbp_get_template_name($origin, $params['user_language']);
   }
 
   // Payload specific to each transaction type.
@@ -221,12 +222,22 @@ function dosomething_mbp_get_common_campaign_payload(&$payload, $params) {
  *
  * @param string $event_name
  *   Example: "campaign_signup", "password_reset", etc
+ * @param string $user_language
+ *   The user language setting as defined by dosomething_settings_get_geo_country_code() and
+ *   dosomething_global_convert_country_to_language().
  *
  * @return string
  *   Name of Mandrill template to use for transactional message.
  */
-function dosomething_mbp_get_template_name($event_name) {
-  $country_code = dosomething_settings_get_affiliate_country_code();
+function dosomething_mbp_get_template_name($event_name, $user_language = NULL) {
+
+  if (isset($user_langauge)) {
+    $country_code = dosomething_global_convert_language_to_country($user_language);
+  }
+  else {
+    $country_code = dosomething_settings_get_affiliate_country_code();
+  }
+
   // Convert from $origin use of "_" to "-" for template name
   $event_name = str_replace('_', '-', $event_name);
   return 'mb-' . $event_name . '-' . $country_code;

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -479,6 +479,7 @@ function dosomething_user_new_user($form, &$form_state) {
     'uid'               => $account->uid,
     'first_name'        => dosomething_user_get_field('field_first_name', $account),
     'birthdate'         => dosomething_user_get_field('field_birthdate', $account),
+    'user_language'     => $account->language,
   );
 
   // 26+ Club: Override Mobile Commons.
@@ -948,7 +949,7 @@ function dosomething_user_get_field_first_name($field_value, $format = 'ucwords'
 }
 
 /**
- * Returns a user's first name.
+ * Returns a user's last name.
  *
  * @param object $account
  *   The account to return value for.

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -480,6 +480,7 @@ function dosomething_user_new_user($form, &$form_state) {
     'first_name'        => dosomething_user_get_field('field_first_name', $account),
     'birthdate'         => dosomething_user_get_field('field_birthdate', $account),
     'user_language'     => $account->language,
+    'user_country'      => isset($user_country_code) ? $user_country_code : 'US'
   );
 
   // 26+ Club: Override Mobile Commons.


### PR DESCRIPTION
#### What's this PR do?
- Adds `user_language` to transactional message request payload for `user_password`.
- Adds `user_country` to transactional message request payload for `user_password`.
#### Where should the reviewer start?
- Request a new password via the user reset form: `/user/password`. 
#### How should this be manually tested?
- Review the message contents ($payload) being generated by `dosomething_mbp_request()` that results in a request to `message_broker_producer_request($production, $payload)`. It should resemble:

```
a:10: {
s:8:"activity";s:13:"user_password";
s:5:"email";s:26:"dlee+vag01@dosomething.org";
s:3:"uid";s:7:"1705348";
s:13:"user_language";s:9:"en-global";
s:12:"user_country";s:2:"US";
s:10:"merge_vars";a:3:{
  s:12:"MEMBER_COUNT";s:11:"3.5 million";
  s:5:"FNAME";s:8:"Test Dee";
  s:10:"RESET_LINK";s:105:"http://dev.dosomething.org:8888/user/reset/
1705348/1443027553/qvucS0vJX0h8T_DQCGLYjNB5q14vEPN7NVHjAAJZfsA";
}
s:14:"email_template";s:19:"mb-user-password-US";
s:10:"email_tags";
  a:1:{
    i:0;s:20:"drupal_user_password";
  }
s:18:"activity_timestamp";i:1443027553;
s:14:"application_id";s:2:"US";
}
```
#### Any background context you want to provide?
- The template name is used to determine the transactional message contents being sent to the user. The country code at the end of the template name allows sending different templates that are specific to the user's origin of registration in a language that's the same as their registration process. Sample template name:

```
    ['email_template']n => "mb-user-password-US"
```

Other supported country codes include:
- BR (Brazil) : Portuguese
- MX (Mexico) Spanish
#### What are the relevant tickets?

Fixes #4955  
