### PR TITLE
Fix undefined variable error.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Swapper.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Swapper.js
@@ -1,9 +1,8 @@
-
 class Swapper {
 
   constructor($content) {
     const $image = $content.find('img');
-    const srcLarge = this.$image.data('src-large') || null;
+    const srcLarge = $image.data('src-large') || null;
 
     this.$image = $image;
 


### PR DESCRIPTION
#### Changes

Fixes an undefined variable that was causing a `TypeError: undefined is not an object (evaluating 'this.$image.data')` error on window resize, by y'know using a _defined_ variable. Whoops.
#### How should I test this?

Go to the homepage and resize the window. You'll see the error in your Web Console. Then pull down this code and resize the window. You won't see the error. :bug: :hammer: 

For review: @weerd 
