### PR TITLE
Adds check to make sure its a translatable content type

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -38,7 +38,10 @@ function dosomething_global_init() {
 
   // Verify we're dealing with a node edit with no translation specification in the URL
   if ($node_variables['is_node'] && $node_variables['is_node_edit'] && $node_variables['node_edit_language'] == NULL) {
-    dosomething_global_redirect_node_edit($node_variables['node'], $user_variables['user_language']);
+    // Make sure this is a translatable content type
+    if ($node_variables['node']->translations->original != NULL) {
+      dosomething_global_redirect_node_edit($node_variables['node'], $user_variables['user_language']);
+    }
     return;
   }
 

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -39,7 +39,7 @@ function dosomething_global_init() {
   // Verify we're dealing with a node edit with no translation specification in the URL
   if ($node_variables['is_node'] && $node_variables['is_node_edit'] && $node_variables['node_edit_language'] == NULL) {
     // Make sure this is a translatable content type
-    if ($node_variables['node']->translations->original != NULL) {
+    if (dosomething_helpers_isset($node_variables['node']->translations, 'original')) {
       dosomething_global_redirect_node_edit($node_variables['node'], $user_variables['user_language']);
     }
     return;


### PR DESCRIPTION
#### What's this PR do?

Makes sure the node is translatable before performing a node edit redirect 
#### How should this be manually tested?

Can you correctly access a campaign group?
#### Any background context you want to provide?

This was the only reliable method I could find for determining if content is translatable or not
#### What are the relevant tickets?

Fixes #5716 
