### PR TITLE
Translate home page content

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_base.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_base.inc
@@ -33,6 +33,7 @@ function dosomething_campaign_group_field_default_field_bases() {
     'locked' => 0,
     'module' => 'entityreference',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'handler' => 'base',
       'handler_settings' => array(
         'behaviors' => array(
@@ -74,6 +75,7 @@ function dosomething_campaign_group_field_default_field_bases() {
         1 => '',
       ),
       'allowed_values_function' => '',
+      'entity_translation_sync' => FALSE,
     ),
     'translatable' => 0,
     'type' => 'list_boolean',
@@ -102,6 +104,7 @@ function dosomething_campaign_group_field_default_field_bases() {
     'locked' => 0,
     'module' => 'entityreference',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'handler' => 'base',
       'handler_settings' => array(
         'behaviors' => array(
@@ -119,7 +122,7 @@ function dosomething_campaign_group_field_default_field_bases() {
       ),
       'target_type' => 'node',
     ),
-    'translatable' => 0,
+    'translatable' => 1,
     'type' => 'entityreference',
   );
 
@@ -144,6 +147,7 @@ function dosomething_campaign_group_field_default_field_bases() {
         1 => 'display',
       ),
       'allowed_values_function' => '',
+      'entity_translation_sync' => FALSE,
     ),
     'translatable' => 0,
     'type' => 'list_boolean',
@@ -171,7 +175,9 @@ function dosomething_campaign_group_field_default_field_bases() {
     ),
     'locked' => 0,
     'module' => 'text',
-    'settings' => array(),
+    'settings' => array(
+      'entity_translation_sync' => FALSE,
+    ),
     'translatable' => 0,
     'type' => 'text_long',
   );
@@ -199,6 +205,7 @@ function dosomething_campaign_group_field_default_field_bases() {
     'locked' => 0,
     'module' => 'text',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'max_length' => 255,
     ),
     'translatable' => 0,
@@ -227,7 +234,9 @@ function dosomething_campaign_group_field_default_field_bases() {
     ),
     'locked' => 0,
     'module' => 'text',
-    'settings' => array(),
+    'settings' => array(
+      'entity_translation_sync' => FALSE,
+    ),
     'translatable' => 0,
     'type' => 'text_long',
   );
@@ -255,6 +264,7 @@ function dosomething_campaign_group_field_default_field_bases() {
     'locked' => 0,
     'module' => 'text',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'max_length' => 255,
     ),
     'translatable' => 0,
@@ -284,6 +294,7 @@ function dosomething_campaign_group_field_default_field_bases() {
     'locked' => 0,
     'module' => 'text',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'max_length' => 255,
     ),
     'translatable' => 0,
@@ -312,7 +323,9 @@ function dosomething_campaign_group_field_default_field_bases() {
     ),
     'locked' => 0,
     'module' => 'text',
-    'settings' => array(),
+    'settings' => array(
+      'entity_translation_sync' => FALSE,
+    ),
     'translatable' => 0,
     'type' => 'text_long',
   );

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.field_instance.inc
@@ -43,6 +43,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Action Type',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -86,6 +87,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Active Hours',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -130,6 +132,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Additional Text Copy',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 1,
       'user_register_form' => FALSE,
     ),
@@ -180,6 +183,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Additional Text Image',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -228,6 +232,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Additional Text Header',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -278,6 +283,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Automatic Parent Signup',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -324,6 +330,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Call to Action',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -378,6 +385,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Campaigns',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -426,6 +434,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Cause',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -473,6 +482,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Show End Date',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -522,6 +532,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Display Signup Form?',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -579,6 +590,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'FAQ',
     'required' => FALSE,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -626,6 +638,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Gallery',
     'required' => FALSE,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -677,6 +690,7 @@ function dosomething_campaign_group_field_default_field_instances() {
       'default_value2' => 'same',
       'default_value_code' => '',
       'default_value_code2' => '',
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -731,6 +745,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Cover Image',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -779,6 +794,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Intro',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 1,
       'user_register_form' => FALSE,
     ),
@@ -829,6 +845,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Intro Image',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -877,6 +894,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Intro Title',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -935,6 +953,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Sponsors and Partners',
     'required' => FALSE,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -978,6 +997,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Post Signup Copy',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 1,
       'user_register_form' => FALSE,
     ),
@@ -1024,6 +1044,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Post Signup Title',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -1071,6 +1092,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Pre Launch Copy',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 1,
       'user_register_form' => FALSE,
     ),
@@ -1118,6 +1140,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Pre Launch Title',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -1175,6 +1198,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Scholarship Amount',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'max' => '',
       'min' => '',
       'prefix' => '$',
@@ -1222,6 +1246,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Signup Confirmation Message',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -1273,6 +1298,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Is Staff Pick',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -1319,6 +1345,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Tags',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -1365,6 +1392,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Transactional Email Copy',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 1,
       'user_register_form' => FALSE,
     ),
@@ -1416,6 +1444,7 @@ function dosomething_campaign_group_field_default_field_instances() {
     'label' => 'Video',
     'required' => FALSE,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.info
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.info
@@ -83,4 +83,4 @@ features[variable][] = node_options_campaign_group
 features[variable][] = node_preview_campaign_group
 features[variable][] = node_submitted_campaign_group
 features[variable][] = pathauto_node_campaign_group_pattern
-mtime = 1428597800
+mtime = 1442330910

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -5,6 +5,7 @@
  */
 
 include_once 'dosomething_global.features.inc';
+define("TRANSLATABLE_TYPES", 'static_content,campaign,home');
 
 /**
  * Implements hook_init().
@@ -51,7 +52,12 @@ function dosomething_global_node_insert($node) {
 /**
  * Implements hook_form_alter().
  */
-function dosomething_global_form_campaign_node_form_alter(&$form, &$form_state, $form_id) {
+function dosomething_global_form_node_form_alter(&$form, &$form_state, $form_id) {
+  // Only run this form alter on translatable types.
+  $translatable_types = explode(',', TRANSLATABLE_TYPES);
+  if (!(in_array($form['type']['#value'], $translatable_types))) {
+    return;
+  }.
   // Don't autopublish tranlsations.
   $form['translation']['status']['#default_value'] = FALSE;
   // Check if the user is a mexico or brazil admin

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -57,7 +57,7 @@ function dosomething_global_form_node_form_alter(&$form, &$form_state, $form_id)
   $translatable_types = explode(',', TRANSLATABLE_TYPES);
   if (!(in_array($form['type']['#value'], $translatable_types))) {
     return;
-  }.
+  }
   // Don't autopublish tranlsations.
   $form['translation']['status']['#default_value'] = FALSE;
   // Check if the user is a mexico or brazil admin

--- a/lib/modules/dosomething/dosomething_home/dosomething_home.features.field_base.inc
+++ b/lib/modules/dosomething/dosomething_home/dosomething_home.features.field_base.inc
@@ -33,6 +33,7 @@ function dosomething_home_field_default_field_bases() {
     'locked' => 0,
     'module' => 'entityreference',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'handler' => 'base',
       'handler_settings' => array(
         'behaviors' => array(

--- a/lib/modules/dosomething/dosomething_home/dosomething_home.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_home/dosomething_home.features.field_instance.inc
@@ -40,6 +40,7 @@ function dosomething_home_field_default_field_instances() {
     'label' => 'Campaigns',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -90,6 +91,7 @@ function dosomething_home_field_default_field_instances() {
           'status' => TRUE,
         ),
       ),
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -131,6 +133,7 @@ function dosomething_home_field_default_field_instances() {
     'label' => 'Subtitle',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),

--- a/lib/modules/dosomething/dosomething_home/dosomething_home.features.user_permission.inc
+++ b/lib/modules/dosomething/dosomething_home/dosomething_home.features.user_permission.inc
@@ -35,6 +35,8 @@ function dosomething_home_user_default_permissions() {
   $permissions['edit any home content'] = array(
     'name' => 'edit any home content',
     'roles' => array(
+      'brazil admin' => 'brazil admin',
+      'mexico admin' => 'mexico admin',
       'site admin' => 'site admin',
     ),
     'module' => 'node',

--- a/lib/modules/dosomething/dosomething_home/dosomething_home.info
+++ b/lib/modules/dosomething/dosomething_home/dosomething_home.info
@@ -31,4 +31,4 @@ features[variable][] = menu_parent_home
 features[variable][] = node_options_home
 features[variable][] = node_preview_home
 features[variable][] = node_submitted_home
-mtime = 1416603772
+mtime = 1442330910

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.features.field_base.inc
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.features.field_base.inc
@@ -564,7 +564,7 @@ function dosomething_static_content_field_default_field_bases() {
       'entity_translation_sync' => FALSE,
       'max_length' => 255,
     ),
-    'translatable' => 0,
+    'translatable' => 1,
     'type' => 'text',
   );
 

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.info
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.info
@@ -79,4 +79,4 @@ features[variable][] = node_options_static_content
 features[variable][] = node_preview_static_content
 features[variable][] = node_submitted_static_content
 features[variable][] = pathauto_node_static_content_pattern
-mtime = 1441917845
+mtime = 1442347003

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.strongarm.inc
@@ -68,7 +68,7 @@ function dosomething_static_content_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'language_content_type_static_content';
-  $strongarm->value = '0';
+  $strongarm->value = '4';
   $export['language_content_type_static_content'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
#### what does this pr do?
- adds permission for regional admins to edit home page nodes
- allows `campaigns` field reference field to be translated
- allows `subtitle` field to be translated
- run node_alter hook to hide non-translatable fields only on translatable content types
#### background context

I am not granting regional admins the ability to create new home page nodes, only translate the current one. 
#### relevant tickets

fixes #4968
