### PR TITLE
Country-specific "Who We Are" node links

### DIFF
--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.install
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.install
@@ -37,3 +37,17 @@ function dosomething_settings_update_7001() {
   variable_set('dosomething_settings_copy_scholarships', $copy);
 
 }
+
+/**
+ * Update theme settings for Global 1.0.
+ */
+function dosomething_settings_update_7002() {
+  $paraneue_settings = variable_get('theme_paraneue_dosomething_settings', []);
+
+  $countries = dosomething_global_get_countries();
+  foreach($countries as $country) {
+    $paraneue_settings['header_who_we_are_link_' . $country] = $paraneue_settings['header_who_we_are_link'];
+  }
+
+  variable_set('theme_paraneue_dosomething_settings', $paraneue_settings);
+}

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -49,7 +49,6 @@ function paraneue_dosomething_preprocess_page(&$vars) {
   /**
    * Global Main Navigation
    */
-
   $modifier_classes = '-white -floating';
   if(isset($vars['use_black_navigation']) && $vars['use_black_navigation'] == 1) {
     $modifier_classes = '-floating';
@@ -64,7 +63,7 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     $vars['logo'] = '/' . PARANEUE_PATH . '/images/logo-dev.png';
   }
 
-  $navigation_vars = array(
+  $navigation_vars = [
     'base_path'        => $vars['base_path'],
     'modifier_classes' => $modifier_classes,
     'logo'             => $vars['logo'],
@@ -72,17 +71,17 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     'logged_in'        => $vars['logged_in'],
     'search_box'       => $vars['search_box'],
     'user_identifier'  => $vars['user_identifier'],
-    'who_we_are'       => array(
+    'who_we_are'       => [
       'text' => t(theme_get_setting('header_who_we_are_text')),
       'subtext' => t(theme_get_setting('header_who_we_are_subtext')),
       'link' => t(theme_get_setting('header_who_we_are_link')),
-    ),
-    'explore_campaigns'=> array(
+    ],
+    'explore_campaigns'=> [
       'text' => t(theme_get_setting('header_explore_campaigns_text')),
       'subtext' => t(theme_get_setting('header_explore_campaigns_subtext')),
       // 'link' => theme_get_setting('header_explore_campaigns_link'),
-    ),
-  );
+    ],
+  ];
 
   $vars['navigation'] = theme('navigation', $navigation_vars);
 
@@ -180,7 +179,6 @@ function paraneue_dosomething_preprocess_page(&$vars) {
   /**
    * Global Page Footer
    */
-
   $country = dosomething_global_get_current_country_code();
   $columns = array('first', 'second', 'third');
   $footer_links = array();

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -74,7 +74,7 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     'who_we_are'       => [
       'text' => t(theme_get_setting('header_who_we_are_text')),
       'subtext' => t(theme_get_setting('header_who_we_are_subtext')),
-      'link' => t(theme_get_setting('header_who_we_are_link')),
+      'link' => theme_get_setting('header_who_we_are_link_' . dosomething_global_get_current_country_code()),
     ],
     'explore_campaigns'=> [
       'text' => t(theme_get_setting('header_explore_campaigns_text')),

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -125,13 +125,23 @@ function _paraneue_dosomething_theme_settings_header(&$form, $form_state) {
     '#title'         => 'Subtext',
     '#default_value' => theme_get_setting('header_who_we_are_subtext'),
   );
-  $form['header']['who_we_are']['header_who_we_are_link'] = array(
-    '#type'          => 'entity_autocomplete',
-    '#title'         => 'Link to',
-    '#bundles'       => array('static_content'),
-    '#default_value' => theme_get_setting('header_who_we_are_link'),
-  );
 
+  $form['header']['who_we_are']['header_who_we_are_links'] = [
+    '#type'        => 'fieldset',
+    '#title'       => t('Country-Specific Links'),
+    '#collapsible' => TRUE,
+    '#collapsed'   => TRUE,
+  ];
+
+  $countries = dosomething_global_get_countries();
+  foreach($countries as $country) {
+    $form['header']['who_we_are']['header_who_we_are_links'][$country] = array(
+      '#type'          => 'entity_autocomplete',
+      '#title'         => 'Link (' . $country . ')',
+      '#bundles'       => ['static_content'],
+      '#default_value' => theme_get_setting('header_who_we_are_link_' . $country),
+    );
+  }
 
   $form['header']['explore_campaigns'] = array(
     '#type'        => 'fieldset',

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -135,12 +135,12 @@ function _paraneue_dosomething_theme_settings_header(&$form, $form_state) {
 
   $countries = dosomething_global_get_countries();
   foreach($countries as $country) {
-    $form['header']['who_we_are']['header_who_we_are_links'][$country] = array(
+    $form['header']['who_we_are']['header_who_we_are_links']['header_who_we_are_link_' . $country] = [
       '#type'          => 'entity_autocomplete',
       '#title'         => 'Link (' . $country . ')',
       '#bundles'       => ['static_content'],
       '#default_value' => theme_get_setting('header_who_we_are_link_' . $country),
-    );
+    ];
   }
 
   $form['header']['explore_campaigns'] = array(


### PR DESCRIPTION
#### Changes

Fixes #5629 by adding theme settings to set a unique node to link "Who We Are" to for each country. I've also added an update hook to automatically migrate the old settings to the new country-specific ones.
#### How should I manually test this?

Pull this branch and run the update hook. Everything should still be good. If you go to the admin panel, you should see fields to set a link for each country, pre-filled with the old universal link. If you change the link for a given country, you should see that node linked on pages with that country's prefix in the URL.
#### Screenshots

<img width="405" alt="screen shot 2015-10-27 at 10 45 57 am" src="https://cloud.githubusercontent.com/assets/583202/10762588/15e1cfd8-7c9d-11e5-9dd9-3876b3500352.png">
