### PR TITLE
Add default country code of global

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -671,6 +671,11 @@ function dosomething_signup_get_mailchimp_list_id() {
   global $user;
   $user_language = $user->language;
   $country_code = dosomething_global_convert_language_to_country($user_language);
+  // Default to the global MailChimp list if a country is not found for the user language
+  // Most global users will have a language setting of en-global.
+  if (empty($country_code)) {
+    $country_code = 'global';
+  }
   $field_name = "dosomething_signup_" . strtolower($country_code) . '_mail_list_id';
   return variable_get($field_name);
 }


### PR DESCRIPTION
Fixes #5635

When a global (non-affiliate or US) user registers on the site the user language setting is used to:
- lookup a related country
- with a country code, lookup a mailchimp_list_id value

This PR provides a default country value of "global" when `dosomething_global_convert_language_to_country()` returns a NULL value. This results in `variable_get("dosomething_signup_global_mail_list_id");`

**To Test**:
For example, a global user from Iceland, the message payload sent to Message Broker via `message_broker_producer.module -> message_broker_producer_request()` should contain:

```
(
    [activity] => user_register
    [email] => dlee+THORTest-IS-1027-01@dosomething.org
    [uid] => 3118846
    [merge_vars] => Array
        (
            [MEMBER_COUNT] => 4.2 million
            [FNAME] => Dee Thor Test Is 01
        )

    [user_country] => IS
    [user_language] => en-global
    [email_template] => mb-user-register-IS
    [mailchimp_list_id] => 8e7844f6dd
    [birthdate] => 929232000
    [subscribed] => 1
    [email_tags] => Array
        (
            [0] => drupal_user_register
        )

    [activity_timestamp] => 1445990277
    [application_id] => US
)

```
