### PR TITLE
BR/MX contact us emails instead of zendesk form 

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -597,4 +597,6 @@ function dosomething_global_get_current_prefix() {
       }
     }
   }
+
+  return NULL;
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -581,3 +581,20 @@ function dosomething_global_url($path, $options = NULL) {
   }
   return url($path, $options);
 }
+
+/**
+ * Return the current country prefix being used.
+ *
+ */
+function dosomething_global_get_current_prefix() {
+  $request_path = explode('/', request_path());
+  if (!empty($request_path[0])) {
+    $languages = language_list();
+
+    foreach ($languages as $langcode => $lang_data) {
+      if ($lang_data->prefix == $request_path[0]) {
+        return $lang_data->prefix;
+      }
+    }
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -351,7 +351,8 @@ function paraneue_dosomething_add_info_bar(&$vars) {
       if (array_key_exists($country_prefix, $country_contact_emails)) {
         $info_bar_vars['contact_us_email'] = '<a href="mailto:' . $country_contact_emails[$country_prefix] .'">'. $country_contact_emails[$country_prefix] . '</a>';
       // All other countries get the zendesk form.
-      } else {
+      }
+      else {
         $zendesk_form_header = t(variable_get('dosomething_zendesk_form_header'));
         $info_bar_vars['zendesk_form_header'] = $zendesk_form_header;
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -338,23 +338,27 @@ function paraneue_dosomething_add_info_bar(&$vars) {
     $info_bar_vars['formatted_partners'] = $vars['formatted_partners'];
   }
 
-  $country_code = dosomething_settings_get_geo_country_code();
+  if (module_exists('dosomething_global')) {
+    $country_prefix = dosomething_global_get_current_prefix();
 
-  $country_contact_emails = array(
-    'BR' => 'ajuda@dosomething.org',
-    'MX' => 'ayuda@dosomething.org',
-  );
+    if ($country_prefix) {
+      $country_contact_emails = array(
+        'br' => 'ajuda@dosomething.org',
+        'mx' => 'ayuda@dosomething.org',
+      );
 
-  // For the countries in $country_contact_emails, use a contact email address instead of zendesk form.
-  if (array_key_exists($country_code, $country_contact_emails)) {
-    $info_bar_vars['contact_us_email'] = '<a href="mailto:' . $country_contact_emails[$country_code] .'">'. $country_contact_emails[$country_code] . '</a>';
-  // All other countries get the zendesk form.
-  } else {
-    $zendesk_form_header = t(variable_get('dosomething_zendesk_form_header'));
-    $info_bar_vars['zendesk_form_header'] = $zendesk_form_header;
+      // For the countries in $country_contact_emails, use a contact email address instead of zendesk form.
+      if (array_key_exists($country_prefix, $country_contact_emails)) {
+        $info_bar_vars['contact_us_email'] = '<a href="mailto:' . $country_contact_emails[$country_prefix] .'">'. $country_contact_emails[$country_prefix] . '</a>';
+      // All other countries get the zendesk form.
+      } else {
+        $zendesk_form_header = t(variable_get('dosomething_zendesk_form_header'));
+        $info_bar_vars['zendesk_form_header'] = $zendesk_form_header;
 
-    if (isset($vars['zendesk_form'])) {
-      $info_bar_vars['zendesk_form'] = $vars['zendesk_form'];
+        if (isset($vars['zendesk_form'])) {
+          $info_bar_vars['zendesk_form'] = $vars['zendesk_form'];
+        }
+      }
     }
   }
 


### PR DESCRIPTION
#### What's this PR do?

When I first implemented this functionality, I had based the logic on the users country code. This PR updates that logic to use the country prefix in the url. This way, for example, if a use is in the US but visits a `/mx` url they will get the contact email for mx users. 
#### Where should the reviewer start?

I made a helper function in `dosomething_global.module` that finds the current country prefix in the URL and then just updated `preprocess.inc` to use this new function instead of country code, as well as some sanity checks.
#### What are the relevant tickets?

Fixes #5078 
