### PR TITLE
Fix login and registration events

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -471,7 +471,24 @@ function dosomething_user_update_user($form, &$form_state) {
  * Does actions after a new user has registered via the web.
  * Sign user up for emails/texts.
  */
-function dosomething_user_new_user($form, &$form_state) {
+function dosomething_user_new_user($form, &$form_state)
+{
+  // Trigger an analytics event on registration
+  // @NOTE: The 'Authentication - Login' event will *also* be triggered here,
+  // since registered users are subsequently logged in to their new accounts.
+  dosomething_helpers_add_analytics_event('Authentication', 'Register');
+
+  // Sign the user up for transactional messaging
+  _dosomething_user_send_to_message_broker();
+}
+
+/**
+ * Sign the authenticated user up for transactional messaging through Message Broker
+ * if the required modules are enabled and the user meets relevant criteria.
+ *
+ * @see dosomething_user_new_user
+ */
+function _dosomething_user_send_to_message_broker() {
   if (!module_exists('dosomething_mbp') || !module_exists('dosomething_signup')) {
     return;
   }
@@ -699,11 +716,6 @@ function dosomething_user_user_insert(&$edit, &$account, $category = NULL) {
     $edit['name'] = $account->uid;
     $account->name = $account->uid;
   }
-
-  // Trigger an analytics event on registration
-  // @NOTE: The 'Authentication - Login' event will *also* be triggered here,
-  // since registered users are subsequently logged in to their new accounts.
-  dosomething_helpers_add_analytics_event('Authentication', 'Register');
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -15,11 +15,6 @@ include_once 'dosomething_user.theme.inc';
  */
 function dosomething_user_preprocess_page(&$vars) {
   $school_api_endpoint = variable_get('dosomething_user_school_api_endpoint', 'http://lofischools.herokuapp.com/search');
-  if (isset($_SESSION['dosomething_user_log_login'])) {
-    dosomething_helpers_add_analytics_event("login", $_SESSION['dosomething_user_log_login']);
-    unset($_SESSION['dosomething_user_log_login']);
-  }
-
   $date_format = (dosomething_settings_get_geo_country_code() === 'US') ? 'MM/DD/YYYY' : 'DD/MM/YYYY';
   drupal_add_js(
     array('dosomethingUser' =>
@@ -234,7 +229,6 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
       // Helper text & additional data.
       _dosomething_user_add_signup_data($form);
       $form['#submit'][] = 'dosomething_user_login_submit';
-      $_SESSION['dosomething_user_log_login'] = "login";
     break;
 
     case 'user_profile_form':
@@ -478,7 +472,6 @@ function dosomething_user_update_user($form, &$form_state) {
  * Sign user up for emails/texts.
  */
 function dosomething_user_new_user($form, &$form_state) {
-  $_SESSION['dosomething_user_log_login'] = "register";
   if (!module_exists('dosomething_mbp') || !module_exists('dosomething_signup')) {
     return;
   }
@@ -682,6 +675,16 @@ function dosomething_user_login_submit($form, &$form_state) {
 }
 
 /**
+ * Implements hook_user_login().
+ */
+function dosomething_user_user_login(&$edit, $account) {
+  // Trigger an analytics event on login
+  // @NOTE: This will *also* be triggered on registration, since registered
+  // users are subsequently logged in to their new accounts.
+  dosomething_helpers_add_analytics_event('Authentication', 'Login');
+}
+
+/**
  * Implements hook_user_insert().
  */
 function dosomething_user_user_insert(&$edit, &$account, $category = NULL) {
@@ -696,6 +699,11 @@ function dosomething_user_user_insert(&$edit, &$account, $category = NULL) {
     $edit['name'] = $account->uid;
     $account->name = $account->uid;
   }
+
+  // Trigger an analytics event on registration
+  // @NOTE: The 'Authentication - Login' event will *also* be triggered here,
+  // since registered users are subsequently logged in to their new accounts.
+  dosomething_helpers_add_analytics_event('Authentication', 'Register');
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -222,8 +222,6 @@ function dosomething_user_is_staff($user = NULL) {
  * Implements hook_form_alter().
  */
 function dosomething_user_form_alter(&$form, $form_state, $form_id) {
-  global $user;
-  $account = $user;
   // If UPS is set to validate, and the user is from the US, validate address.
   $validate_address = (variable_get('dosomething_user_validate_address') && dosomething_settings_get_geo_country_code() === 'US');
 


### PR DESCRIPTION
#### Changes

Fixes #5119. Since the `dosomething_user_form_alter` and `dosomething_user_preprocess_page` hooks are called on every page load (as we prepare that form on every page load), this event was constantly being triggered. This PR moves that logic in to the appropriate hooks for the user login and registration events.
#### How should this be tested?

I tested on my local box by adding a `dpm` call to [`dosomething_helpers_add_analytics_event`](https://github.com/DFurnes/phoenix/blob/d0627f7e9a2aebf64f877138987c59bab4998ee9/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module#L521-531). Everything seemed to function correctly when logging in or registering from either the header or the campaign pitch page.
#### Questions

Because `hook_user_login` is also called after registering a new user, registration will trigger both an `Authentication - Register` and an `Authentication - Login` event on the subsequent page load. I think this makes sense and keeps the implementation from getting too hairy... does anyone see any problems?

---

For review: @angaither 
