### PR TITLE
Readding code to add prefixes to URLs in signups

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -575,7 +575,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     'mobile' => dosomething_user_get_field('field_mobile', $account),
     'event_id' => $node->nid,
     'campaign_title' => $wrapper->language($language)->title_field->value(),
-    'campaign_link' => url('node/' . $node->nid, $url_options),
+    'campaign_link' => dosomething_global_url('node/' . $node->nid, $url_options),
     'user_language' => $language,
   );
 


### PR DESCRIPTION
This code was removed because adding prefixes in production breaks things at the moment. This PR readds it.
