### PR TITLE
Update the redirect logic for translated nodes.

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -78,8 +78,8 @@ function dosomething_global_init() {
     return;
   }
 
-  // If the node isn't translatable, don't do any redirection.
-  if (count($node_variables['node']->translations->data) <= 1) {
+  // If the node doesn't have translations, don't do any redirection.
+  if (empty($node_variables['node']->translations->data)) {
     return;
   }
 


### PR DESCRIPTION
Fixes #5677
This was failing because the node had one translation in the array, the source lang node.
There was no redirect logic being applied, even though it should have been.
This now only exits the code if the node has no translations.
### How to test
- find a campaign with only one translation (local example [thumb wars](http://dev.dosomething.org:8888/campaigns/thumb-wars))
- go directly with no /us in the url
- does it redirect to /us? 
### Additional context

should also not perform redirect logic on fact pages or things without translations still 
