### PR TITLE
Reportback emails 4957

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1026,6 +1026,8 @@ function dosomething_reportback_flush_caches() {
  * @return SelectQuery object
  */
 function dosomething_reportback_build_reportbacks_query($params = array()) {
+  global $language;
+
   $query = db_select('dosomething_reportback', 'rb');
   $query->join('dosomething_reportback_file', 'rbf', 'rb.rbid = rbf.rbid');
   $query->leftJoin('field_data_field_reportback_noun', 'fn', 'rb.nid = fn.entity_id');
@@ -1044,6 +1046,8 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
   }
 
   if (isset($params['nid'])) {
+    $query->condition('fn.language', $language->language);
+    $query->condition('fv.language', $language->language);
     if (is_array($params['nid'])) {
       $query->condition('rb.nid', $params['nid'], 'IN');
     }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -988,8 +988,11 @@ function dosomething_reportback_get_count_by_uid($uid = NULL) {
  *   An object containing reportback noun & verb
  */
 function dosomething_reportback_get_noun_and_verb($nid) {
+  global $language;
+
   $query = db_select('field_data_field_reportback_noun', 'noun')
-    ->condition('noun.entity_id', $nid);
+    ->condition('noun.entity_id', $nid)
+    ->condition('noun.language', $language);
   $query->addField('noun', 'field_reportback_noun_value', 'noun');
   $query->addField('verb', 'field_reportback_verb_value', 'verb');
   $query->join('field_data_field_reportback_verb', 'verb', 'noun.entity_id = verb.entity_id');


### PR DESCRIPTION
Updating reportback queries to be language-aware so that reportback emails display the appropriate language to users.

Fixes #4957 
