### PR TITLE
Hide address field for non-us users

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -263,6 +263,12 @@ function paraneue_dosomething_form_user_profile_form_alter(&$form, &$form_state,
   unset($form['account']['mail']['#description']);
   $form['account']['current_pass']['#title'] = t("Current Password");
   unset($form['field_address'][LANGUAGE_NONE][0]['#title']);
+
+  // Hides address fields for non-us users.
+  if (dosomething_settings_get_geo_country_code() !== 'US') {
+    $form['field_address']['#access'] = FALSE;
+  }
+
   $form['field_birthdate'][LANGUAGE_NONE][0]['#after_build'][] = 'paraneue_dosomething_form_user_profile_after_build';
 
   // Thanks to https://www.drupal.org/node/540340#comment-6576704.


### PR DESCRIPTION
#### What's this PR do?

Hides address fields for non-us users on the update profile form.
#### Where should the reviewer start?

Only one place to go `form.inc`
#### How should this be manually tested?

Log in as an authenticated non-admin user and edit your profile. You should see address fields if your country code is `US`, you should **not** see address fields if it is not. 
#### Any background context you want to provide?

This is a temp solution for the global 1.0 release. In global 1.1 we will be deciding on a global solution for address collection (see #5193 )
#### What are the relevant tickets?

Fixes #5052 
