### PR TITLE
Fixes fatal error on campaign collections signup flow.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -567,13 +567,21 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     ),
   );
 
+  // Get node title, normal for collections, translatable for campaigns.
+  $title = '';
+  if (isset($node->title_field)) {
+    $title = $wrapper->language($language)->title_field->value();
+  } else {
+    $title = $node->title;
+  }
+
   $params = array(
     'email' => $account->mail,
     'uid' => $account->uid,
     'first_name' => dosomething_user_get_field('field_first_name', $account),
     'mobile' => dosomething_user_get_field('field_mobile', $account),
     'event_id' => $node->nid,
-    'campaign_title' => $wrapper->language($language)->title_field->value(),
+    'campaign_title' => $title,
     'campaign_link' => url('node/' . $node->nid, $url_options),
     'user_language' => $language,
   );


### PR DESCRIPTION
#### What's this PR do?
- Fixes fatal error on campaign collections signup flow.
#### Where should the reviewer start?

Read #5433
#### How should this be manually tested?
1. Open http://dev.dosomething.org:8888/volunteer/grandparents-gone-wired
2. Signup for it
3. Make sure this error doesn't appear:
   ![image](https://cloud.githubusercontent.com/assets/6330971/10378003/6e3388ca-6dd4-11e5-9b04-8587674196ed.png)
#### Any background context you want to provide?

Context: `dosomething_signup_get_mbp_params()` works both for translatable campaigns and not translatable campaign collections. The changes in #5153 ([this line](https://github.com/DoSomething/phoenix/pull/5153/files#diff-480d0c18d1c3b8dc40bff0004b3e6d12R569)) assumed that normal node `title` is always replaced by translatable `field_title`, which is just not the case for campaign collections.
So access to unknown `title_field` in wrapper caused this:
![image](https://cloud.githubusercontent.com/assets/672669/10770091/1f2cbfda-7cf2-11e5-9e17-97eb15bb03a2.png)

```
EntityMetadataWrapperException: Unknown data property title_field. in EntityStructureWrapper->getPropertyInfo() (line 335 of /var/www/dev.dosomething.org/html/profiles/dosomething/modules/contrib/entity/includes/entity.wrapper.inc).
```
#### What are the relevant tickets?

Fixes #5433.

---

cc @blisteringherb @DeeZone 
