### PR TITLE
Remove asset path

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -479,9 +479,6 @@ function pull_db {
       echo "Setting Stage File Proxy to staging URL..."
       drush vset stage_file_proxy_origin "http://staging.beta.dosomething.org"
 
-      echo "Unsetting Asset Path theme setting..."
-      drush php-eval '$theme_settings = variable_get("theme_paraneue_dosomething_settings", array()); $theme_settings["asset_path"] = ""; variable_set("theme_paraneue_dosomething_settings", $theme_settings);'
-
       echo "Unsetting tagged version variable..."
       drush variable-delete ds_version -y
 

--- a/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
+++ b/lib/themes/dosomething/paraneue_dosomething/Gruntfile.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
       // On production builds, minify and remove comments.
       prod: {
         files: {
-          'dist/app.min.css': 'scss/app.scss'
+          'dist/app.css': 'scss/app.scss'
         },
         options: {
           outputStyle: 'compressed'
@@ -45,7 +45,7 @@ module.exports = function(grunt) {
       // On development builds, include source maps & do not minify.
       debug: {
         files: {
-          'dist/app.min.css': 'scss/app.scss'
+          'dist/app.css': 'scss/app.scss'
         },
         options: {
           sourceMap: true
@@ -72,7 +72,7 @@ module.exports = function(grunt) {
 
       // On production builds, omit source maps.
       prod: {
-        src: ['dist/app.min.css'],
+        src: ['dist/app.css'],
         options: {
           map: false
         }
@@ -80,7 +80,7 @@ module.exports = function(grunt) {
 
       // On development builds, include source maps.
       debug: {
-        src: ['dist/app.min.css']
+        src: ['dist/app.css']
       }
     },
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -4,6 +4,14 @@
  * Implements theme_preprocess_html().
  */
 function paraneue_dosomething_preprocess_html(&$vars) {
+  // Add theme stylesheet
+  drupal_add_css(PARANEUE_DS_PATH. '/dist/app.css', [
+    'group' => CSS_THEME,
+    'weight' => 0,
+    'every_page' => TRUE,
+    'preprocess' => FALSE
+  ]);
+
   // Used to print current tagged version in page source
   $vars['ds_version'] = variable_get('ds_version', '[dev]');
 

--- a/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
+++ b/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
@@ -13,9 +13,6 @@ features[] = main_menu
 features[] = secondary_menu
 
 ; ### Settings.
-; Assets
-settings[asset_path] = ''
-settings[use_minified_assets] = 1
 ; Blocks
 settings[show_campaign_finder] = 0
 settings[show_sponsors] = 1

--- a/lib/themes/dosomething/paraneue_dosomething/template.php
+++ b/lib/themes/dosomething/paraneue_dosomething/template.php
@@ -13,12 +13,6 @@ if(theme_get_setting('asset_path')) {
   define('DS_ASSET_PATH', LOCAL_ASSET_PATH);
 }
 
-// Determine whether to use minified stylesheets or not.
-if(theme_get_setting('use_minified_assets')) {
-  define('DS_STYLE_PATH', DS_ASSET_PATH . '/dist/app.min.css?' . variable_get('ds_version', 'latest'));
-} else {
-  define('DS_STYLE_PATH', DS_ASSET_PATH . '/dist/app.css?' . variable_get('ds_version', 'latest'));
-}
 
 // Define asset directory paths
 define('VENDOR_ASSET_PATH', DS_ASSET_PATH . '/node_modules');

--- a/lib/themes/dosomething/paraneue_dosomething/template.php
+++ b/lib/themes/dosomething/paraneue_dosomething/template.php
@@ -2,20 +2,9 @@
 
 // Define theme directory path
 define('PARANEUE_DS_PATH', drupal_get_path('theme', 'paraneue_dosomething'));
-define('LOCAL_ASSET_PATH', '/' . PARANEUE_DS_PATH);
-
-// If ds_version is set, use CDN assets
-if(theme_get_setting('asset_path')) {
-  $cdn_path = theme_get_setting('asset_path');
-  $cdn_path = str_replace('{ds_version}', variable_get('ds_version', 'latest'), $cdn_path);
-  define('DS_ASSET_PATH', $cdn_path);
-} else {
-  define('DS_ASSET_PATH', LOCAL_ASSET_PATH);
-}
-
 
 // Define asset directory paths
-define('VENDOR_ASSET_PATH', DS_ASSET_PATH . '/node_modules');
+define('VENDOR_ASSET_PATH', PARANEUE_DS_PATH . '/node_modules');
 define('FORGE_ASSET_PATH', VENDOR_ASSET_PATH . '/@dosomething/forge');
 
 // Theme includes
@@ -36,6 +25,9 @@ require_once PARANEUE_DS_PATH . '/includes/auth/register.inc';
  * Implements hook_css_alter().
  */
 function paraneue_dosomething_css_alter(&$css) {
+  // We add `app.css` in `paraneue_dosomething_preprocess_html`.
+  // @see: includes/preprocess.inc
+
   // Load excluded CSS files from theme.
   $excludes = _paraneue_dosomething_alter(paraneue_dosomething_theme_get_info('exclude'), 'css');
   $css = array_diff_key($css, $excludes);
@@ -47,6 +39,7 @@ function paraneue_dosomething_css_alter(&$css) {
   unset($css[drupal_get_path('module', 'views') . '/css/views.css']);
   unset($css[drupal_get_path('module', 'field_group') . '/field_group.field_ui.css']);
   unset($css[drupal_get_path('module', 'addressfield') . '/addressfield.css']);
+  unset($css[drupal_get_path('module', 'locale') . '/locale.css']);
 }
 
 /**
@@ -56,30 +49,20 @@ function paraneue_dosomething_css_alter(&$css) {
  * Implements hook_js_alter().
  */
 function paraneue_dosomething_js_alter(&$js) {
-  // Get $js_dir path:
-  //    a) DS_ASSET_PATH is local. Path must be built with drupal_get_path()
-  //       function (already assigned to PARANEUE_DS_PATH).
-  //       Using DS_ASSET_PATH in this case is wrong: it starts
-  //       with '/' so Drupal can't open js file for parsing.
-  //       @see drupal_add_js().
-  //    b) DS_ASSET_PATH is not local. It is already a valid URL to CDN.
-  $is_local_asset = DS_ASSET_PATH == LOCAL_ASSET_PATH;
-  $js_dir = $is_local_asset ? PARANEUE_DS_PATH : DS_ASSET_PATH;
-
   // Add lib.js and app.js using Drupal API:
-  drupal_add_js($js_dir . '/dist/lib.js', array(
+  drupal_add_js(PARANEUE_DS_PATH . '/dist/lib.js', [
     'group'      => JS_LIBRARY,
     'weight'     => -200,
     'every_page' => TRUE,
     'preprocess' => FALSE,
-  ));
+  ]);
 
-  drupal_add_js($js_dir . '/dist/app.js', array(
+  drupal_add_js(PARANEUE_DS_PATH . '/dist/app.js', [
     'group'      => JS_THEME,
     'weight'     => 999,
     'every_page' => TRUE,
     'preprocess' => FALSE,
-  ));
+  ]);
 
   // Force settings to be embedded after lib, before app scripts.
   if(isset($js['settings'])) {

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -25,18 +25,14 @@
       <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/html5shiv/dist/html5shiv.min.js"></script>
       <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/es5-shim/es5-shim.min.js"></script>
       <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/es5-shim/es5-sham.min.js"></script>
-
       <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/respond.js/dest/respond.min.js"></script>
-      <link href="<?php print VENDOR_ASSET_PATH; ?>/respond.js/cross-domain/respond-proxy.html" id="respond-proxy" rel="respond-proxy" />
-      <link href="<?php print LOCAL_ASSET_PATH; ?>/node_modules/respond.js/cross-domain/respond.proxy.gif" id="respond-redirect" rel="respond-redirect" />
-      <script type="text/javascript" src="<?php print LOCAL_ASSET_PATH; ?>/node_modules/respond.js/cross-domain/respond.proxy.js"></script>
   <![endif]-->
 
   <link rel="shortcut icon" href="<?php print FORGE_ASSET_PATH; ?>/dist/assets/images/favicon.ico">
   <link rel="apple-touch-icon-precomposed" href="<?php print FORGE_ASSET_PATH; ?>/dist/assets/images/apple-touch-icon-precomposed.png">
   <?php print $head; ?>
 
-  <script type="text/javascript" src="<?php print DS_ASSET_PATH; ?>/dist/modernizr.js"></script>
+  <script type="text/javascript" src="<?php print PARANEUE_DS_PATH; ?>/dist/modernizr.js"></script>
 </head>
 
 <body class="<?php print $classes; if ($variables['is_affiliate']) print ' -affiliate'; ?>" <?php print $attributes;?>>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -19,7 +19,6 @@
 
   <title><?php print $head_title; ?></title>
 
-  <link rel="stylesheet" href="<?php print DS_STYLE_PATH; ?>" type="text/css" />
   <?php print $styles; ?>
 
   <!--[if lte IE 8]>

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -15,20 +15,6 @@ function paraneue_dosomething_form_system_theme_settings_alter(&$form, &$form_st
       '#weight'      => -19
   );
 
-  $form['theme_settings']['asset_path'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Asset Path'),
-    '#description'   => t('Path to load assets from. The <code>{ds_version}</code> string can be used to include the current <code>ds_version</code> value, or "latest" if not set. If left blank, assets will be loaded from the local theme folder.'),
-    '#default_value' => theme_get_setting('asset_path')
-  );
-
-  $form['theme_settings']['use_minified_assets'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Minify Assets'),
-    '#description'   => t('Will use minified assets. Uncheck this if debugging in a browser without source maps. <strong>(Unminified assets are only created in production builds.)</strong>'),
-    '#default_value' => theme_get_setting('use_minified_assets')
-  );
-
   $form['feature_flags'] = array(
       '#type'        => 'fieldset',
       '#title'       => t('Feature Flags'),


### PR DESCRIPTION
# Changes

International sites are still configured to point to Akamai (`dosomething-a.akamaihd.net`) through the "Asset Path" theme setting. This is kinda lame, since we have Fastly now! :tada: These commits remove the theme setting and some of the hairier conditional logic happening in the template.

I also switched to including `app.css` via `drupal_add_css()`, since it automatically adds a cache-busting query string to the outputted style tag. Unless we get collisions, this may be a better solution than using the version as a query string since a malicious user couldn't just ping future asset versions and cache them prematurely.

For review: @DoSomething/front-end @sergii-tkachenko 
