### PR TITLE
Updating home page URLs 

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -244,7 +244,7 @@ function dosomething_global_convert_country_to_language($country) {
   return NULL;
 }
 
-/*
+/**
  * Get the appropriate language for the application.
  *
  * @param $account
@@ -254,16 +254,27 @@ function dosomething_global_convert_country_to_language($country) {
  *
  */
 function dosomething_global_get_language($account, stdClass $node = NULL) {
-  if ($node) {
+  // Respect the URL first.
+  $request_path = explode('/', request_path());
+  if (!empty($request_path[0])) {
+    $languages = language_list();
+    foreach ($languages as $langcode => $lang_data) {
+      if ($lang_data->prefix == $request_path[0]) {
+        return $langcode;
+      }
+    }
+  }
+
+  if (is_object($node)) {
     // If there is a published translation for the node in the user's language, use it.
     if ($node->translations->data{$account->language}['status']) {
       $language = $account->language;
     }
-    // If there's no published translation in their language try 'en-global'.
-    elseif ($node->translations->data['en-global']['status']) {
-      $language = 'en-global';
+    // If there's no published translation in their language try the default language.
+    elseif ($node->translations->data[language_default('language')]['status']) {
+      $language = language_default('language');
     }
-    // Default to node language if there's no translation in their language and no 'en-global'.
+    // Default to node language if there's no translation in their language and no translation in the system default language.
     else {
       $language = $node->language;
     }
@@ -276,4 +287,32 @@ function dosomething_global_get_language($account, stdClass $node = NULL) {
   }
 
   return $language;
+}
+
+
+/**
+ * Build a URL that appropriately adds the prefix.
+ *
+ * @param string $path
+ *   The path to pass to url()
+ * @param  $options
+ *   Optional options array to be passed to url()
+ *
+ */
+function dosomething_global_url($path, $options = NULL) {
+  global $language;
+  $languages = language_list();
+
+  if (!isset($options['language'])) {
+    if (isset($language)) {
+      $options['language'] = $language->language;
+    }
+    else {
+      $options['language'] = language_default('language');
+    }
+  }
+  if (!isset($options['prefix']) && !empty($languages[$options['language']]->prefix)) {
+    $options['prefix'] = $languages[$options['language']]->prefix . '/';
+  }
+  return url($path, $options);
 }

--- a/lib/modules/dosomething/dosomething_home/dosomething_home.module
+++ b/lib/modules/dosomething/dosomething_home/dosomething_home.module
@@ -10,6 +10,7 @@ include_once 'dosomething_home.features.inc';
  * Implements hook_preprocess_node();
  */
 function dosomething_home_preprocess_node(&$vars) {
+  global $user;
   if ($vars['type'] != 'home') { return; }
 
   // Replaces any global/site tokens in the title.
@@ -32,16 +33,16 @@ function dosomething_home_preprocess_node(&$vars) {
         $nid = $campaign;
       }
       $node = node_load($nid);
-
-      global $language;
-      $lang_code = $language->language;
+      $lang_code = dosomething_global_get_language($user, $node);
 
       // Grab all tiles attributes.
       $tiles = array();
       $tiles['nid'] = $nid;
       $tiles['is_staff_pick'] = $node->field_staff_pick[LANGUAGE_NONE][0]['value'];
-      $tiles['title'] = $node->title;
-      $tiles['tagline'] = $node->field_call_to_action[$node->language][0]['safe_value'];
+      // node_load() doesn't allow language to be passed in and using dosomething_global_get_language()
+      // will go through the proper chain to pull the correct language.
+      $tiles['title'] = $node->title_field[$lang_code][0]['safe_value'];
+      $tiles['tagline'] = $node->field_call_to_action[$lang_code][0]['safe_value'];
 
       // Get the campaign cover image. If there is no image for the user's language,
       // use the image from the node's language.
@@ -86,10 +87,8 @@ function dosomething_home_preprocess_node(&$vars) {
           'source' => 'node/' . $vars['nid'],
         ),
       );
-      if ($country = strtolower(dosomething_global_convert_language_to_country($lang_code))) {
-        $url_options['prefix'] = $country . '/';
-      }
-      $tiles['link'] = url('node/' . $nid, $url_options);
+
+      $tiles['link'] = dosomething_global_url('node/' . $nid, $url_options);
 
       $thumbnails[$nid] = paraneue_dosomething_get_gallery_item($tiles, 'tile');
     }


### PR DESCRIPTION
#### What does this PR do?

Currently in the dev branch even when the prefix is removed in the UI, the home page URLs still append a prefix with the country code. Additionally, the URLs for the home page are using `global $language`, when they should instead be going through the dosomething_get_language() function which respects the following precedence:
1. URL prefix
2. User's account language if published
3. System default language if published
4. Node's default language

The home page URLs are now using the prefix as defined in the language object returned by `language_list()`.

I've also updated the title and the CTA to use the same precedence so that URLs are in sync with the title and CTA. I did some debugging, and it doesn't look like the $node->language changes to the appropriate language on node_load(). It works fine for now in dev, but it doesn't seem to show the correct CTA when there are multiple translations.
#### How should this be manually tested?

Visit the home page and observe the URLs, titles and CTAs for the tiles. You can also change the prefix manually to make sure that the translations and URLs change properly with the addition of a prefix.

@mshmsh5000 @DFurnes 
