### PR TITLE
Fixing syntax error and ensuring user's country is set for emails

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -247,7 +247,7 @@ function dosomething_global_convert_country_to_language($country) {
 function dosomething_global_get_language($account, stdClass $node = NULL) {
   if ($node) {
     // If there is a published translation for the node in the user's language, use it.
-    if ($node->translations->data['$account->language']['status']) {
+    if ($node->translations->data{$account->language}['status']) {
       $language = $account->language;
     }
     // If there's no published translation in their language try 'en-global'.

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -96,6 +96,7 @@ function dosomething_mbp_request($origin, $params = NULL) {
 function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
   // Payload items common to all transactional messages.
   $params['first_name'] = isset($params['first_name']) ? $params['first_name'] : 'Doer';
+  $params['user_country'] = isset($params['user_country']) ? $params['user_country'] : dosomething_settings_get_geo_country_code();
   $payload = array(
     'activity' => $origin,
     'email' => $params['email'],
@@ -231,7 +232,6 @@ function dosomething_mbp_get_common_campaign_payload(&$payload, $params) {
  *   Name of Mandrill template to use for transactional message.
  */
 function dosomething_mbp_get_template_name($event_name, $user_language = NULL) {
-
   if (isset($user_langauge)) {
     $country_code = dosomething_global_convert_language_to_country($user_language);
     if ($country_code == NULL) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -559,6 +559,14 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
   }
   $wrapper = entity_metadata_wrapper('node', $node);
   $language = dosomething_global_get_language($account, $node);
+  $url_options = array(
+    'language' => $language,
+    'absolute' => TRUE,
+    'prefix' => strtolower(dosomething_global_convert_language_to_country($language)) . '/',
+    'query' => array(
+      'source' => 'node/' . $node->nid,
+    ),
+  );
 
   $params = array(
     'email' => $account->mail,
@@ -567,7 +575,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     'mobile' => dosomething_user_get_field('field_mobile', $account),
     'event_id' => $node->nid,
     'campaign_title' => $wrapper->language($language)->title_field->value(),
-    'campaign_link' => url(drupal_get_path_alias('node/' . $node->nid, $language), array('absolute' => TRUE)),
+    'campaign_link' => url('node/' . $nid, $url_options),
     'user_language' => $language,
   );
 


### PR DESCRIPTION
#### What's this PR do?

When checking for the appropriate language to use when getting a signup, the code was trying to point to the wrong name of the $node object property.

Also making sure the user's country is set so that the template is properly selected.
#### Where should the reviewer start?

If you don't have the messagebroker setup working locally, this will have to be tested locally by signing up for a campaign with your BR or MX proxy on and looking at the emails you receive. 
#### What are the relevant tickets?

Fixes #5286 and #5285
