### PR TITLE
Fact problem share bug olé

### DIFF
--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -142,7 +142,7 @@ function dosomething_fact_get_facts_data($node, $field_names) {
  * Return the entity, whether it was already loaded in the field data,
  * or if it needs to go and retrieve it.
  *
- * @param $data
+ * @param array $data Specific field item in loaded node data.
  * @param string $language
  * @return mixed
  */

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -95,7 +95,7 @@ function dosomething_fact_get_facts_data($node, $field_names) {
 
     if ($field_data) {
       if (array_key_exists($language, $field_data)) {
-        $entity = $field_data[$language][0]['entity'];
+        $entity = dosomething_fact_get_entity($field_data, $language);
       }
 
       if (isset($field_data[0]['entity']) && is_object($field_data[0]['entity'])) {
@@ -136,6 +136,23 @@ function dosomething_fact_get_facts_data($node, $field_names) {
   }
 
   return NULL;
+}
+
+/**
+ * Return the entity, whether it was already loaded in the field data,
+ * or if it needs to go and retrieve it.
+ *
+ * @param $data
+ * @param string $language
+ * @return mixed
+ */
+function dosomething_fact_get_entity($data, $language = LANGUAGE_NONE) {
+  if (isset($data[$language][0]['target_id'])) {
+    $entity = entity_load('node', [$data[$language][0]['target_id']]);
+    return $entity ? array_shift($entity) : NULL;
+  }
+
+  return $data[$language][0]['entity'];
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
@@ -80,7 +80,6 @@
             </div>
             <div class="card__copy">
               <p class="heading -alpha"><?php print $node->title; ?></p>
-
               <?php if ($node->fact_problem['fact']): ?>
                 <h3><?php print t('The Problem'); ?></h3>
                 <p><?php print $node->fact_problem['fact']; ?></p>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-permalink.tpl.php
@@ -80,6 +80,7 @@
             </div>
             <div class="card__copy">
               <p class="heading -alpha"><?php print $node->title; ?></p>
+
               <?php if ($node->fact_problem['fact']): ?>
                 <h3><?php print t('The Problem'); ?></h3>
                 <p><?php print $node->fact_problem['fact']; ?></p>


### PR DESCRIPTION
Fixes #5684
#### What's this PR do?

As it turns out not all stages in Drupal request/page data load cycle are created equal. During the loading of the node for the reportback share, when the node is loaded for the campaign, not all the nested nodes (ie: facts) are loaded as well; instead those nodes are loaded with just a target_id indicator. So sometimes we need to roll up our sleeves and load the node ourselves!
#### Where should the reviewer start?
#### How should this be manually tested?

We can test it on Thor to make sure content is showing up, and relevant based on regional prefixes (and if content is available).
#### What are the relevant tickets?
#5684

---

@angaither 

CC: @mikefantini 
