### PR TITLE
Issue5578 language country in transactionals

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -573,4 +573,28 @@ function dosomething_global_get_current_prefix() {
   }
 
   return $languages[DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE]->prefix;
+
+  /*
+   *  Lookup global related details about a user:
+   *  - language
+   *  - country_code
+   *
+   *  @param object $account
+   *    Drupal user object based on an existing user account.
+   *
+   *  @return array
+   *    Details about the user account:
+   *      - language
+   *      - country_code
+   */
+  function dosomething_global_user_details($account = NULL) {
+
+    if (!isset($account)) {
+      global $account;
+    }
+    $language = dosomething_global_get_language($account);
+    $country_code = dosomething_global_get_country();
+
+    return array($language, $country_code);
+  }
 }

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -96,17 +96,23 @@ function dosomething_mbp_request($origin, $params = NULL) {
 function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
   // Payload items common to all transactional messages.
   $params['first_name'] = isset($params['first_name']) ? $params['first_name'] : 'Doer';
-  $params['user_country'] = isset($params['user_country']) ? $params['user_country'] : dosomething_settings_get_geo_country_code();
   $payload = array(
     'activity' => $origin,
     'email' => $params['email'],
     'uid' => $params['uid'],
-    'user_language' =>  $params['user_language'],
-    'user_country' => $params['user_country'],
     'merge_vars' => array(
       'MEMBER_COUNT' => dosomething_user_get_member_count(TRUE),
     ),
   );
+  if (isset($params['user_country'])) {
+    $payload['user_country'] = $params['user_country'];
+  }
+  else {
+    $payload['user_country'] = dosomething_settings_get_geo_country_code();
+  }
+  if (isset($params['user_language'])) {
+    $payload['user_language'] = $params['user_language'];
+  }
 
   // If email template wasn't set before, get standart template name.
   if (!empty($params['email_template'])) {
@@ -171,6 +177,7 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
       $payload['merge_vars']['IMPACT_NOUN'] = $params['impact_noun'];
       $payload['merge_vars']['REPORTBACK_IMAGE_MARKUP'] = $params['image_markup'];
       $payload['email_tags'][] = 'drupal_campaign_reportback';
+      $payload['campaign_language'] = isset($params['campaign_language']) ? $params['campaign_language'] : NULL;
       break;
 
   }
@@ -194,6 +201,10 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
 function dosomething_mbp_get_common_campaign_payload(&$payload, $params) {
   $payload['subscribed']        = 1;
   $payload['event_id']          = $params['event_id'];
+
+  if (isset($params['campaign_language'])) {
+    $payload['campaign_language'] = $params['campaign_language'];
+  }
 
   $payload['email_tags'][] = $params['event_id'];
   // Check for Mailchimp grouping_id+group_name:

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -440,8 +440,8 @@ function dosomething_user_user_pass_submit($form, &$form_state) {
     $account = user_load_by_mail($form_state['input']['name']);
     if (isset($account->mail)) {
       if (module_exists('dosomething_global')) {
-        $user_language = dosomething_global_get_user_language($account);
-        $user_country_code = dosomething_global_convert_language_to_country($user_language);
+        $user_language = dosomething_global_get_language($account);
+        $user_country_code = dosomething_global_get_country();
       }
       // Send external message request
       $params = array(
@@ -504,8 +504,8 @@ function _dosomething_user_send_to_message_broker() {
   global $user;
   $account = $user;
   if (module_exists('dosomething_global')) {
-    $user_language = dosomething_global_get_user_language($account);
-    $user_country_code = dosomething_global_convert_language_to_country($user_language);
+    $user_language = dosomething_global_get_language($account);
+    $user_country_code = dosomething_global_get_country();
   }
 
   // Send external message request.

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -440,17 +440,16 @@ function dosomething_user_user_pass_submit($form, &$form_state) {
     $account = user_load_by_mail($form_state['input']['name']);
     if (isset($account->mail)) {
       if (module_exists('dosomething_global')) {
-        $user_language = dosomething_global_get_language($account);
-        $user_country_code = dosomething_global_get_country();
+        list($user_language, $user_country_code) = dosomething_global_user_details($account);
       }
       // Send external message request
       $params = array(
-        'email' => $account->mail,
-        'uid' => $account->uid,
-        'first_name' => dosomething_user_get_field('field_first_name', $account),
-        'reset_link' => user_pass_reset_url($account),
-        'user_language'     => isset($user_language) ? $user_language : 'en',
-        'user_country'      => isset($user_country_code) ? $user_country_code : 'US',
+        'email'         => $account->mail,
+        'uid'           => $account->uid,
+        'first_name'    => dosomething_user_get_field('field_first_name', $account),
+        'reset_link'    => user_pass_reset_url($account),
+        'user_language' => isset($user_language) ? $user_language : 'en',
+        'user_country'  => isset($user_country) ? $user_country : 'US',
       );
       if (module_exists('dosomething_mbp')) {
         dosomething_mbp_request('user_password', $params);
@@ -504,8 +503,7 @@ function _dosomething_user_send_to_message_broker() {
   global $user;
   $account = $user;
   if (module_exists('dosomething_global')) {
-    $user_language = dosomething_global_get_language($account);
-    $user_country_code = dosomething_global_get_country();
+    list($user_language, $user_country_code) = dosomething_global_user_details($account);
   }
 
   // Send external message request.
@@ -516,7 +514,7 @@ function _dosomething_user_send_to_message_broker() {
     'first_name'        => dosomething_user_get_field('field_first_name', $account),
     'birthdate'         => dosomething_user_get_field('field_birthdate', $account),
     'user_language'     => isset($user_language) ? $user_language : 'en',
-    'user_country'      => isset($user_country_code) ? $user_country_code : 'US',
+    'user_country'      => isset($user_country) ? $user_country : 'US',
   );
 
   // 26+ Club: Override Mobile Commons.


### PR DESCRIPTION
User registration and password reset requests should include `user_language` and `user_country` values in transactional payloads.

**To Test**:
- Payloads from `message_broker_producer` module to Rabbit should look like:
- [x] `user_register`:

```
(
    [activity] => user_register
    [email] => dlee+VAGTest27@dosomething.org
    [uid] => 1705478
    [user_language] => pt-br
    [user_country] => BR
    [merge_vars] => Array
        (
            [MEMBER_COUNT] => 3.5 million
            [FNAME] => Dee Vag Test 27
        )
    [email_template] => mb-user-register-BR
    [mailchimp_list_id] => 66fd18c5a9
    [birthdate] => 929232000
    [subscribed] => 1
    [email_tags] => Array
        (
            [0] => drupal_user_register
        )
    [activity_timestamp] => 1445462046
    [application_id] => US
)
```
- [x] `user_password`:

```
(
    [activity] => user_password
    [email] => dlee+VAGTest27@dosomething.org
    [uid] => 1705478
    [user_language] => pt-br
    [user_country] => BR
    [merge_vars] => Array
        (
            [MEMBER_COUNT] => 3.5 million
            [FNAME] => Dee Vag Test 27
            [RESET_LINK] => http://localhost:8888/br/user/reset/1705478/1445462130/2tUbpFnHSEN6DoMGKLvl73utxEKj7Nzw1YcxIqPpDDY
        )
    [email_template] => mb-user-password-BR
    [email_tags] => Array
        (
            [0] => drupal_user_password
        )
    [activity_timestamp] => 1445462130
    [application_id] => US
)
```
