### PR TITLE
Contact Emails for BR and MX users

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -305,7 +305,7 @@ function paraneue_dosomething_preprocess_node(&$vars) {
  * @see paraneue_dosomething_preprocess_node().
  */
 function paraneue_dosomething_add_info_bar(&$vars) {
-  // Initialize info_bar_vars with avariable that will always be set:
+  // Initialize info_bar_vars with a variable that will always be set:
   if (isset($vars['formatted_partners'])) {
     $info_bar_vars = array(
       'formatted_partners' => $vars['formatted_partners'],

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -305,7 +305,7 @@ function paraneue_dosomething_preprocess_node(&$vars) {
  * @see paraneue_dosomething_preprocess_node().
  */
 function paraneue_dosomething_add_info_bar(&$vars) {
-
+  // Initialize info_bar_vars with avariable that will always be set:
   if (isset($vars['formatted_partners'])) {
     $info_bar_vars = array(
       'formatted_partners' => $vars['formatted_partners'],
@@ -319,11 +319,11 @@ function paraneue_dosomething_add_info_bar(&$vars) {
     'MX' => 'ayuda@dosomething.org',
   );
 
-  // For specific countries, us a contact email address instead of zendesk form.
+  // For the countries in $country_contact_emails, use a contact email address instead of zendesk form.
   if (array_key_exists($country_code, $country_contact_emails)) {
     $info_bar_vars['contact_us_email'] = '<a href="mailto:' . $country_contact_emails[$country_code] .'">'. $country_contact_emails[$country_code] . '</a>';
+  // All other countries get the zendesk form.
   } else {
-    // Initialize info_bar_vars with variable that will always be set:
     $zendesk_form_header = t(variable_get('dosomething_zendesk_form_header'));
     $info_bar_vars['zendesk_form_header'] = $zendesk_form_header;
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -305,11 +305,10 @@ function paraneue_dosomething_preprocess_node(&$vars) {
  * @see paraneue_dosomething_preprocess_node().
  */
 function paraneue_dosomething_add_info_bar(&$vars) {
-  // Initialize info_bar_vars with a variable that will always be set:
+  $info_bar_vars = array();
+
   if (isset($vars['formatted_partners'])) {
-    $info_bar_vars = array(
-      'formatted_partners' => $vars['formatted_partners'],
-    );
+    $info_bar_vars['formatted_partners'] = $vars['formatted_partners'];
   }
 
   $country_code = dosomething_settings_get_geo_country_code();

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -305,23 +305,30 @@ function paraneue_dosomething_preprocess_node(&$vars) {
  * @see paraneue_dosomething_preprocess_node().
  */
 function paraneue_dosomething_add_info_bar(&$vars) {
-  // Initialize info_bar_vars with variable that will always be set:
-  $zendesk_form_header = t(variable_get('dosomething_zendesk_form_header'));
-  $info_bar_vars = array(
-    'zendesk_form_header' => $zendesk_form_header,
+
+  if (isset($vars['formatted_partners'])) {
+    $info_bar_vars = array(
+      'formatted_partners' => $vars['formatted_partners'],
+    );
+  }
+
+  $country_code = dosomething_settings_get_geo_country_code();
+
+  $country_contact_emails = array(
+    'BR' => 'ajuda@dosomething.org',
+    'MX' => 'ayuda@dosomething.org',
   );
-  // List $vars variable names to pass to info bar:
-  $info_var_names = array(
-    'formatted_partners',
-    'zendesk_form',
-  );
-  // Loop through the variable names:
-  foreach ($info_var_names as $variable) {
-    $info_bar_vars[$variable] = NULL;
-    // If the vars is set for this variable name:
-    if (isset($vars[$variable])) {
-      // Store its value.
-      $info_bar_vars[$variable] = $vars[$variable];
+
+  // For specific countries, us a contact email address instead of zendesk form.
+  if (array_key_exists($country_code, $country_contact_emails)) {
+    $info_bar_vars['contact_us_email'] = '<a href="mailto:' . $country_contact_emails[$country_code] .'">'. $country_contact_emails[$country_code] . '</a>';
+  } else {
+    // Initialize info_bar_vars with variable that will always be set:
+    $zendesk_form_header = t(variable_get('dosomething_zendesk_form_header'));
+    $info_bar_vars['zendesk_form_header'] = $zendesk_form_header;
+
+    if (isset($vars['zendesk_form'])) {
+      $info_bar_vars['zendesk_form'] = $vars['zendesk_form'];
     }
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
@@ -5,14 +5,18 @@
  **/
 ?>
 
-<?php if (isset($zendesk_form) || isset($formatted_partners)): ?>
+<?php if (isset($zendesk_form) || isset($formatted_partners) || isset($contact_us_email)): ?>
 <footer class="info-bar">
   <div class="wrapper">
     <?php if (isset($formatted_partners)): ?>
       <?php print t("In partnership with"); ?> <?php print $formatted_partners; ?>
     <?php endif; ?>
 
-    <?php if (isset($zendesk_form)): ?>
+    <?php if (isset($contact_us_email)): ?>
+      <div class="info-bar__secondary">
+        <?php print t('Questions? Email: '); ?> <?php print $contact_us_email; ?>
+      </div>
+    <?php elseif (isset($zendesk_form)): ?>
       <div class="info-bar__secondary">
         <?php print t('Questions?'); ?> <a href="#" data-modal-href="#modal-contact-form"><?php print t('Contact Us'); ?></a>
         <div data-modal id="modal-contact-form" class="modal--contact" role="dialog">


### PR DESCRIPTION
#### What's this PR do?

For BR and MX users, we display a contact email in the info bar instead of the zendesk form modal.
#### Where should the reviewer start?

`preprocess.inc` sets all the variables we need for the info bar depending on if it's a country that has an email contact or uses the zendesk form.
#### What are the relevant tickets?

Fixes #5078 
