### PR TITLE
Fixes /admin/content edit button

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -598,9 +598,9 @@ function dosomething_helpers_application_path($path = '') {
  */
 function dosomething_helpers_form_node_admin_content_alter(&$form, &$form_state, $form_id) {
   // Remove destination?=admin/content from edit button
-  foreach ($form['admin']['nodes']['#rows'] as $nid => $node) {
-    if (!empty($form['admin']['nodes']['#rows'][$nid]['operations'])) {
-      unset($form['admin']['nodes']['#rows'][$nid]['operations']['data']['#options']['query']['destination']);
+  foreach ($form['admin']['nodes']['#options'] as $nid => $node) {
+    if (!empty($form['admin']['nodes']['#options'][$nid]['operations'])) {
+      unset($form['admin']['nodes']['#options'][$nid]['operations']['data']['#links']['edit']['query']['destination']);
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -598,9 +598,18 @@ function dosomething_helpers_application_path($path = '') {
  */
 function dosomething_helpers_form_node_admin_content_alter(&$form, &$form_state, $form_id) {
   // Remove destination?=admin/content from edit button
-  foreach ($form['admin']['nodes']['#options'] as $nid => $node) {
-    if (!empty($form['admin']['nodes']['#options'][$nid]['operations'])) {
-      unset($form['admin']['nodes']['#options'][$nid]['operations']['data']['#links']['edit']['query']['destination']);
+  if (dosomething_user_is_staff()) {
+    foreach ($form['admin']['nodes']['#options'] as $nid => $node) {
+      if (!empty($form['admin']['nodes']['#options'][$nid]['operations'])) {
+        unset($form['admin']['nodes']['#options'][$nid]['operations']['data']['#links']['edit']['query']['destination']);
+      }
+    }
+  }
+  else if (dosomething_global_is_regional_admin()) {
+    foreach ($form['admin']['nodes']['#rows'] as $nid => $node) {
+      if (!empty($form['admin']['nodes']['#rows'][$nid]['operations'])) {
+        unset($form['admin']['nodes']['#rows'][$nid]['operations']['data']['#options']['query']['destination']);
+      }
     }
   }
 }


### PR DESCRIPTION
#### What's this PR do?

Fixes the edit button on /admin/content
#### How should this be manually tested?

Go to /admin/content and try as all types of admins (regional, administrator, editor etc) to make sure the error doesn't popup
#### Any background context you want to provide?

In the context from my PR yesterday trying to fix this issue https://github.com/DoSomething/phoenix/pull/5417#user-content-context I pointed out that the structure some how changed. Turns out, the structure for regional admins is different than normal admins. Hence why the code fix didn't work, as we need two different versions.
#### What are the relevant tickets?

Fixes #5413 
