### PR TITLE
Fixes static content images.

### DIFF
--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
@@ -140,7 +140,7 @@ function dosomething_static_content_preprocess_galleries(&$vars) {
       $gallery_item = [
         'title' => $link_field['url'] ? l(t($link_field['title']), $link_field['url'], ['target' => '_blank']) : $link_field['title'],
         'description' => $field_item['field_image_description'][0]['#markup'],
-        'image' => dosomething_image_get_themed_image($field_item['field_gallery_image']['#items'][0]['target_id'], $image_ratio, $image_style),
+        'image' => dosomething_image_get_themed_image($field_item['#entity']->field_gallery_image[LANGUAGE_NONE][0]['target_id'], $image_ratio, $image_style),
         'url' => $link_field['url'],
       ];
 


### PR DESCRIPTION
So when anonymous user accesses the US static content page it can't see the images on it. Admin can.
Hardcode debugging shows that [here](https://github.com/DoSomething/phoenix/blob/1a0e3efc77ba7c43fdebc6904ad0324593340868/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module#L143) `field_gallery_image` just doesn't exist for normal users and anonymous. Have NO IDEA why.

Luckily, the duplicate of that info was in `#entity` object. I just took it from there.

![image](https://cloud.githubusercontent.com/assets/672669/10923485/df213e8c-8289-11e5-84e9-1c5dd8eaba24.png)
## 

cc @mikefantini @sheyd @mshmsh5000 
