### PR TITLE
Fixes #4973: title translation overwrites original title.

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -202,6 +202,9 @@ projects[taxonomy_access_fix][subdir] = "contrib"
 ; Fixes a bug with table layout on content type manage fields page.
 projects[title][version] = "1.x-dev"
 projects[title][subdir] = "contrib"
+; Fixes #4973: title translation overwrites original title.
+; See https://www.drupal.org/node/1991988.
+projects[title][patch][] = https://www.drupal.org/files/title_1991988-10.patch
 
 ; Token
 projects[token][version] = "1.5"


### PR DESCRIPTION
#### What's this PR do?
- Fixes a bug with original title being overwritten with new translation
#### How should this be manually tested?
- Add a translation for a campaign, ex.: http://dev.dosomething.org:8888/node/1727/edit
- Change the title
- Make sure the title isn't changed on original (English) translation: http://dev.dosomething.org:8888/node/1727/edit/en?language=en
- Make sure the title is changed on the translation of your choice
#### Any background context you want to provide?

See https://www.drupal.org/node/1991988.
#### What are the relevant tickets?

Fixes #4973

cc @mikefantini @deadlybutter 
