### PR TITLE
Fix issue with column overflow in Chrome 45.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_finder.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_finder.scss
@@ -29,7 +29,9 @@
     }
 
     li {
-      display: inline;
+      float: left;
+      clear: both;
+      display: inline-block;
       position: relative;
       margin: 0;
       break-inside: avoid;
@@ -125,7 +127,6 @@
 
   .error {
     clear: both;
-    // margin-top: 18px;
   }
 
   input[type="checkbox"] {
@@ -139,7 +140,7 @@
   label {
     clear: none;
     float: none;
-    display: block;
+    display: inline-block;
     height: auto;
     font-size: 14px;
     font-weight: $weight-normal;
@@ -152,8 +153,8 @@
     transition: left 0.1s linear;
 
     @include media($tablet) {
-      padding-bottom: 4px;
-      padding-top: 4px;
+      padding-bottom: 2px;
+      padding-top: 2px;
     }
   }
 


### PR DESCRIPTION
#### Changes

Fixes #5409. Resolves issue with columns overflowing in Chrome 45. (Get it together, Google!)
#### How should I test this?

Check it out in all sorts of browsers and screen sizes. Tested across a few screen sizes in Chrome 45, Safari 9, Firefox 41 and thing seem to be working well.
#### Screenshots

Before (in Chrome 45):
![before](https://cloud.githubusercontent.com/assets/583202/10585322/bbfa4902-7664-11e5-8c3d-67750387cc11.png)

After (in Chrome 45):
![after](https://cloud.githubusercontent.com/assets/583202/10585323/c004068c-7664-11e5-9e04-1036ce2f302f.png)
## 

For review: @DoSomething/front-end 
