### PR TITLE
Fixes #5554: Updates Vagrant box version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@ Vagrant.configure("2") do |config|
 
   ## Choose your base box
   config.vm.box = "dosomething/phoenix"
-  config.vm.box_version = "1.0.5"
+  config.vm.box_version = "1.0.6"
 
   config.vm.provider "virtualbox" do |v|
     v.customize ["modifyvm", :id, "--memory", 3072]
@@ -50,4 +50,3 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision :shell, :inline => 'more /vagrant/scripts/install_complete.txt'
 end
-


### PR DESCRIPTION
#### What's this PR do?

Updates the Vagrantfile's box version to 1.0.6.

https://atlas.hashicorp.com/dosomething/boxes/phoenix/versions/1.0.6
#### Where should the reviewer start?

One-line change to Vagrantfile.
#### How should this be manually tested?

```
% vagrant destroy
% vagrant up
```
#### Any background context you want to provide?

We need to update the Vagrant box to pull in new SSH keys for contributors. This is not optimal.
#### What are the relevant tickets?
#5554
#### Screenshots (if appropriate)

N/A
#### Questions:

N/A
