### PR TITLE
3col short gallery bug

### DIFF
--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
@@ -112,7 +112,7 @@ function dosomething_static_content_preprocess_galleries(&$vars) {
       $chosen_style = $collection_item['field_gallery_style']['#items'][0]['value'];
 
       // If a key exists and it's not the default:
-      if ($chosen_style && $chosen_style == '2col') {
+      if ($chosen_style == '2col') {
         $gallery_style = 'duo';
         $image_ratio = 'thumb';
         $image_style = '100x100';

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
@@ -119,6 +119,7 @@ function dosomething_static_content_preprocess_galleries(&$vars) {
         $item_style[] = '-left';
       }
       else if ($chosen_style == '3col_short') {
+        $image_ratio = 'thumb';
         $image_style = 'wmax-300-hmax-75';
         $item_style[] = '-aligned';
       }


### PR DESCRIPTION
#### Changes

Fixes #5655. The `$image_ratio` was not set, and so it was causing three column galleries not to render because they were not querying an image node correctly. This was a problem introduced when I was refactoring static content galleries in #5561.
#### Where should the reviewer start?

I'd recommend taking a look at each commit individually: 68a4df7, e58905f
#### How should I test?

Visit @mikefantini's favorite static content node, [This is PT](https://staging.dosomething.org/about/pt), on your local dev. You won't see any images under the "3 Column Short" heading. Now pull down this PR. You will see images under the "3 Column Short" heading. :mount_fuji: :eyes: 

![screen shot 2015-10-28 at 5 29 29 pm](https://cloud.githubusercontent.com/assets/583202/10803619/7a3d6d78-7d99-11e5-9ad9-5ad0bbce196a.png)

---

For review: @sbsmith86
