### PR TITLE
Ensures that the desired language is available.

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -118,6 +118,10 @@ function dosomething_helpers_extract_field_data($field, $language = LANGUAGE_NON
     }
     // ---
 
+    if (!array_key_exists($language, $field)) {
+      return NULL;
+    }
+
     $data = $field[$language];
 
     $values = array();

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -150,8 +150,10 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     $header_vars = array(
       'title' => drupal_get_title(),
     );
+
     // If there's a subtitle field on this node, send it to the header
     global $user;
+
     if ($user->uid) {
       $language = $user->language;
     }
@@ -159,6 +161,7 @@ function paraneue_dosomething_preprocess_page(&$vars) {
       $code = dosomething_global_get_current_country_code();
       $language = dosomething_global_convert_country_to_language($code);
     }
+
     $field_data = dosomething_helpers_extract_field_data($vars['node']->field_subtitle, $language);
     if (isset($field_data)) {
       $header_vars['subtitle'] = $field_data;


### PR DESCRIPTION
Fixes #5730
Refs #5727
#### What's this PR do?

When extracting field datat if a specific language is provided, then we need to make sure that if the data is not available in the language specified, then return NULL and exit out of the function otherwise we will get PHP warnings.
#### Where should the reviewer start?

With the new conditional added to **dosomething_helpers.module**
#### Any background context you want to provide?

We were getting a bunch of PHP Warnings because a language was being passed, but the data was not available in that language and we didn't have a check for that.
#### What are the relevant tickets?
#5730

---

@deadlybutter 

cc: @angaither 
