### PR TITLE
Show country to staff

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.features.field_instance.inc
@@ -52,13 +52,11 @@ function dosomething_user_field_default_field_instances() {
       'active' => 1,
       'module' => 'addressfield',
       'settings' => array(
-        'available_countries' => array(
-          'US' => 'US',
-        ),
+        'available_countries' => array(),
         'format_handlers' => array(
           'dosomething-affiliate-country' => 'dosomething-affiliate-country',
           'address' => 'address',
-          'address-hide-country' => 'address-hide-country',
+          'address-hide-country' => 0,
           'organisation' => 0,
           'name-full' => 0,
           'name-oneline' => 0,

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.info
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.info
@@ -131,4 +131,4 @@ features[views_view][] = content_search
 features[views_view][] = user_search
 files[] = dosomething_user.test
 files[] = includes/dosomething_user_remote.inc
-mtime = 1444250077
+mtime = 1444843755

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -271,7 +271,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
         unset($form['field_under_thirteen']);
         unset($form['field_job_title']);
         // Add an after build to remove the language switcher.
-        $form['#after_build'][] = 'dosomething_user_remove_language_switcher';
+        $form['#after_build'][] = 'dosomething_user_remove_language_and_country_switcher';
       }
       // else if staff:
       else {
@@ -316,7 +316,8 @@ function dosomething_user_non_us_birthday_format($form, &$form_state) {
  * After build to remove language switcher.
  *
  */
-function dosomething_user_remove_language_switcher($form, &$form_state) {
+function dosomething_user_remove_language_and_country_switcher($form, &$form_state) {
+  $form['field_address'][LANGUAGE_NONE][0]['address']['country']['#access'] = FALSE;
   unset($form['locale']);
   return $form;
 }


### PR DESCRIPTION
expose the country field on the user/edit form to staff members
allow there to be more than the US selected, because #global 

fixes #5500 
