### PR TITLE
Adding cleaned up dosomething_helpers module POT file.

### DIFF
--- a/pots/dosomething_helpers.pot
+++ b/pots/dosomething_helpers.pot
@@ -1,0 +1,59 @@
+# $Id$
+#
+# LANGUAGE translation of Drupal (general)
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+# Generated from files:
+#  modal-links.tpl.php: n/a
+#  dosomething_helpers.theme.inc: n/a
+#  dosomething_helpers.variable.inc: n/a
+#  dosomething_helpers.module: n/a
+#  dosomething_helpers.info: n/a
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2015-09-23 20:57+0000\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: modal-links.tpl.php:3;22
+msgid "FAQs"
+msgstr ""
+
+#: modal-links.tpl.php:7
+msgid "Learn more about @issue"
+msgstr ""
+
+#: modal-links.tpl.php:14
+msgid "Why we &lt;3 @partner"
+msgstr ""
+
+#: modal-links.tpl.php:31;60;81
+msgid "Back to main page"
+msgstr ""
+
+#: modal-links.tpl.php:39
+msgid "Facts"
+msgstr ""
+
+#: modal-links.tpl.php:50
+msgid "Sources"
+msgstr ""
+
+#: modal-links.tpl.php:69
+msgid "We &lt;3 @partner"
+msgstr ""
+
+#: dosomething_helpers.theme.inc:139;145
+msgid "and"
+msgstr ""
+
+#: dosomething_helpers.module:54
+msgid "Thank you for sharing"
+msgstr ""


### PR DESCRIPTION
Fixes #5215
#### What's this PR do?

This PR adds the extracted POT file for the dosomething_helpers module that has been edited to only add strings immediately needed for translation.
#### Where should the reviewer start?

Just review the strings to make sure all seems well.
#### Any background context you want to provide?

Strings relating to the CMS admin interface have been pulled out for the time being since we do not require them to be translated.
#### What are the relevant tickets?
#5147
#5144
#5215

---

@angaither 
