### PR TITLE
Kidding, let's _not_ pass asset URLs through `url()`.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -22,17 +22,17 @@
   <?php print $styles; ?>
 
   <!--[if lte IE 8]>
-      <script type="text/javascript" src="<?php print url(VENDOR_ASSET_PATH . '/html5shiv/dist/html5shiv.min.js'); ?>"></script>
-      <script type="text/javascript" src="<?php print url(VENDOR_ASSET_PATH . '/es5-shim/es5-shim.min.js'); ?>"></script>
-      <script type="text/javascript" src="<?php print url(VENDOR_ASSET_PATH . '/es5-shim/es5-sham.min.js'); ?>"></script>
-      <script type="text/javascript" src="<?php print url(VENDOR_ASSET_PATH . '/respond.js/dest/respond.min.js'); ?>"></script>
+      <script type="text/javascript" src="<?php print '/' . VENDOR_ASSET_PATH . '/html5shiv/dist/html5shiv.min.js' ?>"></script>
+      <script type="text/javascript" src="<?php print '/' . VENDOR_ASSET_PATH . '/es5-shim/es5-shim.min.js' ?>"></script>
+      <script type="text/javascript" src="<?php print '/' . VENDOR_ASSET_PATH . '/es5-shim/es5-sham.min.js' ?>"></script>
+      <script type="text/javascript" src="<?php print '/' . VENDOR_ASSET_PATH . '/respond.js/dest/respond.min.js' ?>"></script>
   <![endif]-->
 
-  <link rel="shortcut icon" href="<?php print url(FORGE_ASSET_PATH . '/dist/assets/images/favicon.ico'); ?>">
-  <link rel="apple-touch-icon-precomposed" href="<?php print url(FORGE_ASSET_PATH . '/dist/assets/images/apple-touch-icon-precomposed.png'); ?>">
+  <link rel="shortcut icon" href="<?php print '/' . FORGE_ASSET_PATH . '/dist/assets/images/favicon.ico' ?>">
+  <link rel="apple-touch-icon-precomposed" href="<?php print '/' . FORGE_ASSET_PATH . '/dist/assets/images/apple-touch-icon-precomposed.png' ?>">
   <?php print $head; ?>
 
-  <script type="text/javascript" src="<?php print url(PARANEUE_PATH . '/dist/modernizr.js') ?>"></script>
+  <script type="text/javascript" src="<?php print '/' . PARANEUE_PATH . '/dist/modernizr.js' ?>"></script>
 </head>
 
 <body class="<?php print $classes; if ($variables['is_affiliate']) print ' -affiliate'; ?>" <?php print $attributes;?>>


### PR DESCRIPTION
Once more, with feeling! :musical_score: 

It turns out that `url()` adds the required `/` to indicate a root-relative URL, but on international sites it _also_ seems to add the country code. Lame. So we'll just hardcode the path, but ensure that it always gets the prepended slash.

For more information, see #5373 and #5386.

For review: @DoSomething/front-end 
