### PR TITLE
Blocking redirect for non-translatable nodes

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -60,6 +60,11 @@ function dosomething_global_init() {
     return;
   }
 
+  // If the node isn't translatable, don't do any redirection.
+  if (!$node_variables['node']->translate) {
+    return;
+  }
+
   // Handle translation redirects for authenticated and anonymous users when
   // they request bare (Global English) URLs to nodes.
   //


### PR DESCRIPTION
#### What does this PR do?
- Fact pages shouldn't be redirected to a prefixed URL. Because they're
  non-translatable, we can check for that and return before doing any
  redirection logic.
#### How should this be manually tested?

Visit a fact page as an MX, US or BR user and make sure that you can view the node at the bare URL without the prefix.
#### What are the relevant tickets?

Fixes #5505 
