### PR TITLE
Adding missing term to POT file and fixing text wrapped in t().

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -180,7 +180,7 @@ function paraneue_dosomething_file($variables) {
 
   // Need to include the <input> within <label> to universalize style for file input.
   if ($element['#attributes']['is_supersized']) {
-    $message = '<div class="message-callout -below"><div class="message-callout__copy"><p>' . t('Join the cool kids!<br/> Add your photo here!') . '</p></div></div>';
+    $message = '<div class="message-callout -below"><div class="message-callout__copy"><p>' . t("Join the cool kids! \r\nAdd your photo here!") . '</p></div></div>';
     return '<label class="gigantor" id="' . $id . '">' . $message . '<input' . drupal_attributes($element['#attributes']) . ' /></label>';
   }
   else {

--- a/pots/paraneue_dosomething.pot
+++ b/pots/paraneue_dosomething.pot
@@ -1151,3 +1151,7 @@ msgstr ""
 msgid "Frequently Asked Questions"
 msgstr ""
 
+#: includes/form.inc:183
+msgid "Join the cool kids! \r\nAdd your photo here!"
+msgstr ""
+


### PR DESCRIPTION
Refs #5517
#### What's this PR do?

This PR adds a term from the campaign theme to the **paraneue_dosomething.pot** file and also updates the code with how the term is wrapped in `t()` function.
#### Where should the reviewer start?

Take a quick :eyes: 
#### How should this be manually tested?

Will be tested on Thor.
#### Any background context you want to provide?

So when importing PO files that have terms with html tags inside of them into Drupal, Drupal gets angry and doesn't accept them. So I'm trying an alternative and using the `\r\n` characters instead of explicitly using the `<br>` tag to see if this works better.
#### What are the relevant tickets?
#5517

---

@angaither 
