### PR TITLE
Server Side Date Validation for different date formats

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -292,8 +292,9 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
         $form['#after_build'][] = 'dosomething_user_add_validation_attributes_to_address_fields';
       }
 
+      // Change date format for non-us users.
       if (dosomething_settings_get_geo_country_code() !== 'US') {
-        $form['#after_build'][] = 'dosomething_user_birthdate_settings';
+        $form['#after_build'][] = 'dosomething_user_birthdate_format';
       }
 
       // Custom validation & submission handlers.
@@ -313,7 +314,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
  * After build to change date format of birthdate field for non-us users
  * so it passes date validation
  */
-function dosomething_user_birthdate_settings($form, &$form_state) {
+function dosomething_user_birthdate_format($form, &$form_state) {
   $form_state['field']['field_birthdate']['und']['instance']['widget']['settings']['input_format'] = 'd/m/Y - H:i:s';
   return $form;
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -291,6 +291,11 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
       if ($is_validate_address_set) {
         $form['#after_build'][] = 'dosomething_user_add_validation_attributes_to_address_fields';
       }
+
+      if (dosomething_settings_get_geo_country_code() !== 'US') {
+        $form['#after_build'][] = 'dosomething_user_birthdate_settings';
+      }
+
       // Custom validation & submission handlers.
       $form['#validate'][] = 'dosomething_user_register_validate';
       $form['#submit'][] = 'dosomething_user_login_submit';
@@ -305,6 +310,15 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
 }
 
 /**
+ * After build to change date format of birthdate field for non-us users
+ * so it passes date validation
+ */
+function dosomething_user_birthdate_settings($form, &$form_state) {
+  $form_state['field']['field_birthdate']['und']['instance']['widget']['settings']['input_format'] = 'd/m/Y - H:i:s';
+  return $form;
+}
+
+/**
  * After build to remove language switcher.
  *
  */
@@ -312,6 +326,7 @@ function dosomething_user_remove_language_switcher($form, &$form_state) {
   unset($form['locale']);
   return $form;
 }
+
 /**
  * After build to alter the address field options.
  *

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -294,7 +294,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
 
       // Change date format for non-us users.
       if (dosomething_settings_get_geo_country_code() !== 'US') {
-        $form['#after_build'][] = 'dosomething_user_birthdate_format';
+        $form['#after_build'][] = 'dosomething_user_non_us_birthday_format';
       }
 
       // Custom validation & submission handlers.
@@ -314,8 +314,8 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
  * After build to change date format of birthdate field for non-us users
  * so it passes date validation
  */
-function dosomething_user_birthdate_format($form, &$form_state) {
-  $form_state['field']['field_birthdate']['und']['instance']['widget']['settings']['input_format'] = 'd/m/Y - H:i:s';
+function dosomething_user_non_us_birthday_format($form, &$form_state) {
+  $form_state['field']['field_birthdate'][LANGUAGE_NONE]['instance']['widget']['settings']['input_format'] = 'd/m/Y - H:i:s';
   return $form;
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -282,7 +282,17 @@ function paraneue_dosomething_form_user_profile_form_alter(&$form, &$form_state,
 function paraneue_dosomething_form_user_profile_after_build($form, &$form_state) {
   $form['#weight'] = '-18';
   $form['#attributes']['class'] = array('auth-twocol');
-  $date_format = (dosomething_settings_get_geo_country_code() === 'US') ? 'MM/DD/YYYY' : 'DD/MM/YYYY';
+
+  $date_format = 'MM/DD/YYYY';
+
+  // Update the format of the default value of the birthdate field for non-US users.
+  if (dosomething_settings_get_geo_country_code() !== 'US') {
+    $date_format = 'DD/MM/YYYY';
+    if ($form['value']['date']['#value'] && dosomething_user_get_field('field_birthdate')) {
+      $form['value']['date']['#value'] = dosomething_user_get_field_birthdate(dosomething_user_get_field('field_birthdate'), 'd/m/Y');
+    }
+  }
+
   $form['value']['date']['#attributes']['placeholder'] = $date_format;
   $form['value']['date']['#attributes']['class'] = array('js-validate');
   $form['value']['date']['#attributes']['data-validate'] = 'birthday';


### PR DESCRIPTION
#### What's this PR do?

This PR uses an `#after_build` function to change the date format setting for the birthdate field widget so that when users enter a date in the form of `DD/MM/YYYY` the date will pass server side date validation. 

Also, in this PR I update the format of default value for the birthdate field in the user profile edit form to switch based on country code.
#### Where should the reviewer start?

Start at `dosomething_user.module`
#### How should this be manually tested?

You have try registering a new account as a global user and a US user and it should work with the different formats.
#### What are the relevant tickets?

Fixes #5262 
