### PR TITLE
Fix incorrect variable for `url()` options array.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -226,7 +226,7 @@ function paraneue_dosomething_get_node_gallery_item($nid, $source = NULL) {
   $node = node_load($nid);
   $url_options = [];
   if ($source) {
-    $options['query']['source'] = $source;
+    $url_options['query']['source'] = $source;
   }
   $link = url(drupal_get_path_alias('node/' . $nid), $url_options);
 


### PR DESCRIPTION
#### Changes

Fixes a typo noted by @sergii-tkachenko in #5643.
#### Where should the reviewer start?

Preferably on line 229 of `helpers.inc`.
#### How should this be manually tested?

Before, I was dumb and none of the tiles on taxonomy pages/campaign groups were getting `?source=xxxx` appended to their links. Now, they are. :chart_with_upwards_trend: :bug: :hammer: 
