### PR TITLE
Translation status view

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.info
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.info
@@ -131,4 +131,4 @@ features[views_view][] = content_search
 features[views_view][] = user_search
 files[] = dosomething_user.test
 files[] = includes/dosomething_user_remote.inc
-mtime = 1443199426
+mtime = 1444064621

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1452,4 +1452,10 @@ function dosomething_user_views_pre_render(&$view) {
   if ($view->name == 'user_search' && count($view->result) == 1) {
     drupal_goto('user/' . $view->result[0]->uid);
   }
+
+  if ($view->name == 'content_search') {
+    // Remove grouping labels
+    $table_style = 'table caption { display: none }';
+    drupal_add_css($table_style, $option['type'] = inline);
+  }
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1456,6 +1456,6 @@ function dosomething_user_views_pre_render(&$view) {
   if ($view->name == 'content_search') {
     // Remove grouping labels
     $table_style = 'table caption { display: none }';
-    drupal_add_css($table_style, $option['type'] = inline);
+    drupal_add_css($table_style, ['type' => 'inline']);
   }
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.views_default.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.views_default.inc
@@ -22,7 +22,7 @@ function dosomething_user_views_default_views() {
 
   /* Display: Master */
   $handler = $view->new_display('default', 'Master', 'default');
-  $handler->display->display_options['title'] = 'Content Search';
+  $handler->display->display_options['title'] = 'Translation Status';
   $handler->display->display_options['use_more_always'] = FALSE;
   $handler->display->display_options['access']['type'] = 'role';
   $handler->display->display_options['access']['role'] = array(
@@ -210,9 +210,192 @@ function dosomething_user_views_default_views() {
   $handler->display->display_options['menu']['weight'] = '0';
   $handler->display->display_options['menu']['context'] = 0;
   $handler->display->display_options['menu']['context_only_inline'] = 0;
+
+  /* Display: Translation Status */
+  $handler = $view->new_display('page', 'Translation Status', 'page_2');
+  $handler->display->display_options['defaults']['css_class'] = FALSE;
+  $handler->display->display_options['css_class'] = 'translation-status';
+  $handler->display->display_options['defaults']['style_plugin'] = FALSE;
+  $handler->display->display_options['style_plugin'] = 'table';
+  $handler->display->display_options['style_options']['grouping'] = array(
+    0 => array(
+      'field' => 'nid',
+      'rendered' => 1,
+      'rendered_strip' => 0,
+    ),
+  );
+  $handler->display->display_options['style_options']['columns'] = array(
+    'nid' => 'nid',
+    'title' => 'title',
+    'translate_link' => 'translate_link',
+    'status' => 'status',
+    'source' => 'source',
+    'language' => 'language',
+  );
+  $handler->display->display_options['style_options']['default'] = '-1';
+  $handler->display->display_options['style_options']['info'] = array(
+    'nid' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'title' => array(
+      'sortable' => 1,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'translate_link' => array(
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'status' => array(
+      'sortable' => 1,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'source' => array(
+      'sortable' => 0,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'language' => array(
+      'sortable' => 1,
+      'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+  );
+  $handler->display->display_options['style_options']['sticky'] = TRUE;
+  $handler->display->display_options['defaults']['style_options'] = FALSE;
+  $handler->display->display_options['defaults']['row_plugin'] = FALSE;
+  $handler->display->display_options['defaults']['row_options'] = FALSE;
+  $handler->display->display_options['defaults']['relationships'] = FALSE;
+  /* Relationship: Content: Entity translation: translations */
+  $handler->display->display_options['relationships']['entity_translations']['id'] = 'entity_translations';
+  $handler->display->display_options['relationships']['entity_translations']['table'] = 'node';
+  $handler->display->display_options['relationships']['entity_translations']['field'] = 'entity_translations';
+  $handler->display->display_options['defaults']['fields'] = FALSE;
+  /* Field: Content: Nid */
+  $handler->display->display_options['fields']['nid']['id'] = 'nid';
+  $handler->display->display_options['fields']['nid']['table'] = 'node';
+  $handler->display->display_options['fields']['nid']['field'] = 'nid';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+  $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+  /* Field: Entity translation: Translate link */
+  $handler->display->display_options['fields']['translate_link']['id'] = 'translate_link';
+  $handler->display->display_options['fields']['translate_link']['table'] = 'entity_translation';
+  $handler->display->display_options['fields']['translate_link']['field'] = 'translate_link';
+  $handler->display->display_options['fields']['translate_link']['relationship'] = 'entity_translations';
+  /* Field: Content: Published */
+  $handler->display->display_options['fields']['status']['id'] = 'status';
+  $handler->display->display_options['fields']['status']['table'] = 'node';
+  $handler->display->display_options['fields']['status']['field'] = 'status';
+  $handler->display->display_options['fields']['status']['not'] = 0;
+  /* Field: Entity translation: Source */
+  $handler->display->display_options['fields']['source']['id'] = 'source';
+  $handler->display->display_options['fields']['source']['table'] = 'entity_translation';
+  $handler->display->display_options['fields']['source']['field'] = 'source';
+  $handler->display->display_options['fields']['source']['relationship'] = 'entity_translations';
+  /* Field: Entity translation: Language */
+  $handler->display->display_options['fields']['language']['id'] = 'language';
+  $handler->display->display_options['fields']['language']['table'] = 'entity_translation';
+  $handler->display->display_options['fields']['language']['field'] = 'language';
+  $handler->display->display_options['fields']['language']['relationship'] = 'entity_translations';
+  $handler->display->display_options['fields']['language']['label'] = 'Translation';
+  $handler->display->display_options['defaults']['arguments'] = FALSE;
+  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
+  $handler->display->display_options['defaults']['filters'] = FALSE;
+  /* Filter criterion: Content: Title */
+  $handler->display->display_options['filters']['title']['id'] = 'title';
+  $handler->display->display_options['filters']['title']['table'] = 'node';
+  $handler->display->display_options['filters']['title']['field'] = 'title';
+  $handler->display->display_options['filters']['title']['operator'] = 'contains';
+  $handler->display->display_options['filters']['title']['group'] = 1;
+  $handler->display->display_options['filters']['title']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['title']['expose']['operator_id'] = 'title_op';
+  $handler->display->display_options['filters']['title']['expose']['label'] = 'Title';
+  $handler->display->display_options['filters']['title']['expose']['operator'] = 'title_op';
+  $handler->display->display_options['filters']['title']['expose']['identifier'] = 'title';
+  $handler->display->display_options['filters']['title']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+  );
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['group'] = 1;
+  $handler->display->display_options['filters']['type']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['type']['expose']['operator_id'] = 'type_op';
+  $handler->display->display_options['filters']['type']['expose']['label'] = 'Type';
+  $handler->display->display_options['filters']['type']['expose']['operator'] = 'type_op';
+  $handler->display->display_options['filters']['type']['expose']['identifier'] = 'type';
+  $handler->display->display_options['filters']['type']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+  );
+  /* Filter criterion: Content: Cause (field_cause) */
+  $handler->display->display_options['filters']['field_cause_tid']['id'] = 'field_cause_tid';
+  $handler->display->display_options['filters']['field_cause_tid']['table'] = 'field_data_field_cause';
+  $handler->display->display_options['filters']['field_cause_tid']['field'] = 'field_cause_tid';
+  $handler->display->display_options['filters']['field_cause_tid']['group'] = 1;
+  $handler->display->display_options['filters']['field_cause_tid']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['field_cause_tid']['expose']['operator_id'] = 'field_cause_tid_op';
+  $handler->display->display_options['filters']['field_cause_tid']['expose']['label'] = 'Cause (field_cause)';
+  $handler->display->display_options['filters']['field_cause_tid']['expose']['operator'] = 'field_cause_tid_op';
+  $handler->display->display_options['filters']['field_cause_tid']['expose']['identifier'] = 'field_cause_tid';
+  $handler->display->display_options['filters']['field_cause_tid']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+  );
+  $handler->display->display_options['filters']['field_cause_tid']['type'] = 'select';
+  $handler->display->display_options['filters']['field_cause_tid']['vocabulary'] = 'cause';
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 'All';
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['status']['expose']['operator_id'] = '';
+  $handler->display->display_options['filters']['status']['expose']['label'] = 'Published';
+  $handler->display->display_options['filters']['status']['expose']['operator'] = 'status_op';
+  $handler->display->display_options['filters']['status']['expose']['identifier'] = 'status';
+  $handler->display->display_options['filters']['status']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+    6 => 0,
+    7 => 0,
+    8 => 0,
+    9 => 0,
+    10 => 0,
+  );
+  $handler->display->display_options['path'] = 'admin/content/search/translation';
   $translatables['content_search'] = array(
     t('Master'),
-    t('Content Search'),
+    t('Translation Status'),
     t('more'),
     t('Apply'),
     t('Reset'),
@@ -235,6 +418,11 @@ function dosomething_user_views_default_views() {
     t('Published'),
     t('Cause (field_cause)'),
     t('Page'),
+    t('Translations'),
+    t('Nid'),
+    t('Translate link'),
+    t('Source'),
+    t('Translation'),
   );
   $export['content_search'] = $view;
 


### PR DESCRIPTION
#### What's this PR do?

Adds a new view to the /admin/content/search/translation which lists all campaigns and there associated translations 
#### How should this be manually tested?

navigate to the above URL ^ and check the data in the table is correct
#### Any background context you want to provide?

@angaither and I opted to make a quick n' dirty solution to this that doesn't look to great rathter than coding & theming this custom. @mikefantini approved the v1 version
#### What are the relevant tickets?

Fixes #5300 

@blisteringherb can you verify the exports?
@DFurnes can you verify the css?

EDIT: also ffs of course theres a merge conflict
