### PR TITLE
Global footer

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -159,7 +159,7 @@ function _dosomething_global_get_regional_roles() {
 }
 
 /**
- * Returns the user's langauge based on the role.
+ * Returns the user's language based on the role.
  *
  * @param Object $user
  *   Optional - A specified user to check

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -211,6 +211,19 @@ function dosomething_global_get_user_language($user = NULL) {
  }
 
 /**
+ * Returns the session's country code, or `global` if it's not
+ * one of our whitelisted global countries.
+ */
+function dosomething_global_get_country() {
+  $country_code = dosomething_settings_get_geo_country_code();
+  if (in_array($country_code, dosomething_global_get_countries())) {
+    return $country_code;
+  }
+
+  return 'global';
+}
+
+/**
  * Gets the country from a given language.
  *
  * @param string language

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -181,15 +181,29 @@ function paraneue_dosomething_preprocess_page(&$vars) {
    * Global Page Footer
    */
 
+  $country = dosomething_global_get_country();
   $columns = array('first', 'second', 'third');
   $footer_links = array();
 
   foreach($columns as $column) {
-    $prefix = "footer_links_" . $column . "_column_";
+    $prefix = "footer_links_" . $country . '_' . $column . "_column_";
     $footer_links[$column] = array();
-    $footer_links[$column]['heading'] = theme_get_setting($prefix . "heading");
 
-    $links = explode("\n", trim(theme_get_setting($prefix . "links")));
+    // Get new country code setting if it exists, if not fallback to old setting.
+    // @TODO: Remove this after we've updated theme settings everywhere.
+    $heading_setting = theme_get_setting($prefix . 'heading');
+    if(!$heading_setting === NULL) {
+      $heading_setting = theme_get_setting('footer_links_' . $column . '_column_heading');
+    }
+    $footer_links[$column]['heading'] = $heading_setting;
+
+    // Get new country code setting if it exists, if not fallback to old setting.
+    // @TODO: Remove this after we've updated theme settings everywhere.
+    $links_setting = theme_get_setting($prefix . 'links');
+    if(!$links_setting === NULL) {
+      $links_setting = theme_get_setting('footer_links_' . $column . '_column_links');
+    }
+    $links = explode("\n", trim($links_setting));
     $links = array_filter($links); // Remove empty items
 
     foreach($links as &$link) {

--- a/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
+++ b/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
@@ -47,12 +47,10 @@ settings[footer_links_first_column_heading] = 'Help'
 settings[footer_links_first_column_links] = 'Contact Us|node/516
 Hotlines|node/518
 FAQs|node/1052'
-settings[footer_links_first_column_class] = 'help'
 settings[footer_links_second_column_heading] = 'Get to Know Us'
 settings[footer_links_second_column_links] = 'Partners|node/532
 Donate|node/539
 TMI Agency|http://www.tmiagency.org'
-settings[footer_links_second_column_class] = 'knowus'
 settings[footer_links_third_column_heading] = 'About'
 settings[footer_links_third_column_links] = 'What is DoSomething.org?|node/538
 Our Team|node/1044
@@ -61,7 +59,6 @@ Internships|node/940
 Old People|node/329
 Sexy Financials|node/540
 International|node/523'
-settings[footer_links_third_column_class] = 'about'
 
 ; User
 settings[user_validate_js_postcode] = 1

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -307,7 +307,7 @@ function _paraneue_dosomething_theme_settings_user(&$form, $form_state) {
   );
   $form_user = &$form['user'];
 
-  // Validaions.
+  // Validations.
   $form_user['validations'] = array(
     '#type'        => 'fieldset',
     '#title'       => t('JS Validations'),

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -297,6 +297,8 @@ function _paraneue_dosomething_theme_settings_footer(&$form, $form_state) {
 
       $link_column = &$links[$country. '_links'][$prefix];
 
+      // Get new country code setting if it exists, if not fallback to old setting.
+      // @TODO: Remove this after we've updated theme settings everywhere.
       $heading_default = theme_get_setting('footer_links_' . $country . '_' . $column . '_column_heading');
       if(!$heading_default === NULL) {
         $heading_default = theme_get_setting('footer_links_' . $column . '_column_heading');
@@ -308,6 +310,8 @@ function _paraneue_dosomething_theme_settings_footer(&$form, $form_state) {
         '#default_value' => $heading_default,
       ];
 
+      // Get new country code setting if it exists, if not fallback to old setting.
+      // @TODO: Remove this after we've updated theme settings everywhere.
       $links_default = theme_get_setting('footer_links_' . $country . '_' . $column . '_column_links');
       if(!$links_default === NULL) {
         $links_default = theme_get_setting('footer_links_' . $column . '_column_links');

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -296,20 +296,6 @@ function _paraneue_dosomething_theme_settings_footer(&$form, $form_state) {
       '#title' => t(ucwords($column) . ' Column Links'),
       '#default_value' => theme_get_setting('footer_links_' . $column . '_column_links')
     );
-
-    $link_column[$prefix. '_advanced'] = array(
-      '#type' => 'fieldset',
-      '#title' => t('Advanced options'),
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE
-    );
-
-    $link_column[$prefix . '_advanced'][$prefix . '_column_class'] = array(
-      '#type' => 'textfield',
-      '#title' => t(ucwords($column) . ' Column Class'),
-      '#default_value' => theme_get_setting('footer_links_' . $column . '_column_class')
-    );
-
   }
 
 }

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -272,32 +272,55 @@ function _paraneue_dosomething_theme_settings_footer(&$form, $form_state) {
   );
 
   $links = &$form['footer']['links'];
-  $columns = array('first', 'second', 'third');
-  foreach ($columns as $column) {
-    $prefix = 'footer_links_' . $column;
 
-    $links[$prefix] = array(
+  // Set up theme settings for each country's footer
+  $countries = dosomething_global_get_countries();
+  foreach($countries as $country) {
+    $links[$country. '_links'] = [
       '#type' => 'fieldset',
-      '#title' => t(ucwords($column) .' column'),
+      '#title' => t('@country Links', ['@country' => $country]),
       '#collapsible' => TRUE,
-      '#collapsed' => TRUE
-    );
+      '#collapsed' => TRUE,
+    ];
 
-    $link_column = &$links[$prefix];
+    // Set up theme settings for each of the three columns
+    $columns = ['first', 'second', 'third'];
+    foreach ($columns as $column) {
+      $prefix = 'footer_links_' . $country . '_' . $column;
 
-    $link_column[$prefix . '_column_heading'] = array(
-      '#type' => 'textfield',
-      '#title' => t(ucwords($column) . ' Column Heading'),
-      '#default_value' => theme_get_setting('footer_links_' . $column . '_column_heading')
-    );
+      $links[$country. '_links'][$prefix] = [
+        '#type' => 'fieldset',
+        '#title' => t(ucwords($column) .' column'),
+        '#collapsible' => TRUE,
+        '#collapsed' => TRUE,
+      ];
 
-    $link_column[$prefix . '_column_links'] = array(
-      '#type' => 'textarea',
-      '#title' => t(ucwords($column) . ' Column Links'),
-      '#default_value' => theme_get_setting('footer_links_' . $column . '_column_links')
-    );
+      $link_column = &$links[$country. '_links'][$prefix];
+
+      $heading_default = theme_get_setting('footer_links_' . $country . '_' . $column . '_column_heading');
+      if(!$heading_default === NULL) {
+        $heading_default = theme_get_setting('footer_links_' . $column . '_column_heading');
+      }
+
+      $link_column[$prefix . '_column_heading'] = [
+        '#type' => 'textfield',
+        '#title' => t(ucwords($country) . ' ' . ucwords($column) . ' Column Heading'),
+        '#default_value' => $heading_default,
+      ];
+
+      $links_default = theme_get_setting('footer_links_' . $country . '_' . $column . '_column_links');
+      if(!$links_default === NULL) {
+        $links_default = theme_get_setting('footer_links_' . $column . '_column_links');
+      }
+
+      $link_column[$prefix . '_column_links'] = [
+        '#type' => 'textarea',
+        '#title' => t(ucwords($country) . ' ' . ucwords($column) . ' Column Links'),
+        '#default_value' => $links_default,
+      ];
+    }
+
   }
-
 }
 
 function _paraneue_dosomething_theme_settings_user(&$form, $form_state) {


### PR DESCRIPTION
### Changes

Closes #5166. Adds theme settings to set different footers depending on which global country the current session is coming from (4c2978d). The footer (and theme settings admin panel) [will both fallback to the old general footer theme settings](https://github.com/DoSomething/phoenix/blob/417d532382d704251830bf46f7ed3b1148a7161f/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc#L192-L197) if no country-specific value has been set. 

I also removed some old theme settings that were no longer needed after we re-worked the footer markup in ~~Neue~~ Forge 6.0 (b125728).

I added a new helper function which returns the session's country code, but only if it's in our array of "whitelisted" countries. (5caab39) From what I could tell, this didn't already exist but please let me know if I missed something!
### Screenshots

Example "global" footer, filled with the specified links from @julielorch's [Google Doc](https://docs.google.com/document/d/1_nK9VZQ6DQIZ46A6XCxQqeK1TUcO1ssMyJUNSbyPDr4):
![screen shot 2015-10-13 at 12 32 28 pm](https://cloud.githubusercontent.com/assets/583202/10462214/6a83fdd8-71ab-11e5-9374-50ac475efeb4.png)

---

For review: @angaither
/cc @weerd @sbsmith86 
