### PR TITLE
Removes entity usage in static content long text preprocess

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -91,7 +91,7 @@ function dosomething_global_init() {
     drupal_goto($url_variables['url_path_prefix'] . '/' . current_path());
     return;
   }
-    
+
   // If the node doesn't have translations, don't do any redirection.
   if (empty($node_variables['node']->translations->data)) {
     return;

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
@@ -50,8 +50,7 @@ function dosomething_static_content_preprocess_node(&$vars) {
             break;
 
           case 'text_formatted':
-            global $user;
-            $vars[$label] = dosomething_helpers_extract_field_data($vars['node']->{$field_name}, $user->language);
+            $vars[$label] = dosomething_helpers_extract_field_data($vars['node']->{$field_name}, $vars['node']->language);
             break;
 
           case 'image':

--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
@@ -50,7 +50,8 @@ function dosomething_static_content_preprocess_node(&$vars) {
             break;
 
           case 'text_formatted':
-            $vars[$label] = $field->value->value();
+            global $user;
+            $vars[$label] = dosomething_helpers_extract_field_data($vars['node']->{$field_name}, $user->language);
             break;
 
           case 'image':


### PR DESCRIPTION
#### what

Removes entity usage in the static content pre processing for the long text fields. 
#### why does it work?

Cause these entity wrappers are being :hankey: lately with global stuff. good ol dosomething helpers extract field data saves the day again!
#### test it?

All static content should load without error now, regardless if it has intro filled out or not 

fixes #5747 
