### PR TITLE
Adds translation status to admin menu

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.info
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.info
@@ -131,4 +131,4 @@ features[views_view][] = content_search
 features[views_view][] = user_search
 files[] = dosomething_user.test
 files[] = includes/dosomething_user_remote.inc
-mtime = 1445274121
+mtime = 1446143311

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.views_default.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.views_default.inc
@@ -492,7 +492,13 @@ function dosomething_user_views_default_views() {
     9 => 0,
     10 => 0,
   );
-  $handler->display->display_options['path'] = 'admin/content/search/translation';
+  $handler->display->display_options['path'] = 'admin/content/translation';
+  $handler->display->display_options['menu']['type'] = 'tab';
+  $handler->display->display_options['menu']['title'] = 'Translation status';
+  $handler->display->display_options['menu']['description'] = 'translation statuses ';
+  $handler->display->display_options['menu']['weight'] = '0';
+  $handler->display->display_options['menu']['context'] = 0;
+  $handler->display->display_options['menu']['context_only_inline'] = 0;
   $translatables['content_search'] = array(
     t('Master'),
     t('Translation Status'),


### PR DESCRIPTION
#### What's this PR do?
- Adds the translation status view into the tabs on /admin/content 
- **Updates the URL too /admin/content/translation**
#### How should this be manually tested?

Does /admin/content show the tab? Does it work?
#### What are the relevant tickets?

FIxes #5484 

cc: @mikefantini please take note of the new URL in the "Whats this PR do" section"
