### PR TITLE
Allowing chrome nav items to be translateable.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -73,13 +73,13 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     'search_box'       => $vars['search_box'],
     'user_identifier'  => $vars['user_identifier'],
     'who_we_are'       => array(
-      'text' => theme_get_setting('header_who_we_are_text'),
-      'subtext' => theme_get_setting('header_who_we_are_subtext'),
-      'link' => theme_get_setting('header_who_we_are_link'),
+      'text' => t(theme_get_setting('header_who_we_are_text')),
+      'subtext' => t(theme_get_setting('header_who_we_are_subtext')),
+      'link' => t(theme_get_setting('header_who_we_are_link')),
     ),
     'explore_campaigns'=> array(
-      'text' => theme_get_setting('header_explore_campaigns_text'),
-      'subtext' => theme_get_setting('header_explore_campaigns_subtext'),
+      'text' => t(theme_get_setting('header_explore_campaigns_text')),
+      'subtext' => t(theme_get_setting('header_explore_campaigns_subtext')),
       // 'link' => theme_get_setting('header_explore_campaigns_link'),
     ),
   );


### PR DESCRIPTION
Fixes #5460
#### What's this PR do?

This PR enables the chrome navigation items to be translateable via the use of the `t()` function.
#### Where should the reviewer start?

Only one file updated so I guess start on that one? Huzzah! **preprocess.inc**
#### How should this be manually tested?

Meh. Kinda of a pain in the butt. Easier to test on staging once deployed. Just make sure I closed all my parentheses!
#### What are the relevant tickets?
#5460

---

@DFurnes @angaither 
