### PR TITLE
Issue5499 Global Transactionals

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -96,17 +96,24 @@ function dosomething_mbp_request($origin, $params = NULL) {
 function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
   // Payload items common to all transactional messages.
   $params['first_name'] = isset($params['first_name']) ? $params['first_name'] : 'Doer';
-  $params['user_country'] = isset($params['user_country']) ? $params['user_country'] : dosomething_settings_get_geo_country_code();
+
   $payload = array(
     'activity' => $origin,
     'email' => $params['email'],
     'uid' => $params['uid'],
-    'user_language' =>  $params['user_language'],
-    'user_country' => $params['user_country'],
     'merge_vars' => array(
       'MEMBER_COUNT' => dosomething_user_get_member_count(TRUE),
     ),
   );
+  if (isset($params['user_country'])) {
+    $payload['user_country'] = $params['user_country'];
+  }
+  else {
+    $payload['user_country'] = dosomething_settings_get_geo_country_code();
+  }
+  if (isset($params['user_language'])) {
+    $payload['user_language'] = $params['user_language'];
+  }
 
   // If email template wasn't set before, get standart template name.
   if (!empty($params['email_template'])) {
@@ -192,8 +199,11 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
  *   $payload - Composed values ready to be sent as a message payload.
  */
 function dosomething_mbp_get_common_campaign_payload(&$payload, $params) {
-  $payload['subscribed']        = 1;
-  $payload['event_id']          = $params['event_id'];
+  $payload['subscribed'] = 1;
+  $payload['event_id'] = $params['event_id'];
+  if (isset($params['campaign_language'])) {
+    $payload['campaign_language'] = $params['campaign_language'];
+  }
 
   $payload['email_tags'][] = $params['event_id'];
   // Check for Mailchimp grouping_id+group_name:

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -843,11 +843,15 @@ function dosomething_reportback_mbp_request($entity) {
 
   if (module_exists('dosomething_user')) {
     $account = user_load($entity->uid);
+    $language = dosomething_global_get_language($account, $entity);
+    $user_language = dosomething_global_get_user_language($account);
     $params = array(
       'email' => $account->mail,
       'uid' => $account->uid,
       'first_name' => dosomething_user_get_field('field_first_name', $account),
+      'user_language' => $user_language,
       'campaign_title' => $entity->node_title,
+      'campaign_language' => $language,
       'event_id' => $entity->nid,
       'impact_verb' => $entity->verb,
       'impact_number' => $entity->quantity,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -843,15 +843,17 @@ function dosomething_reportback_mbp_request($entity) {
 
   if (module_exists('dosomething_user')) {
     $account = user_load($entity->uid);
-    $language = dosomething_global_get_language($account, $entity);
-    $user_language = dosomething_global_get_user_language($account);
+    if (module_exists('dosomething_global')) {
+      $user_language = dosomething_global_get_user_language($account);
+    }
+
     $params = array(
       'email' => $account->mail,
       'uid' => $account->uid,
       'first_name' => dosomething_user_get_field('field_first_name', $account),
-      'user_language' => $user_language,
+      'user_language' => isset($user_language) ? $user_language : 'en',
       'campaign_title' => $entity->node_title,
-      'campaign_language' => $language,
+      'campaign_language' => isset($campaign_language) ? $campaign_language : 'en',
       'event_id' => $entity->nid,
       'impact_verb' => $entity->verb,
       'impact_number' => $entity->quantity,

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -559,6 +559,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
   }
   $wrapper = entity_metadata_wrapper('node', $node);
   $language = dosomething_global_get_language($account, $node);
+  $user_language = dosomething_global_get_user_language($account);
   $url_options = array(
     'language' => $language,
     'absolute' => TRUE,
@@ -575,7 +576,8 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     'event_id' => $node->nid,
     'campaign_title' => $wrapper->language($language)->title_field->value(),
     'campaign_link' => url('node/' . $node->nid, $url_options),
-    'user_language' => $language,
+    'campaign_language' => $language,
+    'user_language' => $user_language,
   );
 
   // Don't subscribe 26+ yo users for Mobile Commons.

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -440,6 +440,7 @@ function dosomething_user_user_pass_submit($form, &$form_state) {
       if (module_exists('dosomething_global')) {
         $user_language = dosomething_global_get_user_language($account);
       }
+
       // Send external message request
       $params = array(
         'email' => $account->mail,
@@ -500,7 +501,8 @@ function _dosomething_user_send_to_message_broker() {
   global $user;
   $account = $user;
   if (module_exists('dosomething_global')) {
-    $user_language = dosomething_global_get_user_language($account);
+    $user_country = dosomething_settings_get_geo_country_code();
+    $user_language = dosomething_global_convert_country_to_language($user_country);
   }
 
   // Send external message request.
@@ -510,6 +512,7 @@ function _dosomething_user_send_to_message_broker() {
     'uid'               => $account->uid,
     'first_name'        => dosomething_user_get_field('field_first_name', $account),
     'birthdate'         => dosomething_user_get_field('field_birthdate', $account),
+    'user_country'      => isset($user_country) ? $user_country : 'US',
     'user_language'     => isset($user_language) ? $user_language : 'en',
   );
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -439,7 +439,6 @@ function dosomething_user_user_pass_submit($form, &$form_state) {
     if (isset($account->mail)) {
       if (module_exists('dosomething_global')) {
         $user_language = dosomething_global_get_user_language($account);
-        $user_country_code = dosomething_global_convert_language_to_country($user_language);
       }
       // Send external message request
       $params = array(
@@ -448,7 +447,6 @@ function dosomething_user_user_pass_submit($form, &$form_state) {
         'first_name' => dosomething_user_get_field('field_first_name', $account),
         'reset_link' => user_pass_reset_url($account),
         'user_language'     => isset($user_language) ? $user_language : 'en',
-        'user_country'      => isset($user_country_code) ? $user_country_code : 'US',
       );
       if (module_exists('dosomething_mbp')) {
         dosomething_mbp_request('user_password', $params);
@@ -503,7 +501,6 @@ function _dosomething_user_send_to_message_broker() {
   $account = $user;
   if (module_exists('dosomething_global')) {
     $user_language = dosomething_global_get_user_language($account);
-    $user_country_code = dosomething_global_convert_language_to_country($user_language);
   }
 
   // Send external message request.
@@ -514,7 +511,6 @@ function _dosomething_user_send_to_message_broker() {
     'first_name'        => dosomething_user_get_field('field_first_name', $account),
     'birthdate'         => dosomething_user_get_field('field_birthdate', $account),
     'user_language'     => isset($user_language) ? $user_language : 'en',
-    'user_country'      => isset($user_country_code) ? $user_country_code : 'US',
   );
 
   // 26+ Club: Override Mobile Commons.


### PR DESCRIPTION
**BLOCKERS** - This PR not possible until resolved.
**BLOCKING** - Users being added to the correct MailChimp accounts: https://github.com/DoSomething/phoenix/issues/5499
- [x] `user_password` transactional, `user_language` not correct value, see example payload below. Blocked by https://github.com/DoSomething/phoenix/issues/5553
- `campaign_signup` transactional, 
  - [x] `user_language` not correct value, see example payload below. Blocked by https://github.com/DoSomething/phoenix/issues/5553
  - [ ] Brazilian user signing up for English campaign should get transactional in English, currently `mb-campaign-signup-BR` is sent. Blocked by https://github.com/DoSomething/phoenix/issues/5563
- `campaign_reportback`, 
  - [ ] Brazilian user signed up for English campaign should get report back in campaign language - English. Currently language of user location (Brazian) is used to define template name.
  - [ ] `user_language` not correct value, see example payload below. Blocked by https://github.com/DoSomething/phoenix/issues/5553

**cc:** @mikefantini 

Fixes #5499 , #5470
- Removes `user_country` from user registrations to allow `dosomething_mbp` to coordinate value.
- Add `campaign_language` and `user_language` to campaign signups and report back mbp requests.

**To test**:
The payload generated by `dosomething_mbp` to send to RabbitMQ server should look like:
- [x] `user_register`:

```
Array
(
    [activity] => user_register
    [email] => dlee+VAGTest27@dosomething.org
    [uid] => 1705478
    [user_language] => pt-br
    [user_country] => BR
    [merge_vars] => Array
        (
            [MEMBER_COUNT] => 3.5 million
            [FNAME] => Dee Vag Test 27
        )
    [email_template] => mb-user-register-BR
    [mailchimp_list_id] => 66fd18c5a9
    [birthdate] => 929232000
    [subscribed] => 1
    [email_tags] => Array
        (
            [0] => drupal_user_register
        )
    [activity_timestamp] => 1445462046
    [application_id] => US
)
```
- [ ] `user_password`:

```
(
    [activity] => user_password
    [email] => dlee+VAGTest27@dosomething.org
    [uid] => 1705478
    [user_language] => pt-br
    [user_country] => BR
    [merge_vars] => Array
        (
            [MEMBER_COUNT] => 3.5 million
            [FNAME] => Dee Vag Test 27
            [RESET_LINK] => http://localhost:8888/br/user/reset/1705478/1445462130/2tUbpFnHSEN6DoMGKLvl73utxEKj7Nzw1YcxIqPpDDY
        )
    [email_template] => mb-user-password-BR
    [email_tags] => Array
        (
            [0] => drupal_user_password
        )
    [activity_timestamp] => 1445462130
    [application_id] => US
)
```
- [ ] `campaign_signup` Brazilian user signing up for English campaign should get transactional in English:

```
(
    [activity] => campaign_signup
    [email] => dlee+VAGTest27@dosomething.org
    [uid] => 1705478
    [user_language] => pt-br
    [user_country] => BR
    [merge_vars] => Array
        (
            [MEMBER_COUNT] => 3.5 million
            [FNAME] => Dee Vag Test 27
            [CAMPAIGN_TITLE] => Test Campaign BR
            [CAMPAIGN_LINK] => http://localhost:8888/br/voluntario/test-campaign-br?source=node/1485
            [CALL_TO_ACTION] => This is a test unsponsored campaign.
            [STEP_ONE] => Get your 'Fee!
            [STEP_TWO] => Snap a Pic
            [STEP_THREE] => Submit your photo!
        )
    [email_template] => mb-campaign-signup-BR
    [subscribed] => 1
    [event_id] => 1485
    [email_tags] => Array
        (
            [0] => 1485
            [1] => drupal_campaign_signup
        )
    [activity_timestamp] => 1445462362
    [application_id] => US
)
```
- [ ] `campaign_reportback`:

```
(
    [activity] => campaign_reportback
    [email] => dlee+VAGTest09@dosomething.org
    [uid] => 1705481
    [merge_vars] => Array
        (
            [MEMBER_COUNT] => 3.5 million
            [FNAME] => Dee Vag Test 09
            [CAMPAIGN_TITLE] => Video Chat 4 Seniors
            [IMPACT_VERB] => helped
            [IMPACT_NUMBER] => 76
            [IMPACT_NOUN] => people
            [REPORTBACK_IMAGE_MARKUP] => 
        )
    [user_country] => BR
    [user_language] => en
    [email_template] => mb-campaign-reportback-BR
    [event_id] => 1427
    [email_tags] => Array
        (
            [0] => drupal_campaign_reportback
        )
    [activity_timestamp] => 1445396277
    [application_id] => US
)
```
