### PR TITLE
Adding missing terms to POT file and wrapping terms in t().

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -352,12 +352,12 @@ function paraneue_dosomething_get_themed_placeholder_reportbacks($count = 6) {
   $placeholder_urls = dosomething_campaign_get_default_gallery_image_urls();
   $placeholders = array();
   $placeholder_captions = array(
-    'DoSomething? Just did.',
-    'Doing good never looked so good.',
-    'Don’t let the smile fool you. I crushed it.',
-    'Making the world suck less, one photo at a time.',
-    'Pics or it didn’t happen? Oh, it happened.',
-    'I get action. Social action.',
+    t('DoSomething? Just did.'),
+    t('Doing good never looked so good.'),
+    t('Don’t let the smile fool you. I crushed it.'),
+    t('Making the world suck less, one photo at a time.'),
+    t('Pics or it didn’t happen? Oh, it happened.'),
+    t('I get action. Social action.'),
   );
 
   // If no placeholders added to site, let's fallback to locally stored ones.

--- a/pots/paraneue_dosomething.pot
+++ b/pots/paraneue_dosomething.pot
@@ -511,6 +511,30 @@ msgstr ""
 msgid "Stay Tuned"
 msgstr ""
 
+#: includes/helpers.inc:355
+msgid "DoSomething? Just did."
+msgstr ""
+
+#: includes/helpers.inc:356
+msgid "Doing good never looked so good."
+msgstr ""
+
+#: includes/helpers.inc:357
+msgid "Don’t let the smile fool you. I crushed it."
+msgstr ""
+
+#: includes/helpers.inc:358
+msgid "Making the world suck less, one photo at a time."
+msgstr ""
+
+#: includes/helpers.inc:359
+msgid "Pics or it didn’t happen? Oh, it happened."
+msgstr ""
+
+#: includes/helpers.inc:360
+msgid "I get action. Social action."
+msgstr ""
+
 #: includes/preprocess.inc:129
 msgid "Edit Profile"
 msgstr ""


### PR DESCRIPTION
Refs #5517
#### What's this PR do?

This PR adds a few missing terms from the campaign theme to the **paraneue_dosomething.pot** file and also ensure the associated terms are wrapped in the `t()` function where they are output.
#### Where should the reviewer start?

Take a quick :eyes: 
#### How should this be manually tested?

Will be tested on Thor.
#### What are the relevant tickets?
#5517

---

@angaither 
