### PR TITLE
Updating view more button text to allow translation.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -164,9 +164,10 @@ define(function(require) {
      */
     enableViewMore: function () {
       var _this = this;
+      var buttonText = Drupal.t('View more');
 
       this.$viewMoreContainer = $("<div class=\"reportback__view-more\"></div>");
-      this.$viewMoreButton = $("<button id=\"view-more-button\" class=\"button button--view-more -tertiary inline-alt-text-color\">View more</button>");
+      this.$viewMoreButton = $("<button id=\"view-more-button\" class=\"button button--view-more -tertiary inline-alt-text-color\">" + buttonText + "</button>");
 
       this.$viewMoreContainer.append(this.$viewMoreButton);
 

--- a/pots/paraneue_dosomething.pot
+++ b/pots/paraneue_dosomething.pot
@@ -1134,3 +1134,7 @@ msgstr ""
 #: templates/campaign/node--campaign.tpl.php:369
 msgid "Crop"
 msgstr ""
+
+#: js/reportback/Reportback.js:167
+msgid "View more"
+msgstr ""


### PR DESCRIPTION
Refs #5517 
#### What's this PR do?

The 'View more' button in the Campaign gallery needs to be translated, but since it is generated via JavaScript, needed to use the custom Drupal JS object and Drupal.t() to translate it.
#### How should this be manually tested?

Meh. Will be testable once POEditor has term included and imported PO file into CMS.
#### What are the relevant tickets
#5517

---

@angaither 

CC: @namimody 
