### PR TITLE
allows for mobile_app and mobile_app_date querys to be used at same time

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -458,10 +458,10 @@ function dosomething_campaign_build_campaigns_query($params = array()) {
   }
 
   if (isset($params['mobile_app_date'])) {
-    $query->join('field_data_field_mobile_app_date', 'm', 'm.entity_id = n.nid');
+    $query->join('field_data_field_mobile_app_date', 'mad', 'mad.entity_id = n.nid');
     $query
-      ->condition('m.field_mobile_app_date_value', dosomething_helpers_convert_date($params['mobile_app_date']), '<=')
-      ->condition('m.field_mobile_app_date_value2', dosomething_helpers_convert_date($params['mobile_app_date']), '>=');
+      ->condition('mad.field_mobile_app_date_value', dosomething_helpers_convert_date($params['mobile_app_date']), '<=')
+      ->condition('mad.field_mobile_app_date_value2', dosomething_helpers_convert_date($params['mobile_app_date']), '>=');
   }
 
   if (isset($params['term_id'])) {


### PR DESCRIPTION
#### What's this PR do?

Allows for both mobile_app and mobile_app_date queries to be used at the same time.
#### How should this be manually tested?

http://dev.dosomething.org:8888/api/v1/campaigns.json?mobile_app=1&mobile_app_date=2015-10-01 should return campaigns that satisfy both `mobile_app` and `mobile_app_date` queries. 
#### What are the relevant tickets?

Fixes #5328 
