### PR TITLE
Update logic for the publish transltion checkbox.

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -58,8 +58,19 @@ function dosomething_global_form_node_form_alter(&$form, &$form_state, $form_id)
   if (!(in_array($form['type']['#value'], $translatable_types))) {
     return;
   }
-  // Don't autopublish tranlsations.
-  $form['translation']['status']['#default_value'] = FALSE;
+  // Get the last item in the url, to get the edit/add node language.
+  $node_lang = array_pop(explode('/', (parse_url(current_path(), PHP_URL_PATH))));
+  $translations = $form['#node']->translations->data;
+  // If we are on a node lang page, and a translation exists
+  if (array_key_exists($node_lang, $translations)) {
+    // Set the publish status to the translation status
+    $form['translation']['status']['#default_value'] = $translations[$node_lang]['status'];
+  }
+  else {
+    // Otherwise, don't autocheck that publish box.
+    $form['translation']['status']['#default_value'] = FALSE;
+  }
+
   // Check if the user is a mexico or brazil admin
   if (dosomething_global_is_regional_admin()) {
     // Get translatable fields.


### PR DESCRIPTION
### what does this pr do

Set the 'publish translation checkbox' to match the status of the translation
I set the default value to false, in #5180 but once a translation was published, the checkbox was still unchecked. This is some gross work around, because it appears there isn't a setting to not autopublish translations.
### additional context

there's no setting for auto publish translation content?
### apologies

this code seems wildly unnecessary    
### tickets

Fixes #5260
[see comment](https://github.com/DoSomething/phoenix/issues/5260#issuecomment-144094623)
