### PR TITLE
Gallery heading

### DIFF
--- a/lib/modules/dosomething/dosomething_image/dosomething_image.module
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.module
@@ -43,7 +43,7 @@ function dosomething_image_get_themed_image($nid, $ratio, $style, $alt = '', $at
     $path = dosomething_image_get_themed_image_url($nid, $ratio, $style);
     // Set drupal attributes.
     $attributes = drupal_attributes($attributes);
-    // Construst themed image tag.
+    // Construct themed image tag.
     $themed_image =  '<img src="' . check_url($path) . '" alt="' . check_plain($alt) . '"' .  $attributes .'>';
     // Store the themed image.
     cache_set('ds_img_' . $nid . '_' . $ratio . '_' . $style, $themed_image, 'cache_dosomething_image');

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
@@ -65,7 +65,7 @@ function dosomething_static_content_preprocess_node(&$vars) {
     }
 
     // Preprocess gallery variables.
-    dosomething_static_content_preprocess_gallery_vars($vars);
+    dosomething_static_content_preprocess_galleries($vars);
 
     // If values present in the field_partners collection:
     if (!empty($vars['field_partners'])) {
@@ -83,59 +83,68 @@ function dosomething_static_content_preprocess_node(&$vars) {
  *
  * @see dosomething_static_content_preprocess_node().
  */
-function dosomething_static_content_preprocess_gallery_vars(&$vars) {
+function dosomething_static_content_preprocess_galleries(&$vars) {
   $content = $vars['content'];
   $gallery_count = count($content['field_gallery']['#items']);
 
-  $vars['galleries'] = array();
+  $vars['galleries'] = [];
 
   // Loop through the galleries.
   for ($i = 0; $i < $gallery_count; $i++) {
 
     // Set Gallery style default variables:
-    $style = 'default';
+    $gallery_style = 'triad';
+    $classes = [];
+
     // Defaults to use the Image node square field.
     $image_ratio = 'square';
     $image_style = '400x400';
 
-    $vars['galleries'][$i] = array();
+    $vars['galleries'][$i] = [];
     $collection_item = reset($content['field_gallery'][$i]['entity']['field_collection_item']);
-    $vars['galleries'][$i]['title'] = $collection_item['field_gallery_title'][0]['#markup'];
 
     // Check for a Gallery Style field value:
+    $item_style = [];
     if (isset($collection_item['field_gallery_style'][0])) {
       // Store the Gallery Style key.
-      $style = $collection_item['field_gallery_style']['#items'][0]['value'];
+      $chosen_style = $collection_item['field_gallery_style']['#items'][0]['value'];
+
       // If a key exists and it's not the default:
-      if ($style && $style != 'default') {
+      if ($chosen_style && $chosen_style == '2col') {
+        $gallery_style = 'duo';
         $image_ratio = 'thumb';
-        if ($style == '3col_short') {
-          $image_style = 'wmax-300-hmax-75';
-        }
-        else {
-          // Set to use the thumbnail field on the Image node instead.
-          $image_style = '100x100';
-        }
+        $image_style = '100x100';
+        $item_style[] = '-left';
+      }
+      else if ($chosen_style == '3col_short') {
+        $image_style = 'wmax-300-hmax-75';
+        $item_style[] = '-aligned';
       }
     }
-    // Set Style variable for theme layer.
-    $vars['galleries'][$i]['style'] = $style;
 
+    $title = $collection_item['field_gallery_title'][0]['#markup'];
+    $vars['galleries'][$i]['layout'] = $gallery_style;
+    $vars['galleries'][$i]['classes'] = $classes;
+
+    // Prepare & theme the gallery items.
+    $items = [];
     $collection_item = $collection_item['field_gallery_item'];
     $gallery_item_count = count($collection_item['#items']);
-
-    // Loop through the gallery items.
     for ($a = 0; $a < $gallery_item_count; $a++) {
-      $gallery_item = reset($collection_item[$a]['entity']['field_collection_item']);
-      $vars['galleries'][$i]['items'][$a]['image'] = dosomething_image_get_themed_image($gallery_item['field_gallery_image']['#items'][0]['target_id'], $image_ratio, $image_style);
+      $field_item = reset($collection_item[$a]['entity']['field_collection_item']);
 
-      $link_field = $gallery_item['field_image_title'][0]['#element'];
+      $link_field = $field_item['field_image_title'][0]['#element'];
+      $gallery_item = [
+        'title' => $link_field['url'] ? l(t($link_field['title']), $link_field['url'], ['target' => '_blank']) : $link_field['title'],
+        'description' => $field_item['field_image_description'][0]['#markup'],
+        'image' => dosomething_image_get_themed_image($field_item['field_gallery_image']['#items'][0]['target_id'], $image_ratio, $image_style),
+        'url' => $link_field['url'],
+      ];
 
-      $vars['galleries'][$i]['items'][$a]['image_title'] = $link_field['url'] ? l(t($link_field['title']), $link_field['url'], array('target' => '_blank')) : $link_field['title'];
-      $vars['galleries'][$i]['items'][$a]['image_url'] = $link_field['url'];
-      $vars['galleries'][$i]['items'][$a]['image_description'] = $gallery_item['field_image_description'][0]['#markup'];
+      $items[$a] = paraneue_dosomething_get_gallery_item($gallery_item, 'figure', TRUE, $item_style);
     }
 
+    $vars['galleries'][$i]['markup'] = paraneue_dosomething_get_gallery($items, $gallery_style, $classes, FALSE, $title);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
@@ -76,7 +76,7 @@ function dosomething_static_content_preprocess_node(&$vars) {
 }
 
 /**
- * Preprocesses variables for the field_gallery field collection.
+ * Preprocess variables for the field_gallery field collection.
  *
  * @param array $vars
  *   Variable array as passed from a hook_preprocess_node.

--- a/lib/themes/dosomething/paraneue_dosomething/includes/patterns.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/patterns.inc
@@ -53,7 +53,7 @@ function paraneue_dosomething_get_gallery_item($content, $type = 'figure', $use_
  *
  * @return string
  */
-function paraneue_dosomething_get_gallery($content, $layout = 'triad', $classes_array = array(), $show_more = FALSE) {
+function paraneue_dosomething_get_gallery($content, $layout = 'triad', $classes_array = array(), $show_more = FALSE, $title = '') {
   if (empty($content)) {
     return '';
   }
@@ -72,6 +72,7 @@ function paraneue_dosomething_get_gallery($content, $layout = 'triad', $classes_
   // Prepare variables to send to gallery theme functions.
   $variables = array(
     'items' => $items,
+    'title' => $title,
     'layout' => $layout,
     'classes' => $classes,
     'roles' => $data_roles,

--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "chart.js": "~1.0.2",
-    "@dosomething/forge": "~6.6.0",
+    "@dosomething/forge": "~6.6.2",
     "dosomething-modal": "~0.3.0",
     "dosomething-validation": "~0.2.0",
     "dotty": "0.0.2",

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_gallery.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_gallery.scss
@@ -1,5 +1,9 @@
 .gallery {
 
+  .gallery__heading {
+    margin-top: $base-spacing;
+  }
+
   &.-shuffle {
     &.-quartet {
       @include media($medium) {

--- a/lib/themes/dosomething/paraneue_dosomething/templates/static_content/node--static_content.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/static_content/node--static_content.tpl.php
@@ -68,43 +68,11 @@
 
   <?php if (!empty($galleries)): ?>
     <?php foreach ($galleries as $gallery): ?>
-    <section class="container">
+    <section class="container -padded">
       <div class="wrapper">
-        <?php if (isset($gallery['title'])): ?>
-        <div class="container__block -narrow">
-          <h1><?php print $gallery['title']; ?></h1>
-        </div>
+        <?php if (isset($gallery['markup'])): ?>
+          <?php print $gallery['markup'] ?>
         <?php endif; ?>
-
-        <?php if (isset($gallery['items'])): ?>
-          <ul class="gallery <?php print $gallery['class']; ?>">
-            <?php foreach ($gallery['items'] as $gallery_item): ?>
-              <li>
-                <div class="figure <?php if ($gallery['class'] == '-duo'): print '-left'; endif; ?>">
-                  <?php if (isset($gallery_item['image'])): ?>
-                    <div class="figure__media">
-                      <?php if (isset($gallery_item['image_title']) AND $gallery_item['image_url'] !== '') : ?>
-                        <a href="<?php print $gallery_item['image_url']; ?>"><?php print $gallery_item['image']; ?></a>
-                      <?php else : ?>
-                        <?php print $gallery_item['image']; ?>
-                      <?php endif; ?>
-                    </div>
-                  <?php endif; ?>
-
-                  <div class="figure__body">
-                    <?php if (isset($gallery_item['image_title'])): ?>
-                      <h3><?php print $gallery_item['image_title']; ?></h3>
-                    <?php endif; ?>
-                    <?php if (isset($gallery_item['image_description'])): ?>
-                      <?php print $gallery_item['image_description']; ?>
-                    <?php endif; ?>
-                  </div>
-                </div>
-              </li>
-            <?php endforeach; ?>
-          </ul>
-        <?php endif; ?>
-
       </div>
     </section>
     <?php endforeach; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/gallery.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/gallery.tpl.php
@@ -15,6 +15,11 @@
  */
 ?>
 <ul class="gallery -<?php print $layout; ?> <?php print $classes; ?>" <?php if (isset($roles)) { print $roles; } ?>>
+  <?php if (!empty($title)): ?>
+    <div class="gallery__heading">
+      <h1><?php print $title; ?></h1>
+    </div>
+  <?php endif; ?>
   <?php if (!empty($items)): ?>
     <?php foreach ($items as $item): ?>
       <li>


### PR DESCRIPTION
#### Changes

Fall cleaning! :maple_leaf: This cleans up padding between gallery titles and their items, using the new [Gallery heading](http://forge.dosomething.org/#gallery) optional element. While we're at it, why not [use those handy theme functions instead of unique markup and render array](https://github.com/DoSomething/phoenix/commit/e60ff927434cf6be3c38b6524ef1a85c472d3b60). So clean! :sparkles:
#### How should I review?

Take a peek at static content. Does it look slightly better? Good. Does it look completely broken? Bad.
#### Show me some screenshots!

Before (ewww):
![staging](https://cloud.githubusercontent.com/assets/583202/10619631/a7032dbc-7744-11e5-899d-e3266c40f83e.png)

After (yayyyy):
![dev](https://cloud.githubusercontent.com/assets/583202/10619626/a1463bd0-7744-11e5-89e9-eb8a19a308d1.png)

---

For review: @DoSomething/front-end 
