### PR TITLE
Add dosomething_global_convert_language_to_country() lookup to user registration mbp call

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -446,7 +446,8 @@ function dosomething_user_user_pass_submit($form, &$form_state) {
     $account = user_load_by_mail($form_state['input']['name']);
     if (isset($account->mail)) {
       if (module_exists('dosomething_global')) {
-        $user_country_code = dosomething_global_convert_language_to_country($account->language);
+        $user_language = dosomething_global_get_user_language($account);
+        $user_country_code = dosomething_global_convert_language_to_country($user_language);
       }
       // Send external message request
       $params = array(
@@ -454,7 +455,7 @@ function dosomething_user_user_pass_submit($form, &$form_state) {
         'uid' => $account->uid,
         'first_name' => dosomething_user_get_field('field_first_name', $account),
         'reset_link' => user_pass_reset_url($account),
-        'user_language'     => isset($account->language) ? $account->language : 'en',
+        'user_language'     => isset($user_language) ? $user_language : 'en',
         'user_country'      => isset($user_country_code) ? $user_country_code : 'US',
       );
       if (module_exists('dosomething_mbp')) {
@@ -492,9 +493,9 @@ function dosomething_user_new_user($form, &$form_state) {
 
   global $user;
   $account = $user;
-
   if (module_exists('dosomething_global')) {
-    $user_country_code = dosomething_global_convert_language_to_country($account->language);
+    $user_language = dosomething_global_get_user_language($account);
+    $user_country_code = dosomething_global_convert_language_to_country($user_language);
   }
 
   // Send external message request.
@@ -504,7 +505,7 @@ function dosomething_user_new_user($form, &$form_state) {
     'uid'               => $account->uid,
     'first_name'        => dosomething_user_get_field('field_first_name', $account),
     'birthdate'         => dosomething_user_get_field('field_birthdate', $account),
-    'user_language'     => isset($account->language) ? $account->language : 'en',
+    'user_language'     => isset($user_language) ? $user_language : 'en',
     'user_country'      => isset($user_country_code) ? $user_country_code : 'US',
   );
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -454,8 +454,8 @@ function dosomething_user_user_pass_submit($form, &$form_state) {
         'uid' => $account->uid,
         'first_name' => dosomething_user_get_field('field_first_name', $account),
         'reset_link' => user_pass_reset_url($account),
-        'user_language'     => $account->language,
-        'user_country'      => isset($user_country_code) ? $user_country_code : 'US'
+        'user_language'     => isset($account->language) ? $account->language : 'en',
+        'user_country'      => isset($user_country_code) ? $user_country_code : 'US',
       );
       if (module_exists('dosomething_mbp')) {
         dosomething_mbp_request('user_password', $params);
@@ -485,12 +485,16 @@ function dosomething_user_new_user($form, &$form_state) {
     return;
   }
 
-  global $user;
-  $account = $user;
-
   // Should we sign this kid up for messages?
   if (dosomething_user_is_under_thirteen()) {
     return;
+  }
+
+  global $user;
+  $account = $user;
+
+  if (module_exists('dosomething_global')) {
+    $user_country_code = dosomething_global_convert_language_to_country($account->language);
   }
 
   // Send external message request.
@@ -500,8 +504,8 @@ function dosomething_user_new_user($form, &$form_state) {
     'uid'               => $account->uid,
     'first_name'        => dosomething_user_get_field('field_first_name', $account),
     'birthdate'         => dosomething_user_get_field('field_birthdate', $account),
-    'user_language'     => $account->language,
-    'user_country'      => isset($user_country_code) ? $user_country_code : 'US'
+    'user_language'     => isset($account->language) ? $account->language : 'en',
+    'user_country'      => isset($user_country_code) ? $user_country_code : 'US',
   );
 
   // 26+ Club: Override Mobile Commons.


### PR DESCRIPTION
Fixes #5418

Bug fix to ensure settings for `user_country` and `user_language` in `dosomething_mbp()` params.

**To test**:
- Review payload produced in request to RabbitMQ / Message Broker `loggingQueue` (/queues/dosomething/loggingQueue). It should look like:
- **user_register**:

```
Array
(
    [activity] => user_register
    [email] => ascottdicker+BrazilThor@dosomething.org
    [uid] => 3118629
    [user_language] => pt-br
    [user_country] => BR
    [merge_vars] => Array
        (
            [MEMBER_COUNT] => 4.2 million
            [FNAME] => Ariél
        )
    [email_template] => mb-user-register-BR
    [mailchimp_list_id] => 66fd18c5a9
    [birthdate] => 631152000
    [subscribed] => 1
    [email_tags] => Array
        (
            [0] => drupal_user_register
        )
    [activity_timestamp] => 1444413729
    [application_id] => US
)
```
- **user_password**

```
Array
(
    [activity] => user_password
    [email] => ascottdicker+BrazilThor@dosomething.org
    [uid] => 3118629
    [user_language] => pt-br
    [user_country] => BR
    [merge_vars] => Array
        (
            [MEMBER_COUNT] => 4.2 million
            [FNAME] => Ariél
            [RESET_LINK] => https://thor.dosomething.org/br/user/reset/3118629/1444415436/GCfGZZ5_ph42o-d-v4NlPASoIfvvunjzIKEr9kfcnRk
        )

    [email_template] => mb-user-password-BR
    [email_tags] => Array
        (
            [0] => drupal_user_password
        )
    [activity_timestamp] => 1444415436
    [application_id] => US
)
```
