### PR TITLE
Global Date Validation

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -19,11 +19,14 @@ function dosomething_user_preprocess_page(&$vars) {
     dosomething_helpers_add_analytics_event("login", $_SESSION['dosomething_user_log_login']);
     unset($_SESSION['dosomething_user_log_login']);
   }
+
+  $date_format = (dosomething_settings_get_geo_country_code() === 'US') ? 'MM/DD/YYYY' : 'DD/MM/YYYY';
   drupal_add_js(
     array('dosomethingUser' =>
       array(
         'schoolFinderAPIEndpoint' => $school_api_endpoint,
-      )
+      ),
+      'dsValidation' => array('dateFormat' => $date_format)
     ),
     'setting'
   );

--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -276,7 +276,8 @@ function paraneue_dosomething_form_user_profile_form_alter(&$form, &$form_state,
 function paraneue_dosomething_form_user_profile_after_build($form, &$form_state) {
   $form['#weight'] = '-18';
   $form['#attributes']['class'] = array('auth-twocol');
-  $form['value']['date']['#attributes']['placeholder'] = t('MM/DD/YYYY');
+  $date_format = (dosomething_settings_get_geo_country_code() === 'US') ? 'MM/DD/YYYY' : 'DD/MM/YYYY';
+  $form['value']['date']['#attributes']['placeholder'] = t($date_format);
   $form['value']['date']['#attributes']['class'] = array('js-validate');
   $form['value']['date']['#attributes']['data-validate'] = 'birthday';
   $form['value']['date']['#attributes']['data-validate-required'] = '';

--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -277,7 +277,7 @@ function paraneue_dosomething_form_user_profile_after_build($form, &$form_state)
   $form['#weight'] = '-18';
   $form['#attributes']['class'] = array('auth-twocol');
   $date_format = (dosomething_settings_get_geo_country_code() === 'US') ? 'MM/DD/YYYY' : 'DD/MM/YYYY';
-  $form['value']['date']['#attributes']['placeholder'] = t($date_format);
+  $form['value']['date']['#attributes']['placeholder'] = $date_format;
   $form['value']['date']['#attributes']['class'] = array('js-validate');
   $form['value']['date']['#attributes']['data-validate'] = 'birthday';
   $form['value']['date']['#attributes']['data-validate-required'] = '';


### PR DESCRIPTION
#### What's this PR do?

Updates the birthday field in the registration modal to ask for and validate against the appropriate date format based on the users country code. BR, MX, and Global users should get `DD/MM/YYYY`. US users should get `MM/DD/YYYY` 
#### Where should the reviewer start?

`dosomething_user.module` passes the the date format we want to use for validation to the JS.
`form.inc` just updates the placeholder text appropriately. 
#### How should this be manually tested?

Vist the site using different country code headers to verify you are being asked for your birthday in the correct format. 

Also, try bad dates (bad month, years in the future, etc) and make sure the field is being validated correctly. 
#### Any background context you want to provide?

Similar functionality to how we do this in the `dosomething_uk` module. 
#### What are the relevant tickets?

Fixes #5084 
