### PR TITLE
Static content: enable field_intro, field_intro_image translation.

### DIFF
--- a/bin/ds-global
+++ b/bin/ds-global
@@ -158,6 +158,8 @@ function make_static_content_translatable {
   # Don't need: field_hero_image
   # Done: field_subtitle
   drush ds-global-field-fix field_intro_title
+  drush ds-global-field-fix field_intro
+  drush ds-global-field-fix field_intro_image
   # Don't need: field_video
   # Done: field_call_to_action
   drush ds-global-field-fix field_cta_link
@@ -170,8 +172,6 @@ function make_static_content_translatable {
   # drush ds-global-field-fix field_gallery
 
   # Defined in other places, to do:
-  # drush ds-global-field-fix field_intro
-  # drush ds-global-field-fix field_intro_image
   # drush ds-global-field-fix field_partners
 }
 

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.features.field_base.inc
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.features.field_base.inc
@@ -435,7 +435,7 @@ function dosomething_static_content_field_default_field_bases() {
     'settings' => array(
       'entity_translation_sync' => FALSE,
     ),
-    'translatable' => 0,
+    'translatable' => 1,
     'type' => 'text_long',
   );
 
@@ -478,7 +478,7 @@ function dosomething_static_content_field_default_field_bases() {
       ),
       'target_type' => 'node',
     ),
-    'translatable' => 0,
+    'translatable' => 1,
     'type' => 'entityreference',
   );
 

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.info
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.info
@@ -81,4 +81,4 @@ features[variable][] = node_options_static_content
 features[variable][] = node_preview_static_content
 features[variable][] = node_submitted_static_content
 features[variable][] = pathauto_node_static_content_pattern
-mtime = 1443199426
+mtime = 1445872906


### PR DESCRIPTION
#### What's this PR do?
- Translates intro fields: `field_intro` and `field_intro_image` of static content
#### What are the relevant tickets?

A part of #4992, #5575 and #5609.
