### PR TITLE
Revert to using patched version of grunt-modernizr.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -36,7 +36,7 @@
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-eslint": "^16.0.0",
-    "grunt-modernizr": "~1.0.0",
+    "grunt-modernizr": "metaloha/grunt-modernizr#d6657bf302bd9288e25a513197fb0e30c64ce677",
     "grunt-postcss": "^0.2.0",
     "grunt-sass": "^0.18.0",
     "grunt-sasslint": "0.0.5",


### PR DESCRIPTION
#### Changes

Fixes #5719. Our `grunt-modernizr` dependency was updated to the latest stable release in 95cde86, but unfortunately that release still seems to have issues with custom tests and CSS prefixes, so let's hold off on using it for now. (See the linked issue for some more details.)
#### How do I manually test this?

Pull this branch on your local machine, and run `npm install && grunt build` in the theme directory. Does it explode violently and refuse to produce a `modernizr.js`?

For review: @DoSomething/front-end 
