### PR TITLE
fixes user country code, address, and update function

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -65,7 +65,6 @@ function dosomething_api_services_request_postprocess_alter($controller, $args, 
   }
 }
 
-
 /**
  * Returns the Reportback Gallery of a specified node.
  *

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -64,6 +64,8 @@ function dosomething_api_services_request_postprocess_alter($controller, $args, 
     }
   }
 }
+
+
 /**
  * Returns the Reportback Gallery of a specified node.
  *

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -64,7 +64,6 @@ function dosomething_api_services_request_postprocess_alter($controller, $args, 
     }
   }
 }
-
 /**
  * Returns the Reportback Gallery of a specified node.
  *

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -107,43 +107,17 @@ function _dosomething_northstar_build_http_client() {
 function dosomething_northstar_update_user($form_state) {
   $user = $form_state['user'];
   $id = $user->uid;
-
   $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
 
   $northstar = new Northstar();
   $client = _dosomething_northstar_build_http_client();
 
-  // $northstar_user_info = dosomething_northstar_get_northstar_user($id);
-  // $northstar_user_info = json_decode($northstar_user_info->data, TRUE);
-  // $northstar_user_info = (object) $northstar_user_info['data'][0];
-  // $ns_id = $northstar_user_info->_id;
-
-  $response = drupal_http_request($client['base_url'] . '/users/drupal_id' . $id, array(
+  $response = drupal_http_request($client['base_url'] . '/users/drupal_id/' . $id, array(
     'headers' => $client['headers'],
     'method' => 'PUT',
     'data' => json_encode($ns_user),
     ));
 
-  if ($response->code === '200' && module_exists('stathat')) {
-    stathat_send_ez_count('drupal - Northstar - user updated - count', 1);
-  }
-  elseif ($response->code !== '200') {
-    watchdog('dosomething_northstar', 'User not updated : ' . $response->code, NULL, WATCHDOG_ERROR);
-  }
-
-}
-
-function dosomething_northstar_update_user($form_state) {
-  $user = $form_state['user'];
-  $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
-
-  $northstar = new Northstar();
-  $client = _dosomething_northstar_build_http_client();
-  $response = drupal_http_request($client['base_url'] . '/users', array(
-    'headers' => $client['headers'],
-    'method' => 'POST',
-    'data' => json_encode($ns_user),
-    ));
   if ($response->code === '200' && module_exists('stathat')) {
     stathat_send_ez_count('drupal - Northstar - user updated - count', 1);
   }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -106,15 +106,24 @@ function _dosomething_northstar_build_http_client() {
  */
 function dosomething_northstar_update_user($form_state) {
   $user = $form_state['user'];
+  $id = $user->uid;
+
   $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
 
   $northstar = new Northstar();
   $client = _dosomething_northstar_build_http_client();
-  $response = drupal_http_request($client['base_url'] . '/users', array(
+
+  $northstar_user_info = dosomething_northstar_get_northstar_user($id);
+  $northstar_user_info = json_decode($northstar_user_info->data, true);
+  $northstar_user_info = (object) $northstar_user_info['data'][0];
+  $ns_id = $northstar_user_info->_id;
+
+  $response = drupal_http_request($client['base_url'] . '/users/' . $ns_id, array(
     'headers' => $client['headers'],
-    'method' => 'POST',
+    'method' => 'PUT',
     'data' => json_encode($ns_user),
     ));
+
   if ($response->code === '200' && module_exists('stathat')) {
     stathat_send_ez_count('drupal - Northstar - user updated - count', 1);
   }
@@ -183,8 +192,13 @@ function dosomething_northstar_build_ns_user($user, $form_state) {
   }
   foreach ($address as $ns_key => $drupal_key) {
     $field = $user->field_address[LANGUAGE_NONE][0];
-    if (isset($field[$drupal_key])) {
+
+    if ($drupal_key == 'country') {
       $ns_user[$ns_key] = $field[$drupal_key];
+    }
+
+    if (isset($field[$drupal_key]['value'])) {
+      $ns_user[$ns_key] = $field[$drupal_key]['value'];
     }
   }
 

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -104,34 +104,34 @@ function _dosomething_northstar_build_http_client() {
 /**
  * Send user profile updates to northstar.
  */
-// function dosomething_northstar_update_user($form_state) {
-//   $user = $form_state['user'];
-//   $id = $user->uid;
+function dosomething_northstar_update_user($form_state) {
+  $user = $form_state['user'];
+  $id = $user->uid;
 
-//   $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
+  $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
 
-//   $northstar = new Northstar();
-//   $client = _dosomething_northstar_build_http_client();
+  $northstar = new Northstar();
+  $client = _dosomething_northstar_build_http_client();
 
-//   $northstar_user_info = dosomething_northstar_get_northstar_user($id);
-//   $northstar_user_info = json_decode($northstar_user_info->data, TRUE);
-//   $northstar_user_info = (object) $northstar_user_info['data'][0];
-//   $ns_id = $northstar_user_info->_id;
+  $northstar_user_info = dosomething_northstar_get_northstar_user($id);
+  $northstar_user_info = json_decode($northstar_user_info->data, TRUE);
+  $northstar_user_info = (object) $northstar_user_info['data'][0];
+  $ns_id = $northstar_user_info->_id;
 
-//   $response = drupal_http_request($client['base_url'] . '/users/' . $ns_id, array(
-//     'headers' => $client['headers'],
-//     'method' => 'PUT',
-//     'data' => json_encode($ns_user),
-//     ));
+  $response = drupal_http_request($client['base_url'] . '/users/' . $ns_id, array(
+    'headers' => $client['headers'],
+    'method' => 'PUT',
+    'data' => json_encode($ns_user),
+    ));
 
-//   if ($response->code === '200' && module_exists('stathat')) {
-//     stathat_send_ez_count('drupal - Northstar - user updated - count', 1);
-//   }
-//   elseif ($response->code !== '200') {
-//     watchdog('dosomething_northstar', 'User not updated : ' . $response->code, NULL, WATCHDOG_ERROR);
-//   }
+  if ($response->code === '200' && module_exists('stathat')) {
+    stathat_send_ez_count('drupal - Northstar - user updated - count', 1);
+  }
+  elseif ($response->code !== '200') {
+    watchdog('dosomething_northstar', 'User not updated : ' . $response->code, NULL, WATCHDOG_ERROR);
+  }
 
-// }
+}
 
 function dosomething_northstar_update_user($form_state) {
   $user = $form_state['user'];

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -113,12 +113,12 @@ function dosomething_northstar_update_user($form_state) {
   $northstar = new Northstar();
   $client = _dosomething_northstar_build_http_client();
 
-  $northstar_user_info = dosomething_northstar_get_northstar_user($id);
-  $northstar_user_info = json_decode($northstar_user_info->data, TRUE);
-  $northstar_user_info = (object) $northstar_user_info['data'][0];
-  $ns_id = $northstar_user_info->_id;
+  // $northstar_user_info = dosomething_northstar_get_northstar_user($id);
+  // $northstar_user_info = json_decode($northstar_user_info->data, TRUE);
+  // $northstar_user_info = (object) $northstar_user_info['data'][0];
+  // $ns_id = $northstar_user_info->_id;
 
-  $response = drupal_http_request($client['base_url'] . '/users/' . $ns_id, array(
+  $response = drupal_http_request($client['base_url'] . '/users/drupal_id' . $id, array(
     'headers' => $client['headers'],
     'method' => 'PUT',
     'data' => json_encode($ns_user),

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -189,9 +189,7 @@ function dosomething_northstar_build_ns_user($user, $form_state) {
 
     if ($drupal_key == 'country') {
       $ns_user[$ns_key] = $field[$drupal_key];
-    }
-
-    if (isset($field[$drupal_key]['value'])) {
+    } else if (isset($field[$drupal_key]['value'])) {
       $ns_user[$ns_key] = $field[$drupal_key]['value'];
     }
   }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -104,26 +104,46 @@ function _dosomething_northstar_build_http_client() {
 /**
  * Send user profile updates to northstar.
  */
+// function dosomething_northstar_update_user($form_state) {
+//   $user = $form_state['user'];
+//   $id = $user->uid;
+
+//   $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
+
+//   $northstar = new Northstar();
+//   $client = _dosomething_northstar_build_http_client();
+
+//   $northstar_user_info = dosomething_northstar_get_northstar_user($id);
+//   $northstar_user_info = json_decode($northstar_user_info->data, TRUE);
+//   $northstar_user_info = (object) $northstar_user_info['data'][0];
+//   $ns_id = $northstar_user_info->_id;
+
+//   $response = drupal_http_request($client['base_url'] . '/users/' . $ns_id, array(
+//     'headers' => $client['headers'],
+//     'method' => 'PUT',
+//     'data' => json_encode($ns_user),
+//     ));
+
+//   if ($response->code === '200' && module_exists('stathat')) {
+//     stathat_send_ez_count('drupal - Northstar - user updated - count', 1);
+//   }
+//   elseif ($response->code !== '200') {
+//     watchdog('dosomething_northstar', 'User not updated : ' . $response->code, NULL, WATCHDOG_ERROR);
+//   }
+
+// }
+
 function dosomething_northstar_update_user($form_state) {
   $user = $form_state['user'];
-  $id = $user->uid;
-
   $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
 
   $northstar = new Northstar();
   $client = _dosomething_northstar_build_http_client();
-
-  $northstar_user_info = dosomething_northstar_get_northstar_user($id);
-  $northstar_user_info = json_decode($northstar_user_info->data, true);
-  $northstar_user_info = (object) $northstar_user_info['data'][0];
-  $ns_id = $northstar_user_info->_id;
-
-  $response = drupal_http_request($client['base_url'] . '/users/' . $ns_id, array(
+  $response = drupal_http_request($client['base_url'] . '/users', array(
     'headers' => $client['headers'],
-    'method' => 'PUT',
+    'method' => 'POST',
     'data' => json_encode($ns_user),
     ));
-
   if ($response->code === '200' && module_exists('stathat')) {
     stathat_send_ez_count('drupal - Northstar - user updated - count', 1);
   }


### PR DESCRIPTION
#### What's this PR do?

Fixes to send both country code and address fields from phoenix -> ns.
#### Where should the reviewer start?

lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module lines 195-202 grabs correct country value and includes address values. 
lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module `dosomething_northstar_update_user` function - updates to hit `/users/:user_id` endpoint. For some reason, `/users` endpoint wasn't saving address properly.
#### How should this be manually tested?

Create new user on ds.org. Hit ns endpoint GET /users/email/<email> and make sure country code is returned. https://github.com/DoSomething/northstar/wiki/Spec#retrieving-a-user

Update user profile and add address. Hit the same endpoint above and make sure address is returned.
#### What are the relevant tickets?

Fixes #5263
