### PR TITLE
Adds langauge to page preprocessing

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -151,12 +151,16 @@ function paraneue_dosomething_preprocess_page(&$vars) {
       'title' => drupal_get_title(),
     );
     // If there's a subtitle field on this node, send it to the header
-    if (isset($vars['node']->field_subtitle[LANGUAGE_NONE][0]['safe_value'])) {
-      $header_vars['subtitle'] = $vars['node']->field_subtitle[LANGUAGE_NONE][0]['safe_value'];
+    global $user;
+    $language = $user->language;
+    $field_data = dosomething_helpers_extract_field_data($vars['node']->field_subtitle, $language);
+    if (isset($field_data)) {
+      $header_vars['subtitle'] = $field_data;
     }
 
-    if (isset($vars['node']->field_partners[LANGUAGE_NONE])) {
-      $vars['partners'] = dosomething_taxonomy_get_partners_data($vars['node']->field_partners[LANGUAGE_NONE]);
+    $field_data = dosomething_helpers_extract_field_data($vars['node']->field_partners, $language);
+    if (isset($field_data)) {
+      $vars['partners'] = dosomething_taxonomy_get_partners_data($field_data);
       $vars['sponsor_logos'] = paraneue_dosomething_get_sponsor_logos($vars['partners']);
 
       // Output sponsor, if it exists.
@@ -722,4 +726,3 @@ function paraneue_dosomething_preprocess_fact_page(&$vars) {
     $vars['yahoo_logo']= '/' . PARANEUE_PATH .'/dist/images/yahoo_white.png';
   }
 }
-

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -152,7 +152,13 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     );
     // If there's a subtitle field on this node, send it to the header
     global $user;
-    $language = $user->language;
+    if ($user->uid) {
+      $language = $user->language;
+    }
+    else {
+      $code = dosomething_global_get_current_country_code();
+      $language = dosomething_global_convert_country_to_language($code);
+    }
     $field_data = dosomething_helpers_extract_field_data($vars['node']->field_subtitle, $language);
     if (isset($field_data)) {
       $header_vars['subtitle'] = $field_data;


### PR DESCRIPTION
#### What's this PR do?

Adds the language when extracting fields in the page preprocess. Thus fixing the subtitle not displaying.
#### How should this be manually tested?

Do subtitles display correctly?
#### Any background context you want to provide?

We switched to global and that LANGUAGE_NONE is obsolete here!
#### What are the relevant tickets?

Fixes #5666 
