### PR TITLE
Only add a prefix if the user's language has a corresponding country

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -562,11 +562,14 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
   $url_options = array(
     'language' => $language,
     'absolute' => TRUE,
-    'prefix' => strtolower(dosomething_global_convert_language_to_country($language)) . '/',
     'query' => array(
       'source' => 'node/' . $node->nid,
     ),
   );
+
+  if ($country = strtolower(dosomething_global_convert_language_to_country($language))) {
+    $url_options['prefix'] = $country . '/';
+  }
 
   $params = array(
     'email' => $account->mail,

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -567,7 +567,8 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     ),
   );
 
-  if ($country = strtolower(dosomething_global_convert_language_to_country($language))) {
+  $country = strtolower(dosomething_global_convert_language_to_country($language);
+  if (!empty($country))) {
     $url_options['prefix'] = $country . '/';
   }
 


### PR DESCRIPTION
- Prefixes should only be added if the user is coming from a supported
  country and not for global users

Fixes #5366
