### PR TITLE
Api caching

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.install
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.install
@@ -5,9 +5,10 @@
  */
 
 /**
- * Implements hook_schema().
+ * Create a new database table "cache_dosomething_api" for API request caching.
  */
-function dosomething_api_schema() {
+function dosomething_api_update_7001() {
   $schema['cache_dosomething_api'] = drupal_get_schema_unprocessed('system', 'cache');
-  return $schema;
+  db_create_table('cache_dosomething_api', $schema['cache_dosomething_api']);
 }
+

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.install
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.install
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @file
+ * Installation and schema hooks for dosomething_api.module
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function dosomething_api_schema() {
+  $schema['cache_dosomething_api'] = drupal_get_schema_unprocessed('system', 'cache');
+  return $schema;
+}

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.install
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.install
@@ -6,9 +6,22 @@
 
 /**
  * Create a new database table "cache_dosomething_api" for API request caching.
+ * Implements hook_schema().
+ */
+function dosomething_api_schema() {
+  $schema['cache_dosomething_api'] = drupal_get_schema_unprocessed('system', 'cache');
+  return $schema;
+}
+
+
+/**
+ * Redundancy if module is already enabled and dosomething_api_schema won't run.
+ * Create a new database table "cache_dosomething_api" for API request caching.
  */
 function dosomething_api_update_7001() {
-  $schema['cache_dosomething_api'] = drupal_get_schema_unprocessed('system', 'cache');
-  db_create_table('cache_dosomething_api', $schema['cache_dosomething_api']);
+  if (!db_table_exists('cache_dosomething_api')) {
+    $schema['cache_dosomething_api'] = drupal_get_schema_unprocessed('system', 'cache');
+    db_create_table('cache_dosomething_api', $schema['cache_dosomething_api']);
+  }
 }
 

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -6,6 +6,7 @@
 
 include_once 'dosomething_api.features.inc';
 include_once 'includes/Transformer.php';
+include_once 'includes/ApiCache.php';
 include_once 'resources/campaign_resource.inc';
 include_once 'resources/member_resource.inc';
 include_once 'resources/reportback_resource.inc';

--- a/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
+++ b/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
@@ -2,18 +2,33 @@
 
 class ApiCache {
 
+  /**
+   * @param string  $endpoint
+   * @param array   $parameters
+   * @return mixed
+   */
   public function get($endpoint, $parameters) {
     $id = $this->generate_id($endpoint, $parameters);
 
-    return cache_get($id, 'cache_dosomething_api');
+    $cache = cache_get($id, 'cache_dosomething_api');
+
+    if ($cache && $cache->expire < REQUEST_TIME) {
+      cache_clear_all($id, 'cache_dosomething_api');
+
+      return FALSE;
+    }
+
+    return $cache;
   }
 
 
   /**
-   * @param  $endpoint
-   * @param  $parameters
-   * @param  $data
+   * @param  string  $endpoint
+   * @param  array   $parameters
+   * @param  mixed   $data
    * @return bool
+   *
+   * @todo: not ideal that Drupal doesn't return anything concrete from the cache_set() function.
    */
   public function set($endpoint, $parameters, $data) {
     $id = $this->generate_id($endpoint, $parameters);

--- a/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
+++ b/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
@@ -2,6 +2,8 @@
 
 class ApiCache {
 
+  public $hours_cached = 24;
+
   /**
    * Clear a specified item from cache.
    *
@@ -69,7 +71,7 @@ class ApiCache {
       return FALSE;
     }
 
-    cache_set($id, $data, 'cache_dosomething_api', REQUEST_TIME + (60 * 60 * 24));
+    cache_set($id, $data, 'cache_dosomething_api', REQUEST_TIME + (60 * 60 * $this->hours_cached));
 
     return TRUE;
   }

--- a/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
+++ b/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
@@ -3,6 +3,8 @@
 class ApiCache {
 
   /**
+   * Get data from cache based on id from endpoint and URL parameters.
+   *
    * @param  string  $endpoint  Type of resource based on endpoint.
    * @param  array   $parameters  The URL parameters passed that define the request.
    * @return mixed
@@ -23,23 +25,25 @@ class ApiCache {
 
 
   /**
+   * Set data in cache with id based on endpoint and URL parameters.
+   *
    * @param  string  $endpoint
    * @param  array   $parameters
    * @param  mixed   $data
    * @return bool
-   *
-   * @todo: not ideal that Drupal doesn't return anything concrete from the cache_set() function.
    */
   public function set($endpoint, $parameters, $data) {
     $id = $this->generate_id($endpoint, $parameters);
 
-    cache_set($id, $data, 'cache_dosomething_api', REQUEST_TIME + 60);
+    cache_set($id, $data, 'cache_dosomething_api', REQUEST_TIME + (60 * 60 * 6));
 
     return TRUE;
   }
 
 
   /**
+   * Generate an id from resource endpoint type and URL parameters.
+   *
    * @param  string  $endpoint
    * @param  array   $parameters
    * @return string
@@ -50,6 +54,8 @@ class ApiCache {
 
 
   /**
+   * Create a concatenated string from URL parameters.
+   *
    * @param  array  $parameters
    * @return string
    * @todo: may want to allow passing nested array instead of one-dimensional array.

--- a/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
+++ b/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
@@ -3,8 +3,8 @@
 class ApiCache {
 
   /**
-   * @param string  $endpoint
-   * @param array   $parameters
+   * @param  string  $endpoint  Type of resource based on endpoint.
+   * @param  array   $parameters  The URL parameters passed that define the request.
    * @return mixed
    */
   public function get($endpoint, $parameters) {

--- a/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
+++ b/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
@@ -35,7 +35,7 @@ class ApiCache {
   public function set($endpoint, $parameters, $data) {
     $id = $this->generate_id($endpoint, $parameters);
 
-    cache_set($id, $data, 'cache_dosomething_api', REQUEST_TIME + (60 * 60 * 6));
+    cache_set($id, $data, 'cache_dosomething_api', REQUEST_TIME + (60 * 60 * 1));
 
     return TRUE;
   }
@@ -71,3 +71,4 @@ class ApiCache {
     return $string;
   }
 }
+

--- a/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
+++ b/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
@@ -5,14 +5,22 @@ class ApiCache {
   public function get($endpoint, $parameters) {
     $id = $this->generate_id($endpoint, $parameters);
 
-    return cache_get($id, 'dosomething_api_cache');
+    return cache_get($id, 'cache_dosomething_api');
   }
 
 
+  /**
+   * @param  $endpoint
+   * @param  $parameters
+   * @param  $data
+   * @return bool
+   */
   public function set($endpoint, $parameters, $data) {
     $id = $this->generate_id($endpoint, $parameters);
 
-    return cache_set($id, $data, 'dosomething_api_cache', REQUEST_TIME + 60);
+    cache_set($id, $data, 'cache_dosomething_api', REQUEST_TIME + 60);
+
+    return TRUE;
   }
 
 

--- a/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
+++ b/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
@@ -1,0 +1,44 @@
+<?php
+
+class ApiCache {
+
+  public function get($endpoint, $parameters) {
+    $id = $this->generate_id($endpoint, $parameters);
+
+    return cache_get($id, 'dosomething_api_cache');
+  }
+
+
+  public function set($endpoint, $parameters, $data) {
+    $id = $this->generate_id($endpoint, $parameters);
+
+    return cache_set($id, $data, 'dosomething_api_cache', REQUEST_TIME + 60);
+  }
+
+
+  /**
+   * @param  string  $endpoint
+   * @param  array   $parameters
+   * @return string
+   */
+  private function generate_id($endpoint, $parameters) {
+    return $endpoint . '_api_request' . $this->stringify($parameters);
+  }
+
+
+  /**
+   * @param  array  $parameters
+   * @return string
+   * @todo: may want to allow passing nested array instead of one-dimensional array.
+   */
+  private function stringify($parameters) {
+    $string = '';
+    $items = array_filter($parameters);
+
+    foreach ($items as $key => $value) {
+      $string .= '|' . $key . '=' . $value;
+    }
+
+    return $string;
+  }
+}

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -12,7 +12,7 @@ abstract class Transformer {
    * Format a string of comma separated data items into an array, or
    * if a single item, return it without formatting.
    *
-   * @param string $data Single or multiple comma separated data items.
+   * @param  string  $data Single or multiple comma separated data items.
    * @return string|array
    */
   protected function formatData($data) {
@@ -29,14 +29,14 @@ abstract class Transformer {
   /**
    * Get the URI for the next page in the collection of data.
    *
-   * @param array $data
+   * @param  array $data
    *   An associative array of pagination parameters:
    *   - total: (int) Complete total number of available data items found.
    *   - per_page: (int) Total number of data items to show per page.
    *   - current_page: (int) Current page number.
    *   - total_pages: (int) Total number of pages available.
-   * @param array $parameters
-   * @param string $endpoint Endpoint for building URI.
+   * @param  array $parameters
+   * @param  string $endpoint Endpoint for building URI.
    * @return null|string
    */
   protected function getNextPageUri($data, $parameters, $endpoint) {
@@ -56,14 +56,14 @@ abstract class Transformer {
   /**
    * Get the URI for the previous page in the collection of data.
    *
-   * @param array $data
+   * @param  array $data
    *   An associative array of pagination parameters:
    *   - total: (int) Complete total number of available data items found.
    *   - per_page: (int) Total number of data items to show per page.
    *   - current_page: (int) Current page number.
    *   - total_pages: (int) Total number of pages available.
-   * @param array $parameters An associative array of current location parameters.
-   * @param string $endpoint Endpoint for building URI.
+   * @param  array $parameters An associative array of current location parameters.
+   * @param  string $endpoint Endpoint for building URI.
    * @return null|string
    */
   protected function getPrevPageUri($data, $parameters, $endpoint) {
@@ -83,7 +83,7 @@ abstract class Transformer {
   /**
    * Extract the path parameters passed and recreate the query string.
    *
-   * @param array $parameters
+   * @param  array $parameters
    *   An associative array of query parameters and values for building URI:
    *   - nid: (array) Campaign ids.
    *   - status: (array) Reportback statuses to retrieve.
@@ -91,7 +91,7 @@ abstract class Transformer {
    *   - page: (int) Current page number.
    *   - offset: (int) Number of items displayed from prior pages.
    *   - random: (boolean) Whether to retrieve a random assortment of data items.
-   * @param string $endpoint Endpoint for building URI.
+   * @param  string $endpoint Endpoint for building URI.
    * @return string
    */
   protected function getPathParameters($parameters, $endpoint) {

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -13,7 +13,7 @@ abstract class Transformer {
    * if a single item, return it without formatting.
    *
    * @param  string  $data Single or multiple comma separated data items.
-   * @return string|array
+   * @return mixed
    */
   protected function formatData($data) {
     $array = explode(',', $data);
@@ -29,15 +29,15 @@ abstract class Transformer {
   /**
    * Get the URI for the next page in the collection of data.
    *
-   * @param  array $data
+   * @param  array   $data
    *   An associative array of pagination parameters:
    *   - total: (int) Complete total number of available data items found.
    *   - per_page: (int) Total number of data items to show per page.
    *   - current_page: (int) Current page number.
    *   - total_pages: (int) Total number of pages available.
-   * @param  array $parameters
-   * @param  string $endpoint Endpoint for building URI.
-   * @return null|string
+   * @param  array   $parameters
+   * @param  string  $endpoint Endpoint for building URI.
+   * @return mixed
    */
   protected function getNextPageUri($data, $parameters, $endpoint) {
     $uri = $this->getPathParameters($parameters, $endpoint);
@@ -56,15 +56,15 @@ abstract class Transformer {
   /**
    * Get the URI for the previous page in the collection of data.
    *
-   * @param  array $data
+   * @param  array   $data
    *   An associative array of pagination parameters:
    *   - total: (int) Complete total number of available data items found.
    *   - per_page: (int) Total number of data items to show per page.
    *   - current_page: (int) Current page number.
    *   - total_pages: (int) Total number of pages available.
-   * @param  array $parameters An associative array of current location parameters.
-   * @param  string $endpoint Endpoint for building URI.
-   * @return null|string
+   * @param  array   $parameters An associative array of current location parameters.
+   * @param  string  $endpoint Endpoint for building URI.
+   * @return mixed
    */
   protected function getPrevPageUri($data, $parameters, $endpoint) {
     $uri = $this->getPathParameters($parameters, $endpoint);
@@ -83,7 +83,7 @@ abstract class Transformer {
   /**
    * Extract the path parameters passed and recreate the query string.
    *
-   * @param  array $parameters
+   * @param  array   $parameters
    *   An associative array of query parameters and values for building URI:
    *   - nid: (array) Campaign ids.
    *   - status: (array) Reportback statuses to retrieve.
@@ -91,7 +91,7 @@ abstract class Transformer {
    *   - page: (int) Current page number.
    *   - offset: (int) Number of items displayed from prior pages.
    *   - random: (boolean) Whether to retrieve a random assortment of data items.
-   * @param  string $endpoint Endpoint for building URI.
+   * @param  string  $endpoint Endpoint for building URI.
    * @return string
    */
   protected function getPathParameters($parameters, $endpoint) {
@@ -117,9 +117,9 @@ abstract class Transformer {
   /**
    * Retrieve Reportback Items by the specified id(s).
    *
-   * @param string $ids Comma separated list of Reportback Item ids.
+   * @param  string  $ids Comma separated list of Reportback Item ids.
    * @return array
-   * * @deprecated since version... because I said so!
+   * @deprecated since version... because I said so!
    * @TODO: Remove.
    */
   protected function getReportbackItems($ids) {
@@ -137,8 +137,8 @@ abstract class Transformer {
   /**
    * Get metadata for pagination of response data.
    *
-   * @param int $total Complete total number of items found.
-   * @param array $parameters
+   * @param  int     $total Complete total number of items found.
+   * @param  array   $parameters
    *   An associative array of query parameters and values:
    *   - nid: (array) Campaign ids.
    *   - status: (array) Reportback statuses to retrieve.
@@ -146,7 +146,7 @@ abstract class Transformer {
    *   - page: (int) Current page number.
    *   - offset: (int) Number of items displayed from prior pages.
    *   - random: (boolean) Whether to retrieve a random assortment of data items.
-   * @param string $endpoint
+   * @param  string  $endpoint
    * @return array
    */
   protected function paginate($total, $parameters, $endpoint) {
@@ -170,8 +170,8 @@ abstract class Transformer {
   /**
    * Get the offset for requests based on specified page number and count of items.
    *
-   * @param int $page Current page number.
-   * @param int $count Number of items per page.
+   * @param  int  $page Current page number.
+   * @param  int  $count Number of items per page.
    * @return int
    */
   protected function setOffset($page, $count) {
@@ -186,7 +186,7 @@ abstract class Transformer {
   /**
    * Transform data and prepare for API response.
    *
-   * @param object $object Single object of retrieved data.
+   * @param object  $object Single object of retrieved data.
    */
   abstract protected function transform($object);
 
@@ -207,7 +207,7 @@ abstract class Transformer {
   /**
    * Transform Campaign data and prepare for API response.
    *
-   * @param object $data
+   * @param  object  $data
    *   An object containing properties of Campaign data:
    *   - id: (string)
    *   - title: (string)
@@ -301,7 +301,7 @@ abstract class Transformer {
   /**
    * Transform Kudos data and prepare for API response.
    *
-   * @param object $data A Kudos object containing the following properties:
+   * @param  object  $data A Kudos object containing the following properties:
    *  - id: (string)
    *  - term: (array)
    *  - reportback_item: (array)
@@ -325,9 +325,9 @@ abstract class Transformer {
   /**
    * Transform Media data and prepare for API response.
    *
-   * @param array $data
-   * @param string|null $aspect_ratio
-   * @return array|null
+   * @param  array  $data
+   * @param  mixed  $aspect_ratio
+   * @return mixed
    */
   protected function transformMedia($data, $aspect_ratio = NULL) {
     if ($data['type'] === 'image') {
@@ -358,7 +358,7 @@ abstract class Transformer {
   /**
    * Transform Reportback data and prepare for API response.
    *
-   * @param object $data Standard object or Reportback object.
+   * @param  object  $data Standard object or Reportback object.
    *   An object containing properties of Reportback data:
    *   - id: (string) The Reportback id.
    *   - created_at: (string) Date Reportback was created.
@@ -411,7 +411,7 @@ abstract class Transformer {
   /**
    * Transform Reportback Item data and prepare for API response.
    *
-   * @param object $data
+   * @param  object  $data
    *   A Reportback Item object containing following properties:
    *   - id: (string) Reportback Item id.
    *   - status: (string) Reportback Item status.
@@ -450,7 +450,7 @@ abstract class Transformer {
   /**
    * Transform user data and prepare for API response.
    *
-   * @param object $data
+   * @param  object  $data
    *   An object containing properties of User data:
    *   - uid: (int) User id.
    * @return array

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -78,6 +78,14 @@ function _campaign_resource_definition() {
             'source' => array('param' => 'page'),
             'default value' => 1,
           ],
+          [
+            'name' => 'cache',
+            'description' => 'Boolean to indicate whether to cache data.',
+            'optional' => TRUE,
+            'type' => 'boolean',
+            'source' => ['param' => 'cache'],
+            'default value' => TRUE,
+          ],
         ],
         'access callback' => '_campaign_resource_access_alt',
         'access arguments' => ['index'],
@@ -279,9 +287,10 @@ function _campaign_resource_retrieve($nid) {
  * @param  int     $count
  * @param  bool    $random
  * @param  int     $page
+ * @param  bool    $cache
  * @return object
  */
-function _campaign_resource_index($ids, $staff_pick, $mobile_app, $mobile_app_date, $term_ids, $count, $random, $page) {
+function _campaign_resource_index($ids, $staff_pick, $mobile_app, $mobile_app_date, $term_ids, $count, $random, $page, $cache) {
   $parameters = [
     'ids' => $ids,
     'staff_pick' => $staff_pick,
@@ -291,6 +300,7 @@ function _campaign_resource_index($ids, $staff_pick, $mobile_app, $mobile_app_da
     'count' => $count,
     'random' => $random,
     'page' => $page,
+    'cache' => $cache,
   ];
 
   return (new CampaignTransformer)->index($parameters);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -5,6 +5,7 @@
  */
 
 module_load_include('php', 'dosomething_api', 'includes/Transformer');
+module_load_include('php', 'dosomething_api', 'includes/ApiCache');
 
 include_once 'dosomething_campaign.features.inc';
 include_once 'dosomething_campaign.helpers.inc';

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -7,8 +7,8 @@ class CampaignTransformer extends Transformer {
    *
    * @param  array  $parameters Filter parameters to limit collection based on specific criteria.
    *  - ids (string)
-   *  - staff_pick (boolean)
-   *  - mobile_app (boolean)
+   *  - staff_pick (bool)
+   *  - mobile_app (bool)
    *  - mobile_app_date (string)
    *  - term_ids (string)
    *  - count (int)
@@ -21,47 +21,33 @@ class CampaignTransformer extends Transformer {
 
     $campaigns = $cache->get('campaigns', $parameters);
 
-    if (!$campaigns) {
-      $something = $cache->set('campaigns', $parameters, 'poopie doopie goopie');
-      print_r(gettype($something));
+    if ($campaigns) {
+      $campaigns = $campaigns->data;
     }
 
-//    $campaigns = $campaigns ? $campaigns : 'nay';
-
-    print_r($campaigns);
-//    print_r(gettype($campaigns));
-    die();
-
-
-
-
-    $filters = [
-      'nid' => $this->formatData($parameters['ids']),
-      'type' => 'campaign',
-      'staff_pick' => (bool) $parameters['staff_pick'],
-      'mobile_app' => (bool) $parameters['mobile_app'],
-      'mobile_app_date' => $parameters['mobile_app_date'],
-      'term_id' => $this->formatData($parameters['term_ids']),
-      'count' => (int) $parameters['count'] ?: 25,
-      'random' => $parameters['random'],
-      'page' => (int) $parameters['page'],
-    ];
-
-    $filters['offset'] = $this->setOffset($filters['page'], $filters['count']);
-
-
-    print_r($parameters);
-    print_r($filters);
-    die();
-
-    //cache_set($cid, $data, $bin = 'cache', $expire = CACHE_PERMANENT)
-    //cache_set('northstar_user_info_' . $id, $northstar_user_info, 'cache_northstar_user_info', REQUEST_TIME + 60*60*24);
-    // cache_get($cid, $bin = 'cache')
-    //$northstar_user_info = cache_get('northstar_user_info_' . $id, 'cache_northstar_user_info');
-
     try {
-      $campaigns = Campaign::find($filters, 'full');
+      if (!$campaigns) {
+        $filters = [
+          'nid' => $this->formatData($parameters['ids']),
+          'type' => 'campaign',
+          'staff_pick' => (bool) $parameters['staff_pick'],
+          'mobile_app' => (bool) $parameters['mobile_app'],
+          'mobile_app_date' => $parameters['mobile_app_date'],
+          'term_id' => $this->formatData($parameters['term_ids']),
+          'count' => (int) $parameters['count'] ?: 25,
+          'random' => $parameters['random'],
+          'page' => (int) $parameters['page'],
+        ];
+
+        $filters['offset'] = $this->setOffset($filters['page'], $filters['count']);
+
+        $campaigns = Campaign::find($filters, 'full');
+
+        $cache->set('campaigns', $parameters, $campaigns);
+      }
+
       $campaigns = services_resource_build_index_list($campaigns, 'campaigns', 'id');
+
       $total = dosomething_campaign_get_campaign_query_count($filters);
     }
     catch (Exception $error) {

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -21,29 +21,16 @@ class CampaignTransformer extends Transformer {
 
     $campaigns = $cache->get('campaigns', $parameters);
 
-    if ($campaigns) {
-      $campaigns = $campaigns->data;
-    }
-
     try {
       if (!$campaigns) {
-        $filters = [
-          'nid' => $this->formatData($parameters['ids']),
-          'type' => 'campaign',
-          'staff_pick' => (bool) $parameters['staff_pick'],
-          'mobile_app' => (bool) $parameters['mobile_app'],
-          'mobile_app_date' => $parameters['mobile_app_date'],
-          'term_id' => $this->formatData($parameters['term_ids']),
-          'count' => (int) $parameters['count'] ?: 25,
-          'random' => $parameters['random'],
-          'page' => (int) $parameters['page'],
-        ];
-
-        $filters['offset'] = $this->setOffset($filters['page'], $filters['count']);
+        $filters = $this->setFilters($parameters);
 
         $campaigns = Campaign::find($filters, 'full');
 
         $cache->set('campaigns', $parameters, $campaigns);
+      }
+      else {
+        $campaigns = $campaigns->data;
       }
 
       $campaigns = services_resource_build_index_list($campaigns, 'campaigns', 'id');
@@ -103,6 +90,29 @@ class CampaignTransformer extends Transformer {
     $data += $this->transformCampaign($item);
 
     return $data;
+  }
+
+
+  /**
+   * @param  array $parameters
+   * @return array
+   */
+  private function setFilters($parameters) {
+    $filters = [
+      'nid' => $this->formatData($parameters['ids']),
+      'type' => 'campaign',
+      'staff_pick' => (bool) $parameters['staff_pick'],
+      'mobile_app' => (bool) $parameters['mobile_app'],
+      'mobile_app_date' => $parameters['mobile_app_date'],
+      'term_id' => $this->formatData($parameters['term_ids']),
+      'count' => (int) $parameters['count'] ?: 25,
+      'random' => $parameters['random'],
+      'page' => (int) $parameters['page'],
+    ];
+
+    $filters['offset'] = $this->setOffset($filters['page'], $filters['count']);
+
+    return $filters;
   }
 
 }

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -5,12 +5,13 @@ class CampaignTransformer extends Transformer {
   /**
    * Display collection of the specified resource.
    *
-   * @param array $parameters Filter parameters to limit collection based on specific criteria.
-   *  - ids (string)
-   *  - staff_pick (bool)
-   *  - mobile_app (bool)
-   *  - mobile_app_date (string)
-   *  - term_ids (string)
+   * @param  array  $parameters Filter parameters to limit collection based on specific criteria.
+   *  - nid (string|array)
+   *  - type (string)
+   *  - staff_pick (boolean)
+   *  - mobile_app (boolean)
+   *  - mobile_app_date (string|array)
+   *  - term_id (string|array)
    *  - count (int)
    *  - random (bool)
    *  - page (int)
@@ -21,14 +22,15 @@ class CampaignTransformer extends Transformer {
 
     $campaigns = $cache->get('campaigns', $parameters);
 
-//    if (!$campaigns) {
-      $something = $cache->set('campaigns', $parameters, 'poopie doopie goop');
+    if (!$campaigns) {
+      $something = $cache->set('campaigns', $parameters, 'poopie doopie goopie');
       print_r(gettype($something));
-//    }
+    }
 
-    $campaigns = $campaigns ? $campaigns : 'nay';
+//    $campaigns = $campaigns ? $campaigns : 'nay';
 
     print_r($campaigns);
+//    print_r(gettype($campaigns));
     die();
 
 

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -17,6 +17,22 @@ class CampaignTransformer extends Transformer {
    * @return array
    */
   public function index($parameters) {
+    $cache = new ApiCache;
+    $campaigns = $cache->get('campaigns', $parameters);
+
+    if (!$campaigns) {
+      $something = $cache->set('campaigns', $parameters, 'poopie doopie doo');
+      print_r(gettype($something));
+    }
+
+//    $campaigns = $campaigns ? $campaigns : 'nay';
+
+    print_r($campaigns);
+    die();
+
+
+
+
     $filters = [
       'nid' => $this->formatData($parameters['ids']),
       'type' => 'campaign',
@@ -30,6 +46,16 @@ class CampaignTransformer extends Transformer {
     ];
 
     $filters['offset'] = $this->setOffset($filters['page'], $filters['count']);
+
+
+    print_r($parameters);
+    print_r($filters);
+    die();
+
+    //cache_set($cid, $data, $bin = 'cache', $expire = CACHE_PERMANENT)
+    //cache_set('northstar_user_info_' . $id, $northstar_user_info, 'cache_northstar_user_info', REQUEST_TIME + 60*60*24);
+    // cache_get($cid, $bin = 'cache')
+    //$northstar_user_info = cache_get('northstar_user_info_' . $id, 'cache_northstar_user_info');
 
     try {
       $campaigns = Campaign::find($filters, 'full');

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -18,14 +18,15 @@ class CampaignTransformer extends Transformer {
    */
   public function index($parameters) {
     $cache = new ApiCache;
+
     $campaigns = $cache->get('campaigns', $parameters);
 
-    if (!$campaigns) {
-      $something = $cache->set('campaigns', $parameters, 'poopie doopie doo');
+//    if (!$campaigns) {
+      $something = $cache->set('campaigns', $parameters, 'poopie doopie goop');
       print_r(gettype($something));
-    }
+//    }
 
-//    $campaigns = $campaigns ? $campaigns : 'nay';
+    $campaigns = $campaigns ? $campaigns : 'nay';
 
     print_r($campaigns);
     die();

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -7,13 +7,14 @@ class CampaignTransformer extends Transformer {
    *
    * @param  array  $parameters Filter parameters to limit collection based on specific criteria.
    *  - ids (string)
-   *  - staff_pick (bool)
-   *  - mobile_app (bool)
+   *  - staff_pick (string|bool)
+   *  - mobile_app (string|bool)
    *  - mobile_app_date (string)
    *  - term_ids (string)
    *  - count (int)
-   *  - random (bool)
+   *  - random (string|bool)
    *  - page (int)
+   *  - cache (string|bool)
    * @return array
    */
   public function index($parameters) {

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -6,12 +6,11 @@ class CampaignTransformer extends Transformer {
    * Display collection of the specified resource.
    *
    * @param  array  $parameters Filter parameters to limit collection based on specific criteria.
-   *  - nid (string|array)
-   *  - type (string)
+   *  - ids (string)
    *  - staff_pick (boolean)
    *  - mobile_app (boolean)
-   *  - mobile_app_date (string|array)
-   *  - term_id (string|array)
+   *  - mobile_app_date (string)
+   *  - term_ids (string)
    *  - count (int)
    *  - random (bool)
    *  - page (int)

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -72,6 +72,12 @@ function dosomething_helpers_convert_date($date, $format = 'ISO-8601') {
   }
 }
 
+/**
+ * Utility function to convert string value of true|false into actual boolean value.
+ *
+ * @param  $string
+ * @return mixed
+ */
 function dosomething_helpers_convert_string_to_boolean($string) {
   return filter_var($string, FILTER_VALIDATE_BOOLEAN);
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -72,6 +72,10 @@ function dosomething_helpers_convert_date($date, $format = 'ISO-8601') {
   }
 }
 
+function dosomething_helpers_convert_string_to_boolean($string) {
+  return filter_var($string, FILTER_VALIDATE_BOOLEAN);
+}
+
 /**
  * Utility function to delete automated test data.
  */


### PR DESCRIPTION
Fixes #5763
#### What's this PR do?

This PR creates a new API caching class, `ApiCache` within the **dosomething_api** module that we can use to cache any of the API requests to Phoenix. It creates a unique id for requests based on the set of URL parameters (if any) passed along with the endpoint request and caches it for 24 hours.

There is also a new parameter added that can be included in the request URL (`/campaigns.json?cache=false`) which indicates that the request should not be cached, and if it was already cached in a prior request, to go ahead and clear the cache. This will help with development purposes.
#### Where should the reviewer start?

Start at the **campaign_resource.inc** file and follow the breadcrumbs from there!
#### How should this be manually tested?

If you feel the desire to pull down a copy of this branch, run `drush updb` to get the new `cache_dosomething_api` table set up and then run a couple API queries on the `/campaigns.json` endpoint and confirm it gets cached in the database.
#### Any background context you want to provide?

Currently this caching only works for the `/campaigns` index collection endpoint, but can be expanded to the rest.

One thing I noticed was that the string booleans passed in the URL parameters are not getting properly casted to actual booleans in the resource transformers, because it casts a string... so there's a new helper function `dosomething_helpers_convert_string_to_boolean()` created to help properly change these string booleans to actual booleans. It will be applied to other URL param items in upcoming PR.
#### Benchmarks

These benchmarks are from caching to the database; expect it to be even faster when caching to Redis. Including for future reference:

```
Request to /campaigns.json?ids=1663
- Before caching: 0.026s
- After caching:  0.002s

Request to /campaigns.json
- Before caching: 0.362s
- After caching:  0.006s
```
#### What are the relevant tickets?
#5763

---

@uy @angaither 

cc: @DFurnes 
