### PR TITLE
Action guide content kills signups.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -465,6 +465,10 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
 
 
   $action_guides = $vars['field_action_guide'];
+  // LANGUAGE_NONE is being added to action guide references with #global see #5585
+  if (array_key_exists(LANGUAGE_NONE, $action_guides)) {
+    $action_guides = $action_guides[LANGUAGE_NONE];
+  }
   if (!empty($action_guides)) {
     foreach ($action_guides as $delta => $target) {
       $action_guide = $target['entity'];


### PR DESCRIPTION
This is caused because `LANGUAGE_NONE` is added to the array for non-admins.
The signup appears to fail because of a metadata wrapper error.
Fixes #5585

this [comment](https://github.com/DoSomething/phoenix/issues/5585#issuecomment-151245196) provides the most context

![](http://i.ytimg.com/vi/Iwuy4hHO3YQ/0.jpg)
