### PR TITLE
Removing code that adds a prefix to signup email link

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -562,7 +562,6 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
   $url_options = array(
     'language' => $language,
     'absolute' => TRUE,
-    'prefix' => strtolower(dosomething_global_convert_language_to_country($language)) . '/',
     'query' => array(
       'source' => 'node/' . $node->nid,
     ),
@@ -575,7 +574,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     'mobile' => dosomething_user_get_field('field_mobile', $account),
     'event_id' => $node->nid,
     'campaign_title' => $wrapper->language($language)->title_field->value(),
-    'campaign_link' => url('node/' . $nid, $url_options),
+    'campaign_link' => url('node/' . $node->nid, $url_options),
     'user_language' => $language,
   );
 


### PR DESCRIPTION
#### What does this PR do?

In production because we're not using prefixes, adding the prefix to the URL for signup emails is breaks things. When merging dev back in to global, which will remove the code necessary to make signup email links work, this code needs to be readded.
#### How should this be manually tested?

In an environment that's set up like production, e.g. where prefixes are disabled, and the default language is 'en', sign up for a campaign, and check the "get started" link to make sure it goes to the appropriate place.
#### Any background context you want to provide?

Currently in production the link looks like `https://www.dosomething.org/us/node/?source=node/5840`. It should look like `https://www.dosomething.org/node/5840?source=node/5840`, or have the URL alias of the node.
