### PR TITLE
Enabling pathauto i18n node module

### DIFF
--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -51,6 +51,7 @@ dependencies[] = module_filter
 dependencies[] = new_relic_rpm
 dependencies[] = pathauto
 dependencies[] = pathauto_i18n
+dependencies[] = pathauto_i18n_node
 dependencies[] = poeditor
 dependencies[] = potx
 dependencies[] = redirect


### PR DESCRIPTION
After translating around 200 nodes, rebuilding the URL alias table, and reindexing solr, it seems that not all the correct aliases are being created. I believe we need to enable pathauto_i18n_node in addition to the base pathauto_i18n module.

@mshmsh5000 @deadlybutter 
