### PR TITLE
Output head links for available translated content nodes.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -359,7 +359,11 @@ function paraneue_dosomething_get_regional_url_data($node) {
     return NULL;
   }
 
-  $supported_languages = variable_get('dosomething_global_language_map');
+  $supported_languages = language_list();
+  foreach ($supported_languages as $language) {
+    $language->country = dosomething_global_convert_language_to_country($language->language);
+  }
+
   $regional_url_data = [];
 
   foreach ($available_translations as $language_key => $translation) {
@@ -369,7 +373,7 @@ function paraneue_dosomething_get_regional_url_data($node) {
     }
 
     if (array_key_exists($language_key, $supported_languages) && $language_key !== $language_url->language) {
-      $country = strtolower($supported_languages[$language_key]['country']);
+      $country = strtolower($supported_languages[$language_key]->country);
       $regional_url_data[$language_key] = $base_url . '/' . $country . '/' . drupal_get_path_alias('node/' . $node->nid, $language_key);
     }
   }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -344,6 +344,40 @@ function paraneue_dosomething_get_themed_placeholder_reportbacks($count = 6) {
 }
 
 /**
+ * Get regional url data for specified node if it has translated content available.
+ *
+ * @param object $node  Specified Node object for which to add regional urls.
+ * @return array|null
+ */
+function paraneue_dosomething_get_regional_url_data($node) {
+  global $language_url;
+  global $base_url;
+
+  $available_translations = dosomething_helpers_isset($node->translations->data);
+
+  if (!$available_translations) {
+    return NULL;
+  }
+
+  $supported_languages = variable_get('dosomething_global_language_map');
+  $regional_url_data = [];
+
+  foreach ($available_translations as $language_key => $translation) {
+    // Skip creating regional url for global english.
+    if ($language_key === 'en-global') {
+      continue;
+    }
+
+    if (array_key_exists($language_key, $supported_languages) && $language_key !== $language_url->language) {
+      $country = strtolower($supported_languages[$language_key]['country']);
+      $regional_url_data[$language_key] = $base_url . '/' . $country . '/' . drupal_get_path_alias('node/' . $node->nid, $language_key);
+    }
+  }
+
+  return $regional_url_data;
+}
+
+/**
  * Return an assimilated collection of Reportbacks based on Promoted & Approved Reportback counts.
  *
  * @param array $reportbacks

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -249,6 +249,14 @@ function paraneue_dosomething_preprocess_page(&$vars) {
  * Implements theme_preprocess_node().
  */
 function paraneue_dosomething_preprocess_node(&$vars) {
+  $regional_url_data = paraneue_dosomething_get_regional_url_data($vars['node']);
+
+  if ($regional_url_data) {
+    foreach ($regional_url_data as $language => $url) {
+      drupal_add_html_head_link(['rel' => 'alternate', 'hreflang' => $language, 'href' => $url]);
+    }
+  }
+
 
   switch($vars['node']->type) {
 


### PR DESCRIPTION
Addresses part of #5136
#### What's this PR do?

This PR adds the ability to output `<link>` tags in the `<head>` that provide references to translated content if it's available, so it can help search engines show a user appropriate links to site content pages depending on user's language/country origin. So if the user is in Mexico, they will see search results that link them to the `/mx/` page if it's available. 

So, for the below content page:

```
http://dev.dosomething.org:8888/campaigns/patient-playbooks
```

If there is a mexican spanish translation available, there will be the following link in the head:

```
<link rel="alternate" hreflang="es-mx" href="http://dev.dosomething.org:8888/mx/campaigns/playbooks-para-pacientes">
```

There will be `<link>` tags added for all available content, and it will **not** add tags if url in question is already a specific language url; no `<link>` tag for `es-mx` if url in question is: `http://dev.dosomething.org:8888/mx/campaigns/playbooks-para-pacientes`.

Also, no `<link>` tags added for global english.
#### Where should the reviewer start?

Start at the `paraneue_dosomething_preprocess_node()` function, specifically at the `$regional_url_data` variable.
#### How should this be manually tested?

If you so desire, pull down the branch load up a node page that has translations and confirm `<link>` tags for the languages is output.
#### What are the relevant tickets?
#5136

---

@angaither 
cc: @mshmsh5000 
