### PR TITLE
Share links should not have a lang pre-appended

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -121,11 +121,12 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
       $vars['problem_share_prompt'] = $problem_share_prompt;
     }
 
-    $base_url = url(base_path(), array('absolute'=> TRUE));
+    $base_url = url(base_path(), array('absolute'=> TRUE, 'language' => 'en-global'));
     $campaign_path = url(current_path(), array('absolute' => TRUE));
 
+
     // Create the image path to the problem fact statement image generated for the node.
-    $problem_share_image = $base_url . 'sites/default/files/images/problem-' . $vars['nid'] . '.png';
+    $problem_share_image = $base_url . '/sites/default/files/images/problem-' . $vars['nid'] . '.png';
 
     $share_types = array(
       'facebook' => array(

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -32,8 +32,8 @@ function dosomething_helpers_get_facebook_intent($link, $type = NULL, $custom_op
     // different from what is set in the metatags.
     case 'feed_dialog':
       // Build the redirect url.
-      $base_path = url(base_path(), array('absolute' => TRUE));
-      $redirect_path = url(base_path(), array('absolute' => TRUE)) . 'ds-share-complete';
+      $base_path = url(base_path(), array('absolute' => TRUE, 'language' => 'en-global'));
+      $redirect_path = url(base_path(), array('absolute' => TRUE, 'language' => 'en-global')) . 'ds-share-complete';
 
       // Pass in all the feed dialog parameters
       $facebook_app_id = variable_get('dosomething_settings_facebook_app_id');


### PR DESCRIPTION
to get share links without a `us` prefix, the lang should be `en-global` with no prefix. 

Fixes #5482
