### PR TITLE
Yahoo prototype

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
@@ -57,12 +57,22 @@
   <?php endif; ?>
 
   <?php if (isset($call_to_action)): ?>
-    <div class="cta">
+    <div class="cta show-at-medium">
       <div class="wrapper">
         <h2 class="cta__message"><?php print $call_to_action; ?></h2>
         <?php print $cta_link; ?>
       </div>
     </div>
+
+    <?php // Yahoo prototype ?>
+    <?php if ($nid == 176): ?>
+      <div class="cta show-only-small">
+        <div class="wrapper">
+          <h2 class="cta__message">Want to learn more about volcanoes?</h2>
+          <a href="https://search.yahoo.com/search;_ylt=A0LEV1PdFwNW2ukAuyel87UF;_ylc=X1MDOTU4MTA0NjkEX3IDMgRmcgMEZ3ByaWQDMHVnUmhsV0lSMi5WWFZ1NWhWQVE2QQRuX3JzbHQDMARuX3N1Z2cDOQRvcmlnaW4Dc2VhcmNoLnlhaG9vLmNvbQRwb3MDMARwcXN0cgMEcHFzdHJsAwRxc3RybAM3BHF1ZXJ5A3ZvbGNhbm8EdF9zdG1wAzE0NDMwNDMyOTg-?p=volcano&fr=sfp&fr2=sb-top-search&iscqry=" class="button">Find out</a>
+        </div>
+      </div>
+    <?php endif; ?>
   <?php endif; ?>
 
   <section class="container">
@@ -93,12 +103,22 @@
   </section>
 
   <?php if (isset($call_to_action)): ?>
-    <div class="cta">
+    <div class="cta show-at-medium">
       <div class="wrapper">
         <h2 class="cta__message"><?php print $call_to_action; ?></h2>
         <?php print $cta_link; ?>
       </div>
     </div>
+
+    <?php // Yahoo prototype ?>
+    <?php if ($nid == 176): ?>
+      <div class="cta show-only-small">
+        <div class="wrapper">
+          <h2 class="cta__message">Want to learn more about volcanoes?</h2>
+          <a href="https://search.yahoo.com/search;_ylt=A0LEV1PdFwNW2ukAuyel87UF;_ylc=X1MDOTU4MTA0NjkEX3IDMgRmcgMEZ3ByaWQDMHVnUmhsV0lSMi5WWFZ1NWhWQVE2QQRuX3JzbHQDMARuX3N1Z2cDOQRvcmlnaW4Dc2VhcmNoLnlhaG9vLmNvbQRwb3MDMARwcXN0cgMEcHFzdHJsAwRxc3RybAM3BHF1ZXJ5A3ZvbGNhbm8EdF9zdG1wAzE0NDMwNDMyOTg-?p=volcano&fr=sfp&fr2=sb-top-search&iscqry=" class="button">Find out</a>
+        </div>
+      </div>
+    <?php endif; ?>
   <?php endif; ?>
 
   <?php if ($info_bar): ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
@@ -13,7 +13,7 @@
  * - $cta_link: Call To Action link of fact page (string).
  */
 ?>
-
+<?php $yahoo_prototype = ($nid == 176 && theme_get_setting('show_yahoo_prototype')) ? TRUE : FALSE; ?>
 <article id="node-<?php print $node->nid; ?>" class="<?php print $classes; ?>"<?php print $attributes; ?>>
   <header role="banner" class="header">
     <div class="wrapper">
@@ -57,7 +57,7 @@
   <?php endif; ?>
 
   <?php if (isset($call_to_action)): ?>
-    <div class="cta show-at-medium">
+    <div class="cta <?php if ($yahoo_prototype) { print 'show-at-medium'; } ?>">
       <div class="wrapper">
         <h2 class="cta__message"><?php print $call_to_action; ?></h2>
         <?php print $cta_link; ?>
@@ -65,7 +65,7 @@
     </div>
 
     <?php // Yahoo prototype ?>
-    <?php if ($nid == 176): ?>
+    <?php if ($yahoo_prototype): ?>
       <div class="cta show-only-small">
         <div class="wrapper">
           <h2 class="cta__message">Want to learn more about volcanoes?</h2>
@@ -103,7 +103,7 @@
   </section>
 
   <?php if (isset($call_to_action)): ?>
-    <div class="cta show-at-medium">
+    <div class="cta <?php if ($yahoo_prototype) { print 'show-at-medium'; } ?>">
       <div class="wrapper">
         <h2 class="cta__message"><?php print $call_to_action; ?></h2>
         <?php print $cta_link; ?>
@@ -111,7 +111,7 @@
     </div>
 
     <?php // Yahoo prototype ?>
-    <?php if ($nid == 176): ?>
+    <?php if ($yahoo_prototype): ?>
       <div class="cta show-only-small">
         <div class="wrapper">
           <h2 class="cta__message">Want to learn more about volcanoes?</h2>

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -51,6 +51,10 @@ function paraneue_dosomething_form_system_theme_settings_alter(&$form, &$form_st
       '#title' => t('Show problem statement share buttons'),
       '#description' => t('Toggles the display of problem statement share buttons on the action page.')
     ),
+    'show_yahoo_prototype' => array(
+      '#title' => t('Turn on yahoo 11 facts prototype'),
+      '#description' => t('Toggles the display of a CTA prototype on node 176 for the Yahoo partnership')
+    ),
   );
 
   foreach ($flags as $name => $flag) {


### PR DESCRIPTION
#### What's this PR do?

A lightweight protoype for the yahoo partnership that shows a different CTA and CTA button link on mobile vs desktop. Only shows on node 176 and I also moved it under a feature flag so we can turn it off on prod if we do a deploy. 
#### Where should the reviewer start?

Everything happens in `node--fact_page.tpl.php`
#### How should this be manually tested?

Go to `/facts/11-facts-about-volcanoes` and resize your screen. On mobile, it should display a CTA that says "Want to learn more about volcanos?" and a button that says "Find out" and links to a yahoo search page. On desktop, it should be the regs CTA and button.
#### What are the relevant tickets?

Fixes #5203 
