### PR TITLE
Tidy up global

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -411,7 +411,7 @@ function dosomething_global_convert_language_to_country($language) {
 function dosomething_global_convert_country_to_language($country) {
   $lang_map = variable_get('dosomething_global_language_map', '');
   foreach ($lang_map as $lang_key => $lang) {
-    if ($lang['country'] == $country) {
+    if (isset($lang['country']) && $lang['country'] == $country) {
       return $lang_key;
     }
   }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -309,6 +309,7 @@ function dosomething_global_is_regional_admin($user = NULL) {
  */
 function _dosomething_global_get_regional_roles() {
   $languages = variable_get('dosomething_global_language_map', '');
+  $roles = [];
   foreach ($languages as $language) {
     if (isset($language['default_roles'][0])) {
       $roles[] = $language['default_roles'][0];

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -5,7 +5,7 @@
  */
 
 include_once 'dosomething_global.features.inc';
-define("TRANSLATABLE_TYPES", 'static_content,campaign,home');
+define('TRANSLATABLE_TYPES', 'static_content,campaign,home');
 
 // Default language: Global English
 define('DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE', 'en-global');
@@ -94,7 +94,7 @@ function dosomething_global_init() {
  * Implements hook_node_access.
  */
 function dosomething_global_node_access($node, $op, $account) {
-  // Allow access for privledged members.
+  // Allow access for privileged members.
   if (user_access('access administration menu')) {
     return NODE_ACCESS_ALLOW;
   }
@@ -304,7 +304,7 @@ function dosomething_global_is_regional_admin($user = NULL) {
 /**
  * Get the roles that are defined as regional admins.
  *
- * @return - array
+ * @return array
  *  The roles that are regional admins.
  */
 function _dosomething_global_get_regional_roles() {
@@ -372,6 +372,9 @@ function dosomething_global_get_user_language($user = NULL) {
 /**
  * Returns the session's country code, or `global` if it's not
  * one of our whitelisted global countries.
+ *
+ * @return string
+ *   country code, or 'global'
  */
 function dosomething_global_get_country() {
   $country_code = dosomething_settings_get_geo_country_code();
@@ -385,10 +388,10 @@ function dosomething_global_get_country() {
 /**
  * Gets the country from a given language.
  *
- * @param string language
+ * @param string $language
  *  A two letter language code.
  *
- * @return string language
+ * @return string
  *  The country that maps to the language passed in.
  */
 function dosomething_global_convert_language_to_country($language) {
@@ -399,10 +402,10 @@ function dosomething_global_convert_language_to_country($language) {
 /**
  * Converts the given country into its assigned language.
  *
- * @param string country
+ * @param string $country
  *  The country Code
  *
- * @return
+ * @return string|null
  *  The language mapped to this country or NULL
  */
 function dosomething_global_convert_country_to_language($country) {
@@ -418,7 +421,7 @@ function dosomething_global_convert_country_to_language($country) {
 /**
  * Converts the given language into its assigned URL prefix.
  *
- * @param string language
+ * @param string $language
  *  The language to get the prefix for (eg: 'en', 'mx')
  *
  * @return
@@ -447,6 +450,7 @@ function dosomething_global_is_path_prefix($prefix) {
  * @param  $node
  *   Optional node.
  *
+ * @return string
  */
 function dosomething_global_get_language($account, stdClass $node = NULL) {
   // Respect the URL first.
@@ -566,6 +570,8 @@ function dosomething_global_redirect_node($user_lang, $node, $redirect_status) {
  * @param  $options
  *   Optional options array to be passed to url()
  *
+ * @return string
+ *   The URL with country prefix
  */
 function dosomething_global_url($path, $options = NULL) {
   global $language;
@@ -588,6 +594,9 @@ function dosomething_global_url($path, $options = NULL) {
 /**
  * Return the current country prefix being used.
  *
+ * @return string
+ *   Country prefix of currently page (e.g. 'us', 'mx'...)
+ *
  */
 function dosomething_global_get_current_prefix() {
   $request_path = explode('/', request_path());
@@ -605,7 +614,12 @@ function dosomething_global_get_current_prefix() {
 }
 
 /**
- * Return the full country name
+ * Return the full country name.
+ *
+ * @param $country_code
+ *   Two letter country code
+ * @return string|null
+ *   Full country name
  */
 function dosomething_global_get_country_name($country_code) {
   $lang_map = variable_get('dosomething_global_language_map', '');
@@ -619,7 +633,7 @@ function dosomething_global_get_country_name($country_code) {
   return NULL;
 }
 
-/*
+/**
  *  Lookup global related details about a user:
  *  - language
  *  - country_code
@@ -633,10 +647,10 @@ function dosomething_global_get_country_name($country_code) {
  *      - country_code
  */
 function dosomething_global_user_details($account = NULL) {
-
   if (!isset($account)) {
     global $account;
   }
+
   $language = dosomething_global_get_language($account);
   $country_code = dosomething_global_get_country();
 

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -365,7 +365,7 @@ function dosomething_global_get_user_language($user = NULL) {
        array_push($countries, $country);
      }
    }
-   array_push($countries, "global");
+   array_push($countries, 'global');
    return $countries;
  }
 

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -600,9 +600,8 @@ function dosomething_global_url($path, $options = NULL) {
  */
 function dosomething_global_get_current_prefix() {
   $request_path = explode('/', request_path());
+  $languages = language_list();
   if (!empty($request_path[0])) {
-    $languages = language_list();
-
     foreach ($languages as $langcode => $lang_data) {
       if ($lang_data->prefix == $request_path[0]) {
         return $lang_data->prefix;


### PR DESCRIPTION
#### Changes

Tidy up some things in the `dosomething_global` module. :leaves: 

Also fixes three warnings: ensures that the index `country` exists before comparing it (f4c5282), explicitly define `$roles` before assigning to an index of the array (f262a56), and ensure that `$languages` is defined since we're using that object in scenarios where `$request_path[0]` is empty.
#### How should this be manually tested?

Ehhh. Most changes are within docblocks. Skimming the code should be enough. :)

---

For review: @angaither 
