### PR TITLE
Update to fix PHP errors with regional tabs

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -11,11 +11,16 @@
  * @return mixed mixed
  */
 function paraneue_dosomething_edit_regional_admin_tabs($tabs) {
+  $primary_tabs = $tabs['#primary'];
+
+  if (!$primary_tabs) {
+    return $tabs;
+  }
+
   $removeable_tabs = [
     'Devel',
     'Translate',
   ];
-  $primary_tabs = $tabs['#primary'];
 
   foreach($primary_tabs as $index => $tab) {
     if (in_array($tab['#link']['title'], $removeable_tabs)) {


### PR DESCRIPTION
Fixes #5383
#### What's this PR do?

When passing `$vars[tabs]` to the paraneue_dosomething_edit_regional_admin_tabs()`function, if the`#primary` item in the array is empty, then the following code in the function shouldn't execute. It previously did and PHP would throw warnings. So now we check to make sure it's not an empty array; if it is, then we return back with the untouched .
#### What are the relevant tickets?
#5383

---

@sbsmith86 @dfurnes
