### PR TITLE
Filing divorce papers for languages and countries.

### DIFF
--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -86,7 +86,7 @@ function dosomething_fact_get_mutiple_fact_field_vars($node, $field_names) {
 function dosomething_fact_get_facts_data($node, $field_names) {
   $facts = [];
   $sources = [];
-  $language = dosomething_global_convert_country_to_language(dosomething_global_get_current_prefix());
+  $language = dosomething_settings_format_browser_language();
 
   foreach($field_names as $field_name) {
     $entity = NULL;

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -86,7 +86,7 @@ function dosomething_fact_get_mutiple_fact_field_vars($node, $field_names) {
 function dosomething_fact_get_facts_data($node, $field_names) {
   $facts = [];
   $sources = [];
-  $language = dosomething_settings_format_browser_language();
+  $language = dosomething_global_get_user_language();
 
   foreach($field_names as $field_name) {
     $entity = NULL;

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -377,8 +377,21 @@ function dosomething_global_get_user_language($user = NULL) {
   }
 
   $browser_lang = dosomething_settings_format_browser_language();
+  // If the browser language does not directly correspond to one of ours
   if (!dosomething_global_get_prefix_for_language($browser_lang)) {
-    $browser_lang = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
+    // Check for partial match
+    $languages = language_list();
+    foreach($languages as $language => $object) {
+      if (strpos($language, $browser_lang) !== FALSE) {
+        $browser_lang = $language;
+        break;
+      }
+    }
+
+    // If we didn't find a match, default to global EN
+    if ($browser_lang == dosomething_settings_format_browser_language()) {
+      $browser_lang = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
+    }
   }
 
   if (!$user->uid) {

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -14,6 +14,8 @@ define('DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE', 'en-global');
  * Implements hook_init().
  */
 function dosomething_global_init() {
+  dosomething_settings_format_browser_language();
+
   // We don't need to redirect cli request, such as drush.
   if (drupal_is_cli()) {
     return;

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -15,6 +15,7 @@ define('DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE', 'en-global');
  */
 function dosomething_global_init() {
   dosomething_settings_format_browser_language();
+  dosomething_global_get_user_language();
 
   // We don't need to redirect cli request, such as drush.
   if (drupal_is_cli()) {
@@ -133,7 +134,7 @@ function dosomething_global_node_access($node, $op, $account) {
 
   // If on a translation page, make sure it's published before allowing access.
   if (in_array($current_prefix, dosomething_global_get_countries())) {
-    $current_lang = dosomething_global_convert_country_to_language($current_prefix);
+    $current_lang = dosomething_global_get_user_language($account);
     // Note: this cannot be strict === because it will fail, even if the value is zero.
     if ($node->translations->data[$current_lang]['status'] == 0) {
        return NODE_ACCESS_DENY;
@@ -179,7 +180,7 @@ function dosomething_global_get_url_variables() {
  */
 function dosomething_global_get_user_variables() {
   $header_country_code = dosomething_settings_get_geo_country_code();
-  $user_language = dosomething_global_convert_country_to_language($header_country_code);
+  $user_language = dosomething_settings_format_browser_language();
   $user_path_prefix = dosomething_global_get_prefix_for_language($user_language);
   $is_user_page = arg(0) == 'user';
   $is_login = $is_user_page && (arg(1) == "login");
@@ -372,6 +373,23 @@ function _dosomething_global_get_regional_roles() {
   return $roles;
 }
 
+function dosomething_global_get_user_language($user = NULL) {
+  if ($user == NULL) {
+    global $user;
+  }
+
+  if (!$user->uid) {
+    return dosomething_settings_format_browser_language();
+  }
+
+  $current_user_lang = $user->language;
+  if (!isset($current_user_lang)) {
+    return dosomething_settings_format_browser_language();
+  }
+
+  return $current_user_lang;
+}
+
 /**
  * Returns the user's language based on the role.
  *
@@ -381,7 +399,7 @@ function _dosomething_global_get_regional_roles() {
  * @return string
  *   The language key.
  */
-function dosomething_global_get_user_language($user = NULL) {
+function dosomething_global_get_user_language_for_role($user = NULL) {
   if (!isset($user)) {
     global $user;
   }
@@ -425,6 +443,7 @@ function dosomething_global_get_countries() {
 }
 
 /**
+ * DEPRECATED.
  * Gets the country from a given language.
  *
  * @param string $language
@@ -439,6 +458,7 @@ function dosomething_global_convert_language_to_country($language) {
 }
 
 /**
+ * DEPRECATED.
  * Converts the given country into its assigned language.
  *
  * @param string $country

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -178,7 +178,7 @@ function dosomething_global_get_url_variables() {
  */
 function dosomething_global_get_user_variables() {
   $header_country_code = dosomething_settings_get_geo_country_code();
-  $user_language = dosomething_settings_format_browser_language();
+  $user_language = dosomething_global_get_user_language();
   $user_path_prefix = dosomething_global_get_prefix_for_language($user_language);
   $is_user_page = arg(0) == 'user';
   $is_login = $is_user_page && (arg(1) == "login");

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -377,7 +377,7 @@ function dosomething_global_get_user_language($user = NULL) {
   }
 
   $browser_lang = dosomething_settings_format_browser_language();
-  if (dosomething_global_get_prefix_for_language($browser_lang)) {
+  if (!dosomething_global_get_prefix_for_language($browser_lang)) {
     $browser_lang = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
   }
 

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -378,13 +378,18 @@ function dosomething_global_get_user_language($user = NULL) {
     global $user;
   }
 
+  $browser_lang = dosomething_settings_format_browser_language();
+  if (dosomething_global_get_prefix_for_language($browser_lang)) {
+    $browser_lang = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
+  }
+
   if (!$user->uid) {
-    return dosomething_settings_format_browser_language();
+    return $browser_lang;
   }
 
   $current_user_lang = $user->language;
   if (!isset($current_user_lang)) {
-    return dosomething_settings_format_browser_language();
+    return $browser_lang;
   }
 
   return $current_user_lang;

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -14,8 +14,6 @@ define('DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE', 'en-global');
  * Implements hook_init().
  */
 function dosomething_global_init() {
-  dosomething_settings_format_browser_language();
-  dosomething_global_get_user_language();
 
   // We don't need to redirect cli request, such as drush.
   if (drupal_is_cli()) {

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
@@ -175,8 +175,17 @@ function dosomething_settings_get_geo_region() {
  * @return string
  */
 function dosomething_settings_get_browser_language() {
-  $name = 'HTTP_ACCEPT_LANGUAGE';
-  return dosomething_settings_get_header($name);
+  // For production env.
+  $name = 'Accept-Language';
+  $header = dosomething_settings_get_header($name);
+
+  if (!isset($header)) {
+    // For local env.
+    $name = 'HTTP_ACCEPT_LANGUAGE';
+    $header = dosomething_settings_get_header($name);
+  }
+
+  return $header;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
@@ -152,8 +152,8 @@ function dosomething_settings_get_geo_latlong() {
   $lat_name = 'HTTP_X_FASTLY_LATITUDE';
   $long_name = 'HTTP_X_FASTLY_LONGITUDE';
   return array(
-    'lat' => return dosomething_settings_get_header($lat_name),
-    'long' => return dosomething_settings_get_header($long_name),
+    'lat' => dosomething_settings_get_header($lat_name),
+    'long' => dosomething_settings_get_header($long_name),
   );
 }
 
@@ -167,11 +167,34 @@ function dosomething_settings_get_geo_region() {
   return dosomething_settings_get_header($name);
 }
 
+/**
+ * Returns raw HTTP Accept Lang header.
+ * Note: You will probably want to use the format browser language
+ * function below in order to get something useful out.
+ *
+ * @return string
+ */
 function dosomething_settings_get_browser_language() {
   $name = 'HTTP_ACCEPT_LANGUAGE';
   return dosomething_settings_get_header($name);
 }
 
+/**
+ * Formats the output of dosomething_settings_get_browser_language()
+ *
+ * @return string
+ */
+function dosomething_settings_format_browser_language() {
+  
+}
+
+/**
+ * Grabs the specified header and checks if it exists first.
+ * This prevents the debug log from being spammed with errors
+ * if the header doesn't exist.
+ *
+ * @return string or NULL
+ */
 function dosomething_settings_get_header($name) {
   if (isset($_SERVER[$name])) {
     return $_SERVER[$name];

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
@@ -185,7 +185,13 @@ function dosomething_settings_get_browser_language() {
  * @return string
  */
 function dosomething_settings_format_browser_language() {
-  
+  $raw = dosomething_settings_get_browser_language();
+  if ($raw == NULL) {
+    return DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
+  }
+  $split = explode('-', $raw);
+  $language = $split[0];
+  return $language;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
@@ -120,10 +120,7 @@ function dosomething_settings_get_sitewide_copy() {
  */
 function dosomething_settings_get_geo_country_code() {
   $name = 'HTTP_X_FASTLY_COUNTRY_CODE';
-  if (isset($_SERVER[$name])) {
-    return $_SERVER[$name];
-  }
-  return NULL;
+  return dosomething_settings_get_header($name);
 }
 
 /**
@@ -133,10 +130,7 @@ function dosomething_settings_get_geo_country_code() {
  */
 function dosomething_settings_get_geo_city() {
   $name = 'HTTP_X_FASTLY_CITY';
-  if (isset($_SERVER[$name])) {
-    return $_SERVER[$name];
-  }
-  return NULL;
+  return dosomething_settings_get_header($name);
 }
 
 /**
@@ -146,10 +140,7 @@ function dosomething_settings_get_geo_city() {
  */
 function dosomething_settings_get_geo_country_name() {
   $name = 'HTTP_X_FASTLY_COUNTRY_NAME';
-  if (isset($_SERVER[$name])) {
-    return $_SERVER[$name];
-  }
-  return NULL;
+  return dosomething_settings_get_header($name);
 }
 
 /**
@@ -160,13 +151,10 @@ function dosomething_settings_get_geo_country_name() {
 function dosomething_settings_get_geo_latlong() {
   $lat_name = 'HTTP_X_FASTLY_LATITUDE';
   $long_name = 'HTTP_X_FASTLY_LONGITUDE';
-  if (isset($lat_name) && isset($long_name)) {
-    return array(
-      'lat' => $_SERVER[$lat_name],
-      'long' => $_SERVER[$long_name],
-    );
-  }
-  return NULL;
+  return array(
+    'lat' => return dosomething_settings_get_header($lat_name),
+    'long' => return dosomething_settings_get_header($long_name),
+  );
 }
 
 /**
@@ -176,6 +164,15 @@ function dosomething_settings_get_geo_latlong() {
  */
 function dosomething_settings_get_geo_region() {
   $name = 'HTTP_X_FASTLY_REGION';
+  return dosomething_settings_get_header($name);
+}
+
+function dosomething_settings_get_browser_language() {
+  $name = 'HTTP_ACCEPT_LANGUAGE';
+  return dosomething_settings_get_header($name);
+}
+
+function dosomething_settings_get_header($name) {
   if (isset($_SERVER[$name])) {
     return $_SERVER[$name];
   }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -164,17 +164,9 @@ function paraneue_dosomething_preprocess_page(&$vars) {
       'title' => drupal_get_title(),
     );
 
+    $language = dosomething_global_get_user_language();
+
     // If there's a subtitle field on this node, send it to the header
-    global $user;
-
-    if ($user->uid) {
-      $language = $user->language;
-    }
-    else {
-      $code = dosomething_global_get_current_country_code();
-      $language = dosomething_global_convert_country_to_language($code);
-    }
-
     $field_data = dosomething_helpers_extract_field_data($vars['node']->field_subtitle, $language);
     if (isset($field_data)) {
       $header_vars['subtitle'] = $field_data;


### PR DESCRIPTION
### EXPLOSIVE CHANGES

:boom: :boom: :boom: :boom: :boom: :boom: :boom: 

This PR is removing the connection between languages and countries in the code. For further global expansion this is a must. Example:

If a Canadian user visits the site, do we serve them french or english?

Our current logic wouldn't know, and just return the first lang listed under the country. Many distinctions and assumptions are made throughout the code that one language always relates to one country (except global). For 1.0 this is ok, but going beyond that we need to update this.

To solve it, I'm relying on a header value called "Accept-Language" that's basically guaranteed to be sent by the browser. You can see the reasoning I chose to use this in the issue for this PR here (and more details on how it works) https://github.com/DoSomething/phoenix/issues/5664#issuecomment-153436293

In the event a Accept-Language header is not sent by the browser, there is a fallback. First, for authenticated users it will try your account language. If that is not set, or you're an anonymous user, it will return global english.

Here is where things get complicated, **for testing this you now need to change your browser language** in addition to using Torgaurd. Yes, this makes testing more annoying, but it's also the most accurate simulation we can make next to actually being in the country. 

After this PR is merged I'll be able to begin the large global documentation readme & diagramming that explains which functions should be used in what cases, in the event parts of this are still unclear.
### EXPLOSIVE CHANGES

:boom: :boom: :boom: :boom: :boom: :boom: :boom: 
**Do not merge yet, still testing and developing**
