### PR TITLE
Fixes issue where a caption may not break to a new line.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
@@ -209,6 +209,7 @@
   font-size: $font-smaller;
   line-height: 1.1;
   padding-top: ($base-spacing / 2);
+  word-wrap: break-word;
 
   @include media($large) {
     font-size: $font-small;


### PR DESCRIPTION
#### Changes

Fixes issue where a caption may not break to a new line if the caption includes a very long word, because the browser will not create a line break within a word unless `break-word` is specified.

Closes #5589.
#### How should this be tested?

Use [a word that is at least 40 characters long](https://en.wikipedia.org/wiki/Pneumonoultramicroscopicsilicovolcanoconiosis) as your caption. It should correctly break to two lines.

---

For review: @DoSomething/front-end 
