### PR TITLE
Fixing url generated by Droops

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -655,7 +655,7 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
         'title' => $value['link'],
         'image' => $image,
         'description' => $value['call_to_action'],
-        'url' => dosomething_global_url($value['path_alias'] . '#prove'),
+        'url' => dosomething_global_url($value['path_alias'], ['fragment' => 'prove']),
         'button_text' => t("Prove It"),
       );
       $doing_items[$delta] = paraneue_dosomething_get_gallery_item($item, 'figure');


### PR DESCRIPTION
Refs #5584
#### What's this PR do?

Instead of adding the #prove to the path passed to the url() function, need to pass it within the options array as a 'fragment', so Droops can construct the url properly without encoding the # character.
#### Where should the reviewer start?

I'll give you a sticker if you guess which file ;)
#### What are the relevant tickets?
#5584

---

@angaither 

cc: @DFurnes 
