### PR TITLE
Updating legal copy in create account.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -171,7 +171,7 @@ function dosomething_campaign_preprocess_win_module(&$vars, $wrapper) {
   $rb_progress = dosomething_reportback_get_reportback_total_plus_override($node->nid);
   $copy = t(variable_get('dosomething_campaign_win_copy'));
   $copy_token_replaced = token_replace($copy, array('node' => $node));
-  
+
   // Get random promoted reportback image
   $parameters = array(
     'nid' => $vars['nid'],

--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
@@ -38,9 +38,9 @@ function paraneue_dosomething_form_alter_register(&$form, &$form_state, $form_id
       '#weight' => 500,
     );
 
-    $copy = t("Creating an account means you agree to our !terms & !policy and to receive our weekly update. Message & data rates may apply. Text STOP to opt-out, HELP for help", [
+    $copy = t("Creating an account means you agree to our !terms & !privacy and to receive our weekly update. Message & data rates may apply. Text STOP to opt-out, HELP for help", [
       '!terms' => dosomething_user_get_link_terms_service(),
-      '!policy' => dosomething_user_get_link_privacy_policy(),
+      '!privacy' => dosomething_user_get_link_privacy_policy(),
     ]);
 
     $form['legal-text'] = array(

--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
@@ -38,10 +38,11 @@ function paraneue_dosomething_form_alter_register(&$form, &$form_state, $form_id
       '#weight' => 500,
     );
 
-    $copy = t("Creating an account means you agree to our !terms & to receive our weekly update. Message & data rates may apply. Text STOP to opt-out, HELP for help", array(
-      '!terms' => dosomething_user_get_link_privacy_policy(),
-      '!privacy' => dosomething_user_get_link_terms_service(),
-    ));
+    $copy = t("Creating an account means you agree to our !terms & !policy and to receive our weekly update. Message & data rates may apply. Text STOP to opt-out, HELP for help", [
+      '!terms' => dosomething_user_get_link_terms_service(),
+      '!policy' => dosomething_user_get_link_privacy_policy(),
+    ]);
+
     $form['legal-text'] = array(
       '#type' => 'item',
       '#markup' => '<p class="footnote">' . $copy . '</p>',

--- a/pots/paraneue_dosomething.pot
+++ b/pots/paraneue_dosomething.pot
@@ -560,7 +560,7 @@ msgid "Log in to an existing account"
 msgstr ""
 
 #: includes/auth/register.inc:41
-msgid "Creating an account means you agree to our !terms & to receive our weekly update. Message & data rates may apply. Text STOP to opt-out, HELP for help"
+msgid "Creating an account means you agree to our !terms & !policy and to receive our weekly update. Message & data rates may apply. Text STOP to opt-out, HELP for help"
 msgstr ""
 
 #: includes/auth/register.inc:54

--- a/pots/paraneue_dosomething.pot
+++ b/pots/paraneue_dosomething.pot
@@ -560,7 +560,7 @@ msgid "Log in to an existing account"
 msgstr ""
 
 #: includes/auth/register.inc:41
-msgid "Creating an account means you agree to our !terms & !policy and to receive our weekly update. Message & data rates may apply. Text STOP to opt-out, HELP for help"
+msgid "Creating an account means you agree to our !terms & !privacy and to receive our weekly update. Message & data rates may apply. Text STOP to opt-out, HELP for help"
 msgstr ""
 
 #: includes/auth/register.inc:54


### PR DESCRIPTION
Refs #5504
#### What's this PR do?

While working to translate the term "Privacy Policy" a bug was noticed that the legal copy was missing the Terms of Service and the variables in the code were mis-labled. They are now corrected and the copy updated to read properly. The copy in POEditor will be updated shortly to match.
#### Where should the reviewer start?

With the change in **register.inc**.
#### What are the relevant tickets?
#5504

---

@angaither 

cc: @mikefantini 
