### PR TITLE
Redirects users on homepage to proper path prefix

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -307,12 +307,8 @@ function dosomething_global_convert_country_to_language($country) {
  *  The URL prefix mapped to this language
  */
 function dosomething_global_get_prefix_for_language($language) {
-  $result = db_select('languages', 'l')
-    ->fields('l')
-    ->condition('language', $language, '=')
-    ->execute()
-    ->fetchAssoc();
-  return $result['prefix'];
+  $languages = language_list();
+  return $languages[$language]->prefix;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -16,16 +16,17 @@ define('DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE', 'en-global');
 function dosomething_global_init() {
   global $user;
 
-  // Redirect people hitting the homepage to there local version
-  if (drupal_is_front_page() && is_numeric(arg(1))) {
-
+  // Redirect people hitting the homepage or explore campaigns to there local version
+  $path = request_path();
+  if ((drupal_is_front_page() && is_numeric(arg(1))) || $path == 'campaigns') {
     // Cannot use arg() as it doesn't return path prefixes
-    $path = request_path();
     $args = explode('/', $path);
 
-    // Only apply logic to Global homepage.
-    if (!empty($path) && $args[0] != 'node') {
-      return;
+    // Only apply logic to Global homepage
+    if (drupal_is_front_page()) {
+      if (!empty($path) && $args[0] != 'node') {
+        return;
+      }
     }
 
     $country_code = dosomething_settings_get_geo_country_code();

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -16,7 +16,7 @@ define('DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE', 'en-global');
 function dosomething_global_init() {
   global $user;
 
-  // Redirect people hitting the homepage or explore campaigns to there local version
+  // Redirect people hitting the homepage or explore campaigns to their local version
   $path = request_path();
   if ((drupal_is_front_page() && is_numeric(arg(1))) || $path == 'campaigns') {
     // Cannot use arg() as it doesn't return path prefixes

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -16,6 +16,35 @@ define('DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE', 'en-global');
 function dosomething_global_init() {
   global $user;
 
+  // Redirect people hitting the homepage to there local version
+  if (drupal_is_front_page() && is_numeric(arg(1))) {
+
+    // Cannot use arg() as it doesn't return path prefixes
+    $path = request_path();
+    $args = explode('/', $path);
+
+    // Only apply logic to Global homepage.
+    if (!empty($path) && $args[0] != 'node') {
+      return;
+    }
+
+    $country_code = dosomething_settings_get_geo_country_code();
+    $language = dosomething_global_convert_country_to_language($country_code);
+    // No matching language, serve the global page
+    if ($language == NULL) {
+      return;
+    }
+
+    // Get users local path prefix and verify we support it
+    $path_prefix = dosomething_global_get_prefix_for_language($language);
+    if ($path_prefix == NULL) {
+      return;
+    }
+
+    // Redirect user
+    drupal_goto($path_prefix . '/' . current_path());
+  }
+
   // Verify we're dealing with a node edit with no translation specification in the URL
   if (arg(0) == "node" && is_numeric(arg(1)) && arg(2) == "edit" && null == arg(3)) {
     // Load the page node and user
@@ -266,6 +295,15 @@ function dosomething_global_convert_country_to_language($country) {
   }
   // It is not the job of this function to determine a default language
   return NULL;
+}
+
+function dosomething_global_get_prefix_for_language($language) {
+  $result = db_select('languages', 'l')
+    ->fields('l')
+    ->condition('language', $language, '=')
+    ->execute()
+    ->fetchAssoc();
+  return $result['prefix'];
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -297,6 +297,15 @@ function dosomething_global_convert_country_to_language($country) {
   return NULL;
 }
 
+/**
+ * Converts the given language into its assigned URL prefix.
+ *
+ * @param string language
+ *  The language to get the prefix for (eg: 'en', 'mx')
+ *
+ * @return
+ *  The URL prefix mapped to this language
+ */
 function dosomething_global_get_prefix_for_language($language) {
   $result = db_select('languages', 'l')
     ->fields('l')


### PR DESCRIPTION
#### What's this PR do?

Redirects users on the homepage to the proper path prefix (eg: dosomething.org/us, /mx, etc) if they're in one of the countries we support
#### Where should the reviewer start?

dosomething_global_init() changes
#### How should this be manually tested?

Access the homepage as an MX user, verify you goto MX homepage (and rest of our supported languages)
Access the homepage as an French user, verify you goto global homepage (no redirect)
#### Any background context you want to provide?

I think the comments covered everything that needs context. 
#### What are the relevant tickets?

Fixes #5349 
Fixes #5348
#### Screenshots (if appropriate)

This code effects _all_ users, not just anonymous ones like the title of the issue states. Raised this [here](https://dosomething.slack.com/archives/global/p1444758523000759) in Slack for further discussion 
