### PR TITLE
Fixes campaign run field extraction

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -268,7 +268,8 @@ function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$fo
   $form['title']['#description'] = t('The title is not user facing, it just helps when searching for content. Suggestion: Use campaign name and year campaign ended (i.e. Comeback Clothes 2014).');
 
   // If the campaign nid is set let's add some help text!
-  $campaign_nid = $form['#node']->field_campaigns[LANGUAGE_NONE][0]['target_id'];
+  // This will break when we create MX & BR (and etc) campaign runs. the helpers extract only checks for 'en'
+  $campaign_nid = $form['#node']->field_campaigns[dosomething_helpers_extract_field_data($form['#node']->field_campaigns)][0]['target_id'];
   if (isset($campaign_nid)) {
     // Get totals & language from the campaign.
     $signup_total_members = dosomething_signup_get_signup_total_by_nid($campaign_nid);

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -269,7 +269,7 @@ function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$fo
 
   // If the campaign nid is set let's add some help text!
   // This will break when we create MX & BR (and etc) campaign runs. the helpers extract only checks for 'en'
-  $campaign_nid = $form['#node']->field_campaigns[dosomething_helpers_extract_field_data($form['#node']->field_campaigns)][0]['target_id'];
+  $campaign_nid = dosomething_helpers_extract_field_data($form['#node']->field_campaigns)[0]['target_id'];
   if (isset($campaign_nid)) {
     // Get totals & language from the campaign.
     $signup_total_members = dosomething_signup_get_signup_total_by_nid($campaign_nid);

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -282,4 +282,4 @@ function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$fo
   }
 
   drupal_add_css(drupal_get_path('module', 'dosomething_campaign_run') . '/campaign_run_node.css');
-  }
+}

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -269,7 +269,7 @@ function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$fo
 
   // If the campaign nid is set let's add some help text!
   // This will break when we create MX & BR (and etc) campaign runs. the helpers extract only checks for 'en'
-  $campaign_nid = dosomething_helpers_extract_field_data($form['#node']->field_campaigns)[0]['target_id'];
+  $campaign_nid = dosomething_helpers_extract_field_data($form['#node']->field_campaigns);
   if (isset($campaign_nid)) {
     // Get totals & language from the campaign.
     $signup_total_members = dosomething_signup_get_signup_total_by_nid($campaign_nid);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -992,7 +992,7 @@ function dosomething_reportback_get_noun_and_verb($nid) {
 
   $query = db_select('field_data_field_reportback_noun', 'noun')
     ->condition('noun.entity_id', $nid)
-    ->condition('noun.language', $language);
+    ->condition('noun.language', $language->language);
   $query->addField('noun', 'field_reportback_noun_value', 'noun');
   $query->addField('verb', 'field_reportback_verb_value', 'verb');
   $query->join('field_data_field_reportback_verb', 'verb', 'noun.entity_id = verb.entity_id');


### PR DESCRIPTION
This title scares me.
#### What's this PR do?
- Updates the campaign run NID extraction logic to support multiple langs
- Updates helper query for noun & verb to support multiple langs
#### How should this be manually tested?

Can you access campaign run edit buttons? Yes? Great!
#### Any background context you want to provide?

In the process of discovering this bug, @angaither exclaimed "who wrote this shitty code" and git blamed herself. Also she threw items my desk into the trash can, I'd like to file a complaint with HR.
#### What are the relevant tickets?

Fixes #5326 
