### PR TITLE
Enable translation with fields on homepage node.

### DIFF
--- a/lib/modules/dosomething/dosomething_home/dosomething_home.info
+++ b/lib/modules/dosomething/dosomething_home/dosomething_home.info
@@ -31,4 +31,4 @@ features[variable][] = menu_parent_home
 features[variable][] = node_options_home
 features[variable][] = node_preview_home
 features[variable][] = node_submitted_home
-mtime = 1442330910
+mtime = 1443185310

--- a/lib/modules/dosomething/dosomething_home/dosomething_home.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_home/dosomething_home.strongarm.inc
@@ -43,7 +43,7 @@ function dosomething_home_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'language_content_type_home';
-  $strongarm->value = '0';
+  $strongarm->value = '4';
   $export['language_content_type_home'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
this feature wasn't correctly exported in #5188
this exports the ability to translation home page content correctly 
Fixes #5244
