### PR TITLE
Ensures Drupal messages are wrapped in t()

### DIFF
--- a/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
+++ b/lib/modules/dosomething/dosomething_reward/dosomething_reward.forms.inc
@@ -59,7 +59,7 @@ function dosomething_reward_redeem_form_submit($form, &$form_state) {
   $reward = entity_load_single('reward', $values['id']);
   $reward->redeem($values);
   $msg = variable_get('dosomething_reward_redeem_form_confirm_msg');
-  drupal_set_message($msg);
+  drupal_set_message(t($msg));
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.forms.inc
+++ b/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.forms.inc
@@ -125,5 +125,5 @@ function dosomething_shipment_form_submit($form, &$form_state) {
   // @todo: If Shipment Item is shirt, add option / additional item values.
   $shipment->save();
 
-  drupal_set_message($values['confirm_msg']);
+  drupal_set_message(t($values['confirm_msg']));
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -68,7 +68,7 @@ function dosomething_signup_form($form, &$form_state, $nid, $label = "Sign Up") 
 function dosomething_signup_form_submit($form, &$form_state) {
   // Shouldn't be able to submit form as anonymous user, but check.
   if (!user_is_logged_in()) {
-    drupal_set_message("Please sign in first.");
+    drupal_set_message(t("Please sign in first."));
     return;
   }
   $nid = $form_state['values']['nid'];

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1227,7 +1227,7 @@ function dosomething_user_info_form_submit($form, &$form_state) {
     // Track usage for the new file.
     file_usage_add($file, 'user', 'user', $account->uid);
   }
-  drupal_set_message("User information saved.");
+  drupal_set_message(t("User information saved."));
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/login.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/login.inc
@@ -131,7 +131,6 @@ function paraneue_dosomething_pass_set_message() {
   $default_msg = 'If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes.';
   $msg = variable_get('dosomething_user_reset_password_copy', $default_msg);
 
-  // @TODO: #Global; translation substitution doesn't seem to work correctly with this. Not sure why...?
   drupal_set_message(t($msg));
 }
 

--- a/pots/dosomething_signup.pot
+++ b/pots/dosomething_signup.pot
@@ -25,6 +25,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
+#: dosomething_signup.forms.inc:71
+msgid "Please sign in first."
+msgstr ""
+
 #: dosomething_signup.forms.inc:170
 msgid "First Name"
 msgstr ""
@@ -136,3 +140,4 @@ msgstr ""
 #: dosomething_signup.info:0
 msgid "DoSomething"
 msgstr ""
+

--- a/pots/dosomething_user.pot
+++ b/pots/dosomething_user.pot
@@ -122,6 +122,10 @@ msgstr ""
 msgid "@type @identifier @id deleted."
 msgstr ""
 
+#: dosomething_user.module:1230
+msgid "User information saved."
+msgstr ""
+
 #: dosomething_user.module:1280
 msgid "million"
 msgstr ""
@@ -133,3 +137,4 @@ msgstr ""
 #: plugins/format/dosomething-affiliate-country.inc:9
 msgid "Dosomething Affiliate Country"
 msgstr ""
+

--- a/pots/paraneue_dosomething.pot
+++ b/pots/paraneue_dosomething.pot
@@ -1110,3 +1110,7 @@ msgstr ""
 #: appearance->settings->paraneue_dosomething
 msgid "dosomething1 on YouTube"
 msgstr ""
+
+#: includes/auth/login.inc
+msgid "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+msgstr ""


### PR DESCRIPTION
Fixes #5142
#### What's this PR do?

This PR ensures that messages output by Drupal to the user are wrapped in `t()` to allow showing translation of the messages if a translation is available. Also adds additional hardcoded strings to respective POT files.
#### Where should the reviewer start?

Just take a gander at the code and make sure it looks fine.
#### What are the relevant tickets?
#5142

---

@angaither 
