### PR TITLE
Translated facts bug fix olé

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -179,7 +179,12 @@ function dosomething_campaign_load($node, $public = FALSE) {
   $campaign->fact_sources = NULL;
   // Collect multiple fact fields values as fact and sources variables.
   $fact_fields = array('field_fact_problem', 'field_fact_solution');
+
+
   $fact_vars = dosomething_fact_get_mutiple_fact_field_vars($wrapper->nid->value(), $fact_fields);
+
+  $fact_data = dosomething_fact_get_facts_data($node, $fact_fields);
+
   if (!empty($fact_vars)) {
     if (isset($fact_vars['facts']['field_fact_problem'])) {
       $campaign->fact_problem = $fact_vars['facts']['field_fact_problem'];
@@ -199,14 +204,14 @@ function dosomething_campaign_load($node, $public = FALSE) {
   }
 
   $campaign->downloads = NULL;
-  if (!empty($node->field_downloads)) {
-    foreach ($node->field_downloads[LANGUAGE_NONE] as $file) {
-      $campaign->downloads[] = array(
-        'url' => file_create_url($file['uri']),
-        'description' => $file['description'],
-      );
-    }
-  }
+//  if (!empty($node->field_downloads)) {
+//    foreach ($node->field_downloads[LANGUAGE_NONE] as $file) {
+//      $campaign->downloads[] = array(
+//        'url' => file_create_url($file['uri']),
+//        'description' => $file['description'],
+//      );
+//    }
+//  }
 
   // Store any dosomething_helpers variables.
   $campaign->variables = dosomething_helpers_get_variables('node', $campaign->nid);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -180,10 +180,12 @@ function dosomething_campaign_load($node, $public = FALSE) {
   // Collect multiple fact fields values as fact and sources variables.
   $fact_fields = array('field_fact_problem', 'field_fact_solution');
 
-
-  $fact_vars = dosomething_fact_get_mutiple_fact_field_vars($wrapper->nid->value(), $fact_fields);
-
-  $fact_data = dosomething_fact_get_facts_data($node, $fact_fields);
+  // @TODO: Consider removing old function.
+  // For global translation work we had issues dealing with the entity_metadata_wrapper method and
+  // EntityDrupalWrapper retrieving appropriate content based on url language prefix, so this function
+  // is disabled for now in favor of the dosomething_fact_get_facts_data() function instead.
+  // $fact_vars = dosomething_fact_get_mutiple_fact_field_vars($wrapper->nid->value(), $fact_fields);
+  $fact_vars = dosomething_fact_get_facts_data($node, $fact_fields);
 
   if (!empty($fact_vars)) {
     if (isset($fact_vars['facts']['field_fact_problem'])) {
@@ -204,14 +206,14 @@ function dosomething_campaign_load($node, $public = FALSE) {
   }
 
   $campaign->downloads = NULL;
-//  if (!empty($node->field_downloads)) {
-//    foreach ($node->field_downloads[LANGUAGE_NONE] as $file) {
-//      $campaign->downloads[] = array(
-//        'url' => file_create_url($file['uri']),
-//        'description' => $file['description'],
-//      );
-//    }
-//  }
+  if (!empty($node->field_downloads)) {
+    foreach ($node->field_downloads[LANGUAGE_NONE] as $file) {
+      $campaign->downloads[] = array(
+        'url' => file_create_url($file['uri']),
+        'description' => $file['description'],
+      );
+    }
+  }
 
   // Store any dosomething_helpers variables.
   $campaign->variables = dosomething_helpers_get_variables('node', $campaign->nid);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
@@ -11,6 +11,7 @@ dependencies[] = dosomething_helpers
 dependencies[] = dosomething_image
 dependencies[] = dosomething_signup
 dependencies[] = dosomething_taxonomy
+dependencies[] = dosomething_global
 dependencies[] = entityreference
 dependencies[] = features
 dependencies[] = field_collection

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -580,14 +580,9 @@ function dosomething_campaign_get_campaign_block_vars($nid, $image_size = '740x4
  * Implements hook_preprocess_page().
  */
 function dosomething_campaign_preprocess_page(&$vars) {
-//  var_dump(array_keys($vars), 'PREPROCESS PAGE &VARS');
-//  var_dump($vars['node'], 'PREPROCESS PAGE &VARS->Node');
-
   if (isset($vars['node']) && $vars['node']->type == 'campaign') {
 
     $campaign = dosomething_campaign_load($vars['node']);
-//    var_dump($campaign, 'PREPROCESS PAGE Campaign Loaded');
-
 
     $cover_image_dark_background = $campaign->image_header['is_dark_image'];
 
@@ -595,7 +590,7 @@ function dosomething_campaign_preprocess_page(&$vars) {
     // If image *doesn't* have a dark background, use black.
     $vars['use_black_navigation'] = ($cover_image_dark_background == 1) ? 0 : 1;
 
-    // On confirmation page, always use white text
+    // On confirmation page, always use white text.
     $is_confirmation_page = preg_match("/confirmation/", current_path());
     if( $is_confirmation_page ) {
       $vars['use_black_navigation'] = 0;

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -5,6 +5,7 @@
  */
 
 module_load_include('php', 'dosomething_api', 'includes/Transformer');
+module_load_include('module', 'dosomething_global', 'dosomething_global');
 
 include_once 'dosomething_campaign.features.inc';
 include_once 'dosomething_campaign.helpers.inc';
@@ -12,7 +13,11 @@ include_once 'includes/Campaign.php';
 include_once 'includes/CampaignController.php';
 include_once 'includes/CampaignTransformer.php';
 include_once 'dosomething_campaign.theme.inc';
+
 define('DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER', t('Snap a Pic'));
+
+$default_language = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
+
 
 /**
  * Implements hook_form_alter().
@@ -575,9 +580,15 @@ function dosomething_campaign_get_campaign_block_vars($nid, $image_size = '740x4
  * Implements hook_preprocess_page().
  */
 function dosomething_campaign_preprocess_page(&$vars) {
+//  var_dump(array_keys($vars), 'PREPROCESS PAGE &VARS');
+//  var_dump($vars['node'], 'PREPROCESS PAGE &VARS->Node');
+
   if (isset($vars['node']) && $vars['node']->type == 'campaign') {
 
     $campaign = dosomething_campaign_load($vars['node']);
+//    var_dump($campaign, 'PREPROCESS PAGE Campaign Loaded');
+
+
     $cover_image_dark_background = $campaign->image_header['is_dark_image'];
 
     // The usual default for navigation is white.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -5,7 +5,6 @@
  */
 
 module_load_include('php', 'dosomething_api', 'includes/Transformer');
-module_load_include('module', 'dosomething_global', 'dosomething_global');
 
 include_once 'dosomething_campaign.features.inc';
 include_once 'dosomething_campaign.helpers.inc';
@@ -15,9 +14,6 @@ include_once 'includes/CampaignTransformer.php';
 include_once 'dosomething_campaign.theme.inc';
 
 define('DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER', t('Snap a Pic'));
-
-$default_language = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
-
 
 /**
  * Implements hook_form_alter().

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -9,15 +9,10 @@
  * Implements hook_preprocess_node().
  */
 function dosomething_campaign_preprocess_node(&$vars) {
-//  var_dump(array_keys($vars), 'PREPROCESS NODE &VARS');
-//  var_dump($vars['node'], 'PREPROCESS NODE &VARS->Node');
-
   if ($vars['type'] != 'campaign' || $vars['view_mode'] != 'full') return;
 
   $node = $vars['node'];
   $vars['campaign'] = dosomething_campaign_load($node);
-//  var_dump($vars['campaign'], 'PREPROCESS NODE Campaign Loaded');
-
 
   $wrapper = dosomething_helpers_node_metadata_wrapper($node);
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -9,10 +9,16 @@
  * Implements hook_preprocess_node().
  */
 function dosomething_campaign_preprocess_node(&$vars) {
+//  var_dump(array_keys($vars), 'PREPROCESS NODE &VARS');
+//  var_dump($vars['node'], 'PREPROCESS NODE &VARS->Node');
+
   if ($vars['type'] != 'campaign' || $vars['view_mode'] != 'full') return;
 
   $node = $vars['node'];
   $vars['campaign'] = dosomething_campaign_load($node);
+//  var_dump($vars['campaign'], 'PREPROCESS NODE Campaign Loaded');
+
+
   $wrapper = dosomething_helpers_node_metadata_wrapper($node);
 
   $current_path = current_path();

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.info
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.info
@@ -4,6 +4,7 @@ core = 7.x
 package = DoSomething
 version = 7.x-1.0
 dependencies[] = ctools
+dependencies[] = dosomething_global
 dependencies[] = entity
 dependencies[] = features
 dependencies[] = strongarm

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -109,15 +109,19 @@ function dosomething_fact_get_facts_data($node, $field_names) {
       $facts[$field_name]['nid'] = $entity_data['nid'];
       $fact_sources = dosomething_helpers_extract_field_data($entity->field_source_copy);
       $fact_sources = dosomething_fact_get_formatted_sources($fact_sources);
-      $facts[$field_name]['footnotes'] = '';
-      foreach ($fact_sources as $index => $source) {
-        $count = count($sources);
-        $facts[$field_name]['footnotes'][] = $count + 1;
-        $facts[$field_name]['sources'][$count] = $source;
-        $sources[] = $source;
-      }
 
-      $facts[$field_name]['footnotes'] = implode(' ', $facts[$field_name]['footnotes']);
+      if ($fact_sources) {
+        $facts[$field_name]['footnotes'] = '';
+
+        foreach ($fact_sources as $index => $source) {
+          $count = count($sources);
+          $facts[$field_name]['footnotes'][] = $count + 1;
+          $facts[$field_name]['sources'][$count] = $source;
+          $sources[] = $source;
+        }
+
+        $facts[$field_name]['footnotes'] = implode(' ', $facts[$field_name]['footnotes']);
+      }
     }
   }
 
@@ -134,10 +138,16 @@ function dosomething_fact_get_facts_data($node, $field_names) {
 }
 
 /**
+ * Get specific data from the fact entity.
+ *
  * @param $entity
  * @return array
  */
 function dosomething_fact_get_entity_data($entity) {
+  if (!$entity && !is_object($entity)) {
+    return NULL;
+  }
+
   $data = [];
 
   $data['title'] = $entity->title;
@@ -146,7 +156,17 @@ function dosomething_fact_get_entity_data($entity) {
   return $data;
 }
 
+/**
+ * Return just the formatted sources copy.
+ *
+ * @param $sources
+ * @return array|null
+ */
 function dosomething_fact_get_formatted_sources($sources) {
+  if (!$sources) {
+    return NULL;
+  }
+
   if (!is_array($sources[0])) {
     $sources = [$sources];
   }
@@ -158,6 +178,7 @@ function dosomething_fact_get_formatted_sources($sources) {
 
   return $formatted_sources;
 }
+
 
 /**
  * Returns array of values of a Fact entityreference field.

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -77,20 +77,86 @@ function dosomething_fact_get_mutiple_fact_field_vars($node, $field_names) {
 }
 
 /**
- * @TODO: Mediator function!
- * @param $node
- * @param $field_names
+ * Returns data for multiple specified fields.
+ *
+ * @param object $node The loaded node to collect field data from.
+ * @param array $field_names Array of field machine names to collect data from.
+ * @return array|null
  */
 function dosomething_fact_get_facts_data($node, $field_names) {
+  $entity = NULL;
+  $facts = [];
+  $sources = [];
   $language = dosomething_global_convert_country_to_language(dosomething_global_get_current_prefix());
-//  var_dump($language, 'LANGUAGE MOFO!');
 
   foreach($field_names as $field_name) {
     $field_data = $node->$field_name;
-//    var_dump(array_keys($field_data), 'KEYS');
+
+    if ($field_data) {
+      if (array_key_exists($language, $field_data)) {
+        $entity = $field_data[$language][0]['entity'];
+      }
+
+      if (isset($field_data[0]['entity']) && is_object($field_data[0]['entity'])) {
+        $entity = $field_data[0]['entity'];
+      }
+    }
+
+    if ($entity) {
+      $entity_data = dosomething_fact_get_entity_data($entity);
+
+      $facts[$field_name]['fact'] = $entity_data['title'];
+      $facts[$field_name]['nid'] = $entity_data['nid'];
+      $fact_sources = dosomething_helpers_extract_field_data($entity->field_source_copy);
+      $fact_sources = dosomething_fact_get_formatted_sources($fact_sources);
+      $facts[$field_name]['footnotes'] = '';
+      foreach ($fact_sources as $index => $source) {
+        $count = count($sources);
+        $facts[$field_name]['footnotes'][] = $count + 1;
+        $facts[$field_name]['sources'][$count] = $source;
+        $sources[] = $source;
+      }
+
+      $facts[$field_name]['footnotes'] = implode(' ', $facts[$field_name]['footnotes']);
+    }
   }
 
-  return null;
+  if ($facts) {
+    $data = [
+      'facts' => $facts,
+      'sources' => $sources,
+    ];
+
+    return $data;
+  }
+
+  return NULL;
+}
+
+/**
+ * @param $entity
+ * @return array
+ */
+function dosomething_fact_get_entity_data($entity) {
+  $data = [];
+
+  $data['title'] = $entity->title;
+  $data['nid'] = $entity->nid;
+
+  return $data;
+}
+
+function dosomething_fact_get_formatted_sources($sources) {
+  if (!is_array($sources[0])) {
+    $sources = [$sources];
+  }
+
+  $formatted_sources = [];
+  foreach ($sources as $source) {
+    $formatted_sources[] = $source['formatted'];
+  }
+
+  return $formatted_sources;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -77,6 +77,23 @@ function dosomething_fact_get_mutiple_fact_field_vars($node, $field_names) {
 }
 
 /**
+ * @TODO: Mediator function!
+ * @param $node
+ * @param $field_names
+ */
+function dosomething_fact_get_facts_data($node, $field_names) {
+  $language = dosomething_global_convert_country_to_language(dosomething_global_get_current_prefix());
+//  var_dump($language, 'LANGUAGE MOFO!');
+
+  foreach($field_names as $field_name) {
+    $field_data = $node->$field_name;
+//    var_dump(array_keys($field_data), 'KEYS');
+  }
+
+  return null;
+}
+
+/**
  * Returns array of values of a Fact entityreference field.
  *
  * @param object $fact_field_wrapper

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -395,7 +395,7 @@ function dosomething_global_convert_language_to_country($language) {
 function dosomething_global_convert_country_to_language($country) {
   $lang_map = variable_get('dosomething_global_language_map', '');
   foreach ($lang_map as $lang_key => $lang) {
-    if (isset($lang['country']) && $lang['country'] == $country) {
+    if (isset($lang['country']) && $lang['country'] == strtoupper($country)) {
       return $lang_key;
     }
   }


### PR DESCRIPTION
Fixes #5572
#### What's this PR do?

To minimize the potential for breaking lots of campaign related code, took a more subtle approach to fixing the translation bug related to Facts. The `EntityDrupalWrapper` class was causing problems with grabbing the correct facts related to regional content (translated, but as separate unique nodes and not nodes with translations as part of the node object). 

Instead, created a separate function to handle grabbing that data from the node, without interrupting how the rest of the campaign node data is loaded when constructing the campaign object. It allows for grabbing content if there are translations and ones specific to the language defined by the url path (`/us/` or `/mx/` etc) or just grabbing the available content if no language specific options available, but there is definitely content in the field.
#### Where should the reviewer start?

Probably in the **dosomething_campaign.helpers.inc** file at line 183 with the `@TODO` explanation and then follow the bread crumb trail of code... :bread: 
#### How should this be manually tested?

We'll test on Thor which has a bunch of language related content to make testing easier.
#### Any background context you want to provide?

To help with mitigating bugs and not break how the `dosomething_campaign_load()` function loads and creates the `campaign` standard object, the aim with the custom function was to set it up in a way that it would return data back to the `dosomething_campaign_load()` function in the same format/structure that the `EntityDrupalWrapper` would have, because that's the structure the rest of the code is relying on. Deviating from that structure could end up causing more bugs that we'd need thorough testing to actually find and then iron out. So went with the path of least resistance; but also why some of the code may see a little odd in places, in the effort to accommodate the above intentions! :earth_americas: 
#### What are the relevant tickets?
#5572
#### Screenshots (if appropriate)

US specific content at `/us/node/1283`:
![image](https://cloud.githubusercontent.com/assets/105849/10810976/451b3cb2-7ddd-11e5-9001-97a087ba4e9c.png)

MX specific content at `/mx/node/1283`:
![image](https://cloud.githubusercontent.com/assets/105849/10810996/6a0cfd1c-7ddd-11e5-8859-58ccc346f4dc.png)

MX specific content, but none entered in the admin `/mx/node/1321`:
![image](https://cloud.githubusercontent.com/assets/105849/10811010/915ad0f6-7ddd-11e5-909f-e4c6a1d33112.png)

---

@angaither 

cc: @mikefantini @namimody 
