### PR TITLE
Fixes warning on campaign group pages.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
@@ -144,28 +144,30 @@
             </div>
           <?php endif; ?>
 
-          <ul class="gallery -triad">
-            <?php foreach ($gallery['items'] as $gallery_item): ?>
-              <li class="<?php print $gallery_item['order_class']; ?>">
-                <div class="figure">
-                  <?php if (isset($gallery_item['image'])): ?>
-                    <div class="figure__media">
-                      <?php print $gallery_item['image']; ?>
-                    </div>
-                  <?php endif; ?>
+          <?php if (!empty($gallery['items'])): ?>
+            <ul class="gallery -triad">
+              <?php foreach ($gallery['items'] as $gallery_item): ?>
+                <li class="<?php print $gallery_item['order_class']; ?>">
+                  <div class="figure">
+                    <?php if (isset($gallery_item['image'])): ?>
+                      <div class="figure__media">
+                        <?php print $gallery_item['image']; ?>
+                      </div>
+                    <?php endif; ?>
 
-                  <div class="figure__body">
-                  <?php if (isset($gallery_item['image_title'])): ?>
-                    <h3><?php print $gallery_item['image_title']; ?></h3>
-                  <?php endif; ?>
-                  <?php if (isset($gallery_item['image_description'])): ?>
-                    <?php print $gallery_item['image_description']; ?>
-                  <?php endif; ?>
+                    <div class="figure__body">
+                    <?php if (isset($gallery_item['image_title'])): ?>
+                      <h3><?php print $gallery_item['image_title']; ?></h3>
+                    <?php endif; ?>
+                    <?php if (isset($gallery_item['image_description'])): ?>
+                      <?php print $gallery_item['image_description']; ?>
+                    <?php endif; ?>
+                    </div>
                   </div>
-                </div>
-              </li>
-            <?php endforeach; ?>
-          </ul>
+                </li>
+              <?php endforeach; ?>
+            </ul>
+          <?php endif; ?>
         </div>
       <?php endforeach; ?>
     </section>


### PR DESCRIPTION
#### What's this PR do?

Fixes warning on campaign group pages:

```
Warning: Invalid argument supplied for foreach() in include() (line 148 of /var/www/staging.beta.dosomething.org/releases/20151027212412/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php).
```
#### How should this be manually tested?
- Open http://dev.dosomething.org:8888/volunteer/grandparents-gone-wired
- Refresh
- Make sure you don't see the warning
