### PR TITLE
Api undefined property bug fix

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -89,9 +89,6 @@ class Reportback extends Entity {
     $reportbacks = [];
     $results = dosomething_reportback_get_reportbacks_query_result(['rbid' => $ids]);
 
-//    print_r($results);
-//    die();
-
     if (!$results) {
       throw new Exception('No reportback data found.');
     }

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -89,6 +89,9 @@ class Reportback extends Entity {
     $reportbacks = [];
     $results = dosomething_reportback_get_reportbacks_query_result(['rbid' => $ids]);
 
+//    print_r($results);
+//    die();
+
     if (!$results) {
       throw new Exception('No reportback data found.');
     }
@@ -148,10 +151,11 @@ class Reportback extends Entity {
     $this->created_at = $data->created;
     $this->updated_at = $data->updated;
     $this->quantity = (int) $data->quantity;
-    $this->why_participated = $data->why_participated;
-    $this->flagged = (bool) $data->flagged;
+    $this->why_participated = dosomething_helpers_isset($data, 'why_participated');
+    $this->flagged = (bool) dosomething_helpers_isset($data, 'flagged', FALSE);
     $this->reportback_items = dosomething_helpers_format_data($data->items);
-    $this->language = $user->language;
+    // @TODO: need to potentially remove this and include language from NS user object instead of global $user
+    $this->language = dosomething_helpers_isset($user, 'language', 'en-global');
     $this->campaign = [
       'id' => $data->nid,
       'title' => $data->title,


### PR DESCRIPTION
Fixes #5706 
Refs #5705 
#### What's this PR do?

If you are an anonymous requester retrieving data from the api, some properies such as 'flagged' and 'why_participated' are not exposed, but were not being checked properly to provide a sensible default. Using the dosomething_helpers_isset() function allows us to check the data for the property and if not set assign a default in one fell swoop!
#### Where should the reviewer start?

Just take a gander at the changes; they're pretty straightforward ;)
#### What are the relevant tickets?
#5706

---

@angaither 
