### PR TITLE
Moves user redirect above node redirect

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -78,6 +78,17 @@ function dosomething_global_init() {
     return;
   }
 
+  // Handle translation redirects for authenticated users when they request
+  // bare (Global English) URLs to user pages (user profile, edit, etc.).
+  //
+  // Don't redirect POSTs.
+  //
+  // Passing 'noredirect=1' will defeat the redirect.
+  if ($user_variables['is_user_page'] && !$user_variables['is_login_page'] && !$node_variables['node_no_redirect']) {
+    drupal_goto($url_variables['url_path_prefix'] . '/' . current_path());
+    return;
+  }
+    
   // If the node doesn't have translations, don't do any redirection.
   if (empty($node_variables['node']->translations->data)) {
     return;
@@ -96,16 +107,6 @@ function dosomething_global_init() {
     return;
   }
 
-  // Handle translation redirects for authenticated users when they request
-  // bare (Global English) URLs to user pages (user profile, edit, etc.).
-  //
-  // Don't redirect POSTs.
-  //
-  // Passing 'noredirect=1' will defeat the redirect.
-  if ($user_variables['is_user_page'] && !$user_variables['is_login_page'] && !$node_variables['node_no_redirect']) {
-    drupal_goto($url_variables['url_path_prefix'] . '/' . current_path());
-    return;
-  }
 }
 
 /**


### PR DESCRIPTION
# WHAT

Fixes the issue where user pages weren't being prefixed
# HOW

There is a node translation check occurring before the user redirect, which obviously fails because this is a user page. I just moved this before that check.
# PROOF

Does login / out still work?
Are user profiles redirected correctly?

Fixes #5683 
