### PR TITLE
Fixes logout URL

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/navigation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/navigation.tpl.php
@@ -35,11 +35,11 @@
           <a href="#" class="navigation__dropdown-toggle"><?php print $user_identifier ?></a>
           <ul>
             <li><?php print l("My Account", 'user/'. $user->uid); ?></li>
-            <li><a id="link--logout" href="<?php print $GLOBALS['base_url'] ?>/user/logout"><?php print t('Log Out'); ?></a></li>
+            <li><?php print l(t('Log Out'), 'user/logout', array('attributes' => array('class' => array('secondary-nav-item')))) ?></li>
           </ul>
         </li>
       <?php else: ?>
-        <li class="login"><a id="link--login" class="secondary-nav-item" href="<?php print $front_page; ?>user/login" data-modal-href="#modal--login"><?php print t('Log In'); ?></a></li>
+        <li class="login"><?php print l(t('Log In'), 'user/login', array('attributes' => array('class' => array('secondary-nav-item'), 'data-modal-href' => '#modal--login'))) ?></li>
       <?php endif; ?>
     </ul>
   </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/navigation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/navigation.tpl.php
@@ -35,7 +35,7 @@
           <a href="#" class="navigation__dropdown-toggle"><?php print $user_identifier ?></a>
           <ul>
             <li><?php print l("My Account", 'user/'. $user->uid); ?></li>
-            <li><a id="link--logout" href="<?php print $front_page; ?>user/logout"><?php print t('Log Out'); ?></a></li>
+            <li><a id="link--logout" href="<?php print $GLOBALS['base_url'] ?>/user/logout"><?php print t('Log Out'); ?></a></li>
           </ul>
         </li>
       <?php else: ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/navigation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/navigation.tpl.php
@@ -35,11 +35,11 @@
           <a href="#" class="navigation__dropdown-toggle"><?php print $user_identifier ?></a>
           <ul>
             <li><?php print l("My Account", 'user/'. $user->uid); ?></li>
-            <li><?php print l(t('Log Out'), 'user/logout', array('attributes' => array('class' => array('secondary-nav-item')))) ?></li>
+            <li><?php print l(t('Log Out'), 'user/logout', array('attributes' => array('class' => array('secondary-nav-item'), 'id' => 'link--logout'))) ?></li>
           </ul>
         </li>
       <?php else: ?>
-        <li class="login"><?php print l(t('Log In'), 'user/login', array('attributes' => array('class' => array('secondary-nav-item'), 'data-modal-href' => '#modal--login'))) ?></li>
+        <li class="login"><?php print l(t('Log In'), 'user/login', array('attributes' => array('class' => array('secondary-nav-item'), 'data-modal-href' => '#modal--login', 'id' => 'link--login'))) ?></li>
       <?php endif; ?>
     </ul>
   </div>


### PR DESCRIPTION
#### What's this PR do?

Fixes the logout URL (on path prefixes it fails)
#### How should this be manually tested?

Go to any page, including path prefixed ones, and try logging out
#### Any background context you want to provide?

Issue was the user/logout was being appended to the path prefix, so you'd get a url like ususer/logout. I tried initially just adding a slash to /user/logout, which fixes it on path prefixes. However on other pages this URL breaks. The solution was to just create the URL from scratch and guarantee it's the same URL for everyone, every time on every page.
#### What are the relevant tickets?

Fixes #5283 
