### PR TITLE
Fixes #5183: Redirect requests based on user/GeoIP info

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -7,6 +7,9 @@
 include_once 'dosomething_global.features.inc';
 define("TRANSLATABLE_TYPES", 'static_content,campaign,home');
 
+// Default language: Global English
+define('DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE', 'en-global');
+
 /**
  * Implements hook_init().
  */
@@ -256,8 +259,8 @@ function dosomething_global_get_language($account, stdClass $node = NULL) {
       $language = $account->language;
     }
     // If there's no published translation in their language try 'en-global'.
-    elseif ($node->translations->data['en-global']['status']) {
-      $language = 'en-global';
+    elseif ($node->translations->data[DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE]['status']) {
+      $language = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
     }
     // Default to node language if there's no translation in their language and no 'en-global'.
     else {
@@ -293,7 +296,7 @@ function dosomething_global_is_translation_request() {
 
         // If the prefix matches a language prefix besides that of Global
         // English:
-        if ($matches[1] == $sys_lang->prefix && $sys_lang->language != 'en-global') {
+        if ($matches[1] == $sys_lang->prefix && $sys_lang->language != DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE) {
 
           return TRUE;
         }
@@ -327,7 +330,7 @@ function dosomething_global_redirect_node_auth() {
   // All languages, as an array of objects.
   $languages = language_list();
 
-  $global_lang_code = 'en-global';
+  $global_lang_code = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
 
   if (empty($languages[$global_lang_code])) {
     watchdog('dosomething_global', "Can't load %lang language",
@@ -362,7 +365,7 @@ function dosomething_global_redirect_node_anon() {
 
   // Map GeoIP country to a system language. Default to 'en-global'.
   $user_country_code = dosomething_settings_get_geo_country_code();
-  $target_lang_code = 'en-global';
+  $target_lang_code = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
 
   $lang_map = variable_get('dosomething_global_language_map', '');
   foreach ($lang_map as $lang_key => $lang) {
@@ -373,7 +376,7 @@ function dosomething_global_redirect_node_anon() {
   }
 
   // If we're actually supposed to show the en-global version:
-  if ('en-global' == $target_lang_code) {
+  if ($target_lang_code == DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE) {
     return;
   }
 

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -11,12 +11,13 @@ define("TRANSLATABLE_TYPES", 'static_content,campaign,home');
  * Implements hook_init().
  */
 function dosomething_global_init() {
+  global $user;
+
   // Verify we're dealing with a node edit with no translation specification in the URL
   if (arg(0) == "node" && is_numeric(arg(1)) && arg(2) == "edit" && null == arg(3)) {
     // Load the page node and user
     $nid = arg(1);
     $node = node_load($nid);
-    global $user;
 
     // Load the languages being used
     $src_language = $node->language;
@@ -35,6 +36,22 @@ function dosomething_global_init() {
       drupal_goto($new_url);
     }
   }
+
+  // Handle translation redirects for authenticated and anonymous users when
+  // they request bare (Global English) URLs.
+  //
+  // Passing 'noredirect=1' will defeat the redirect.
+  if (arg(0) == 'node' && is_numeric(arg(1)) && '' == arg(2) &&
+      !dosomething_global_is_translation_request() &&
+      empty($_GET['noredirect'])) {
+
+    if ($user->uid) {
+      dosomething_global_redirect_node_auth();
+    } else {
+      dosomething_global_redirect_node_anon();
+    }
+  }
+
 }
 
 /**
@@ -255,4 +272,144 @@ function dosomething_global_get_language($account, stdClass $node = NULL) {
   }
 
   return $language;
+}
+
+/**
+ * Detect from the original request path whether the current request is for
+ * translated (non-Global English) content.
+ *
+ * This assumes that Global English is mapped to a blank ('') URL prefix.
+ *
+ * @return bool
+ */
+function dosomething_global_is_translation_request() {
+
+  $languages = language_list();
+  $matches = array();
+
+  if (preg_match('/([^\/]+)\//', request_path(), $matches)) {
+    foreach ($languages as $sys_lang) {
+
+      // If the prefix matches a language prefix besides that of Global
+      // English:
+      if ($matches[1] == $sys_lang->prefix && $sys_lang->language != 'en-global') {
+
+        return TRUE;
+      }
+    }
+  }
+  return FALSE;
+}
+
+/**
+ * Handle redirects to translated content for authenticated users. In this
+ * case:
+ *
+ * - If my profile includes a language preference,
+ * - and I'm not a privileged user (admin, editor, etc.),
+ * - and I request a bare URL (e.g., /campaigns/sample),
+ * - and there is a translation available (e.g., /voluntario/ejemplo),
+ * - then issue a 302 redirect to the translation's URL.
+ */
+function dosomething_global_redirect_node_auth() {
+  global $user;
+
+  // Don't do redirects for privileged users.
+  if (user_access('access administration menu')) {
+    return;
+  }
+
+  // User language.
+  $user_lang_code = $user->language ?: 'en';
+
+  // All languages, as an array of objects.
+  $languages = language_list();
+
+  $global_lang_code = 'en-global';
+
+  if (empty($languages[$global_lang_code])) {
+    watchdog('dosomething_global', "Can't load %lang language",
+      array('%lang' => $global_lang_code), WATCHDOG_ERROR);
+    return;
+  }
+  $language_global = $languages[$global_lang_code];
+
+  // Don't redirect for Global English speakers.
+  if ($user_lang_code == $language_global->language) {
+    return;
+  }
+
+  $node = node_load(arg(1));
+
+  if ($languages[$user_lang_code]) {
+    dosomething_global_redirect_node_language($node, $user_lang_code, 302);
+  }
+}
+
+/**
+ * Handle redirects to translated content for anonymous users. In this
+ * case:
+ *
+ * - If I request a bare URL (e.g., /campaigns/sample),
+ * - and there is a translation available (e.g., /voluntario/ejemplo),
+ * - then issue a 301 redirect to the translation's URL.
+ */
+function dosomething_global_redirect_node_anon() {
+
+  // All languages, as an array of objects.
+  $languages = language_list();
+
+  // Map GeoIP country to a system language. Default to 'en-global'.
+  $user_country_code = dosomething_settings_get_geo_country_code();
+  $target_lang_code = 'en-global';
+
+  $lang_map = variable_get('dosomething_global_language_map', '');
+  foreach ($lang_map as $lang_key => $lang) {
+    if ($lang['country'] == $user_country_code) {
+      $target_lang_code = $lang_key;
+      break;
+    }
+  }
+
+  // If we're actually supposed to show the en-global version:
+  if ('en-global' == $target_lang_code) {
+    return;
+  }
+
+  if (empty($languages[$target_lang_code])) {
+    watchdog('dosomething_global', "Can't load %lang language",
+      array('%lang' => $target_lang_code), WATCHDOG_ERROR);
+    return;
+  }
+
+  $node = node_load(arg(1));
+
+  dosomething_global_redirect_node_language($node, $target_lang_code, 301);
+}
+
+/**
+ * Given a node object, a language code (e.g., "en", "en-global", "es-mx"),
+ * and a redirect status, redirect the request to the desired translation's
+ * URL.
+ *
+ * @param $node
+ * @param $language_code
+ * @param int $redirect_status
+ */
+function dosomething_global_redirect_node_language($node, $language_code, $redirect_status = 302) {
+
+  $languages = language_list();
+
+  // Can only redirect to an published, translated version.
+  if (!empty($node->translations->data[$language_code]) && (bool)$node->translations->data[$language_code]['status']) {
+
+    $target_node = $node->translations->data[$language_code];
+
+    // Might be overly formal: We could pull 'node/nid' from the current
+    // request. This is in case of the unlikely (impossible?) event that
+    // a translated version of this node has a different entity ID.
+    $target_path = sprintf('node/%s', $target_node['entity_id']);
+
+    drupal_goto(url($target_path, array('language' => $languages[$language_code])), array(), $redirect_status);
+  }
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -41,7 +41,7 @@ function dosomething_global_init() {
   // they request bare (Global English) URLs.
   //
   // Passing 'noredirect=1' will defeat the redirect.
-  if (arg(0) == 'node' && is_numeric(arg(1)) && '' == arg(2) &&
+  if (arg(0) == 'node' && is_numeric(arg(1)) && empty(arg(2)) &&
       !dosomething_global_is_translation_request() &&
       empty($_GET['noredirect'])) {
 
@@ -288,13 +288,15 @@ function dosomething_global_is_translation_request() {
   $matches = array();
 
   if (preg_match('/([^\/]+)\//', request_path(), $matches)) {
-    foreach ($languages as $sys_lang) {
+    if (!empty($matches[1])) {
+      foreach ($languages as $sys_lang) {
 
-      // If the prefix matches a language prefix besides that of Global
-      // English:
-      if ($matches[1] == $sys_lang->prefix && $sys_lang->language != 'en-global') {
+        // If the prefix matches a language prefix besides that of Global
+        // English:
+        if ($matches[1] == $sys_lang->prefix && $sys_lang->language != 'en-global') {
 
-        return TRUE;
+          return TRUE;
+        }
       }
     }
   }
@@ -332,10 +334,9 @@ function dosomething_global_redirect_node_auth() {
       array('%lang' => $global_lang_code), WATCHDOG_ERROR);
     return;
   }
-  $language_global = $languages[$global_lang_code];
 
   // Don't redirect for Global English speakers.
-  if ($user_lang_code == $language_global->language) {
+  if ($user_lang_code == $global_lang_code) {
     return;
   }
 


### PR DESCRIPTION
#### What's this PR do?

Addresses the two use cases in #5183, specifically when and how to redirect anonymous and authenticated user requests to node URLs.
#### Where should the reviewer start?

All of the work is in `dosomething_global.module`. Start at this comment in `dosomething_global_init()`:

```
  // Handle translation redirects for authenticated and anonymous users when  
  // they request bare (Global English) URLs.
```

The code below calls a different function depending on whether the user is authenticated: `dosomething_global_redirect_node_auth()` or `dosomething_global_redirect_node_anon()`. The rest of the logic is in those two functions.

Both functions end with calling the helper function `dosomething_global_redirect_node_language()`, which is also part of this PR.
#### How should this be manually tested?

_As an anonymous user:_ Use Chrome's [ModHeaders](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj?hl=en) extension, or something similar, to fake requests from different locations to node content. The header is

`X-Fastly-Country-Code: US | BR | MX | etc.`
1. Request a bare URL (e.g., `/campaigns/test`) from a supported country (e.g., `BR`) where the node has a translated, published version. You should get redirected.
2. Request a bare URL (e.g., `/campaigns/test`) from a supported country (e.g., `BR`) where the node has a translated, unpublished version. You should not get redirected.
3. Request a bare URL (e.g., `/campaigns/test`) from an unsupported country (e.g., `IN`). You should not get redirected.

_As an authenticated user:_ Update the user profile to test with different language settings.

_N.b. If you are a privileged user, you will not get redirected._

We base "privileged" on whether you can access the admin area (permission: `access administration menu`).
1. Request a bare URL where the node has a published version in your language. You should get redirected.
2. Request a bare URL where the node has an unpublished version in your language. You should not get redirected.
#### Any background context you want to provide?

This gets hella bejesus confusing, so the goal in the code is to make the logic as simple as possible.
#### What are the relevant tickets?
#5183
#### Screenshots (if appropriate)

N/A
#### Questions:
- Does the knowledge base need an update? _Probably_
