### PR TITLE
Improves translatable fields language detection.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -540,7 +540,7 @@ function dosomething_campaign_get_campaigns_doing($uid = NULL) {
  */
 function dosomething_campaign_get_campaign_block_vars($nid, $image_size = '740x480', $source = NULL) {
   $node = node_load($nid);
-  $clc = dosomething_helpers_get_current_language_code();
+  $clc = dosomething_helpers_get_current_language_content_code();
   $path_alias = drupal_get_path_alias('node/' . $nid);
   if ($source) {
     $path_alias .= '?source=' . $source;

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
@@ -15,7 +15,7 @@
  */
 function dosomething_campaign_reportback_confirmation_page($node) {
   $wrapper = dosomething_helpers_node_metadata_wrapper($node);
-  $clc = dosomething_helpers_get_current_language_code();
+  $clc = dosomething_helpers_get_current_language_content_code();
 
   // Initialize $vars to pass to the reportback_confirmation theme function.
   $vars = array(

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
@@ -157,7 +157,7 @@ function dosomething_campaign_group_get_child_data($node) {
     'nids' => array(),
   );
   if (!empty($node->field_campaigns)) {
-    $clc = dosomething_helpers_get_current_language_code();
+    $clc = dosomething_helpers_get_current_language_content_code();
     foreach ($node->field_campaigns[$clc] as $delta => $value) {
       // Add the child nid to nid's array.
       $data['nids'][] = $value['entity']->nid;

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.info
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.info
@@ -20,4 +20,4 @@ features[variable][] = language_negotiation_language
 features[variable][] = language_negotiation_language_content
 features[variable][] = locale_language_providers_weight_language
 features[variable][] = locale_language_providers_weight_language_content
-mtime = 1442878150
+mtime = 1445972087

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.strongarm.inc
@@ -94,23 +94,11 @@ function dosomething_global_strongarm() {
   $strongarm->api_version = 1;
   $strongarm->name = 'language_negotiation_language_content';
   $strongarm->value = array(
-    'locale-user' => array(
-      'callbacks' => array(
-        'language' => 'locale_language_from_user',
-      ),
-      'file' => 'includes/locale.inc',
-    ),
     'locale-session' => array(
       'callbacks' => array(
         'language' => 'locale_language_from_session',
         'switcher' => 'locale_language_switcher_session',
         'url_rewrite' => 'locale_language_url_rewrite_session',
-      ),
-      'file' => 'includes/locale.inc',
-    ),
-    'locale-interface' => array(
-      'callbacks' => array(
-        'language' => 'locale_language_from_interface',
       ),
       'file' => 'includes/locale.inc',
     ),
@@ -127,9 +115,9 @@ function dosomething_global_strongarm() {
   $strongarm->api_version = 1;
   $strongarm->name = 'locale_language_providers_weight_language';
   $strongarm->value = array(
+    'locale-user' => '-10',
     'locale-url' => '-9',
     'locale-session' => '-8',
-    'locale-user' => '-10',
     'locale-browser' => '-7',
     'language-default' => '-6',
   );
@@ -141,8 +129,8 @@ function dosomething_global_strongarm() {
   $strongarm->name = 'locale_language_providers_weight_language_content';
   $strongarm->value = array(
     'locale-url' => '-10',
-    'locale-session' => '-8',
     'locale-user' => '-9',
+    'locale-session' => '-8',
     'locale-browser' => '-7',
     'locale-interface' => '-6',
     'language-default' => '-5',

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -576,8 +576,8 @@ function dosomething_helpers_node_metadata_wrapper($node, $ignore_language = FAL
  *   ISO-code of current language
  */
 function dosomething_helpers_get_current_language_code() {
-  global $language;
-  return $language->language;
+  global $language_content;
+  return $language_content->language;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -576,6 +576,17 @@ function dosomething_helpers_node_metadata_wrapper($node, $ignore_language = FAL
  *   ISO-code of current language
  */
 function dosomething_helpers_get_current_language_code() {
+  global $language;
+  return $language->language;
+}
+
+/**
+ * Returns current language_content code.
+ *
+ * @return string
+ *   ISO-code of current language
+ */
+function dosomething_helpers_get_current_language_content_code() {
   global $language_content;
   return $language_content->language;
 }

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
@@ -155,7 +155,7 @@ function dosomething_static_content_preprocess_galleries(&$vars) {
  * Implements hook_field_collection_is_empty_alter().
  *
  * @todo get language specific value when video field is translatable
- * @see  dosomething_helpers_get_current_language_code()
+ * @see  dosomething_helpers_get_current_language_content_code()
  */
 function dosomething_static_content_field_collection_is_empty_alter(&$is_empty, $item) {
   // If this is the field_video field_collection:

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -138,7 +138,7 @@ function paraneue_dosomething_get_search_vars($results) {
         $image = $result_node->field_image_campaign_cover;
         // Make it available as a variable, if it exists. Otherwise, leave it empty.
         if (!empty($image)) {
-          $clc = dosomething_helpers_get_current_language_code();
+          $clc = dosomething_helpers_get_current_language_content_code();
           if ($image[$clc]) {
             $value['display_image'] = dosomething_image_get_themed_image($image[$clc][0]['target_id'], 'square', '300x300');
           }
@@ -237,7 +237,7 @@ function paraneue_dosomething_get_node_gallery_item($nid, $source = NULL) {
   }
 
   $image = NULL;
-  $clc = dosomething_helpers_get_current_language_code();
+  $clc = dosomething_helpers_get_current_language_content_code();
   // If the node has a Cover Image:
   if (!empty($node->field_image_campaign_cover)) {
     // Presets for the node's Cover Image display.


### PR DESCRIPTION
#### What's this PR do?
- Turns off `User` and `Interface` content language detection methods:
  ![image](https://cloud.githubusercontent.com/assets/672669/10803904/589ead56-7dcd-11e5-8f77-1a2522d49b46.png)
- Prefers content language over site language in translatable field language detection
#### How should this be manually tested?
- Change your user's language to en-global
- Open http://dev.dosomething.org:8888/volunteer/grandparents-gone-wired
- Note that campaigns aren't there
- Switch to this branch's code
- `drush fra`
- Open http://dev.dosomething.org:8888/volunteer/grandparents-gone-wired
- Make sure the campaigns are back
- Open http://dev.dosomething.org:8888/admin/config/regional/language/configure
- Make sure **Content language detection** is the same as on the picture above
#### Any background context you want to provide?

Reasoning provided in #5647.
#### What are the relevant tickets?

Closes #5647, #5657.

---

:warning: This PR will cause merge conflict of `dosomething_global.strongarm.inc` with global branch.
:warning: Please solve it in favor of global's code.

---

cc @blisteringherb @mshmsh5000 
