### PR TITLE
Updates variable name to validate address.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -288,7 +288,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
       }
 
       $form['#after_build'][] = 'dosomething_user_remove_extra_values_from_address_field';
-      if ($is_validate_address_set) {
+      if ($validate_address) {
         $form['#after_build'][] = 'dosomething_user_add_validation_attributes_to_address_fields';
       }
 


### PR DESCRIPTION
This variable name was updated, but not everywhere, and was causing undefined errors, and address forms not to be validated. 
Fixes #5435
