### PR TITLE
Adds language code if not present in URL

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -209,7 +209,8 @@ function dosomething_global_form_node_form_alter(&$form, &$form_state, $form_id)
     return;
   }
 
-  // Get the last item in the url, to get the edit/add node language.
+  // Get the last item in the url, and verify its the node edit language.
+  // If not set it to the source language
   $node_lang = array_pop(explode('/', (parse_url(current_path(), PHP_URL_PATH))));
   if ($node_lang == 'edit') {
     $node_lang = $form['#node']->language;

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -209,7 +209,6 @@ function dosomething_global_form_node_form_alter(&$form, &$form_state, $form_id)
     return;
   }
 
-
   // Get the last item in the url, to get the edit/add node language.
   $node_lang = array_pop(explode('/', (parse_url(current_path(), PHP_URL_PATH))));
   if ($node_lang == 'edit') {
@@ -225,8 +224,6 @@ function dosomething_global_form_node_form_alter(&$form, &$form_state, $form_id)
     // Otherwise, don't autocheck that publish box.
     $form['translation']['status']['#default_value'] = FALSE;
   }
-
-
 
   // Check if the user is a mexico or brazil admin
   if (dosomething_global_is_regional_admin()) {

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -208,8 +208,13 @@ function dosomething_global_form_node_form_alter(&$form, &$form_state, $form_id)
   if (!(in_array($form['type']['#value'], $translatable_types))) {
     return;
   }
+
+
   // Get the last item in the url, to get the edit/add node language.
   $node_lang = array_pop(explode('/', (parse_url(current_path(), PHP_URL_PATH))));
+  if ($node_lang == 'edit') {
+    $node_lang = $form['#node']->language;
+  }
   $translations = $form['#node']->translations->data;
   // If we are on a node lang page, and a translation exists
   if (array_key_exists($node_lang, $translations)) {
@@ -220,6 +225,8 @@ function dosomething_global_form_node_form_alter(&$form, &$form_state, $form_id)
     // Otherwise, don't autocheck that publish box.
     $form['translation']['status']['#default_value'] = FALSE;
   }
+
+
 
   // Check if the user is a mexico or brazil admin
   if (dosomething_global_is_regional_admin()) {


### PR DESCRIPTION
#### What's this PR do?

Adds the source nodes language to the form alter logic when there is no lang specified in the URL.
#### How should this be manually tested?

Step 1. Take in Fantini's late night debugging issue https://github.com/DoSomething/phoenix/issues/5581
Step 3. Test if its not happening anymore. 
Step 4. Don't ask why I skipped step 2.
#### What are the relevant tickets?

Fixes #5581 
