### PR TITLE
Removes regional admin access from misc. menu's 

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -100,9 +100,13 @@ function dosomething_global_menu_alter(&$items) {
   $items['node/%node/translate']['access callback'] = 'user_access';
   $items['node/%node/translate']['access arguments'] = array('translate any entity');
 
-  // // Make sure all admins can see this
+  // Make sure all admins can see this
   $items['admin/content/search']['access callback'] = 'user_access';
   $items['admin/content/search']['access arguments'] = array('access administration menu');
+
+  // Remove regional admin access
+  $items['admin/config/regional/translate']['access callback'] = 'user_access';
+  $items['admin/config/regional/translate']['access arguments'] = array('translate any entity');
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
+++ b/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
@@ -40,7 +40,7 @@ function dosomething_shipment_menu() {
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_shipment_admin_config_form'),
     'access callback' => 'user_access',
-    'access arguments' => array('administer modules'),
+    'access arguments' => array('edit campaign overrides'),
     'file' => 'dosomething_shipment.admin.inc',
   );
   return $items;

--- a/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
+++ b/lib/modules/dosomething/dosomething_shipment/dosomething_shipment.module
@@ -40,7 +40,7 @@ function dosomething_shipment_menu() {
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_shipment_admin_config_form'),
     'access callback' => 'user_access',
-    'access arguments' => array('edit campaign overrides'),
+    'access arguments' => array('edit campaign overrides'), // All US admins & editors have this, but regional admins do not
     'file' => 'dosomething_shipment.admin.inc',
   );
   return $items;

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -101,7 +101,7 @@ function dosomething_user_menu() {
   $items['admin/users/clean-slate'] = array(
     'title' => 'Clean Slate',
     'access callback' => 'user_access',
-    'access arguments' => array('access administration menu'),
+    'access arguments' => array('edit campaign overrides'),
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_user_clean_slate_form'),
     'file' => 'dosomething_user.admin.inc',


### PR DESCRIPTION
#### What's this PR do?

Removes regional admin access from the following places https://github.com/DoSomething/phoenix/issues/4901#issuecomment-138592399
#### How should this be manually tested?

Test those configurations aren't accessible by regional admins but can still be accessed by normal admins
#### What are the relevant tickets?

Fixes #4901 
