### PR TITLE
Adding missing term to POT file.

### DIFF
--- a/pots/dosomething_campaign.pot
+++ b/pots/dosomething_campaign.pot
@@ -119,3 +119,7 @@ msgstr ""
 msgid "Hype"
 msgstr ""
 
+#: dosomething_campaign.module:16
+msgid "Snap a Pic"
+msgstr ""
+


### PR DESCRIPTION
Refs #5517
#### What's this PR do?

This PR adds a missing term to the **dosomething_campaign.pot** file and also ensures the associated term is wrapped in the `t()` function wherever it is output.
#### Where should the reviewer start?

Take a quick :eyes: 
#### How should this be manually tested?

Will be tested on Thor.
#### What are the relevant tickets?
#5517

---

@angaither 
