### PR TITLE
Validate additional international domains with Mailcheck.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/validators/auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validators/auth.js
@@ -12,8 +12,16 @@ define(function(require) {
   "use strict";
 
   var Validation= require("dosomething-validation");
-  var mailcheck = require("mailcheck");
   var setting = require('../utilities/Setting');
+
+  // We use Mailcheck (https://github.com/mailcheck/mailcheck) to provide
+  // suggestions for typos in email addresses. See the "email" validator below.
+  var Mailcheck = require("mailcheck");
+
+  // We'll add a few extra domains to the defaults provided.
+  // @see: https://github.com/mailcheck/mailcheck/blob/v1.1.1/src/mailcheck.js#L16-L25
+  Mailcheck.defaultDomains.push("dosomething.org", "sina.com");
+
 
   // # Helpers
   // Basic sanity check used by email validation.
@@ -177,14 +185,9 @@ define(function(require) {
   // uses Kicksend's mailcheck library to offer suggestions for misspellings.
   Validation.registerValidationFunction("email", function(string, done) {
     if ( isValidEmailSyntax(string) ) {
-      // we use mailcheck.js to find some common email mispellings
-      mailcheck.run({
+      // We use mailcheck.js to find some common email mispellings
+      Mailcheck.run({
         email: string,
-        domains: ["yahoo.com", "google.com", "hotmail.com", "gmail.com", "me.com", "aol.com", "mac.com",
-                  "live.com", "comcast.net", "googlemail.com", "msn.com", "hotmail.co.uk", "yahoo.co.uk",
-                  "facebook.com", "verizon.net", "sbcglobal.net", "att.net", "gmx.com", "mail.com", "outlook.com",
-                  "aim.com", "ymail.com", "rocketmail.com", "bellsouth.net", "cox.net", "charter.net", "me.com",
-                  "earthlink.net", "optonline.net", "dosomething.org"],
         suggested: function(s) {
           return done({
             success: true,

--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -17,7 +17,7 @@
     "jquery-once": "~2.0.0",
     "jquery.iecors": "DFurnes/jquery.iecors#umd",
     "lodash": "~3.6.0",
-    "mailcheck": "~1.1.0",
+    "mailcheck": "~1.1.1",
     "raf.js": "~0.0.4",
     "respond.js": "~1.4.2",
     "unveil": "DFurnes/unveil.git#umd"


### PR DESCRIPTION
References #5046. Adds `sina.com` to list of "suggestion" domains.

Also switches to extending [Mailcheck's defaults](https://github.com/mailcheck/mailcheck/blob/4ad175791da491f39ebb99c33e8ace9736372c56/src/mailcheck.js#L16-L25) rather than completely overriding with a custom list... this allows us to take advantage of upstream updates while still maintining our own custom additions. (The ability to extend these defaults rather than outright replacing them was added in Mailcheck v1.1.1).

Side benefit? We also get some more common domestic & international domains (that've been added since we started using Mailcheck) for free! The added domains are listed below:

> telus.net, optusnet.com.au, qq.com, sky.com, icloud.com, sympatico.ca, xtra.co.nz, web.de, rogers.com, verizon.net, btinternet.com, shaw.ca

:white_check_mark: 

For review: @DoSomething/front-end 
