### PR TITLE
Hides language selector from regional admins.

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -73,6 +73,10 @@ function dosomething_global_form_node_form_alter(&$form, &$form_state, $form_id)
 
   // Check if the user is a mexico or brazil admin
   if (dosomething_global_is_regional_admin()) {
+    // Hide language selector if it's shown.
+    if (!empty($form['language']['#access'])) {
+      $form['language']['#access'] = FALSE;
+    }
     // Get translatable fields.
     $fields = $form_state['field'];
     foreach ($fields as $field_name => $field) {


### PR DESCRIPTION
#### What's this PR do?
- Hides language selector from regional admins:  
  MX admin:  
  ![image](https://cloud.githubusercontent.com/assets/672669/10229985/911f1aa8-6883-11e5-9341-9de00a89d80f.png)  
  Super admin:  
  ![image](https://cloud.githubusercontent.com/assets/672669/10230061/ebcd1766-6883-11e5-919d-929405a2a601.png)
#### How should this be manually tested?
- Create a campaign with MX admin, try updating it
- Make sure the campaign original language is MX using admin
- Resave the campaign with admin
- Check if the view looks as expected
#### What are the relevant tickets?

Fixes #5330.
