### PR TITLE
Prevents POSTS from being redirected in global init

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -31,6 +31,11 @@ function dosomething_global_init() {
   $user_variables = dosomething_global_get_user_variables();
   $node_variables = dosomething_global_get_node_variables();
 
+  // Never redirect POST requests
+  if ($url_variables['request_method'] == 'post') {
+    return;
+  }
+
   // Verify we're dealing with a node edit with no translation specification in the URL
   if ($node_variables['is_node'] && $node_variables['is_node_edit'] && $node_variables['node_edit_language'] == NULL) {
     dosomething_global_redirect_node_edit($node_variables['node'], $user_variables['user_language']);
@@ -94,10 +99,8 @@ function dosomething_global_init() {
   // Handle translation redirects for authenticated users when they request
   // bare (Global English) URLs to user pages (user profile, edit, etc.).
   //
-  // Don't redirect POSTs.
-  //
   // Passing 'noredirect=1' will defeat the redirect.
-  if ($user_variables['is_user_page'] && $url_variables['request_method'] !== 'post' && !$node_variables['node_no_redirect']) {
+  if ($user_variables['is_user_page'] && !$node_variables['node_no_redirect']) {
     drupal_goto($url_variables['url_path_prefix'] . '/' . current_path());
     return;
   }


### PR DESCRIPTION
## WHAT

Adds check at top of global init() to make sure this ain't a POST request
Also removes the duplicate logic from one of the edge cases
## WHY

Cause POST requests don't need to be redirected 
## ARE YOU SURE?

YEAH! I tested a few post requests and they worked fine. 
## OK. WHAT DOES IT FIX?

NUMBA #5445 
