### PR TITLE
Adding cleaned up dosomething_taxonomy module POT file.

### DIFF
--- a/pots/dosomething_taxonomy.pot
+++ b/pots/dosomething_taxonomy.pot
@@ -1,0 +1,27 @@
+# $Id$
+#
+# LANGUAGE translation of Drupal (general)
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+# Generated from files:
+#  dosomething_taxonomy.features.field_instance.inc: n/a
+#  dosomething_taxonomy.views_default.inc: n/a
+#  dosomething_taxonomy.module: n/a
+#  dosomething_taxonomy.info: n/a
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2015-09-24 19:35+0000\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: dosomething_taxonomy.module:91
+msgid "Facts About @name"
+msgstr ""
+


### PR DESCRIPTION
Fixes #5232
#### What's this PR do?

This PR adds the extracted POT file for the dosomething_taxonomy module that has been edited to only add strings immediately needed for translation.
#### Where should the reviewer start?

Just review the strings to make sure all seems well.
#### Any background context you want to provide?

Strings relating to the CMS admin interface have been pulled out for the time being since we do not require them to be translated.
#### What are the relevant tickets?
#5147
#5144
#5232

---

@angaither 
