### PR TITLE
Removes path prefixes from admin URLS

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -36,6 +36,16 @@ function dosomething_global_init() {
     dosomething_global_redirect_node_edit($node_variables['node'], $user_variables['user_language']);
     return;
   }
+
+  // Verify we're dealing with an admin page that has a path prefix
+  // and if we are, redirect them to that page without a path prefix
+  if ($url_variables['is_admin_page'] && $url_variables['url_path_prefix'] != $languages[DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE]->prefix) {
+    $original_path_without_prefix = str_replace($url_variables['url_path_prefix'], "", $url_variables['path']);
+    $original_path_without_prefix = ltrim($original_path_without_prefix, '/');
+    $redirect_path = url(base_path(), array('absolute' => TRUE, 'language' => 'en-global')) . $original_path_without_prefix;
+    drupal_goto($redirect_path);
+  }
+
   // If we already have a path prefix,
   // or the user is a global english speaker,
   // all logic after this statement should not run.
@@ -124,17 +134,20 @@ function dosomething_global_node_access($node, $op, $account) {
  *      request_method (String) - The type of request (Get, Post, etc)
  *      is_homepage (bool) - Is this the homepage?
  *      url_path_prefix (String) - The path prefix specified in the URL. Default is global.
+ *      is_admin_page (bool) - Is this a /admin page?
  */
 function dosomething_global_get_url_variables() {
   $path = request_path();
   $request_method = strtolower($_SERVER['REQUEST_METHOD']);
   $homepage = (drupal_is_front_page() && is_numeric(arg(1)));
   $url_path_prefix = dosomething_global_get_current_prefix();
+  $is_admin = (arg(0) == "admin");
   return array(
     'path' => $path,
     'request_method' => $request_method,
     'is_homepage' => $homepage,
-    'url_path_prefix' => $url_path_prefix
+    'url_path_prefix' => $url_path_prefix,
+    'is_admin_page' => $is_admin
   );
 }
 

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -40,9 +40,7 @@ function dosomething_global_init() {
   // Verify we're dealing with an admin page that has a path prefix
   // and if we are, redirect them to that page without a path prefix
   if ($url_variables['is_admin_page'] && $url_variables['url_path_prefix'] != $languages[DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE]->prefix) {
-    $original_path_without_prefix = str_replace($url_variables['url_path_prefix'], "", $url_variables['path']);
-    $original_path_without_prefix = ltrim($original_path_without_prefix, '/');
-    $redirect_path = url(base_path(), array('absolute' => TRUE, 'language' => 'en-global')) . $original_path_without_prefix;
+    $redirect_path = url(current_path(), array('absolute' => TRUE, 'language' => 'en-global'));
     drupal_goto($redirect_path);
   }
 


### PR DESCRIPTION
#### What's this PR do?

Removes path prefixes from admin URL's. This should solve :all the things: (hopefully)
#### How should this be manually tested?

Can you create users now via admin interface?
Are all path prefixed url's redirected to global prefix when using admin pages?
#### Any background context you want to provide?

The bug being reported only occurred on path prefixed admin pages, and we dont need path prefixes on admin pages. To reconstruct the URL I took the same approach @angaither did for share links.
https://github.com/DoSomething/phoenix/pull/5646/files
#### What are the relevant tickets?

Fixes #5566 

cc: @blisteringherb 
