### PR TITLE
Fix export from Swapper module.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Swapper.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Swapper.js
@@ -18,4 +18,4 @@ class Swapper {
 
 }
 
-export { Swapper };
+export default Swapper;


### PR DESCRIPTION
Fixes #5389. We were exporting as part of an object, rather than as the default export.
#### Wait, where was the error?

The error was being called in [Gallery.js](https://github.com/DoSomething/phoenix/blob/0137a56384073b6b9a12e28010b3ebc57a3171a9/lib/themes/dosomething/paraneue_dosomething/js/patterns/Gallery.js#L22), but was caused by an improper export from the Swapper module.

The expected import code `import Swapper from '../utilities/Swapper'` wouldn't work (since the export was really an object with a `Swapper` property, rather than the expected [default export](http://www.2ality.com/2014/09/es6-modules-final.html#default_exports_%28one_per_module%29)).

The code we had written before would have to be imported like so `import { Swapper } from '../utilities/Swapper'` which is awkward, since it's the file's only export.

---

@DoSomething/front-end 
