### PR TITLE
Hide/Show cell phone field based on country code

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
@@ -82,7 +82,8 @@ function paraneue_dosomething_form_alter_register(&$form, &$form_state, $form_id
 
     if (!in_array(dosomething_settings_get_geo_country_code(), dosomething_global_get_countries())) {
       $form['field_mobile']['#access'] = FALSE;
-    } else {
+    }
+    else {
       $form['account']['field_mobile'] = $form['field_mobile'];
       $form['account']['field_mobile']['#weight'] = 20;
       $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#title'] = t('Cell Number') . ' <span class="field-label-optional">' . t("(optional)") . '</span>';

--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
@@ -79,14 +79,20 @@ function paraneue_dosomething_form_alter_register(&$form, &$form_state, $form_id
     $form['account']['mail']['#attributes']['data-validate-required'] = '';
     unset($form['account']['mail']['#description']);
 
-    $form['account']['field_mobile'] = $form['field_mobile'];
-    $form['field_mobile']['#access'] = FALSE;
+    $country_codes = array('BR', 'CA', 'GB', 'MX', 'US');
+    if (!in_array(dosomething_settings_get_geo_country_code(), $country_codes)) {
+      $form['field_mobile']['#access'] = FALSE;
+    } else {
+      $form['account']['field_mobile'] = $form['field_mobile'];
+      $form['field_mobile']['#access'] = FALSE;
 
-    $form['account']['field_mobile']['#weight'] = 20;
-    $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#title'] = t('Cell Number') . ' <span class="field-label-optional">' . t("(optional)") . '</span>';
-    $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#attributes']['placeholder'] = t('(555) 555-5555');
-    $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#attributes']['class'] = array('js-validate');
-    $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#attributes']['data-validate'] = 'phone';
+      $form['account']['field_mobile']['#weight'] = 20;
+      $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#title'] = t('Cell Number') . ' <span class="field-label-optional">' . t("(optional)") . '</span>';
+      $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#attributes']['placeholder'] = t('(555) 555-5555');
+      $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#attributes']['class'] = array('js-validate');
+      $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#attributes']['data-validate'] = 'phone';
+
+    }
 
     $form['account']['pass']['#weight'] = 30;
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
@@ -84,8 +84,6 @@ function paraneue_dosomething_form_alter_register(&$form, &$form_state, $form_id
       $form['field_mobile']['#access'] = FALSE;
     } else {
       $form['account']['field_mobile'] = $form['field_mobile'];
-      $form['field_mobile']['#access'] = FALSE;
-
       $form['account']['field_mobile']['#weight'] = 20;
       $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#title'] = t('Cell Number') . ' <span class="field-label-optional">' . t("(optional)") . '</span>';
       $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#attributes']['placeholder'] = t('(555) 555-5555');

--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
@@ -79,8 +79,8 @@ function paraneue_dosomething_form_alter_register(&$form, &$form_state, $form_id
     $form['account']['mail']['#attributes']['data-validate-required'] = '';
     unset($form['account']['mail']['#description']);
 
-    $country_codes = array('BR', 'CA', 'GB', 'MX', 'US');
-    if (!in_array(dosomething_settings_get_geo_country_code(), $country_codes)) {
+
+    if (!in_array(dosomething_settings_get_geo_country_code(), dosomething_global_get_countries())) {
       $form['field_mobile']['#access'] = FALSE;
     } else {
       $form['account']['field_mobile'] = $form['field_mobile'];

--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
@@ -80,18 +80,17 @@ function paraneue_dosomething_form_alter_register(&$form, &$form_state, $form_id
     unset($form['account']['mail']['#description']);
 
 
-    if (!in_array(dosomething_settings_get_geo_country_code(), dosomething_global_get_countries())) {
-      $form['field_mobile']['#access'] = FALSE;
-    }
-    else {
+
+    if (in_array(dosomething_settings_get_geo_country_code(), dosomething_global_get_countries())) {
       $form['account']['field_mobile'] = $form['field_mobile'];
       $form['account']['field_mobile']['#weight'] = 20;
       $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#title'] = t('Cell Number') . ' <span class="field-label-optional">' . t("(optional)") . '</span>';
       $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#attributes']['placeholder'] = t('(555) 555-5555');
       $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#attributes']['class'] = array('js-validate');
       $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#attributes']['data-validate'] = 'phone';
-
     }
+
+    $form['field_mobile']['#access'] = FALSE;
 
     $form['account']['pass']['#weight'] = 30;
 


### PR DESCRIPTION
#### What's this PR do?

This PR hides the cell phone field if the users country code is not in our country language map, otherwise for US, MX, BR, CA and UK we show and collect that info.
#### Where should the reviewer start?

The magic happens in `register.inc`
#### How should this be manually tested?

Change your country code or use VPN to pretend you are in another country and when you try to create an account you should only see the cell phone field if you are in US, MA, BR, CA, or UK. 
#### Any background context you want to provide?

One thing, I sorta lied. Right now, CA and UK are not in our language map so the cell phone field will be hidden for those counties. However, #5205 will add those countries to keep me honest. 
#### What are the relevant tickets?

Fixes #5085 
