### PR TITLE
Fix field collections global

### DIFF
--- a/bin/ds-global
+++ b/bin/ds-global
@@ -119,8 +119,8 @@ function enable {
 }
 
 #=== FUNCTION ==================================================================
-# NAME: enable
-# DESCRIPTION: Enables global.
+# NAME: make_home_translatable
+# DESCRIPTION: Makes Home bundle translatable.
 #===============================================================================
 function make_home_translatable {
   # Display ascii art
@@ -138,6 +138,24 @@ function make_home_translatable {
   drush ds-global-field-fix field_campaigns
 }
 
+
+#=== FUNCTION ==================================================================
+# NAME: enable_campaign_field_collections
+# DESCRIPTION: Runs fixes for campaign field collections.
+#===============================================================================
+function enable_campaign_field_collections {
+  # Display ascii art
+  art
+
+  set -e
+  cd $WEB_PATH
+
+  # Run fixes.
+  drush ds-global-field-fix field_faq
+  drush ds-global-field-fix field_step_pre
+  drush ds-global-field-fix field_step_post
+}
+
 # ==============================================================================
 
 # ==============================================================================
@@ -148,4 +166,11 @@ function make_home_translatable {
 # run
 #----------------------------------------------------------------------
 # enable
-make_home_translatable
+
+if [[ $1 == "make-home-translatable" ]]; then
+  make_home_translatable
+elif [[ $1 == "enable-campaign-field-collections" ]]; then
+  enable_campaign_field_collections
+elif [[ -z $1 ]]; then
+  echo "Error: no arguments." >&2
+fi

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_base.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_base.inc
@@ -543,7 +543,7 @@ function dosomething_campaign_field_default_field_bases() {
       'hide_blank_items' => 1,
       'path' => '',
     ),
-    'translatable' => 0,
+    'translatable' => 1,
     'type' => 'field_collection',
   );
 
@@ -1588,7 +1588,7 @@ function dosomething_campaign_field_default_field_bases() {
       'hide_blank_items' => 1,
       'path' => '',
     ),
-    'translatable' => 0,
+    'translatable' => 1,
     'type' => 'field_collection',
   );
 
@@ -1612,7 +1612,7 @@ function dosomething_campaign_field_default_field_bases() {
       'hide_blank_items' => 1,
       'path' => '',
     ),
-    'translatable' => 0,
+    'translatable' => 1,
     'type' => 'field_collection',
   );
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
@@ -181,4 +181,4 @@ features[variable][] = node_preview_campaign
 features[variable][] = node_submitted_campaign
 features[variable][] = pathauto_node_campaign_pattern
 features[views_view][] = campaigns_by_term
-mtime = 1443449658
+mtime = 1444166026

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -60,7 +60,9 @@ projects[entity_autocomplete][version] = "1.0-beta3"
 projects[entity_autocomplete][subdir] = "contrib"
 
 ; Entity Translation
-projects[entity_translation][version] = "1.0-beta4"
+; Updated to dev to be compatible with latest field_collection patch.
+; Dev branch used: 2015-Aug-16
+projects[entity_translation][version] = "1.x-dev"
 projects[entity_translation][subdir] = "contrib"
 
 ; Entity Connect
@@ -76,8 +78,13 @@ projects[features][version] = "2.2"
 projects[features][subdir] = "contrib"
 
 ; Field Collection
-projects[field_collection][version] = "1.0-beta8"
+; Updated to dev to be compatible with latest field_collection patch.
+; Dev branch used: 2015-Mar-26
+; !! Users are cautioned that data loss has been reported – please test carefully !!
+projects[field_collection][version] = "1.x-dev"
 projects[field_collection][subdir] = "contrib"
+; See https://www.drupal.org/node/1344672?page=1#comment-10320327
+projects[field_collection][patch][] = "https://www.drupal.org/files/issues/field_collection-add_entity_translation_support-1344672-459.patch"
 
 ; Field Group
 projects[field_group][version] = "1.4"


### PR DESCRIPTION
#### What's this PR do?
- Updates `entity_translation` and `field_collection` to dev version
- Patches `field_collection` with https://www.drupal.org/node/1344672?page=1#comment-10320327
- Enables translation for `field_faq`, `field_step_pre`, `field_step_post`
- Improves ds-global: enables arguments support
- Saves a fix for campaign fields
#### How should this be manually tested?
- Build, load stage db
- Open http://dev.dosomething.org:8888/node/955/edit: FAQ field should be empty
- Run `ds-global enable_campaign_field_collections`
- Open http://dev.dosomething.org:8888/node/955/edit: FAQ field should be filled with data
- Open node translation in any other language and translate FAQ field. Make sure your translation displayed correctly in the corresponding language
#### Any background context you want to provide?

:warning: Users are cautioned that data loss has been reported – please test carefully :warning: 

Campaign fields yet to be translated:
- Video
- Sponsors and Partners
#### What are the relevant tickets?
- Closes #4850 
- Copy of #5416, but based on global and merged to global

CC @sheyd 
