### PR TITLE
Refactors ALL THE GLOBAL THINGS.

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -52,7 +52,7 @@ function dosomething_global_init() {
 
   // Redirect people hitting the homepage
   // or explore campaigns to their local version.
-  if ($url_variables['is_homepage'] || $path == 'campaigns') {
+  if ($url_variables['is_homepage'] || $url_variables['path'] == 'campaigns') {
     // Redirect user to /country_code page.
     drupal_goto($url_variables['url_path_prefix'] . '/' . current_path());
     return;

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -14,77 +14,61 @@ define('DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE', 'en-global');
  * Implements hook_init().
  */
 function dosomething_global_init() {
-  global $user;
-
   // We don't need to redirect cli request, such as drush.
   if (drupal_is_cli()) {
     return;
   }
 
-  // Redirect people hitting the homepage or explore campaigns to their local version
-  $path = request_path();
-  if ((drupal_is_front_page() && is_numeric(arg(1))) || $path == 'campaigns') {
-    // Cannot use arg() as it doesn't return path prefixes
-    $args = explode('/', $path);
-
-    // Only apply logic to Global homepage
-    if (drupal_is_front_page()) {
-      if (!empty($path) && $args[0] != 'node') {
-        return;
-      }
-    }
-
-    $country_code = dosomething_settings_get_geo_country_code();
-    $language = dosomething_global_convert_country_to_language($country_code);
-    // No matching language, serve the global page
-    if ($language == NULL) {
-      return;
-    }
-
-    // Get users local path prefix and verify we support it
-    $path_prefix = dosomething_global_get_prefix_for_language($language);
-    if ($path_prefix == NULL) {
-      return;
-    }
-
-    // Redirect user
-    drupal_goto($path_prefix . '/' . current_path());
+  $languages = language_list();
+  if (empty($languages[DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE])) {
+    watchdog('dosomething_global', "Can't load %lang language",
+      array('%lang' => $global_lang_code), WATCHDOG_ERROR);
+    return;
   }
 
+  global $user;
+  $url_variables = dosomething_global_get_url_variables();
+  $user_variables = dosomething_global_get_user_variables();
+  $node_variables = dosomething_global_get_node_variables();
+
   // Verify we're dealing with a node edit with no translation specification in the URL
-  if (arg(0) == "node" && is_numeric(arg(1)) && arg(2) == "edit" && null == arg(3)) {
-    // Load the page node and user
-    $nid = arg(1);
-    $node = node_load($nid);
+  if ($node_variables['is_node'] && $node_variables['is_node_edit'] && $node_variables['node_edit_language'] == NULL) {
+    dosomething_global_redirect_node_edit($node_variables['node'], $user_variables['user_language']);
+    return;
+  }
 
-    // Load the languages being used
-    $src_language = $node->language;
-    $user_language = $user->language ?: 'en';
+  // If we already have a path prefix,
+  // or the user is a global english speaker,
+  // all logic after this statement should not run.
+  if ($url_variables['url_path_prefix'] != dosomething_global_get_prefix_for_language(DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE)) {
+    return;
+  }
+  else if($user_variables['user_language'] == NULL) {
+    return;
+  }
 
-    // If we're not working on a translation, no need to re-direct.
-    if ($src_language != $user_language) {
-      // Determines if the url needs the /add/source/ component
-      $new_translation_prefix = isset($node->translations->data[$user_language]) ? '' : 'add/' . $src_language . '/';
+  // Configure the correct path prefix
+  $url_variables['url_path_prefix'] = dosomething_global_get_prefix_for_language($user_variables['user_language']);
 
-      // Append the user language
-      $lang_append = $new_translation_prefix . $user_language;
-
-      // Build complete URL and redirect
-      $new_url = str_replace(' ', '', '/node/' . $nid . '/edit/' . $lang_append);
-      drupal_goto($new_url);
-    }
+  // Redirect people hitting the homepage
+  // or explore campaigns to their local version.
+  if ($url_variables['is_homepage'] || $path == 'campaigns') {
+    // Redirect user to /country_code page.
+    drupal_goto($url_variables['url_path_prefix'] . '/' . current_path());
+    return;
   }
 
   // Handle translation redirects for authenticated and anonymous users when
   // they request bare (Global English) URLs to nodes.
   //
   // Passing 'noredirect=1' will defeat the redirect.
-  if (arg(0) == 'node' && is_numeric(arg(1)) && empty(arg(2)) && empty($_GET['noredirect'])) {
-    if ($user->uid) {
+  if ($node_variables['is_node'] && !$node_variables['is_node_edit'] && !$node_variables['node_no_redirect']) {
+    if ($user_variables['user']->uid) {
       dosomething_global_redirect_node_auth();
     } else {
       dosomething_global_redirect_node_anon();
     }
+    return;
   }
 
   // Handle translation redirects for authenticated users when they request
@@ -93,36 +77,59 @@ function dosomething_global_init() {
   // Don't redirect POSTs.
   //
   // Passing 'noredirect=1' will defeat the redirect.
-
-  $request_method = strtolower($_SERVER['REQUEST_METHOD']);
-
-  if (arg(0) == 'user' && 'post' !== $request_method && empty($_GET['noredirect'])) {
-
-    if (!dosomething_global_is_translation_request()) {
-      // User language.
-      $user_lang_code = $user->language ?: 'en';
-
-      // All languages, as an array of objects.
-      $languages = language_list();
-
-      $global_lang_code = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
-
-      if (empty($languages[$global_lang_code])) {
-        watchdog('dosomething_global', "Can't load %lang language",
-          array('%lang' => $global_lang_code), WATCHDOG_ERROR);
-        return;
-      }
-
-      // Don't redirect for Global English speakers.
-      if ($user_lang_code != $global_lang_code && !empty($languages[$user_lang_code])) {
-
-        $link = sprintf('%s/%s', $languages[$user_lang_code]->prefix, request_path());
-
-        drupal_goto(url($link));
-      }
-    }
+  if ($user_variables['is_user_page'] && $url_variables['request_method'] !== 'post' && !$node_variables['node_no_redirect']) {
+    drupal_goto($url_variables['url_path_prefix'] . '/' . current_path());
+    return;
   }
+}
 
+function dosomething_global_get_url_variables() {
+  $path = request_path();
+  $request_method = strtolower($_SERVER['REQUEST_METHOD']);
+  $homepage = (drupal_is_front_page() && is_numeric(arg(1)));
+  $url_path_prefix = dosomething_global_get_prefix_for_language(DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE);
+  $possible_prefix = explode('/', $path)[0];
+  if (dosomething_global_is_path_prefix($possible_prefix)) {
+    $url_path_prefix = $possible_prefix;
+  }
+  return array(
+    'path' => $path,
+    'request_method' => $request_method,
+    'is_homepage' => $homepage,
+    'url_path_prefix' => $url_path_prefix
+  );
+}
+
+function dosomething_global_get_user_variables() {
+  $header_country_code = dosomething_settings_get_geo_country_code();
+  $user_language = dosomething_global_convert_country_to_language($header_country_code);
+  $user_path_prefix = dosomething_global_get_prefix_for_language($user_language);
+  $is_user_page = arg(0) == 'user';
+  return array(
+    'header_country_code' => $header_country_code,
+    'user_language' => $user_language,
+    'user_path_prefix' => $user_path_prefix,
+    'is_user_page' => $is_user_page
+  );
+}
+
+function dosomething_global_get_node_variables() {
+  $node_no_redirect = !empty($_GET['noredirect']);
+  $is_node = (arg(0) == "node" && is_numeric(arg(1)));
+  $is_node_edit = (arg(2) == "edit");
+  $vars = array(
+    'node_no_redirect' => $node_no_redirect,
+    'is_node' => $is_node,
+    'is_node_edit' => $is_node_edit
+  );
+  if ($is_node) {
+    $vars['nid'] = arg(1);
+    $vars['node'] = node_load($nid);
+  }
+  if ($is_node_edit) {
+    $vars['node_edit_language'] = arg(3);
+  }
+  return $vars;
 }
 
 /**
@@ -367,6 +374,16 @@ function dosomething_global_get_prefix_for_language($language) {
   return $languages[$language]->prefix;
 }
 
+function dosomething_global_is_path_prefix($prefix) {
+  $languages = language_list();
+  foreach ($languages as $lang) {
+    if ($lang->prefix == $prefix) {
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
 /**
  * Get the appropriate language for the application.
  *
@@ -412,32 +429,22 @@ function dosomething_global_get_language($account, stdClass $node = NULL) {
   return $language;
 }
 
-/**
- * Detect from the original request path whether the current request is for
- * translated (non-Global English) content.
- *
- * This assumes that Global English is mapped to a blank ('') URL prefix.
- *
- * @return bool
- */
-function dosomething_global_is_translation_request() {
+function dosomething_global_redirect_node_edit($node, $user_language) {
+  // Load the languages being used
+  $src_language = $node->language;
 
-  $languages = language_list();
-  $matches = array();
+  // If we're not working on a translation, no need to re-direct.
+  if ($src_language != $user_language) {
+    // Determines if the url needs the /add/source/ component
+    $new_translation_prefix = isset($node->translations->data[$user_language]) ? '' : 'add/' . $src_language . '/';
 
-  if (preg_match('/([^\/]+)\//', request_path(), $matches)) {
-    if (!empty($matches[1])) {
-      foreach ($languages as $sys_lang) {
+    // Append the user language
+    $lang_append = $new_translation_prefix . $user_language;
 
-        // If the prefix matches a language prefix besides that of Global
-        // English:
-        if ($matches[1] == $sys_lang->prefix && $sys_lang->language != DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE) {
-          return TRUE;
-        }
-      }
-    }
+    // Build complete URL and redirect
+    $new_url = str_replace(' ', '', '/node/' . $nid . '/edit/' . $lang_append);
+    drupal_goto($new_url);
   }
-  return FALSE;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -96,11 +96,7 @@ function dosomething_global_get_url_variables() {
   $path = request_path();
   $request_method = strtolower($_SERVER['REQUEST_METHOD']);
   $homepage = (drupal_is_front_page() && is_numeric(arg(1)));
-  $url_path_prefix = dosomething_global_get_prefix_for_language(DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE);
-  $possible_prefix = explode('/', $path)[0];
-  if (dosomething_global_is_path_prefix($possible_prefix)) {
-    $url_path_prefix = $possible_prefix;
-  }
+  $url_path_prefix = dosomething_global_get_current_prefix());
   return array(
     'path' => $path,
     'request_method' => $request_method,
@@ -576,5 +572,5 @@ function dosomething_global_get_current_prefix() {
     }
   }
 
-  return NULL;
+  return $languages[DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE]->prefix;
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -87,10 +87,10 @@ function dosomething_global_init() {
  * to be used in dosomething_global_init().
  *
  * @return array
- *      path - Entire path of the URL, prefix included
- *      request_method - The type of request (Get, Post, etc)
- *      is_homepage - Is this the homepage?
- *      url_path_prefix - The path prefix specified in the URL. Default is global.
+ *      path (String) - Entire path of the URL, prefix included
+ *      request_method (String) - The type of request (Get, Post, etc)
+ *      is_homepage (bool) - Is this the homepage?
+ *      url_path_prefix (String) - The path prefix specified in the URL. Default is global.
  */
 function dosomething_global_get_url_variables() {
   $path = request_path();
@@ -114,10 +114,10 @@ function dosomething_global_get_url_variables() {
  * to be used in dosomething_global_init().
  *
  * @return array
- *      header_country_code - Country code specified in the headers
- *      user_language - Matching language, or NULL for no matching installed language
- *      user_path_prefix - The prefix which matches the users language
- *      is_user_page - Is this the user profile page?
+ *      header_country_code (String) - Country code specified in the headers
+ *      user_language (String) - Matching language, or NULL for no matching installed language
+ *      user_path_prefix (String) - The prefix which matches the users language
+ *      is_user_page (bool) - Is this the user profile page?
  */
 function dosomething_global_get_user_variables() {
   $header_country_code = dosomething_settings_get_geo_country_code();
@@ -137,12 +137,12 @@ function dosomething_global_get_user_variables() {
  * to be used in dosomething_global_init().
  *
  * @return array
- *      node_no_redirect - Should we skip redirecting the node?
- *      is_node - Is this page a node?
- *      is_node_edit - Is this a node edit page?
- *      nid - If this is a node, the NID
- *      node - If this is a node, the loaded node
- *      node_edit_language - If this is a node edit, the specified edit language
+ *      node_no_redirect (bool) - Should we skip redirecting the node?
+ *      is_node (bool) - Is this page a node?
+ *      is_node_edit (bool) - Is this a node edit page?
+ *      nid (String) - If this is a node, the NID
+ *      node (Object) - If this is a node, the loaded node
+ *      node_edit_language (String) - If this is a node edit, the specified edit language
  */
 function dosomething_global_get_node_variables() {
   $node_no_redirect = !empty($_GET['noredirect']);

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -124,7 +124,7 @@ function dosomething_global_get_node_variables() {
   );
   if ($is_node) {
     $vars['nid'] = arg(1);
-    $vars['node'] = node_load($nid);
+    $vars['node'] = node_load($vars['nid']);
   }
   if ($is_node_edit) {
     $vars['node_edit_language'] = arg(3);

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -83,6 +83,16 @@ function dosomething_global_init() {
   }
 }
 
+/**
+ * Extract relevant URL variables from the current request
+ * to be used in dosomething_global_init().
+ *
+ * @return array
+ *      path - Entire path of the URL, prefix included
+ *      request_method - The type of request (Get, Post, etc)
+ *      is_homepage - Is this the homepage?
+ *      url_path_prefix - The path prefix specified in the URL. Default is global.
+ */
 function dosomething_global_get_url_variables() {
   $path = request_path();
   $request_method = strtolower($_SERVER['REQUEST_METHOD']);
@@ -100,6 +110,16 @@ function dosomething_global_get_url_variables() {
   );
 }
 
+/**
+ * Extract relevant user variables from the current request
+ * to be used in dosomething_global_init().
+ *
+ * @return array
+ *      header_country_code - Country code specified in the headers
+ *      user_language - Matching language, or NULL for no matching installed language
+ *      user_path_prefix - The prefix which matches the users language
+ *      is_user_page - Is this the user profile page?
+ */
 function dosomething_global_get_user_variables() {
   $header_country_code = dosomething_settings_get_geo_country_code();
   $user_language = dosomething_global_convert_country_to_language($header_country_code);
@@ -113,6 +133,18 @@ function dosomething_global_get_user_variables() {
   );
 }
 
+/**
+ * Extract relevant node variables from the current request
+ * to be used in dosomething_global_init().
+ *
+ * @return array
+ *      node_no_redirect - Should we skip redirecting the node?
+ *      is_node - Is this page a node?
+ *      is_node_edit - Is this a node edit page?
+ *      nid - If this is a node, the NID
+ *      node - If this is a node, the loaded node
+ *      node_edit_language - If this is a node edit, the specified edit language
+ */
 function dosomething_global_get_node_variables() {
   $node_no_redirect = !empty($_GET['noredirect']);
   $is_node = (arg(0) == "node" && is_numeric(arg(1)));

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -36,14 +36,13 @@ function dosomething_global_init() {
     dosomething_global_redirect_node_edit($node_variables['node'], $user_variables['user_language']);
     return;
   }
-
   // If we already have a path prefix,
   // or the user is a global english speaker,
   // all logic after this statement should not run.
   if ($url_variables['url_path_prefix'] != dosomething_global_get_prefix_for_language(DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE)) {
     return;
   }
-  else if($user_variables['user_language'] == NULL) {
+  else if($user_variables['user_language'] == DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE) {
     return;
   }
 
@@ -461,6 +460,14 @@ function dosomething_global_get_language($account, stdClass $node = NULL) {
   return $language;
 }
 
+/**
+ * Handles redirecting the node edit page to proper translation
+ *
+ * @param $node
+ *   The node to redirect
+ * @param $user_language
+ *   The users language
+ */
 function dosomething_global_redirect_node_edit($node, $user_language) {
   // Load the languages being used
   $src_language = $node->language;
@@ -474,20 +481,27 @@ function dosomething_global_redirect_node_edit($node, $user_language) {
     $lang_append = $new_translation_prefix . $user_language;
 
     // Build complete URL and redirect
-    $new_url = str_replace(' ', '', '/node/' . $nid . '/edit/' . $lang_append);
+    $new_url = str_replace(' ', '', '/node/' . $node->nid . '/edit/' . $lang_append);
     drupal_goto($new_url);
   }
 }
 
 /**
- * Handle redirects to translated content for authenticated users. In this
- * case:
+ * Handle redirects to translated content
  *
- * - If my profile includes a language preference,
- * - and I'm not a privileged user (admin, editor, etc.),
- * - and I request a bare URL (e.g., /campaigns/sample),
- * - and there is a translation available (e.g., /voluntario/ejemplo),
- * - then issue a 302 redirect to the translation's URL.
+ * @param $user_lang
+ *   The users language
+ * @param $node
+ *   The specified node to redirect too
+ * @param $redirect_status
+ *   The status to redirect with. 301 for anonymous, 302 for authenticated
+ *
+ * If the user is an administrator or global english speaker
+ *  - Do not redirect
+ * If the node has a translation available for the specified language
+ *  - Redirect them to the translation
+ * Else
+ *  - 404 the user
  */
 function dosomething_global_redirect_node($user_lang, $node, $redirect_status) {
 
@@ -499,7 +513,7 @@ function dosomething_global_redirect_node($user_lang, $node, $redirect_status) {
   }
 
   // Don't redirect for Global English speakers.
-  if ($user_lang == NULL) {
+  if ($user_lang == DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE) {
     return;
   }
 

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -64,9 +64,9 @@ function dosomething_global_init() {
   // Passing 'noredirect=1' will defeat the redirect.
   if ($node_variables['is_node'] && !$node_variables['is_node_edit'] && !$node_variables['node_no_redirect']) {
     if ($user_variables['user']->uid) {
-      dosomething_global_redirect_node_auth();
+      dosomething_global_redirect_node($user_variables['user_language'], $node_variables['node'], 302);
     } else {
-      dosomething_global_redirect_node_anon();
+      dosomething_global_redirect_node($user_variables['user_language'], $node_variables['node'], 301);
     }
     return;
   }
@@ -457,109 +457,34 @@ function dosomething_global_redirect_node_edit($node, $user_language) {
  * - and there is a translation available (e.g., /voluntario/ejemplo),
  * - then issue a 302 redirect to the translation's URL.
  */
-function dosomething_global_redirect_node_auth() {
-  global $user;
+function dosomething_global_redirect_node($user_lang, $node, $redirect_status) {
 
   // Don't do redirects for privileged users.
-  if (user_access('access administration menu')) {
-    return;
-  }
-
-  // User language.
-  $user_lang_code = $user->language ?: 'en';
-
-  // All languages, as an array of objects.
-  $languages = language_list();
-
-  $global_lang_code = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
-
-  if (empty($languages[$global_lang_code])) {
-    watchdog('dosomething_global', "Can't load %lang language",
-      array('%lang' => $global_lang_code), WATCHDOG_ERROR);
-    return;
-  }
-
-  // Don't redirect for Global English speakers.
-  if ($user_lang_code == $global_lang_code) {
-    return;
-  }
-
-  $node = node_load(arg(1));
-
-  if ($languages[$user_lang_code]) {
-    dosomething_global_redirect_node_language($node, $user_lang_code, 302);
-  }
-}
-
-/**
- * Handle redirects to translated content for anonymous users. In this
- * case:
- *
- * - If I request a bare URL (e.g., /campaigns/sample),
- * - and there is a translation available (e.g., /voluntario/ejemplo),
- * - then issue a 301 redirect to the translation's URL.
- */
-function dosomething_global_redirect_node_anon() {
-
-  // All languages, as an array of objects.
-  $languages = language_list();
-
-  // Map GeoIP country to a system language. Default to 'en-global'.
-  $user_country_code = dosomething_settings_get_geo_country_code();
-  $target_lang_code = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
-
-  $lang_map = variable_get('dosomething_global_language_map', '');
-  foreach ($lang_map as $lang_key => $lang) {
-    if ($lang['country'] == $user_country_code) {
-      $target_lang_code = $lang_key;
-      break;
+  if ($redirect_status == 302) {
+    if (user_access('access administration menu')) {
+      return;
     }
   }
 
-  // If we're actually supposed to show the en-global version:
-  if ($target_lang_code == DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE) {
+  // Don't redirect for Global English speakers.
+  if ($user_lang == NULL) {
     return;
   }
 
-  if (empty($languages[$target_lang_code])) {
-    watchdog('dosomething_global', "Can't load %lang language",
-      array('%lang' => $target_lang_code), WATCHDOG_ERROR);
-    return;
-  }
-
-  $node = node_load(arg(1));
-
-  dosomething_global_redirect_node_language($node, $target_lang_code, 301);
-}
-
-/**
- * Given a node object, a language code (e.g., "en", "en-global", "es-mx"),
- * and a redirect status, redirect the request to the desired translation's
- * URL.
- *
- * @param $node
- * @param $language_code
- * @param int $redirect_status
- */
-function dosomething_global_redirect_node_language($node, $language_code, $redirect_status = 302) {
-  $languages = language_list();
-
-  // Can only redirect to an published, translated version.
-  if (!empty($node->translations->data[$language_code]) && $node->translations->data[$language_code]['status']) {
-    $target_node = $node->translations->data[$language_code];
+  if (!empty($node->translations->data[$user_lang]) && $node->translations->data[$user_lang]['status']) {
+    $target_node = $node->translations->data[$user_lang];
 
     // Might be overly formal: We could pull 'node/nid' from the current
     // request. This is in case of the unlikely (impossible?) event that
     // a translated version of this node has a different entity ID.
     $target_path = sprintf('node/%s', $target_node['entity_id']);
 
-    drupal_goto(url($target_path, array('language' => $languages[$language_code])), array(), $redirect_status);
+    drupal_goto(url($target_path, array('language' => $languages[$user_lang])), array(), $redirect_status);
   }
   else {
     drupal_not_found();
     drupal_exit();
   }
-
 }
 
 /**


### PR DESCRIPTION
ALL OF THEM.
#### What's this PR do?
- Refactors the dosomething_global_init() to be closer to english than brainfuck
  - Gathers all variables needed at the start using helper functions
  - Breaks conditional logic out into new function and cuts duplicated, confusing or un-needed code
- Adds dosomething_global_is_path_prefix to check if a string is a path prefix
- Condenses the node redirect logic into one small function `dosomething_global_redirect_node` (thanks to the refactoring from above)

And yes, there are lots of comments.
#### Where should the reviewer start?

init()
#### How should this be manually tested?

Where was that doc with all of the test cases again? We'll be needed that...
#### Any background context you want to provide?

See my or andrea's brain.

TLDR: The old global init() was a mess from all of us adding in new URL edge cases and wasn't maintainable, causing multiple bugs.
#### What are the relevant tickets?

Fixes #5506
Fixes #5497
