### PR TITLE
Asset path wonkiness

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -5,7 +5,7 @@
  */
 function paraneue_dosomething_preprocess_html(&$vars) {
   // Add theme stylesheet
-  drupal_add_css(PARANEUE_DS_PATH. '/dist/app.css', [
+  drupal_add_css(PARANEUE_PATH . '/dist/app.css', [
     'group' => CSS_THEME,
     'weight' => 0,
     'every_page' => TRUE,

--- a/lib/themes/dosomething/paraneue_dosomething/includes/theme.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/theme.inc
@@ -81,17 +81,17 @@ function paraneue_dosomething_theme() {
 
     'campaign_creator' => array(
       'template' => 'campaign-creator',
-      'path' => PARANEUE_DS_PATH . '/templates/campaign/partials',
+      'path' => PARANEUE_PATH . '/templates/campaign/partials',
     ),
 
     'campaign_headings' => array(
       'template' => 'campaign-headings',
-      'path' => PARANEUE_DS_PATH . '/templates/campaign/partials',
+      'path' => PARANEUE_PATH . '/templates/campaign/partials',
     ),
 
     'campaign_scholarship' => array(
       'template' => 'campaign-scholarship',
-      'path' => PARANEUE_DS_PATH . '/templates/campaign/partials',
+      'path' => PARANEUE_PATH . '/templates/campaign/partials',
       'variables' => array(
         'amount' => NULL,
         'classes' => NULL,
@@ -100,12 +100,12 @@ function paraneue_dosomething_theme() {
 
     'footer' => array(
       'template' => 'footer',
-      'path' => PARANEUE_DS_PATH . '/templates/system/partials',
+      'path' => PARANEUE_PATH . '/templates/system/partials',
     ),
 
     'social-networks' => array(
       'template' => 'social-networks',
-      'path' => PARANEUE_DS_PATH . '/templates/system/partials',
+      'path' => PARANEUE_PATH . '/templates/system/partials',
       'variables' => array(
         'container_classes' => '',
       )
@@ -113,22 +113,22 @@ function paraneue_dosomething_theme() {
 
     'header' => array(
       'template' => 'header',
-      'path' => PARANEUE_DS_PATH . '/templates/system/partials',
+      'path' => PARANEUE_PATH . '/templates/system/partials',
     ),
 
     'info_bar' => array(
       'template' => 'info-bar',
-      'path' => PARANEUE_DS_PATH . '/templates/system/partials',
+      'path' => PARANEUE_PATH . '/templates/system/partials',
     ),
 
     'navigation' => array(
       'template' => 'navigation',
-      'path' => PARANEUE_DS_PATH . '/templates/system/partials',
+      'path' => PARANEUE_PATH . '/templates/system/partials',
     ),
 
     'sponsor_logos' => array(
       'template' => 'sponsor-logos',
-      'path' => PARANEUE_DS_PATH . '/templates/system/partials',
+      'path' => PARANEUE_PATH . '/templates/system/partials',
       'variables' => array(
         'sponsors' => NULL,
       ),
@@ -136,18 +136,18 @@ function paraneue_dosomething_theme() {
 
     'thumbnail' => array(
       'template' => 'thumbnail',
-      'path' => PARANEUE_DS_PATH . '/templates/home/partials',
+      'path' => PARANEUE_PATH . '/templates/home/partials',
     ),
 
     // Register theme functions for Forge patterns.
     'paraneue_figure' => array(
       'template' => 'figure',
-      'path' => PARANEUE_DS_PATH . '/templates/system/patterns',
+      'path' => PARANEUE_PATH . '/templates/system/patterns',
     ),
 
     'paraneue_media' => array(
       'template' => 'media',
-      'path' => PARANEUE_DS_PATH . '/templates/system/patterns',
+      'path' => PARANEUE_PATH . '/templates/system/patterns',
       'variables' => array(
         'content' => NULL,
       ),
@@ -155,17 +155,17 @@ function paraneue_dosomething_theme() {
 
     'paraneue_photo' => array(
       'template' => 'photo',
-      'path' => PARANEUE_DS_PATH . '/templates/system/patterns',
+      'path' => PARANEUE_PATH . '/templates/system/patterns',
     ),
 
     'paraneue_tile' => array(
       'template' => 'tile',
-      'path' => PARANEUE_DS_PATH . '/templates/system/patterns',
+      'path' => PARANEUE_PATH . '/templates/system/patterns',
     ),
 
     'paraneue_gallery' => array(
       'template' => 'gallery',
-      'path' => PARANEUE_DS_PATH . '/templates/system/patterns',
+      'path' => PARANEUE_PATH . '/templates/system/patterns',
     ),
   );
 }

--- a/lib/themes/dosomething/paraneue_dosomething/template.php
+++ b/lib/themes/dosomething/paraneue_dosomething/template.php
@@ -4,7 +4,7 @@
 define('PARANEUE_PATH', drupal_get_path('theme', 'paraneue_dosomething'));
 
 // Define asset directory paths
-define('VENDOR_ASSET_PATH', PARANEUE_DS_PATH . '/node_modules');
+define('VENDOR_ASSET_PATH', PARANEUE_PATH . '/node_modules');
 define('FORGE_ASSET_PATH', VENDOR_ASSET_PATH . '/@dosomething/forge');
 
 // Theme includes
@@ -50,14 +50,14 @@ function paraneue_dosomething_css_alter(&$css) {
  */
 function paraneue_dosomething_js_alter(&$js) {
   // Add lib.js and app.js using Drupal API:
-  drupal_add_js(PARANEUE_DS_PATH . '/dist/lib.js', [
+  drupal_add_js(PARANEUE_PATH . '/dist/lib.js', [
     'group'      => JS_LIBRARY,
     'weight'     => -200,
     'every_page' => TRUE,
     'preprocess' => FALSE,
   ]);
 
-  drupal_add_js(PARANEUE_DS_PATH . '/dist/app.js', [
+  drupal_add_js(PARANEUE_PATH . '/dist/app.js', [
     'group'      => JS_THEME,
     'weight'     => 999,
     'every_page' => TRUE,

--- a/lib/themes/dosomething/paraneue_dosomething/template.php
+++ b/lib/themes/dosomething/paraneue_dosomething/template.php
@@ -1,21 +1,21 @@
 <?php
 
 // Define theme directory path
-define('PARANEUE_DS_PATH', drupal_get_path('theme', 'paraneue_dosomething'));
+define('PARANEUE_PATH', drupal_get_path('theme', 'paraneue_dosomething'));
 
 // Define asset directory paths
 define('VENDOR_ASSET_PATH', PARANEUE_DS_PATH . '/node_modules');
 define('FORGE_ASSET_PATH', VENDOR_ASSET_PATH . '/@dosomething/forge');
 
 // Theme includes
-require_once PARANEUE_DS_PATH . '/includes/bootstrap.inc';
-require_once PARANEUE_DS_PATH . '/includes/theme.inc';
-require_once PARANEUE_DS_PATH . '/includes/preprocess.inc';
-require_once PARANEUE_DS_PATH . '/includes/helpers.inc';
-require_once PARANEUE_DS_PATH . '/includes/patterns.inc';
-require_once PARANEUE_DS_PATH . '/includes/form.inc';
-require_once PARANEUE_DS_PATH . '/includes/auth/login.inc';
-require_once PARANEUE_DS_PATH . '/includes/auth/register.inc';
+require_once PARANEUE_PATH . '/includes/bootstrap.inc';
+require_once PARANEUE_PATH . '/includes/theme.inc';
+require_once PARANEUE_PATH . '/includes/preprocess.inc';
+require_once PARANEUE_PATH . '/includes/helpers.inc';
+require_once PARANEUE_PATH . '/includes/patterns.inc';
+require_once PARANEUE_PATH . '/includes/form.inc';
+require_once PARANEUE_PATH . '/includes/auth/login.inc';
+require_once PARANEUE_PATH . '/includes/auth/register.inc';
 
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -22,17 +22,17 @@
   <?php print $styles; ?>
 
   <!--[if lte IE 8]>
-      <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/html5shiv/dist/html5shiv.min.js"></script>
-      <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/es5-shim/es5-shim.min.js"></script>
-      <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/es5-shim/es5-sham.min.js"></script>
-      <script type="text/javascript" src="<?php print VENDOR_ASSET_PATH; ?>/respond.js/dest/respond.min.js"></script>
+      <script type="text/javascript" src="<?php print url(VENDOR_ASSET_PATH . '/html5shiv/dist/html5shiv.min.js'); ?>"></script>
+      <script type="text/javascript" src="<?php print url(VENDOR_ASSET_PATH . '/es5-shim/es5-shim.min.js'); ?>"></script>
+      <script type="text/javascript" src="<?php print url(VENDOR_ASSET_PATH . '/es5-shim/es5-sham.min.js'); ?>"></script>
+      <script type="text/javascript" src="<?php print url(VENDOR_ASSET_PATH . '/respond.js/dest/respond.min.js'); ?>"></script>
   <![endif]-->
 
-  <link rel="shortcut icon" href="<?php print FORGE_ASSET_PATH; ?>/dist/assets/images/favicon.ico">
-  <link rel="apple-touch-icon-precomposed" href="<?php print FORGE_ASSET_PATH; ?>/dist/assets/images/apple-touch-icon-precomposed.png">
+  <link rel="shortcut icon" href="<?php print url(FORGE_ASSET_PATH . '/dist/assets/images/favicon.ico'); ?>">
+  <link rel="apple-touch-icon-precomposed" href="<?php print url(FORGE_ASSET_PATH . '/dist/assets/images/apple-touch-icon-precomposed.png'); ?>">
   <?php print $head; ?>
 
-  <script type="text/javascript" src="<?php print PARANEUE_DS_PATH; ?>/dist/modernizr.js"></script>
+  <script type="text/javascript" src="<?php print url(PARANEUE_PATH . '/dist/modernizr.js') ?>"></script>
 </head>
 
 <body class="<?php print $classes; if ($variables['is_affiliate']) print ' -affiliate'; ?>" <?php print $attributes;?>>

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -1,10 +1,10 @@
 <?php
 
 // Include helpers.
-if (!defined('PARANEUE_DS_PATH')) {
-  define('PARANEUE_DS_PATH', drupal_get_path('theme', 'paraneue_dosomething'));
+if (!defined('PARANEUE_PATH')) {
+  define('PARANEUE_PATH', drupal_get_path('theme', 'paraneue_dosomething'));
 }
-require_once PARANEUE_DS_PATH . '/includes/helpers.inc';
+require_once PARANEUE_PATH . '/includes/helpers.inc';
 
 function paraneue_dosomething_form_system_theme_settings_alter(&$form, &$form_state) {
   $form['theme_settings'] = array(


### PR DESCRIPTION
Fixes #5374.

Use `url()` to ensure we're always making root-relative URLs. I accidentally'd the prefixed `/` on the Modernizr script in #5373 so it was requiring relative and (duh) not existing. This fixes that and also runs asset paths through `url()` so we don't make that mistake again in the future!

Also renames `PARANEUE_DS_PATH` to `PARANEUE_PATH` since it reads easier.

For review: @weerd 
