### PR TITLE
Fixes Array showing on static content

### DIFF
--- a/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
+++ b/lib/modules/dosomething/dosomething_static_content/dosomething_static_content.module
@@ -50,7 +50,8 @@ function dosomething_static_content_preprocess_node(&$vars) {
             break;
 
           case 'text_formatted':
-            $vars[$label] = dosomething_helpers_extract_field_data($vars['node']->{$field_name}, $vars['node']->language);
+            $field = dosomething_helpers_extract_field_data($vars['node']->{$field_name}, $vars['node']->language);
+            $vars[$label] = $field['formatted'];
             break;
 
           case 'image':


### PR DESCRIPTION
quick fix for static content, works on my local now: 

![screen shot 2015-11-12 at 4 16 09 pm](https://cloud.githubusercontent.com/assets/897368/11131459/c8b0e26c-8958-11e5-9587-e3b40788aa27.png)

Accidentally set the fields array to the variable instead of the formatted field. 
