### PR TITLE
Footer global page country

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -371,22 +371,6 @@ function dosomething_global_get_countries() {
 }
 
 /**
- * Returns the session's country code, or `global` if it's not
- * one of our whitelisted global countries.
- *
- * @return string
- *   country code, or 'global'
- */
-function dosomething_global_get_country() {
-  $country_code = dosomething_settings_get_geo_country_code();
-  if (in_array($country_code, dosomething_global_get_countries())) {
-    return $country_code;
-  }
-
-  return 'global';
-}
-
-/**
  * Gets the country from a given language.
  *
  * @param string $language

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -622,6 +622,22 @@ function dosomething_global_get_current_prefix() {
 }
 
 /**
+ * Get the country code of the current page (based on the prefix
+ * that is set in the URL), or 'global' if none set.
+ *
+ * @return string
+ */
+function dosomething_global_get_current_country_code() {
+  // Get the prefix, and make uppercase for matching against country array
+  $prefix = strtoupper(dosomething_global_get_current_prefix());
+  if (in_array($prefix, dosomething_global_get_countries())) {
+    return $prefix;
+  }
+
+  return 'global';
+}
+
+/**
  * Return the full country name.
  *
  * @param $country_code

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -433,6 +433,14 @@ function dosomething_global_get_prefix_for_language($language) {
   return $languages[$language]->prefix;
 }
 
+/**
+ * Check if the given URL prefix matches one of our countries.
+ *
+ * @param string $prefix
+ *   The URL prefix to check
+ *
+ * @return bool
+ */
 function dosomething_global_is_path_prefix($prefix) {
   $languages = language_list();
   foreach ($languages as $lang) {

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -676,7 +676,7 @@ function dosomething_global_user_details($account = NULL) {
   }
 
   $language = dosomething_global_get_language($account);
-  $country_code = dosomething_global_get_country();
+  $country_code = dosomething_settings_get_geo_country_code();
 
   return array($language, $country_code);
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -355,20 +355,20 @@ function dosomething_global_get_user_language($user = NULL) {
  * @return array
  *  All of the supported countries
  */
- function dosomething_global_get_countries() {
-   $lang_map = variable_get('dosomething_global_language_map', '');
-   $countries = array();
-   foreach ($lang_map as $lang) {
-     $country = $lang['country'];
+function dosomething_global_get_countries() {
+  $lang_map = variable_get('dosomething_global_language_map', '');
+  $countries = array();
+  foreach ($lang_map as $lang) {
+    $country = $lang['country'];
 
-     // Prevents global english from slipping through
-     if ($country != NULL) {
-       array_push($countries, $country);
-     }
-   }
-   array_push($countries, 'global');
-   return $countries;
- }
+    // Prevents global english from slipping through
+    if ($country != NULL) {
+      array_push($countries, $country);
+    }
+  }
+  array_push($countries, 'global');
+  return $countries;
+}
 
 /**
  * Returns the session's country code, or `global` if it's not

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -181,7 +181,7 @@ function paraneue_dosomething_preprocess_page(&$vars) {
    * Global Page Footer
    */
 
-  $country = dosomething_global_get_country();
+  $country = dosomething_global_get_current_country_code();
   $columns = array('first', 'second', 'third');
   $footer_links = array();
 


### PR DESCRIPTION
#### Changes

Fixes #5608. Add `get_current_country_code` for getting the country code of the page (based on URL prefix), and use that result for displaying the footer. 

Also makes sure we're saving any country code to the user's profile, not just the "whitelisted" ones being passed through `dosomething_global_get_country`. (d3cbe4e)
#### Where should the reviewer start?

As usual, I'd recommend just taking a look at each commit.
#### How should this be manually tested?

Go to a global page (e.g. unprefixed homepage). You should [see the global footer](https://cloud.githubusercontent.com/assets/583202/10732516/de9c0588-7bd0-11e5-86a5-d718f3ddbf1c.png). Now, go to a localized campaign. You should see [the footer for the corresponding country](https://cloud.githubusercontent.com/assets/583202/10732541/f4708028-7bd0-11e5-9d3b-669e5cd09109.png).

---

For review: @angaither 
/cc @DeeZone 
