### PR TITLE
Issue5212 mail chimp global listids

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -234,6 +234,9 @@ function dosomething_mbp_get_template_name($event_name, $user_language = NULL) {
 
   if (isset($user_langauge)) {
     $country_code = dosomething_global_convert_language_to_country($user_language);
+    if ($country_code == NULL) {
+      $country_code = 'US';
+    }
   }
   else {
     $country_code = dosomething_settings_get_affiliate_country_code();

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -101,6 +101,7 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
     'email' => $params['email'],
     'uid' => $params['uid'],
     'user_language' =>  $params['user_language'],
+    'user_country' => $params['user_country'],
     'merge_vars' => array(
       'MEMBER_COUNT' => dosomething_user_get_member_count(TRUE),
     ),

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -426,12 +426,17 @@ function dosomething_user_user_pass_submit($form, &$form_state) {
   if (isset($form_state['input']['name'])) {
     $account = user_load_by_mail($form_state['input']['name']);
     if (isset($account->mail)) {
+      if (module_exists('dosomething_global')) {
+        $user_country_code = dosomething_global_convert_language_to_country($account->language);
+      }
       // Send external message request
       $params = array(
         'email' => $account->mail,
         'uid' => $account->uid,
         'first_name' => dosomething_user_get_field('field_first_name', $account),
         'reset_link' => user_pass_reset_url($account),
+        'user_language'     => $account->language,
+        'user_country'      => isset($user_country_code) ? $user_country_code : 'US'
       );
       if (module_exists('dosomething_mbp')) {
         dosomething_mbp_request('user_password', $params);


### PR DESCRIPTION
#### What's this PR do?

Adds `user_language` and `user_country` to payload sent to Message Broker with password_reset requests.
#### Where should the reviewer start?

Request a user password reset from `user/password`.
#### How should this be manually tested?

Review request payload sent to `message_broker_producer.moduel` module from `dosomething_mbp.module`. The payload should contain the `user_language` and `user_country` settings.

**Example payload**:

```
Array
(
    [activity] => user_password
    [email] => dlee+vag01@dosomething.org
    [uid] => 1705348
    [user_language] => en-global
    [user_country] => US
    [merge_vars] => Array
        (
            [MEMBER_COUNT] => 3.5 million
            [FNAME] => Test Dee
            [RESET_LINK] => http://dev.dosomething.org:8888/user/reset/1705348/1443462436/MtbEhWJ6lfvqgxoANeTebivD-fBzuu78wmUeOr27YPk
        )

    [email_template] => mb-user-password-US
    [email_tags] => Array
        (
            [0] => drupal_user_password
        )

)
```
#### Any background context you want to provide?

The `user_language` is used to define what `email_template` name to send in the request. The addition of the `-US` value at the end of the template is new and will change for the different supported countries.
#### What are the relevant tickets?

Fixes #4962
Fixes #5212

**Note**:
- This also addresses the issue of NULL values being returned in `dosomething_global_convert_language_to_country()` calls as pointed out in PR #5266 by @deadlybutter 

For what it's worth, an invalid or unsupported `country_code` is already trapped here: https://github.com/DoSomething/mbc-transactional-email/blob/master/src/MBC_TransactionalEmail_Consumer.php#L245
