### PR TITLE
Adds !is_null check before json_decode

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -163,7 +163,7 @@ class Reportback extends Entity {
     if ($full) {
       $northstar_user = dosomething_northstar_get_northstar_user($data->uid);
 
-      if (!is_null($northstar_user)){
+      if (!empty($northstar_user)){
         $northstar_user = json_decode($northstar_user, true);
         $northstar_user = (object) $northstar_user['data'][0];
       }

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -162,8 +162,11 @@ class Reportback extends Entity {
 
     if ($full) {
       $northstar_user = dosomething_northstar_get_northstar_user($data->uid);
-      $northstar_user = json_decode($northstar_user, true);
-      $northstar_user = (object) $northstar_user['data'][0];
+
+      if (!is_null($northstar_user)){
+        $northstar_user = json_decode($northstar_user, true);
+        $northstar_user = (object) $northstar_user['data'][0];
+      }
 
       $this->user = [
         'drupal_id' => $data->uid,

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -121,7 +121,7 @@ class ReportbackItem extends Entity {
     if ($full) {
       $northstar_user = dosomething_northstar_get_northstar_user($data->uid);
 
-      if (!is_null($northstar_user)) {
+      if (!empty($northstar_user)) {
         $northstar_user = json_decode($northstar_user->data, true);
         $northstar_user = (object) $northstar_user['data'][0];
       }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -120,8 +120,11 @@ class ReportbackItem extends Entity {
 
     if ($full) {
       $northstar_user = dosomething_northstar_get_northstar_user($data->uid);
-      $northstar_user = json_decode($northstar_user->data, true);
-      $northstar_user = (object) $northstar_user['data'][0];
+
+      if (!is_null($northstar_user)) {
+        $northstar_user = json_decode($northstar_user->data, true);
+        $northstar_user = (object) $northstar_user['data'][0];
+      }
 
       $this->user = [
         'drupal_id' => $data->uid,


### PR DESCRIPTION
#### What does this PR do?

Adds a check to see if ns user is null and if so, do not try to json_decode to prevent error:

```
if (!empty($northstar_user_info->error)) {
        $error = sprintf("Error fetching Northstar user data, uid=%d: '%s'", $id, $northstar_user_info->error);
        watchdog_exception('northstar', new Exception($error));
      } else {
        cache_set('northstar_user_info_' . $id, $northstar_user_info, 'cache_northstar_user_info', REQUEST_TIME + 60*60*24);
}
```
#### How should this be manually tested?

endpoint: `/api/v1/reportbacks.json?load_user=true` should return user info. and not break. Works on local - tested by hard coding `$northstar_user_info == NULL` before new check and it by passed this correctly, return null for all user info in the api response. How do we test if this works with staging without merging? 

Right now, the request to ns to get user information remains the same as what's in this code, so we know that it's successfully getting user info. on staging. 
#### What are the relevant tickets?
#5408
