### PR TITLE
Fixes #5498: don't redirect drush.

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -16,6 +16,11 @@ define('DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE', 'en-global');
 function dosomething_global_init() {
   global $user;
 
+  // We don't need to redirect cli request, such as drush.
+  if (drupal_is_cli()) {
+    return;
+  }
+
   // Redirect people hitting the homepage or explore campaigns to their local version
   $path = request_path();
   if ((drupal_is_front_page() && is_numeric(arg(1))) || $path == 'campaigns') {


### PR DESCRIPTION
#### What's this PR do?
- Excludes Drupal cli requests from being redirected with `dosomething_global_init()` logic
#### Any background context you want to provide?

Turned out that `drupal_is_front_page() === TRUE` in drush requests so the redirect logic kills drush with `Drush command terminated abnormally due to an unrecoverable error.`
#### What are the relevant tickets?

Fixes #5498.

---

:warning:  This is merge to `global` branch.
