### PR TITLE
Fix missing footer

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -192,7 +192,7 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     // Get new country code setting if it exists, if not fallback to old setting.
     // @TODO: Remove this after we've updated theme settings everywhere.
     $heading_setting = theme_get_setting($prefix . 'heading');
-    if(!$heading_setting === NULL) {
+    if($heading_setting === NULL) {
       $heading_setting = theme_get_setting('footer_links_' . $column . '_column_heading');
     }
     $footer_links[$column]['heading'] = $heading_setting;
@@ -200,7 +200,7 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     // Get new country code setting if it exists, if not fallback to old setting.
     // @TODO: Remove this after we've updated theme settings everywhere.
     $links_setting = theme_get_setting($prefix . 'links');
-    if(!$links_setting === NULL) {
+    if($links_setting === NULL) {
       $links_setting = theme_get_setting('footer_links_' . $column . '_column_links');
     }
     $links = explode("\n", trim($links_setting));

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -7,14 +7,6 @@ if (!defined('PARANEUE_PATH')) {
 require_once PARANEUE_PATH . '/includes/helpers.inc';
 
 function paraneue_dosomething_form_system_theme_settings_alter(&$form, &$form_state) {
-  $form['theme_settings'] = array(
-      '#type'        => 'fieldset',
-      '#title'       => t('Theme Settings'),
-      '#collapsible' => FALSE,
-      '#collapsed'   => FALSE,
-      '#weight'      => -19
-  );
-
   $form['feature_flags'] = array(
       '#type'        => 'fieldset',
       '#title'       => t('Feature Flags'),

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -292,7 +292,7 @@ function _paraneue_dosomething_theme_settings_footer(&$form, $form_state) {
       // Get new country code setting if it exists, if not fallback to old setting.
       // @TODO: Remove this after we've updated theme settings everywhere.
       $heading_default = theme_get_setting('footer_links_' . $country . '_' . $column . '_column_heading');
-      if(!$heading_default === NULL) {
+      if($heading_default === NULL) {
         $heading_default = theme_get_setting('footer_links_' . $column . '_column_heading');
       }
 
@@ -305,7 +305,7 @@ function _paraneue_dosomething_theme_settings_footer(&$form, $form_state) {
       // Get new country code setting if it exists, if not fallback to old setting.
       // @TODO: Remove this after we've updated theme settings everywhere.
       $links_default = theme_get_setting('footer_links_' . $country . '_' . $column . '_column_links');
-      if(!$links_default === NULL) {
+      if($links_default === NULL) {
         $links_default = theme_get_setting('footer_links_' . $column . '_column_links');
       }
 


### PR DESCRIPTION
Fixes #5466. When I switched from testing if the theme settings were falsey (which
was failing on "") to testing against `NULL`, I left the "!" prefix in there. Programming is hard.

I also removed an [empty "Theme Settings" fieldset](https://cloud.githubusercontent.com/assets/583202/10468911/c5665592-71cf-11e5-9482-46d14eee754a.png) that didn't seem to be serving any purpose.

For review: @angaither 
