### PR TITLE
Fixes node redirects when hitting global URL

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -66,7 +66,7 @@ function dosomething_global_init() {
   }
 
   // If the node isn't translatable, don't do any redirection.
-  if (sizeof($node_variables['node']->translations->data) <= 1) {
+  if (count($node_variables['node']->translations->data) <= 1) {
     return;
   }
 

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -46,8 +46,13 @@ function dosomething_global_init() {
     return;
   }
 
+  $correct_perfix = dosomething_global_get_prefix_for_language($user_variables['user_language']);
+  if ($correct_perfix == NULL) {
+    return;
+  }
+
   // Configure the correct path prefix
-  $url_variables['url_path_prefix'] = dosomething_global_get_prefix_for_language($user_variables['user_language']);
+  $url_variables['url_path_prefix'] = $correct_perfix;
 
   // Redirect people hitting the homepage
   // or explore campaigns to their local version.

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -66,7 +66,7 @@ function dosomething_global_init() {
   }
 
   // If the node isn't translatable, don't do any redirection.
-  if (!$node_variables['node']->translate) {
+  if (sizeof($node_variables['node']->translations->data) <= 1) {
     return;
   }
 
@@ -546,7 +546,6 @@ function dosomething_global_redirect_node($user_lang, $node, $redirect_status) {
       return;
     }
   }
-
   // Don't redirect for Global English speakers.
   if ($user_lang == DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE) {
     return;

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -46,13 +46,8 @@ function dosomething_global_init() {
     return;
   }
 
-  $correct_perfix = dosomething_global_get_prefix_for_language($user_variables['user_language']);
-  if ($correct_perfix == NULL) {
-    return;
-  }
-
   // Configure the correct path prefix
-  $url_variables['url_path_prefix'] = $correct_perfix;
+  $url_variables['url_path_prefix'] = dosomething_global_get_prefix_for_language($user_variables['user_language']);
 
   // Redirect people hitting the homepage
   // or explore campaigns to their local version.


### PR DESCRIPTION
#### What's this PR do?

When a user hits the global URL of a campaign it correctly redirects them to there translated version 
#### How should this be manually tested?

If a MX user hits campaign with only GL, make sure they are directed to GL.
If a MX user hits campaign with MX translation, make sure they are directed to MX translation.
#### Any background context you want to provide?

See Matt's comment here (what I actually solved) https://github.com/DoSomething/phoenix/issues/5611#issuecomment-150693960

And my explainer here https://github.com/DoSomething/phoenix/issues/5611#issuecomment-151157684

And from Slack

```
Joe Kent [10:28 AM] 
hmmm @sergii @andrea in a node, what is the ‘translate’ field?

Joe Kent [10:29 AM]
translations stores all of the translations, but im not sure what translate is for

Sergii Tkachenko [10:29 AM] 
Hi

Joe Kent [10:29 AM] 
hi!

Sergii Tkachenko [10:29 AM] 
Hm. Could you please make a screenshot?

Sergii Tkachenko [10:29 AM]
Is this a node object?

Sergii Tkachenko [10:29 AM]
or node edit page?

Joe Kent [10:29 AM] 
node object
Joe Kent 
[10:29 AM]  
Uploaded an image: Screen Shot 2015-10-26 at 10.29.30 AM.png 
Add Comment

Sergii Tkachenko [10:31 AM] 
hm.

Joe Kent [10:32 AM] 
this node in particular has a translation too, so i feel like it should be 1

Joe Kent [10:34 AM]
i think the easiest solution is to just get the translations->data array length

Joe Kent [10:35 AM]
if length > 1 then there is translations

Julie Lorch [10:37 AM] 
@nami @fantini are we good with static content translations? I'd like to re-upload all that info before TSG starts testing today

Sergii Tkachenko [10:42 AM] 
@joe: Yes, I think you’re right. It should be in `entity_translation` module
```
#### What are the relevant tickets?

Fixes #5611 
