### PR TITLE
Implements form node admin alter

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -87,16 +87,6 @@ function dosomething_global_menu_alter(&$items) {
 }
 
 /**
- * Implements hook_form_node_admin_content_alter().
- */
-function dosomething_global_form_node_admin_content_alter(&$form, &$form_state, $form_id) {
-  // Remove destination?=admin/content from edit button
-  foreach ($form['admin']['nodes']['#options'] as $nid => $node) {
-    unset($form['admin']['nodes']['#options'][$nid]['operations']['data']['#links']['edit']['query']['destination']);
-  }
-}
-
-/**
  * Implements hook_menu_local_tasks_alter().
  */
 function dosomething_global_menu_local_tasks_alter(&$data, $route_name) {

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -87,7 +87,17 @@ function dosomething_global_menu_alter(&$items) {
 }
 
 /**
- * Implements hook_meny_local_tasks_alter().
+ * Implements hook_form_node_admin_content_alter().
+ */
+function dosomething_global_form_node_admin_content_alter(&$form, &$form_state, $form_id) {
+  // Remove destination?=admin/content from edit button
+  foreach ($form['admin']['nodes']['#options'] as $nid => $node) {
+    unset($form['admin']['nodes']['#options'][$nid]['operations']['data']['#links']['edit']['query']['destination']);
+  }
+}
+
+/**
+ * Implements hook_menu_local_tasks_alter().
  */
 function dosomething_global_menu_local_tasks_alter(&$data, $route_name) {
   // Verify we're operating on a node edit page

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -592,3 +592,13 @@ function dosomething_helpers_get_current_language_code() {
 function dosomething_helpers_application_path($path = '') {
   return realpath(DRUPAL_ROOT . '/../' . $path);
 }
+
+/**
+ * Implements hook_form_node_admin_content_alter().
+ */
+function dosomething_global_form_node_admin_content_alter(&$form, &$form_state, $form_id) {
+  // Remove destination?=admin/content from edit button
+  foreach ($form['admin']['nodes']['#options'] as $nid => $node) {
+    unset($form['admin']['nodes']['#options'][$nid]['operations']['data']['#links']['edit']['query']['destination']);
+  }
+}

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -596,7 +596,7 @@ function dosomething_helpers_application_path($path = '') {
 /**
  * Implements hook_form_node_admin_content_alter().
  */
-function dosomething_global_form_node_admin_content_alter(&$form, &$form_state, $form_id) {
+function dosomething_helpers_form_node_admin_content_alter(&$form, &$form_state, $form_id) {
   // Remove destination?=admin/content from edit button
   foreach ($form['admin']['nodes']['#options'] as $nid => $node) {
     unset($form['admin']['nodes']['#options'][$nid]['operations']['data']['#links']['edit']['query']['destination']);


### PR DESCRIPTION
#### What's this PR do?

Removes `?destination=admin/content` from edit links on admin/content 
#### How should this be manually tested?

Click edit on any campaign on /admin/content
#### Any background context you want to provide?

Please see the chain of comments here which led to me figuring out this was the cause https://github.com/DoSomething/phoenix/issues/5114#issuecomment-142964203
#### What are the relevant tickets?

Fixes #5114 
Fixes #1273 

@angaither 
