### PR TITLE
Fix bug with nesting t().

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -169,8 +169,9 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
 function dosomething_campaign_preprocess_win_module(&$vars, $wrapper) {
   $node = node_load($vars['nid']);
   $rb_progress = dosomething_reportback_get_reportback_total_plus_override($node->nid);
-  $copy_token_replaced = token_replace(t(variable_get('dosomething_campaign_win_copy'), array('node' => $node)));
-
+  $copy = t(variable_get('dosomething_campaign_win_copy'));
+  $copy_token_replaced = token_replace($copy, array('node' => $node));
+  
   // Get random promoted reportback image
   $parameters = array(
     'nid' => $vars['nid'],


### PR DESCRIPTION
Fixes #5455
#### What's this PR do?

If the t() function is nested inside the token_replace() function then it all kinda breaks and the tokens can't be replaced properly. This PR fixes that up; solution is to separate them out.
#### Where should the reviewer start?

There is only one file... Choose wisely.
#### How should this be manually tested?

Meh. Let's just agree to test it on staging once it's up. 
#### What are the relevant tickets?
#5455

---

@sbsmith86 

cc: @mikefantini 
