### PR TITLE
Temporary overrides content language on campaign collection pages.

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.install
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.install
@@ -21,3 +21,10 @@
      ->condition('name', 'dosomething_global', '=')
      ->execute();
  }
+
+ /**
+  * Presets variables.
+  */
+function dosomething_global_update_7002(&$sandbox) {
+  variable_set('dosomething_campaign_group_override_language', TRUE);
+}

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -588,7 +588,22 @@ function dosomething_helpers_get_current_language_code() {
  */
 function dosomething_helpers_get_current_language_content_code() {
   global $language_content;
-  return $language_content->language;
+  $result = $language_content->language;
+
+  // Temporary fix for #5692.
+  $override = variable_get('dosomething_campaign_group_override_language');
+  // Only when turned on and language is GlobalEnglish.
+  if ($override && $result === 'en-global') {
+    // And only for campaign groups.
+    if (arg(0) === 'node' && is_numeric(arg(1))) {
+      $node = node_load(arg(1));
+      if ($node && $node->type === 'campaign_group') {
+        $result = 'en';
+      }
+    }
+  }
+
+  return $result;
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?
- Temporary overrides content language on campaign collection pages.
#### How should this be manually tested?
- Open http://dev.dosomething.org:8888/volunteer/grandparents-gone-wired-0 as anonymous.
- Check out the list of campaigns  

![image](https://cloud.githubusercontent.com/assets/672669/10919063/65aaf29a-8271-11e5-917d-adab92ed03e2.png)
#### What are the relevant tickets?

Fixes #5692.
