### PR TITLE
#5422 /user URL & language behavior

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -541,11 +541,13 @@ function dosomething_campaign_get_campaigns_doing($uid = NULL) {
 function dosomething_campaign_get_campaign_block_vars($nid, $image_size = '740x480', $source = NULL) {
   $node = node_load($nid);
   $clc = dosomething_helpers_get_current_language_code();
+
   $path_alias = drupal_get_path_alias('node/' . $nid);
   if ($source) {
     $path_alias .= '?source=' . $source;
   }
   $image = NULL;
+  $image_nid = NULL;
   if (!empty($node->field_image_campaign_cover)) {
     $image_nid = $node->field_image_campaign_cover[$clc][0]['target_id'];
     $image = dosomething_image_get_themed_image_url($image_nid, 'landscape', $image_size);
@@ -554,10 +556,12 @@ function dosomething_campaign_get_campaign_block_vars($nid, $image_size = '740x4
   if (!empty($node->field_call_to_action)) {
     $cta = $node->field_call_to_action[$clc][0]['value'];
   }
+  $title = $node->title_field[$clc][0]['safe_value'];
+
   return array(
     'nid' => $nid,
-    'title' => $node->title,
-    'link' => l($node->title, 'node/' . $nid),
+    'title' => $title,
+    'link' => l($title, 'node/' . $nid),
     'call_to_action' => $cta,
     'image' => $image,
     'nid_image' => $image_nid,

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -41,7 +41,7 @@ function dosomething_global_init() {
   }
 
   // Handle translation redirects for authenticated and anonymous users when
-  // they request bare (Global English) URLs.
+  // they request bare (Global English) URLs to nodes.
   //
   // Passing 'noredirect=1' will defeat the redirect.
   if (arg(0) == 'node' && is_numeric(arg(1)) && empty(arg(2)) &&
@@ -52,6 +52,38 @@ function dosomething_global_init() {
       dosomething_global_redirect_node_auth();
     } else {
       dosomething_global_redirect_node_anon();
+    }
+  }
+
+  // Handle translation redirects for authenticated users when they request
+  // bare (Global English) URLs to user pages (user profile, edit, etc.).
+  //
+  // Passing 'noredirect=1' will defeat the redirect.
+  if (arg(0) == 'user' && module_exists('dosomething_global') &&
+      empty($_GET['noredirect'])) {
+
+    if (!dosomething_global_is_translation_request()) {
+      // User language.
+      $user_lang_code = $user->language ?: 'en';
+
+      // All languages, as an array of objects.
+      $languages = language_list();
+
+      $global_lang_code = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
+
+      if (empty($languages[$global_lang_code])) {
+        watchdog('dosomething_global', "Can't load %lang language",
+          array('%lang' => $global_lang_code), WATCHDOG_ERROR);
+        return;
+      }
+
+      // Don't redirect for Global English speakers.
+      if ($user_lang_code != $global_lang_code && !empty($languages[$user_lang_code])) {
+
+        $link = sprintf('%s/%s', $languages[$user_lang_code]->prefix, request_path());
+
+        drupal_goto(url($link));
+      }
     }
   }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -33,37 +33,6 @@ function dosomething_user_preprocess_page(&$vars) {
     'setting'
   );
 
-  // If a user requests the raw "/user/uid" path but has another language
-  // preference, bounce to that language prefix.
-  //
-  // @see dosomething_global_redirect_node_auth()
-  if (arg(0) == 'user' && module_exists('dosomething_global')) {
-
-    if (!dosomething_global_is_translation_request()) {
-      // User language.
-      $user_lang_code = $user->language ?: 'en';
-
-      // All languages, as an array of objects.
-      $languages = language_list();
-
-      $global_lang_code = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
-
-      if (empty($languages[$global_lang_code])) {
-        watchdog('dosomething_global', "Can't load %lang language",
-          array('%lang' => $global_lang_code), WATCHDOG_ERROR);
-        return;
-      }
-
-      // Don't redirect for Global English speakers.
-      if ($user_lang_code != $global_lang_code && !empty($languages[$user_lang_code])) {
-
-        $link = sprintf('%s/%s', $languages[$user_lang_code]->prefix, request_path());
-
-        drupal_goto(url($link));
-      }
-    }
-  }
-
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -14,6 +14,8 @@ include_once 'dosomething_user.theme.inc';
  * Implements hook_preprocess_page.
  */
 function dosomething_user_preprocess_page(&$vars) {
+  global $user;
+
   $school_api_endpoint = variable_get('dosomething_user_school_api_endpoint', 'http://lofischools.herokuapp.com/search');
   if (isset($_SESSION['dosomething_user_log_login'])) {
     dosomething_helpers_add_analytics_event("login", $_SESSION['dosomething_user_log_login']);
@@ -30,6 +32,38 @@ function dosomething_user_preprocess_page(&$vars) {
     ),
     'setting'
   );
+
+  // If a user requests the raw "/user/uid" path but has another language
+  // preference, bounce to that language prefix.
+  //
+  // @see dosomething_global_redirect_node_auth()
+  if (arg(0) == 'user' && module_exists('dosomething_global')) {
+
+    if (!dosomething_global_is_translation_request()) {
+      // User language.
+      $user_lang_code = $user->language ?: 'en';
+
+      // All languages, as an array of objects.
+      $languages = language_list();
+
+      $global_lang_code = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
+
+      if (empty($languages[$global_lang_code])) {
+        watchdog('dosomething_global', "Can't load %lang language",
+          array('%lang' => $global_lang_code), WATCHDOG_ERROR);
+        return;
+      }
+
+      // Don't redirect for Global English speakers.
+      if ($user_lang_code != $global_lang_code && !empty($languages[$user_lang_code])) {
+
+        $link = sprintf('%s/%s', $languages[$user_lang_code]->prefix, request_path());
+
+        drupal_goto(url($link));
+      }
+    }
+  }
+
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -14,8 +14,6 @@ include_once 'dosomething_user.theme.inc';
  * Implements hook_preprocess_page.
  */
 function dosomething_user_preprocess_page(&$vars) {
-  global $user;
-
   $school_api_endpoint = variable_get('dosomething_user_school_api_endpoint', 'http://lofischools.herokuapp.com/search');
   if (isset($_SESSION['dosomething_user_log_login'])) {
     dosomething_helpers_add_analytics_event("login", $_SESSION['dosomething_user_log_login']);


### PR DESCRIPTION
#### What's this PR do?

Fixes two behaviors described in #5422:
1. If a user's language is set to a site-supported language (es-mx, pt-br, en-us), and the user loads a raw user path (e.g., `/user/12345`), she will be redirected to that path prefixed with the proper country code (e.g., `/mx/user/12345`).
2. In the _You're Doing_ section on the profile page, campaign titles and CTAs will display in the user's language.
#### Where should the reviewer start?
- `dosomething_global.module`: The `hook_init()` here has new country-code redirect logic for user paths.
- `dosomething_campaign.module`: `dosomething_campaign_get_campaigns_doing()` now sets the node title language in the same way it already pulls CTA and other fields.
#### How should this be manually tested?

_Redirect behavior_
1. Log in as a user with a supported language preference (e.g., `es-mx`).
2. Hit your user profile page (e.g., `/user/12345`).
3. You should be redirected (e.g., `/mx/user/12345`).

_Translated title behavior_
1. Sign up for an `es-mx` campaign.
2. Hit your user profile page.
3. You should see the title and CTA in Mexican Spanish.
#### Any background context you want to provide?

Thoroughly documented in the issue.
#### What are the relevant tickets?
#5422
#### Screenshots (if appropriate)

N/A
#### Questions:

N/A
