### PR TITLE
Fix path for not found sloth.

### DIFF
--- a/lib/modules/dosomething/dosomething_image/dosomething_image.module
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.module
@@ -143,7 +143,7 @@ function dosomething_image_get_themed_image_by_fid($fid, $style, $alt = '') {
   $image = image_load($file->uri);
   if (!$image) {
     $args = array(
-      'path' => DS_ASSET_PATH .'/dist/images/no-image-found.png',
+      'path' => PARANEUE_PATH .'/images/no-image-found.png',
       'alt' => 'No image found placeholder',
       'title' => 'No Image Found',
       'attributes' => NULL,


### PR DESCRIPTION
#### Changes

Fixes the "not found sloth" placeholder image... I missed updating this constant when I was cleaning up the asset path stuff in #5373. Whoops. :grimacing: 
#### Screenshots

Before:
![screen shot 2015-10-26 at 11 38 43 am](https://cloud.githubusercontent.com/assets/583202/10733739/6f0cf5f0-7bd6-11e5-90be-18e1a1fbe773.png)

After:
![screen shot 2015-10-26 at 11 37 31 am](https://cloud.githubusercontent.com/assets/583202/10733744/71a92748-7bd6-11e5-8ee2-464b361d2c3f.png)

---

For review: @DoSomething/front-end 
