### PR TITLE
Removes permissions from regional admins

### DIFF
--- a/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.features.field_base.inc
+++ b/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.features.field_base.inc
@@ -33,6 +33,7 @@ function dosomething_action_guide_field_default_field_bases() {
     'locked' => 0,
     'module' => 'text',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'max_length' => 255,
     ),
     'translatable' => 0,

--- a/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.features.field_instance.inc
@@ -36,6 +36,7 @@ function dosomething_action_guide_field_default_field_instances() {
     'label' => 'Additional Text',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 1,
       'user_register_form' => FALSE,
     ),
@@ -76,6 +77,7 @@ function dosomething_action_guide_field_default_field_instances() {
     'label' => 'Additional Text Title',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -117,6 +119,7 @@ function dosomething_action_guide_field_default_field_instances() {
     'label' => 'Description',
     'required' => 1,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -163,6 +166,7 @@ function dosomething_action_guide_field_default_field_instances() {
     'label' => 'Gallery',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -200,6 +204,7 @@ function dosomething_action_guide_field_default_field_instances() {
     'label' => 'Intro',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 1,
       'user_register_form' => FALSE,
     ),
@@ -244,6 +249,7 @@ function dosomething_action_guide_field_default_field_instances() {
     'label' => 'Intro Image',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -285,6 +291,7 @@ function dosomething_action_guide_field_default_field_instances() {
     'label' => 'Intro Title',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -325,6 +332,7 @@ function dosomething_action_guide_field_default_field_instances() {
     'label' => 'Subtitle',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),

--- a/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.features.user_permission.inc
+++ b/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.features.user_permission.inc
@@ -14,7 +14,6 @@ function dosomething_action_guide_user_default_permissions() {
   $permissions['create action_guide content'] = array(
     'name' => 'create action_guide content',
     'roles' => array(
-      'brazil admin' => 'brazil admin',
       'editor' => 'editor',
       'mexico admin' => 'mexico admin',
     ),
@@ -48,9 +47,7 @@ function dosomething_action_guide_user_default_permissions() {
   $permissions['edit own action_guide content'] = array(
     'name' => 'edit own action_guide content',
     'roles' => array(
-      'brazil admin' => 'brazil admin',
       'editor' => 'editor',
-      'mexico admin' => 'mexico admin',
     ),
     'module' => 'node',
   );

--- a/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.info
+++ b/lib/modules/dosomething/dosomething_action_guide/dosomething_action_guide.info
@@ -31,4 +31,4 @@ features[variable][] = field_bundle_settings_node__action_guide
 features[variable][] = node_options_action_guide
 features[variable][] = node_preview_action_guide
 features[variable][] = node_submitted_action_guide
-mtime = 1428597800
+mtime = 1444314428

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.user_permission.inc
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.features.user_permission.inc
@@ -14,9 +14,7 @@ function dosomething_campaign_group_user_default_permissions() {
   $permissions['create campaign_group content'] = array(
     'name' => 'create campaign_group content',
     'roles' => array(
-      'brazil admin' => 'brazil admin',
       'editor' => 'editor',
-      'mexico admin' => 'mexico admin',
     ),
     'module' => 'node',
   );
@@ -48,9 +46,7 @@ function dosomething_campaign_group_user_default_permissions() {
   $permissions['edit own campaign_group content'] = array(
     'name' => 'edit own campaign_group content',
     'roles' => array(
-      'brazil admin' => 'brazil admin',
       'editor' => 'editor',
-      'mexico admin' => 'mexico admin',
     ),
     'module' => 'node',
   );

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.info
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.info
@@ -83,4 +83,4 @@ features[variable][] = node_options_campaign_group
 features[variable][] = node_preview_campaign_group
 features[variable][] = node_submitted_campaign_group
 features[variable][] = pathauto_node_campaign_group_pattern
-mtime = 1442330910
+mtime = 1444314429

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.field_base.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.field_base.inc
@@ -26,6 +26,7 @@ function dosomething_campaign_run_field_default_field_bases() {
     'locked' => 0,
     'module' => 'field_collection',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'hide_blank_items' => 1,
       'path' => '',
     ),
@@ -55,6 +56,7 @@ function dosomething_campaign_run_field_default_field_bases() {
         'action' => 'Celeb in Action',
       ),
       'allowed_values_function' => '',
+      'entity_translation_sync' => FALSE,
     ),
     'translatable' => 0,
     'type' => 'list_text',
@@ -83,6 +85,7 @@ function dosomething_campaign_run_field_default_field_bases() {
     'locked' => 0,
     'module' => 'text',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'max_length' => 255,
     ),
     'translatable' => 0,
@@ -112,6 +115,7 @@ function dosomething_campaign_run_field_default_field_bases() {
     'locked' => 0,
     'module' => 'text',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'max_length' => 255,
     ),
     'translatable' => 0,
@@ -141,6 +145,7 @@ function dosomething_campaign_run_field_default_field_bases() {
     'locked' => 0,
     'module' => 'text',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'max_length' => 255,
     ),
     'translatable' => 0,
@@ -170,6 +175,7 @@ function dosomething_campaign_run_field_default_field_bases() {
     'locked' => 0,
     'module' => 'entityreference',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'handler' => 'base',
       'handler_settings' => array(
         'behaviors' => array(
@@ -210,7 +216,9 @@ function dosomething_campaign_run_field_default_field_bases() {
     ),
     'locked' => 0,
     'module' => 'text',
-    'settings' => array(),
+    'settings' => array(
+      'entity_translation_sync' => FALSE,
+    ),
     'translatable' => 0,
     'type' => 'text_long',
   );
@@ -238,6 +246,7 @@ function dosomething_campaign_run_field_default_field_bases() {
     'locked' => 0,
     'module' => 'text',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'max_length' => 255,
     ),
     'translatable' => 0,
@@ -266,7 +275,9 @@ function dosomething_campaign_run_field_default_field_bases() {
     ),
     'locked' => 0,
     'module' => 'text',
-    'settings' => array(),
+    'settings' => array(
+      'entity_translation_sync' => FALSE,
+    ),
     'translatable' => 0,
     'type' => 'text_long',
   );
@@ -292,6 +303,7 @@ function dosomething_campaign_run_field_default_field_bases() {
         'grant' => 'Grant',
       ),
       'allowed_values_function' => '',
+      'entity_translation_sync' => FALSE,
     ),
     'translatable' => 0,
     'type' => 'list_text',
@@ -313,6 +325,7 @@ function dosomething_campaign_run_field_default_field_bases() {
     'locked' => 0,
     'module' => 'field_collection',
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'hide_blank_items' => 1,
       'path' => '',
     ),

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.field_instance.inc
@@ -41,6 +41,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'Gallery',
     'required' => FALSE,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -77,6 +78,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'Type',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -118,6 +120,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'Gallery Image',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -163,6 +166,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'User',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -204,6 +208,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'Winner Description',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -244,6 +249,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'User First Name',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -284,6 +290,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'Winner Quote',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -324,6 +331,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'Winner Type',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -361,6 +369,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'Additional Text',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 1,
       'user_register_form' => FALSE,
     ),
@@ -401,6 +410,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'Additional Text Title',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -445,6 +455,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'Campaign',
     'required' => 1,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -492,6 +503,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'Klout Gallery',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
@@ -529,6 +541,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'Intro',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 1,
       'user_register_form' => FALSE,
     ),
@@ -569,6 +582,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'Total Participants',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -609,6 +623,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'Total Quantity',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -649,6 +664,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'Total Quantity Label',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
@@ -695,6 +711,7 @@ function dosomething_campaign_run_field_default_field_instances() {
     'label' => 'Winners',
     'required' => 0,
     'settings' => array(
+      'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
     ),
     'widget' => array(

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.user_permission.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.user_permission.inc
@@ -14,9 +14,7 @@ function dosomething_campaign_run_user_default_permissions() {
   $permissions['create campaign_run content'] = array(
     'name' => 'create campaign_run content',
     'roles' => array(
-      'brazil admin' => 'brazil admin',
       'editor' => 'editor',
-      'mexico admin' => 'mexico admin',
     ),
     'module' => 'node',
   );
@@ -48,9 +46,7 @@ function dosomething_campaign_run_user_default_permissions() {
   $permissions['edit own campaign_run content'] = array(
     'name' => 'edit own campaign_run content',
     'roles' => array(
-      'brazil admin' => 'brazil admin',
       'editor' => 'editor',
-      'mexico admin' => 'mexico admin',
     ),
     'module' => 'node',
   );

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.info
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.info
@@ -61,4 +61,4 @@ features[variable][] = menu_parent_campaign_run
 features[variable][] = node_options_campaign_run
 features[variable][] = node_preview_campaign_run
 features[variable][] = node_submitted_campaign_run
-mtime = 1428597800
+mtime = 1444314429


### PR DESCRIPTION
### What does this PR do?

Remove the following permissions from Regional Admins:

Campaign Run: Create new content
Campaign Run: Edit own content
Action Guide: Create new content
Action Guide: Edit own content
Campaign Collection: Create new content
Campaign Collection: Edit own content
#### How should this be manually tested?

Create a new regional admin and verify they can't do any of these ^^ things
#### What are the relevant tickets?

Fixes #5419 
