### PR TITLE
Date field placeholder format based on country code

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -298,10 +298,13 @@ function paraneue_dosomething_form_user_profile_after_build($form, &$form_state)
   $form['#weight'] = '-18';
   $form['#attributes']['class'] = array('auth-twocol');
 
-  $date_format = t('MM/DD/YYYY');
+  $translated_year = t('YYYY');
+  $date_format = t('MM/DD/' . $translated_year);
 
   // Update the format of the default value of the birthdate field for non-US users.
   if (dosomething_settings_get_geo_country_code() !== 'US') {
+    $date_format = t('DD/MM/' . $translated_year);
+
     if ($form['value']['date']['#value'] && dosomething_user_get_field('field_birthdate')) {
       $form['value']['date']['#value'] = dosomething_user_get_field_birthdate(dosomething_user_get_field('field_birthdate'), 'd/m/Y');
     }


### PR DESCRIPTION
#### What's this PR do?

We had moved translation of the placeholder text for the birthday field into POEditor, but the rules around that conflicted with the format being used for validation. So after much meeting...here comes the fix (i hope) in 3 lines of code. 

POEditor will just be responsible for translating the string `YYYY` to `AAAA` when it needs to. 
This code just updates the placeholder logic to ask for the correct date format based on the users country code which matches up with the validation logic.
#### How should this be manually tested?

The real sanity check for this will be to visit the site as a US user, but then hit a `/mx/` url and then try to register a new account. The format the form asks for would be `MM/DD/AAAA` and it should pass validation.
#### What are the relevant tickets?

Fixes #5576 
Waiting on #5636 for the translation of `YYYY` to `AAAA` to be added. But it is not a blocker.

/cc @DFurnes @angaither 
