### PR TITLE
Fixes content tab visibility and edit links

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -100,10 +100,6 @@ function dosomething_global_menu_alter(&$items) {
   $items['node/%node/translate']['access callback'] = 'user_access';
   $items['node/%node/translate']['access arguments'] = array('translate any entity');
 
-  // Hide default content tab from regional admins
-  $items['admin/content']['access callback'] = 'user_access';
-  $items['admin/content']['access arguments'] = array('translate any entity');
-
   // // Make sure all admins can see this
   $items['admin/content/search']['access callback'] = 'user_access';
   $items['admin/content/search']['access arguments'] = array('access administration menu');

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -96,9 +96,17 @@ function dosomething_global_form_node_form_alter(&$form, &$form_state, $form_id)
  * Implements hook_menu_alter().
  */
 function dosomething_global_menu_alter(&$items) {
-  // Hide the translate tab for people not on staff.
+  // Hide the translate tab from regional admins
   $items['node/%node/translate']['access callback'] = 'user_access';
   $items['node/%node/translate']['access arguments'] = array('translate any entity');
+
+  // Hide default content tab from regional admins
+  $items['admin/content']['access callback'] = 'user_access';
+  $items['admin/content']['access arguments'] = array('translate any entity');
+
+  // // Make sure all admins can see this
+  $items['admin/content/search']['access callback'] = 'user_access';
+  $items['admin/content/search']['access arguments'] = array('access administration menu');
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -598,7 +598,9 @@ function dosomething_helpers_application_path($path = '') {
  */
 function dosomething_helpers_form_node_admin_content_alter(&$form, &$form_state, $form_id) {
   // Remove destination?=admin/content from edit button
-  foreach ($form['admin']['nodes']['#options'] as $nid => $node) {
-    unset($form['admin']['nodes']['#options'][$nid]['operations']['data']['#links']['edit']['query']['destination']);
+  foreach ($form['admin']['nodes']['#rows'] as $nid => $node) {
+    if (!empty($form['admin']['nodes']['#rows'][$nid]['operations'])) {
+      unset($form['admin']['nodes']['#rows'][$nid]['operations']['data']['#options']['query']['destination']);
+    }
   }
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.info
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.info
@@ -131,4 +131,4 @@ features[views_view][] = content_search
 features[views_view][] = user_search
 files[] = dosomething_user.test
 files[] = includes/dosomething_user_remote.inc
-mtime = 1444067591
+mtime = 1444158628

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.info
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.info
@@ -131,4 +131,4 @@ features[views_view][] = content_search
 features[views_view][] = user_search
 files[] = dosomething_user.test
 files[] = includes/dosomething_user_remote.inc
-mtime = 1444158628
+mtime = 1444250077

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.views_default.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.views_default.inc
@@ -205,6 +205,113 @@ function dosomething_user_views_default_views() {
   $handler = $view->new_display('page', 'Page', 'page_1');
   $handler->display->display_options['defaults']['title'] = FALSE;
   $handler->display->display_options['title'] = 'Content Search';
+  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
+  $handler->display->display_options['defaults']['filters'] = FALSE;
+  /* Filter criterion: Content: Title */
+  $handler->display->display_options['filters']['title']['id'] = 'title';
+  $handler->display->display_options['filters']['title']['table'] = 'node';
+  $handler->display->display_options['filters']['title']['field'] = 'title';
+  $handler->display->display_options['filters']['title']['operator'] = 'contains';
+  $handler->display->display_options['filters']['title']['group'] = 1;
+  $handler->display->display_options['filters']['title']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['title']['expose']['operator_id'] = 'title_op';
+  $handler->display->display_options['filters']['title']['expose']['label'] = 'Title';
+  $handler->display->display_options['filters']['title']['expose']['operator'] = 'title_op';
+  $handler->display->display_options['filters']['title']['expose']['identifier'] = 'title';
+  $handler->display->display_options['filters']['title']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+  );
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['group'] = 1;
+  $handler->display->display_options['filters']['type']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['type']['expose']['operator_id'] = 'type_op';
+  $handler->display->display_options['filters']['type']['expose']['label'] = 'Type';
+  $handler->display->display_options['filters']['type']['expose']['operator'] = 'type_op';
+  $handler->display->display_options['filters']['type']['expose']['identifier'] = 'type';
+  $handler->display->display_options['filters']['type']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+  );
+  /* Filter criterion: Content: Cause (field_cause) */
+  $handler->display->display_options['filters']['field_cause_tid']['id'] = 'field_cause_tid';
+  $handler->display->display_options['filters']['field_cause_tid']['table'] = 'field_data_field_cause';
+  $handler->display->display_options['filters']['field_cause_tid']['field'] = 'field_cause_tid';
+  $handler->display->display_options['filters']['field_cause_tid']['group'] = 1;
+  $handler->display->display_options['filters']['field_cause_tid']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['field_cause_tid']['expose']['operator_id'] = 'field_cause_tid_op';
+  $handler->display->display_options['filters']['field_cause_tid']['expose']['label'] = 'Cause (field_cause)';
+  $handler->display->display_options['filters']['field_cause_tid']['expose']['operator'] = 'field_cause_tid_op';
+  $handler->display->display_options['filters']['field_cause_tid']['expose']['identifier'] = 'field_cause_tid';
+  $handler->display->display_options['filters']['field_cause_tid']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+  );
+  $handler->display->display_options['filters']['field_cause_tid']['type'] = 'select';
+  $handler->display->display_options['filters']['field_cause_tid']['vocabulary'] = 'cause';
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 'All';
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['status']['expose']['operator_id'] = '';
+  $handler->display->display_options['filters']['status']['expose']['label'] = 'Published';
+  $handler->display->display_options['filters']['status']['expose']['operator'] = 'status_op';
+  $handler->display->display_options['filters']['status']['expose']['identifier'] = 'status';
+  $handler->display->display_options['filters']['status']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+    6 => 0,
+    7 => 0,
+    8 => 0,
+    9 => 0,
+    10 => 0,
+  );
+  /* Filter criterion: Content: Language */
+  $handler->display->display_options['filters']['language']['id'] = 'language';
+  $handler->display->display_options['filters']['language']['table'] = 'node';
+  $handler->display->display_options['filters']['language']['field'] = 'language';
+  $handler->display->display_options['filters']['language']['value'] = array(
+    '***CURRENT_LANGUAGE***' => '***CURRENT_LANGUAGE***',
+    '***DEFAULT_LANGUAGE***' => '***DEFAULT_LANGUAGE***',
+    'und' => 'und',
+    'en' => 'en',
+    'en-global' => 'en-global',
+    'pt-br' => 'pt-br',
+    'es-mx' => 'es-mx',
+  );
+  $handler->display->display_options['filters']['language']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['language']['expose']['operator_id'] = 'language_op';
+  $handler->display->display_options['filters']['language']['expose']['label'] = 'Language';
+  $handler->display->display_options['filters']['language']['expose']['operator'] = 'language_op';
+  $handler->display->display_options['filters']['language']['expose']['identifier'] = 'language';
+  $handler->display->display_options['filters']['language']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+    6 => 0,
+    7 => 0,
+    8 => 0,
+    9 => 0,
+    10 => 0,
+    11 => 0,
+    12 => 0,
+    13 => 0,
+  );
   $handler->display->display_options['path'] = 'admin/content/search';
   $handler->display->display_options['menu']['type'] = 'tab';
   $handler->display->display_options['menu']['title'] = 'Search content';
@@ -421,6 +528,7 @@ function dosomething_user_views_default_views() {
     t('Cause (field_cause)'),
     t('Page'),
     t('Content Search'),
+    t('Language'),
     t('Translations'),
     t('Nid'),
     t('Translate link'),

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.views_default.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.views_default.inc
@@ -203,6 +203,8 @@ function dosomething_user_views_default_views() {
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page_1');
+  $handler->display->display_options['defaults']['title'] = FALSE;
+  $handler->display->display_options['title'] = 'Content Search';
   $handler->display->display_options['path'] = 'admin/content/search';
   $handler->display->display_options['menu']['type'] = 'tab';
   $handler->display->display_options['menu']['title'] = 'Search content';
@@ -418,6 +420,7 @@ function dosomething_user_views_default_views() {
     t('Published'),
     t('Cause (field_cause)'),
     t('Page'),
+    t('Content Search'),
     t('Translations'),
     t('Nid'),
     t('Translate link'),


### PR DESCRIPTION
#### What's this PR do?
- Allows regional admins to access search tabs
- Adds exposed language filter to search content 
- Fixes search content title
- Fixes the edit link on /admin/content
#### How should this be manually tested?

Create a MX or BR admin and go to /admin/content -- verify the edit button works. Then make sure you can go to the search content page and verify the lang selector works.

<h4 id="context"> Any background context you want to provide?</h4>

Not sure why the edit button broke. The structure of the drupal output changed and the code for this was outdated. Have we updated drupal or installed anything?
#### What are the relevant tickets?

Fixes #5297 
Fixes #5413 
