### PR TITLE
Removing item from pot file that should not be translated.

### DIFF
--- a/pots/paraneue_dosomething.pot
+++ b/pots/paraneue_dosomething.pot
@@ -491,10 +491,6 @@ msgstr ""
 msgid "Confirm Password"
 msgstr ""
 
-#: (duplicate) includes/form.inc:93 ;97
-msgid "!title !required"
-msgstr ""
-
 #: includes/helpers.inc:40
 msgid "Facebook"
 msgstr ""


### PR DESCRIPTION
Refs #5476
#### What's this PR do?

This PR removes some unnecessary strings from a POT file. Putting these Drupal variables into pot files and having them translated was affecting the replacement of them in code for Droooopal.
#### Where should the reviewer start?

There is only one file to rule them all. Take a guess.
#### What are the relevant tickets?
#5476

---

@DFurnes 

cc: @mikefantini 
