### PR TITLE
Campaign collection links

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -224,10 +224,11 @@ function paraneue_dosomething_get_node_gallery_item($nid, $source = NULL) {
   $classes_array = [];
 
   $node = node_load($nid);
-  $link = drupal_get_path_alias('node/' . $nid);
+  $url_options = [];
   if ($source) {
-    $link .= '?source=' . $source;
+    $options['query']['source'] = $source;
   }
+  $link = url(drupal_get_path_alias('node/' . $nid), $url_options);
 
   $title = $node->title;
   if ($node->status == 0) {

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -221,7 +221,7 @@ function paraneue_dosomething_get_search_gallery($results) {
  *   The source query string to append to the link.
  */
 function paraneue_dosomething_get_node_gallery_item($nid, $source = NULL) {
-  $classes_array = array();
+  $classes_array = [];
 
   $node = node_load($nid);
   $link = drupal_get_path_alias('node/' . $nid);
@@ -272,12 +272,13 @@ function paraneue_dosomething_get_node_gallery_item($nid, $source = NULL) {
  * Returns a themed mosaic gallery with campaign tiles for given $nids.
  */
 function paraneue_dosomething_get_campaign_gallery($nids, $source = NULL, $show_more = FALSE) {
-  $items = array();
+  $items = [];
 
   foreach ($nids as $delta => $nid) {
     $item = paraneue_dosomething_get_node_gallery_item($nid, $source);
     $items[] = paraneue_dosomething_get_gallery_item($item['content'], 'tile', TRUE);
   }
+
   $gallery_classes = array('-mosaic');
   // If 5 items or more, the tiles should appear with a featured tile.
   if (count($items) > 4) {


### PR DESCRIPTION
#### Changes

Fixes #5474. Campaign collections were missing the ol' `/` on their links, and so were trying to load campaigns relatively from the collection page. This was 404ing and making people sad. This PR runs those path aliases through the ol' `url()` so that they can be properly formatted. Hurrah!
#### Where should the reviewer start?

First, check out [this commit](https://github.com/DoSomething/phoenix/commit/20ea0c7f4eef9e6b6822dc67e10a6dafe65bc847) where I add some PHP 5.4 hotness. Then wander over to [this commit](https://github.com/DoSomething/phoenix/commit/551d8fa5ccc73d25c23f1d81a4ff3efc51435c21) which fixes the actual issue at hand. :computer: :boom: :hammer: 
#### How should this be manually tested?

Go to a campaign collection. Click on a tile. Does it 404? No? Great.

---

For review: @angaither 
