### PR TITLE
Using the dosomething_global_url() function to build URLs on profile

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -655,7 +655,7 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
         'title' => $value['link'],
         'image' => $image,
         'description' => $value['call_to_action'],
-        'url' => $base_url . '/' . $value['path_alias'] . '#prove',
+        'url' => dosomething_global_url($value['path_alias'] . '#prove'),
         'button_text' => t("Prove It"),
       );
       $doing_items[$delta] = paraneue_dosomething_get_gallery_item($item, 'figure');
@@ -678,7 +678,7 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
       }
       $img = dosomething_image_get_themed_image_by_fid($reportback->fids[0], '300x300');
       // Media gallery template expects a full URL.
-      $url = $base_url . '/' . drupal_get_path_alias('node/' . $reportback->nid);
+      $url = dosomething_global_url('node/' . $reportback->nid);
       $content = array(
         'url' => $url,
         'title' => $reportback->node_title,


### PR DESCRIPTION
#### What does this PR do?

This PR uses the dosomething_global_url() function to build the URLs for the "Prove It" button and the links to previously completed campaigns. Using dosomething_global_url adds the prefixes where appropriate.
#### How should this be manually tested?

Visit the profile page at `/user`, and make sure all links are appropriately prefixed including the "Prove It" link, and the links to previously completed campaigns.

@DFurnes There were comments in the code that the full URL is necessary and that's why the $base_url was included, so I wanted your input to make sure this looks OK. I've tested it locally with TorGuard and the links seem to be correct.

Fixes #5423 
