### PR TITLE
Remove translate tab for regional admins

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -115,8 +115,8 @@ function dosomething_global_menu_local_tasks_alter(&$data, $route_name) {
       }
 
       // Remove the translate tab in CMS side for regional admins
-      $remove_trasnlate_tab_script = "jQuery(document).ready(function () { var tabMenu = jQuery('ul.tabs.primary'); var tab = tabMenu.find('li > a:contains(\"Translate\")').parent().remove(); });";
-      drupal_add_js($remove_trasnlate_tab_script, 'inline');
+      $remove_translate_tab_script = "jQuery(document).ready(function () { var tabMenu = jQuery('ul.tabs.primary'); var tab = tabMenu.find('li > a:contains(\"Translate\")').parent().remove(); });";
+      drupal_add_js($remove_translate_tab_script, 'inline');
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -217,7 +217,7 @@ function dosomething_global_get_user_language($user = NULL) {
  *  A two letter language code.
  *
  * @return string language
- \*  The country that maps to the language passed in.
+ *  The country that maps to the language passed in.
  */
 function dosomething_global_convert_language_to_country($language) {
   $lang_map = variable_get('dosomething_global_language_map', '');

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -113,6 +113,10 @@ function dosomething_global_menu_local_tasks_alter(&$data, $route_name) {
       if (isset($data['tabs'][1]['output'])) {
         unset($data['tabs'][1]['output']);
       }
+
+      // Remove the translate tab in CMS side for regional admins
+      $remove_trasnlate_tab_script = "jQuery(document).ready(function () { var tabMenu = jQuery('ul.tabs.primary'); var tab = tabMenu.find('li > a:contains(\"Translate\")').parent().remove(); });";
+      drupal_add_js($remove_trasnlate_tab_script, 'inline');
     }
   }
 }
@@ -213,7 +217,7 @@ function dosomething_global_get_user_language($user = NULL) {
  *  A two letter language code.
  *
  * @return string language
- *  The country that maps to the language passed in.
+ \*  The country that maps to the language passed in.
  */
 function dosomething_global_convert_language_to_country($language) {
   $lang_map = variable_get('dosomething_global_language_map', '');


### PR DESCRIPTION
Fixes #5191 
#### What's this PR do?

This PR provides a JS solution to remove the "Translate" tab in the Admin CMS for regional admins.
#### Where should the reviewer start?

Checkout the code and confirm it looks like I placed it in the right place Drooopy-wise.
#### How should this be manually tested?

If you feel the desire to do so, pull down the branch, pretend to be a cultural icon from either Mexico or Brasíl and get on with administering a global campaign node like a BO$$. If you see the translate tab in the Admin CMS side, then boy, did I mess up.... so lemme know!
#### Any background context you want to provide?

Decided to go the route of selecting the list item for the tab based on it containing the text "Translate". The list items have no useful class hooks to be able to select them easily, and I didn't want to go based on child item number cause that could easily change in the future. Just FYI.
#### What are the relevant tickets?
#5191

---

@angaither 

cc: @mshmsh5000 @mikefantini 
