### PR TITLE
Temporary overrides content language on taxonomy term pages.

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -594,10 +594,19 @@ function dosomething_helpers_get_current_language_content_code() {
   $override = variable_get('dosomething_campaign_group_override_language');
   // Only when turned on and language is GlobalEnglish.
   if ($override && $result === 'en-global') {
-    // And only for campaign groups.
+    // Override campaign groups.
     if (arg(0) === 'node' && is_numeric(arg(1))) {
       $node = node_load(arg(1));
       if ($node && $node->type === 'campaign_group') {
+        $result = 'en';
+      }
+    }
+
+    // And taxonomy terms.
+    // Override campaign groups.
+    if (arg(0) === 'taxonomy' && arg(1) === 'term' && is_numeric(arg(2))) {
+      $term = taxonomy_term_load(arg(2));
+      if ($term) {
         $result = 'en';
       }
     }


### PR DESCRIPTION
#### What's this PR do?
- Temporary overrides content language on campaign collection pages.
#### How should this be manually tested?
- Open http://dev.dosomething.org:8888/volunteer/animals
- Check out the list of campaigns

![image](https://cloud.githubusercontent.com/assets/672669/10972550/71618dca-83e2-11e5-921d-ab6ada41c095.png)
#### What are the relevant tickets?
- Fixes #5710 
- Similar functionality for Campaign Collections #5697

---

CC @namimody 
