### PR TITLE
Fixes `ds-global enable-campaign-field-collections` command.

### DIFF
--- a/bin/ds-global
+++ b/bin/ds-global
@@ -151,8 +151,17 @@ function enable_campaign_field_collections {
   cd $WEB_PATH
 
   # Run fixes.
+  # Replace language-neutral field values with english language.
+  drush sqlq "update field_data_field_faq set language='en'"       && echo "Fixed language for field_faq."
+  drush sqlq "update field_data_field_step_pre set language='en'"  && echo "Fixed language for field_step_pre."
+  drush sqlq "update field_data_field_step_post set language='en'" && echo "Fixed language for field_step_post."
+
+  # Clear cache after every fix.
+  drush cc all
   drush ds-global-field-fix field_faq
+  drush cc all
   drush ds-global-field-fix field_step_pre
+  drush cc all
   drush ds-global-field-fix field_step_post
 }
 


### PR DESCRIPTION
#### What's this PR do?

In fixer script `ds-global enable-campaign-field-collections` this PR:
- Updates field_collections fields languages
- Cleans up the cache in between of field values replace commands
#### Any background context you want to provide?

See #5580.
#### How should this be manually tested?
1. Build local
2. Pull last staging db
3. Run `drush sqlq 'select count(*) from field_data_field_step_pre\G;select count(*) from field_data_field_step_post\G;select count(*) from field_data_field_faq\G'`
4. Run `ds-global enable-campaign-field-collections`
5. Run item 3 again and make sure the count is the same
6. Open http://dev.dosomething.org:8888/node/1691/edit and make sure FAQ, During Tips and After tips aren't empty
#### What are the relevant tickets?

Fixes #5580.

---

CC @mikefantini @sheyd 
