### PR TITLE
Fixes #5441: Don't redirect /user/* POST requests

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -58,9 +58,14 @@ function dosomething_global_init() {
   // Handle translation redirects for authenticated users when they request
   // bare (Global English) URLs to user pages (user profile, edit, etc.).
   //
+  // Don't redirect POSTs.
+  //
   // Passing 'noredirect=1' will defeat the redirect.
-  if (arg(0) == 'user' && module_exists('dosomething_global') &&
-      empty($_GET['noredirect'])) {
+
+  $request_method = strtolower($_SERVER['REQUEST_METHOD']);
+
+  if (arg(0) == 'user' && module_exists('dosomething_global') && 'post' !== $request_method &&
+    empty($_GET['noredirect'])) {
 
     if (!dosomething_global_is_translation_request()) {
       // User language.

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -64,8 +64,7 @@ function dosomething_global_init() {
 
   $request_method = strtolower($_SERVER['REQUEST_METHOD']);
 
-  if (arg(0) == 'user' && module_exists('dosomething_global') && 'post' !== $request_method &&
-    empty($_GET['noredirect'])) {
+  if (arg(0) == 'user' && 'post' !== $request_method && empty($_GET['noredirect'])) {
 
     if (!dosomething_global_is_translation_request()) {
       // User language.


### PR DESCRIPTION
#### What's this PR do?

Fixes the behavior where POST requests to `/user/*` paths were getting redirected along the lines of #5422.
#### Where should the reviewer start?

We're just checking the request method in `dosomething_global_init()` before going into the user path redirect logic.
#### How should this be manually tested?

You should be able to log in!
#### Any background context you want to provide?

It's Friday.
#### What are the relevant tickets?
#5441
#### Screenshots (if appropriate)

![idgit](https://cloud.githubusercontent.com/assets/149811/10405259/c557e912-6ea5-11e5-80da-bbce068dc32a.png)
#### Questions:
- Does Matt test everything perfectly?
  _No._
