### PR TITLE
Using the dosomething_global_url helper function to build signup link

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -562,11 +562,11 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
   $url_options = array(
     'language' => $language,
     'absolute' => TRUE,
-    'prefix' => strtolower(dosomething_global_convert_language_to_country($language)) . '/',
     'query' => array(
       'source' => 'node/' . $node->nid,
     ),
   );
+  $campaign_link = dosomething_global_url('node/' . $nid, $url_options);
 
   $params = array(
     'email' => $account->mail,
@@ -575,7 +575,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     'mobile' => dosomething_user_get_field('field_mobile', $account),
     'event_id' => $node->nid,
     'campaign_title' => $wrapper->language($language)->title_field->value(),
-    'campaign_link' => url('node/' . $nid, $url_options),
+    'campaign_link' => $campaign_link,
     'user_language' => $language,
   );
 


### PR DESCRIPTION
- The campaign signup link should go through the same chain of hierarchy as
  the home page URLs to determine which language and then apply the appropriate
  prefix to the campaign signup URL
