### PR TITLE
Builds a correct global url when getting campaign block vars

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -542,7 +542,12 @@ function dosomething_campaign_get_campaigns_doing($uid = NULL) {
 function dosomething_campaign_get_campaign_block_vars($nid, $image_size = '740x480', $source = NULL) {
   $node = node_load($nid);
   $clc = dosomething_helpers_get_current_language_content_code();
-  $path_alias = drupal_get_path_alias('node/' . $nid);
+
+  global $user;
+  $language = dosomething_global_get_language($user, $node);
+  // Build a global URL and remove the first slash returned
+  $path_alias = preg_replace('/\//', '', dosomething_global_url('node/' . $nid, array('language' => $language)), 1);
+
   if ($source) {
     $path_alias .= '?source=' . $source;
   }


### PR DESCRIPTION
#### What's this PR do?

Uses the global way of building node URL's when getting the campaign block vars
#### How should this be manually tested?

Doe the campaign gallery thing-er-mo-bobs work? eg: the one here: http://dev.dosomething.org:8888/us/campaigns/1269/confirmation
#### Any background context you want to provide?

The old url's being generated weren't very global friendly. These are!
#### What are the relevant tickets?

Fixes #5673 
