### PR TITLE
Update grunt-sass version.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -38,7 +38,7 @@
     "grunt-eslint": "^16.0.0",
     "grunt-modernizr": "metaloha/grunt-modernizr#d6657bf302bd9288e25a513197fb0e30c64ce677",
     "grunt-postcss": "^0.2.0",
-    "grunt-sass": "^0.18.0",
+    "grunt-sass": "^1.1.0",
     "grunt-sasslint": "0.0.5",
     "grunt-webpack": "^1.0.8",
     "load-grunt-tasks": "^3.1.0",


### PR DESCRIPTION
The older version relied on node-sass 2.x, which had a [known error with compiling Libsass](http://dfurn.es/1PqJnsU). This has been tested manually and works now on Thor.

:computer: :fire: :fire_engine: 

For review: @sheyd 
