### PR TITLE
Adding grouping to the finder query to prevent dupes in results

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/ResultsView.js
@@ -103,14 +103,10 @@ define(function(require) {
         // Results view cleared, and since we have results add the gallery into the container.
         ResultsView.$container.append(ResultsView.$gallery);
 
-        // Loopy loop! (Like me after drinking coffeeeee)
-        for (var i in data.result.response.docs) {
-          let campaign = new Campaign(data.result.response.docs[i]);
-          ResultsView.add(campaign);
-        }
+        ResultsView.campaignHelper(data);
 
         // There are more results than we've shown so far, add "Show More" button
-        ResultsView.showPaginationLink(data.result.response.numFound > ResultsView.start);
+        ResultsView.showPaginationLink(data.result.grouped.entity_id.matches > ResultsView.start);
       } else {
         ResultsView.showEmptyState();
       }
@@ -137,13 +133,11 @@ define(function(require) {
      * @param  {Object} data The raw data from the query
      */
     appendResults: function (data) {
-      // Add those results to the page!
-      for (var i in data.result.response.docs) {
-        ResultsView.add(new Campaign(data.result.response.docs[i]));
-      }
+      // Add those results to the page
+      ResultsView.campaignHelper(data);
 
       // There are more results than we've shown so far, add "Show More" button
-      ResultsView.showPaginationLink(data.result.response.numFound > ResultsView.start);
+      ResultsView.showPaginationLink(data.result.grouped.entity_id.matches > ResultsView.start);
 
       // Hey! We're done loading! I guess we can let the users know we're done.
       ResultsView.loading(false);
@@ -219,6 +213,15 @@ define(function(require) {
           this.style.opacity = 1;
         });
       });
+    },
+
+    campaignHelper: function (data) {
+      // Loopy loop! (Like me after drinking coffeeeee)
+      for (var i in data.result.grouped.entity_id.groups) {
+        var group = data.result.grouped.entity_id.groups[i];
+        let campaign = new Campaign(group.doclist.docs[0]);
+        ResultsView.add(campaign);
+      }
     }
   };
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/SolrAdapter.js
@@ -59,7 +59,9 @@ define(function(require) {
       // TODO: un-hard-code the rows
       "rows=8",
       "fl=label,tid,im_vid_1,sm_vid_Action_Type,tm_vid_1_names,im_field_cause,im_vid_2,sm_vid_Cause,tm_vid_2_names,im_field_tags,im_vid_5,sm_vid_Tags,tm_vid_5_names,fs_field_active_hours,sm_field_call_to_action,bs_field_staff_pick,ss_field_search_image_400x400,ss_field_search_image_720x720,url,ss_language",
-      "bq=ss_language:" + setting('dosomethingSearch.language') + "^10"
+      "bq=ss_language:" + setting('dosomethingSearch.language') + "^10",
+      "group.field=entity_id",
+      "group=true"
     ],
 
     // Map the input field names to the Solr query fields
@@ -159,7 +161,7 @@ define(function(require) {
         success: function (data) {
           responseCallback({
             result: data,
-            retrieved: data.response.docs.length,
+            retrieved: data.grouped.entity_id['groups'].length,
           });
         },
         error: function(data, errorType) {


### PR DESCRIPTION
- Adding the group parameters changes the format of the output and
  returns a set of results grouped in our case by entity id. Only the
  top result from each group is returned, and because the result matching
  the user's language is boosted, it should be returned first in all cases.
