### PR TITLE
Adding cleaned up dosomething_zendesk module POT file.

### DIFF
--- a/pots/dosomething_zendesk.pot
+++ b/pots/dosomething_zendesk.pot
@@ -1,0 +1,54 @@
+# $Id$
+#
+# LANGUAGE translation of Drupal (general)
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+# Generated from files:
+#  dosomething_zendesk.admin.inc: n/a
+#  dosomething_zendesk.module: n/a
+#  dosomething_zendesk.info: n/a
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2015-09-24 18:31+0000\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: dosomething_zendesk.module:101
+msgid "Question about"
+msgstr ""
+
+#: dosomething_zendesk.module:152
+msgid "Submit"
+msgstr ""
+
+#: dosomething_zendesk.module:213
+msgid "Please provide a valid email address."
+msgstr ""
+
+#: dosomething_zendesk.module:230
+msgid "Thanks for submitting your question."
+msgstr ""
+
+#: dosomething_zendesk.module:231
+msgid "We'll send a response to"
+msgstr ""
+
+#: dosomething_zendesk.module:232
+msgid "shortly."
+msgstr ""
+
+#: dosomething_zendesk.module:236
+msgid "Sorry, there was an error with your request, please email !email and we'll get your question sorted out!"
+msgstr ""
+
+#: dosomething_zendesk.module:237
+msgid "help@dosomething.org"
+msgstr ""
+


### PR DESCRIPTION
Fixes #5228
#### What's this PR do?

This PR adds the extracted POT file for the dosomething_zendesk module that has been edited to only add strings immediately needed for translation.
#### Where should the reviewer start?

Just review the strings to make sure all seems well.
#### Any background context you want to provide?

Strings relating to the CMS admin interface have been pulled out for the time being since we do not require them to be translated.
#### What are the relevant tickets?
#5147
#5144
#5228

---

@angaither 
