### PR TITLE
Use the node's default lang to get cover image.

### DIFF
--- a/lib/modules/dosomething/dosomething_home/dosomething_home.module
+++ b/lib/modules/dosomething/dosomething_home/dosomething_home.module
@@ -47,8 +47,9 @@ function dosomething_home_preprocess_node(&$vars) {
       $tiles['tagline'] = $node->field_call_to_action[$lang_code][0]['safe_value'];
 
       // Get the campaign cover image. If there is no image for the user's language,
-      // use the image for the default language.
-      $image_nid = $node->field_image_campaign_cover[$lang_code][0]['target_id'] ?: $node->field_image_campaign_cover[language_default()->language][0]['target_id'];
+      // use the image from the node's language.
+      $image_nid = $node->field_image_campaign_cover[$lang_code][0]['target_id'] ?: $node->field_image_campaign_cover[$node->language][0]['target_id'];
+
       if ($key == 0) {
         $tiles['modifier_classes'] = "big";
         $tiles['image_url'] = dosomething_image_get_themed_image_url($image_nid, 'square', '720x720');


### PR DESCRIPTION
### what's this pr do?

Updates call to get node cover images
### context

when we changed the default language on thor, the images went POOF
the code was trying to get the images in global english, but the nodes were in english. 
### other things

I _think_ the code should be like this, we try to get the image in the user's language first, then get the image in the node's original language.

Fixes #5246
