### PR TITLE
Allow videos on any homepage tile.

### DIFF
--- a/lib/modules/dosomething/dosomething_home/dosomething_home.module
+++ b/lib/modules/dosomething/dosomething_home/dosomething_home.module
@@ -51,31 +51,31 @@ function dosomething_home_preprocess_node(&$vars) {
       if ($key == 0) {
         $tiles['modifier_classes'] = "big";
         $tiles['image_url'] = dosomething_image_get_themed_image_url($image_nid, 'square', '720x720');
-
-        // Get the campaign video for the "featured" tile
-        $video_url = dosomething_image_get_themed_image_url($image_nid, 'video');
-        $video_poster = dosomething_image_get_themed_image_url($image_nid, 'video_poster');
-
-        if(isset($video_url) && isset($video_poster)) {
-          $tiles['video'] = theme('html_tag', array(
-              'element' => array(
-                  '#tag' => 'video',
-                  '#attributes' => array(
-                      'src' => $video_url,
-                      'poster' => $video_poster,
-                      'autoplay' => 'autoplay',
-                      'loop' => 'loop'
-                  ),
-                  '#value' => theme('image', array(
-                      'path' => $tiles['image_url'],
-                      'alt' => $tiles['title']
-                  )),
-              ),
-          ));
-        }
       }
       else {
         $tiles['image_url'] = dosomething_image_get_themed_image_url($image_nid, 'square', '400x400');
+      }
+
+      // Get the campaign video if one is specified
+      $video_url = dosomething_image_get_themed_image_url($image_nid, 'video');
+      $video_poster = dosomething_image_get_themed_image_url($image_nid, 'video_poster');
+
+      if(isset($video_url) && isset($video_poster)) {
+        $tiles['video'] = theme('html_tag', array(
+            'element' => array(
+                '#tag' => 'video',
+                '#attributes' => array(
+                    'src' => $video_url,
+                    'poster' => $video_poster,
+                    'autoplay' => 'autoplay',
+                    'loop' => 'loop'
+                ),
+                '#value' => theme('image', array(
+                    'path' => $tiles['image_url'],
+                    'alt' => $tiles['title']
+                )),
+            ),
+        ));
       }
 
       $tiles['status'] = TRUE;


### PR DESCRIPTION
### Changes

Allows _any_ tile on the homepage to show an associated video. Closes #5488.
### Where should the reviewer start?

There's a big block of code for showing videos that was inside the if-statement for the first "featured" tile block. Now it's outside the if-statement.
### How should this be manually tested?

If you want, you can pull down the code and set up a couple homepage tiles with videos. I did this on my local and [made a screen recording](http://cl.ly/dXgP).

---

For review: @weerd 
