### PR TITLE
Translate tab removed for regional admins on campaign node.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -5,6 +5,31 @@
  */
 
 /**
+ * Returns admin tabs edited for regional admins.
+ *
+ * @param mixed  $tabs
+ * @return mixed mixed
+ */
+function paraneue_dosomething_edit_regional_admin_tabs($tabs) {
+  $removeable_tabs = [
+    'Devel',
+    'Translate',
+  ];
+  $primary_tabs = $tabs['#primary'];
+
+  foreach($primary_tabs as $index => $tab) {
+    if (in_array($tab['#link']['title'], $removeable_tabs)) {
+      unset($primary_tabs[$index]);
+    }
+  }
+
+  // Reset array indexes
+  $tabs['#primary'] = array_values($primary_tabs);
+
+  return $tabs;
+}
+
+/**
  * Returns a gallery css class name for a given gallery cms $style
  *
  * @param string $style

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -89,8 +89,6 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     }
   }
 
-
-
   /**
    * Determine Page template.
    */

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -17,7 +17,6 @@ function paraneue_dosomething_preprocess_html(&$vars) {
  * Implements theme_preprocess_page().
  */
 function paraneue_dosomething_preprocess_page(&$vars) {
-
   // Add theme suggestion for page template based on node.
   if (isset($vars['node']->type)) {
     // If the content type's machine name is "my_machine_name" the file
@@ -82,6 +81,11 @@ function paraneue_dosomething_preprocess_page(&$vars) {
   // Only display tabs for Staff and regional admins.
   if (isset($vars['tabs']) && !dosomething_user_is_staff() && !dosomething_global_is_regional_admin()) {
     unset($vars['tabs']);
+  }
+
+  // Display edited admin tabs for regional admins.
+  if (dosomething_global_is_regional_admin()) {
+    $vars['tabs'] = paraneue_dosomething_edit_regional_admin_tabs($vars['tabs']);
   }
 
   /**

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -79,14 +79,17 @@ function paraneue_dosomething_preprocess_page(&$vars) {
   $vars['navigation'] = theme('navigation', $navigation_vars);
 
   // Only display tabs for Staff and regional admins.
-  if (isset($vars['tabs']) && !dosomething_user_is_staff() && !dosomething_global_is_regional_admin()) {
-    unset($vars['tabs']);
+  if (isset($vars['tabs'])) {
+    if (!dosomething_user_is_staff() && !dosomething_global_is_regional_admin()) {
+      unset($vars['tabs']);
+    }
+    // Display edited admin tabs for regional admins.
+    else if (dosomething_global_is_regional_admin()) {
+      $vars['tabs'] = paraneue_dosomething_edit_regional_admin_tabs($vars['tabs']);
+    }
   }
 
-  // Display edited admin tabs for regional admins.
-  if (dosomething_global_is_regional_admin()) {
-    $vars['tabs'] = paraneue_dosomething_edit_regional_admin_tabs($vars['tabs']);
-  }
+
 
   /**
    * Determine Page template.


### PR DESCRIPTION
# Fixes #5362
#### What's this PR do?

This PR removes the Translate tab (as well as the Devel tab) from the Admin Tabs in the main site view (as opposed to the tab in the admin CMS side).
#### Where should the reviewer start?

Start at line 86 in the **preprocess.inc** file and follow the breadcrumbs over into the **helpers.inc** file :wink: 
#### How should this be manually tested?

If so desired, you can test by pulling down the branch, pretending you're a Brazilian or Mexican admin by changing your admin settings, and then seeing if the Translate tab (and Devel tab) show up for you when viewing the main site.
#### What are the relevant tickets?
#5362

---

@sbsmith86 @DFurnes 

cc: @mikefantini @mshmsh5000 
