### PR TITLE
Show cell phone help text to BR and MX users

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -574,3 +574,18 @@ function dosomething_global_get_current_prefix() {
 
   return $languages[DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE]->prefix;
 }
+
+/**
+ * Return the full country name
+ */
+function dosomething_global_get_country_name($country_code) {
+  $lang_map = variable_get('dosomething_global_language_map', '');
+
+  foreach ($lang_map as $lang_key => $lang) {
+    if ($lang['country'] == $country_code) {
+      return $lang['country_name'];
+    }
+  }
+
+  return NULL;
+}

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.strongarm.inc
@@ -21,6 +21,7 @@ function dosomething_global_strongarm() {
         0 => 'mexico admin',
       ),
       'country' => 'MX',
+      'country_name' => 'Mexico'
     ),
     'pt-br' => array(
       'display_name' => 'Portuguese, Brazil',
@@ -28,11 +29,13 @@ function dosomething_global_strongarm() {
         0 => 'brazil admin',
       ),
       'country' => 'BR',
+      'country_name' => 'Brazil'
     ),
     'en' => array(
       'display_name' => 'English',
       'default_roles' => array(),
       'country' => 'US',
+      'country_name' => 'United States',
     ),
     'en-global' => array(
       'display_name' => 'English, Global',
@@ -44,6 +47,7 @@ function dosomething_global_strongarm() {
         0 => 'UK admin',
       ),
       'country' => 'GB',
+      'country_name' => 'United Kingdom',
     ),
     'en-ca' => array(
       'display_name' => 'English, Canada',
@@ -51,6 +55,7 @@ function dosomething_global_strongarm() {
         0 => 'canada admin',
       ),
       'country' => 'CA',
+      'country_name' => 'Canada',
     ),
     'fr-ca' => array(
       'display_name' => 'French, Canada',
@@ -58,6 +63,7 @@ function dosomething_global_strongarm() {
         0 => 'canada admin',
       ),
       'country' => 'CA',
+      'country_name' => 'Canada',
     ),
   );
   $export['dosomething_global_language_map'] = $strongarm;

--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/register.inc
@@ -80,14 +80,24 @@ function paraneue_dosomething_form_alter_register(&$form, &$form_state, $form_id
     unset($form['account']['mail']['#description']);
 
 
+    $country_code = dosomething_settings_get_geo_country_code();
+    $show_help_text = FALSE;
 
-    if (in_array(dosomething_settings_get_geo_country_code(), dosomething_global_get_countries())) {
+    if (in_array($country_code, dosomething_global_get_countries())) {
+      if ($country_code == 'BR' || $country_code == 'MX') {
+        $show_help_text = TRUE;
+        $country_name = dosomething_global_get_country_name($country_code);
+      }
+
       $form['account']['field_mobile'] = $form['field_mobile'];
       $form['account']['field_mobile']['#weight'] = 20;
       $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#title'] = t('Cell Number') . ' <em>' . t("(optional)") . '</em>';
       $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#attributes']['placeholder'] = t('(555) 555-5555');
       $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#attributes']['class'] = array('js-validate');
       $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#attributes']['data-validate'] = 'phone';
+      if ($show_help_text) {
+        $form['account']['field_mobile'][LANGUAGE_NONE][0]['value']['#description'] = t("Get volunteer opportunities on your phone! Texting available in @country soon", array('@country' => $country_name));
+      }
     }
 
     $form['field_mobile']['#access'] = FALSE;
@@ -136,4 +146,3 @@ function paraneue_dosomething_register_after_build($form, &$form_state) {
 
   return $form;
 }
-

--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -20,7 +20,17 @@ function paraneue_dosomething_form_alter_base(&$form, &$form_state, $form_id) {
  */
 function paraneue_dosomething_form_element($variables) {
   $element = &$variables['element'];
+
+  // Before we start to render the output,
+  // hold any description in a new variable
+  // so we can customize the output later.
+  if (!empty($element['#description'])) {
+    $description = $element['#description'];
+    unset($element['#description']);
+  }
+
   $output = theme_form_element($variables);
+
 
   // If rendering a radio button or checkbox, create rendered element for label
   if($element['#type'] === 'radio' || $element['#type'] === 'checkbox') {
@@ -33,6 +43,11 @@ function paraneue_dosomething_form_element($variables) {
     }
 
     $output = theme('form_element_label', $variables);
+  }
+
+  // Custom HTML for field description.
+  if(isset($description)) {
+    $output .= ' <div class="footnote">' . $description ."</div> \n";
   }
 
   return $output;


### PR DESCRIPTION
#### What's this PR do?

For BR and MX users display "Get volunteer opportunities on your phone! Texting available in {country} soon". 

In order to get `{country}`, I added a new key to the language strongarm, `country_name` that holds the user friendly name of the country as well as a get function that gets the user friendly name based on country code. 
#### Where should the reviewer start?

In `register.inc` - This is where a lot of the logic lies for showing/hiding the help text/

I also had to make some updates in the `theme_form_element()` hook to customize the output of the description field so we could use Forge's `.footnote` class.
#### What are the relevant tickets?

Fixes #5446 
