### PR TITLE
Updates global 

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -205,7 +205,7 @@ function dosomething_global_convert_language_to_country($language) {
 }
 
 /**
- * Converts the given country into its assigned language
+ * Converts the given country into its assigned language.
  *
  * @param string country
  *  The country Code
@@ -220,6 +220,7 @@ function dosomething_global_convert_country_to_language($country) {
       return $lang_key;
     }
   }
+  // It is not the job of this function to determine a default language
   return NULL;
 }
 

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -211,7 +211,7 @@ function dosomething_global_convert_language_to_country($language) {
  *  The country Code
  *
  * @return
- *  The language mapped to this country
+ *  The language mapped to this country or NULL
  */
 function dosomething_global_convert_country_to_language($country) {
   $lang_map = variable_get('dosomething_global_language_map', '');
@@ -220,7 +220,7 @@ function dosomething_global_convert_country_to_language($country) {
       return $lang_key;
     }
   }
-  return 'en';
+  return NULL;
 }
 
 /*

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -465,19 +465,7 @@ function dosomething_user_new_user($form, &$form_state) {
   $account = $user;
 
   if (module_exists('dosomething_global')) {
-    // Adjust language based on location
-    $user_country_code = dosomething_settings_get_geo_country_code();
-    $coverted_language = dosomething_global_convert_country_to_language($user_country_code);
-    $system_languages = language_list();
-    $language = 'en-global';
-    
-    foreach ($system_languages as $lang_key => $system_lang) {
-      if ($coverted_language == $lang_key) {
-        $language = $coverted_language;
-        break;
-      }
-    }
-    user_save($account, ['language' => $language]);
+    dosomething_user_set_global_attributes();
   }
 
   // Should we sign this kid up for messages?
@@ -526,6 +514,44 @@ function dosomething_user_new_user($form, &$form_state) {
    }
 
   dosomething_mbp_request('user_register', $params);
+}
+
+/**
+ * Sets the user global attributes and sends them to Northstar.
+ *
+ * @param object $account
+ *   The account to return value for. If NULL, uses global $user.
+ * @param string $country_code
+ *   The country code where the user currently resides. If NULL, uses
+ *   the headers in current request.
+ * @param string $language
+ *   The new language to set on the user. If NULL, gets the matching
+ *   language or defaults to global-en. 
+ */
+function dosomething_user_set_global_attributes($user = NULL, $country_code = NULL, $language = NULL) {
+  if ($user == NULL) {
+    global $user;
+  }
+  if ($country_code == NULL) {
+    $country_code = dosomething_settings_get_geo_country_code();
+  }
+  if ($language == NULL) {
+    $coverted_language = dosomething_global_convert_country_to_language($country_code);
+    $language = 'en-global';
+    $system_languages = language_list();
+
+    // Verify the language is installed on the system,
+    // if not default to global en
+    foreach ($system_languages as $lang_key => $system_lang) {
+      if ($coverted_language == $lang_key) {
+        $language = $coverted_language;
+        break;
+      }
+    }
+  }
+
+  user_save($account, ['language' => $language]);
+  //TODO: (#5263) Send $language and $country_code to NorthStar
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -250,6 +250,9 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
       if ($form_id == 'user_register_form' && $_SERVER['REQUEST_URI'] != '/admin/people/create') {
         $form['#action'] = '/user/register';
         $form['#submit'][] = 'dosomething_user_new_user';
+        if (module_exists('dosomething_global')) {
+          $form['#submit'][] = 'dosomething_user_new_user_attributes';
+        }
         // Unsets relevant register form fields based on configuration variables.
         _dosomething_user_register_display_fields($form);
         // Add campaign data, if needed.
@@ -464,10 +467,6 @@ function dosomething_user_new_user($form, &$form_state) {
   global $user;
   $account = $user;
 
-  if (module_exists('dosomething_global')) {
-    dosomething_user_set_global_attributes();
-  }
-
   // Should we sign this kid up for messages?
   if (dosomething_user_is_under_thirteen()) {
     return;
@@ -516,6 +515,10 @@ function dosomething_user_new_user($form, &$form_state) {
   dosomething_mbp_request('user_register', $params);
 }
 
+function dosomething_user_new_user_attributes($form, &$form_state) {
+  dosomething_user_set_global_attributes();
+}
+
 /**
  * Sets the user global attributes and sends them to Northstar.
  *
@@ -531,6 +534,7 @@ function dosomething_user_new_user($form, &$form_state) {
 function dosomething_user_set_global_attributes($user = NULL, $country_code = NULL, $language = NULL) {
   if ($user == NULL) {
     global $user;
+    $account = $user;
   }
   if ($country_code == NULL) {
     $country_code = dosomething_settings_get_geo_country_code();
@@ -557,8 +561,7 @@ function dosomething_user_set_global_attributes($user = NULL, $country_code = NU
       }
     }
   }
-
-  user_save($user, ['language' => $language]);
+  user_save($account, ['language' => $language]);
   //TODO: (#5263) Send $language and $country_code to NorthStar
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -526,7 +526,7 @@ function dosomething_user_new_user($form, &$form_state) {
  *   the headers in current request.
  * @param string $language
  *   The new language to set on the user. If NULL, gets the matching
- *   language or defaults to global-en. 
+ *   language or defaults.
  */
 function dosomething_user_set_global_attributes($user = NULL, $country_code = NULL, $language = NULL) {
   if ($user == NULL) {
@@ -534,23 +534,30 @@ function dosomething_user_set_global_attributes($user = NULL, $country_code = NU
   }
   if ($country_code == NULL) {
     $country_code = dosomething_settings_get_geo_country_code();
+    // If no Fastly headers set, use US EN
+    if ($country_code == NULL) {
+      $language = 'en';
+    }
   }
   if ($language == NULL) {
-    $coverted_language = dosomething_global_convert_country_to_language($country_code);
+    $converted_language = dosomething_global_convert_country_to_language($country_code);
     $language = 'en-global';
-    $system_languages = language_list();
 
-    // Verify the language is installed on the system,
-    // if not default to global en
-    foreach ($system_languages as $lang_key => $system_lang) {
-      if ($coverted_language == $lang_key) {
-        $language = $coverted_language;
-        break;
+    // If the country in the headers matched to a language in our strongarm
+    if ($converted_language != NULL) {
+
+      // Verify the language is installed on the system,
+      $system_languages = language_list();
+      foreach ($system_languages as $lang_key => $system_lang) {
+        if ($converted_language == $lang_key) {
+          $language = $converted_language;
+          break;
+        }
       }
     }
   }
 
-  user_save($account, ['language' => $language]);
+  user_save($user, ['language' => $language]);
   //TODO: (#5263) Send $language and $country_code to NorthStar
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -539,6 +539,7 @@ function dosomething_user_set_global_attributes($user = NULL, $country_code = NU
       $language = 'en';
     }
   }
+  // If the language wasn't specified in the function call, determine the user language
   if ($language == NULL) {
     $converted_language = dosomething_global_convert_country_to_language($country_code);
     $language = 'en-global';

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -467,10 +467,15 @@ function dosomething_user_new_user($form, &$form_state) {
   if (module_exists('dosomething_global')) {
     // Adjust language based on location
     $user_country_code = dosomething_settings_get_geo_country_code();
-    $language = dosomething_global_convert_country_to_language($user_country_code);
+    $coverted_language = dosomething_global_convert_country_to_language($user_country_code);
     $system_languages = language_list();
-    if (!in_array($langauge, $system_languages)) {
-      $language = 'en-global';
+    $language = 'en-global';
+    
+    foreach ($system_languages as $lang_key => $system_lang) {
+      if ($coverted_language == $lang_key) {
+        $language = $coverted_language;
+        break;
+      }
     }
     user_save($account, ['language' => $language]);
   }


### PR DESCRIPTION
#### What's this PR do?

Updates the logic used to seta users language upon registering. See here for summary of what was discussed in #global https://github.com/DoSomething/phoenix/issues/5168#issuecomment-143766220

All of this was also moved into a new function per @angaither 's suggestion here https://github.com/DoSomething/phoenix/issues/5263#issuecomment-143743816

Also updates dosomething_global_convert_country_to_language to return null rather than 'en'
#### Where should the reviewer start?

dosomething_user_set_global_attributes();
#### How should this be manually tested?

Create new users and spoof there country codes, check there languages to make sure they match. Also try making a user without a country code header and make sure it goes to English. 
#### Any background context you want to provide?

Slack discussion from here and down https://dosomething.slack.com/archives/global/p1443451428000871
#### What are the relevant tickets?

Fixes #5168 
Unblocks #5263

Also @DeeZone this is going to break your logic here for users coming from countries outside US/MX/BR https://github.com/DoSomething/phoenix/blob/cf11f1b791a9668ae73f403b8121dc055156b447/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module#L235
