### PR TITLE
Clean up user login/registration hooks a bit.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -229,6 +229,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
       // Helper text & additional data.
       _dosomething_user_add_signup_data($form);
       $form['#submit'][] = 'dosomething_user_login_submit';
+      $form['#submit'][] = 'dosomething_user_authentication_submit';
     break;
 
     case 'user_profile_form':
@@ -291,8 +292,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
 
       // Custom validation & submission handlers.
       $form['#validate'][] = 'dosomething_user_register_validate';
-      $form['#submit'][] = 'dosomething_user_login_submit';
-
+      $form['#submit'][] = 'dosomething_user_authentication_submit';
     break;
 
     case 'user_pass':
@@ -648,21 +648,19 @@ function dosomething_user_is_old_person($user = NULL) {
 
 /**
  * Custom login submission handler.
- *
- * If there's a hidden nid, sign the user up for a campaign.
- *
- * This function will only work upon registration if account variables
- * are set to the following:
- * -- A visitor can register for the site without admin approval
- * -- Email verification is not required when user creates account.
- *
- * Otherwise, the global $user upon account creation is set with uid 0
- * and signup will fail.
- *
- * @see dosomething_user_strongarm()
  */
 function dosomething_user_login_submit($form, &$form_state) {
-  // If nid is not present, nothing to sign up for.  Exit.
+  // Trigger an analytics event on login
+  dosomething_helpers_add_analytics_event('Authentication', 'Login');
+}
+
+/**
+ * Custom login/register submission handler. Handles pitch page signups,
+ * forwarding user profiles to Northstar post-registration, and configures
+ * more sensible redirects post-login.
+ */
+function dosomething_user_authentication_submit($form, &$form_state) {
+  // If there's a hidden nid, sign the user up for a campaign.
   if (isset($form['nid']['#value'])) {
     $nid = $form['nid']['#value'];
     $source = NULL;
@@ -680,15 +678,16 @@ function dosomething_user_login_submit($form, &$form_state) {
         dosomething_signup_user_signup($nid, NULL, $source);
       }
     }
-
   }
-  // Send the user into northstar.
+
+  // Send updated user profiles into Northstar.
   if (module_exists('dosomething_northstar')) {
     dosomething_northstar_register_user($form_state);
   }
+
   // After all logins, except reportback pages redirect to page user was just on.
   if (isset($source) && stripos($source, 'reportback') > 0) {
-   $form_state['redirect'] = drupal_get_path_alias($_SERVER['HTTP_REFERER']);
+    $form_state['redirect'] = drupal_get_path_alias($_SERVER['HTTP_REFERER']);
   }
   elseif (isset($nid)) {
     // Redirect to campaign node on reportback permalink pages.
@@ -697,16 +696,18 @@ function dosomething_user_login_submit($form, &$form_state) {
 }
 
 /**
- * Implements hook_user_login().
- */
-function dosomething_user_user_login(&$edit, $account) {
-  // Trigger an analytics event on login
-  // @NOTE: This will *also* be triggered on registration, since registered
-  // users are subsequently logged in to their new accounts.
-  dosomething_helpers_add_analytics_event('Authentication', 'Login');
-}
-
-/**
+ * Automatically generate user names (from UID) for non-staff users.
+ *
+ * This function will only work upon registration if account variables
+ * are set to the following:
+ * -- A visitor can register for the site without admin approval
+ * -- Email verification is not required when user creates account.
+ *
+ * Otherwise, the global $user upon account creation is set with uid 0
+ * and signup will fail.
+ *
+ * @see dosomething_user_strongarm()
+ *
  * Implements hook_user_insert().
  */
 function dosomething_user_user_insert(&$edit, &$account, $category = NULL) {


### PR DESCRIPTION
#### Changes

I was thinking about this after making changes in #5478. Login and registration forms both _shared_ the `dosomething_user_login_submit` hook, which was confusing at first glance. This shuffles things around to have a shared `authentication` submit handler, and a unique `login` handler for the login form.

Side effect: we can now cleanly have login-form specific actions, such as a `Authentication - Login` event that only fires when the user specifically uses the login form. Sweet. :candy: 
#### How should this be tested?

I tested to see that expected behavior still works (`dpm` every step of the way~), but would appreciate an extra pair of :eyes: just to make sure I didn't do something stupid. :grimacing: 

For review: @angaither 
