### PR TITLE
Verifies lang exists before assigning it

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -468,6 +468,10 @@ function dosomething_user_new_user($form, &$form_state) {
     // Adjust language based on location
     $user_country_code = dosomething_settings_get_geo_country_code();
     $language = dosomething_global_convert_country_to_language($user_country_code);
+    $system_languages = language_list();
+    if (!in_array($langauge, $system_languages)) {
+      $language = 'en-global';
+    }
     user_save($account, ['language' => $language]);
   }
 


### PR DESCRIPTION
#### What's this PR do?

Verifies the system language is actually installed before giving it to a user. Default to global en if it doesnt exist.
#### How should this be manually tested?

Create a new user and spoof the country code as GB or CA.
#### What are the relevant tickets?

Fixes #5256
