### PR TITLE
Change additional text type from text, to formatted text.

### DIFF
--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
@@ -16,10 +16,10 @@ function dosomething_static_content_preprocess_node(&$vars) {
         'subtitle',
         'intro_title',
         'additional_text_title',
-        'additional_text',
         'call_to_action',
       ],
       'text_formatted' => [
+        'additional_text',
         'intro',
       ],
       'image' => [


### PR DESCRIPTION
Since this is a long_text field type, we need to grab the value(), otherwise Array is printed.
Fixes #5302
