### PR TITLE
Returns 404 when user access non published translation

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -529,12 +529,7 @@ function dosomething_global_redirect_node_language($node, $language_code, $redir
   $languages = language_list();
 
   // Can only redirect to an published, translated version.
-  if (!empty($node->translations->data[$language_code])) {
-    if (!$node->translations->data[$language_code]['status']) {
-      drupal_not_found();
-      drupal_exit();
-      return;
-    }
+  if (!empty($node->translations->data[$language_code]) && $node->translations->data[$language_code]['status']) {
     $target_node = $node->translations->data[$language_code];
 
     // Might be overly formal: We could pull 'node/nid' from the current
@@ -543,6 +538,9 @@ function dosomething_global_redirect_node_language($node, $language_code, $redir
     $target_path = sprintf('node/%s', $target_node['entity_id']);
 
     drupal_goto(url($target_path, array('language' => $languages[$language_code])), array(), $redirect_status);
+  } else {
+    drupal_not_found();
+    drupal_exit();
   }
 
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -538,7 +538,8 @@ function dosomething_global_redirect_node_language($node, $language_code, $redir
     $target_path = sprintf('node/%s', $target_node['entity_id']);
 
     drupal_goto(url($target_path, array('language' => $languages[$language_code])), array(), $redirect_status);
-  } else {
+  }
+  else {
     drupal_not_found();
     drupal_exit();
   }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -74,10 +74,7 @@ function dosomething_global_init() {
   // they request bare (Global English) URLs to nodes.
   //
   // Passing 'noredirect=1' will defeat the redirect.
-  if (arg(0) == 'node' && is_numeric(arg(1)) && empty(arg(2)) &&
-      !dosomething_global_is_translation_request() &&
-      empty($_GET['noredirect'])) {
-
+  if (arg(0) == 'node' && is_numeric(arg(1)) && empty(arg(2)) && empty($_GET['noredirect'])) {
     if ($user->uid) {
       dosomething_global_redirect_node_auth();
     } else {
@@ -426,7 +423,6 @@ function dosomething_global_is_translation_request() {
         // If the prefix matches a language prefix besides that of Global
         // English:
         if ($matches[1] == $sys_lang->prefix && $sys_lang->language != DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE) {
-
           return TRUE;
         }
       }
@@ -530,12 +526,15 @@ function dosomething_global_redirect_node_anon() {
  * @param int $redirect_status
  */
 function dosomething_global_redirect_node_language($node, $language_code, $redirect_status = 302) {
-
   $languages = language_list();
 
   // Can only redirect to an published, translated version.
-  if (!empty($node->translations->data[$language_code]) && (bool)$node->translations->data[$language_code]['status']) {
-
+  if (!empty($node->translations->data[$language_code])) {
+    if (!$node->translations->data[$language_code]['status']) {
+      drupal_not_found();
+      drupal_exit();
+      return;
+    }
     $target_node = $node->translations->data[$language_code];
 
     // Might be overly formal: We could pull 'node/nid' from the current
@@ -545,6 +544,7 @@ function dosomething_global_redirect_node_language($node, $language_code, $redir
 
     drupal_goto(url($target_path, array('language' => $languages[$language_code])), array(), $redirect_status);
   }
+
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?

Prevents users from accessing unpublished campaign translations. 
#### Where should the reviewer start?

line 77 in the diff
#### How should this be manually tested?

Go to an unpublished campaign translation and make sure you get 404'd
Make sure translation redirects work for published campaigns
#### Any background context you want to provide?

Yes.

I had to remove the call to `dosomething_global_is_translation_request()`, as it checks if the prefixes are present in the URL (And it works fine). The problem is it doesn't check if node actually has a published translation for that language. This meant a URL like dosomething.org:8888/mx/voluntario/closed-campaign was never redirected, even though in this case the spanish translation for that campaign isn't published. 

We could have duplicated the logic in is_translation_request from the redirect functions so we can fetch this data needed to make these determinations. But duplicated code is bad... :/

The temp solution for now was to just remove that function call and assume every URL needs to be double checked for both redirect AND translation publish status. If it fails the publish status, we return a 404 (confirmed that should be the functionality with Fantini) 

In the global 1.3.14159265359 we can re-write this logic to be less hacky (hence why I didnt fully remove the function from the code, it still works and is useful!)
#### What are the relevant tickets?
#5469
