### PR TITLE
Excludes GB and CA from optin form

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -30,16 +30,14 @@ function dosomething_signup_opt_in_config_form($form, &$form_state) {
       '#collapsed' => TRUE,
     );
 
-    if (!in_array($country, $mailchimp_excluded_countries)) {
-      $name = $field_prefix . $country . '_mail_list_id';
-      $form['general']['dosomething_signup'][$country][$name] = array(
-        '#type' => 'textfield',
-        '#required' => TRUE,
-        '#title' => 'Mail List ID',
-        '#default_value' => variable_get($name),
-        '#description' => "General MailChimp List ID used in registrations and signups.",
-      );
-    }
+    $name = $field_prefix . $country . '_mail_list_id';
+    $form['general']['dosomething_signup'][$country][$name] = array(
+      '#type' => 'textfield',
+      '#required' => !in_array($country, $mailchimp_excluded_countries),
+      '#title' => 'Mail List ID',
+      '#default_value' => variable_get($name),
+      '#description' => "General MailChimp List ID used in registrations and signups.",
+    );
 
     //TEMPORARY -- Remove the IF statement to fix #5121
     if ($country == "us") {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.admin.inc
@@ -20,6 +20,7 @@ function dosomething_signup_opt_in_config_form($form, &$form_state) {
 
   $field_prefix = "dosomething_signup_";
   $countries = dosomething_global_get_countries();
+  $mailchimp_excluded_countries = ['ca', 'gb'];
   foreach ($countries as $country) {
     $country = strtolower($country);
     $form['general']['dosomething_signup'][$country] = array(
@@ -29,14 +30,16 @@ function dosomething_signup_opt_in_config_form($form, &$form_state) {
       '#collapsed' => TRUE,
     );
 
-    $name = $field_prefix . $country . '_mail_list_id';
-    $form['general']['dosomething_signup'][$country][$name] = array(
-      '#type' => 'textfield',
-      '#required' => TRUE,
-      '#title' => 'Mail List ID',
-      '#default_value' => variable_get($name),
-      '#description' => "General MailChimp List ID used in registrations and signups.",
-    );
+    if (!in_array($country, $mailchimp_excluded_countries)) {
+      $name = $field_prefix . $country . '_mail_list_id';
+      $form['general']['dosomething_signup'][$country][$name] = array(
+        '#type' => 'textfield',
+        '#required' => TRUE,
+        '#title' => 'Mail List ID',
+        '#default_value' => variable_get($name),
+        '#description' => "General MailChimp List ID used in registrations and signups.",
+      );
+    }
 
     //TEMPORARY -- Remove the IF statement to fix #5121
     if ($country == "us") {


### PR DESCRIPTION
#### What's this PR do?

Removes Great Britain and Canada (SORRY) mailchimp list ID from the 3rd party optin form and provides an array others can add country codes too (or remove).
#### How should this be manually tested?

Open http://dev.dosomething.org:8888/admin/config/dosomething/opt_in and check the form
#### What are the relevant tickets?

Fixes #5254 
