### PR TITLE
Hide the translate tab for people who don't have access to translate …

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -72,7 +72,16 @@ function dosomething_global_form_campaign_node_form_alter(&$form, &$form_state, 
 }
 
 /**
- * Implements hook_meny_local_tasks_alter
+ * Implements hook_menu_alter().
+ */
+function dosomething_global_menu_alter(&$items) {
+  // Hide the translate tab for people not on staff.
+  $items['node/%node/translate']['access callback'] = 'user_access';
+  $items['node/%node/translate']['access arguments'] = array('translate any entity');
+}
+
+/**
+ * Implements hook_meny_local_tasks_alter().
  */
 function dosomething_global_menu_local_tasks_alter(&$data, $route_name) {
   // Verify we're operating on a node edit page


### PR DESCRIPTION
…any entity.

Only staff members with the role [editor, admin, creative team, global admin] will have access to the translate tab

Fixes #5191
