### PR TITLE
Enables X-Frame-Options header.

### DIFF
--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.info
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.info
@@ -23,4 +23,4 @@ features[variable][] = pathauto_file_pattern
 features[variable][] = pathauto_node_pattern
 features[variable][] = seckit_clickjacking
 features[variable][] = seckit_xss
-mtime = 1447437469
+mtime = 1447688428

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.strongarm.inc
@@ -36,8 +36,8 @@ function dosomething_settings_strongarm() {
   $strongarm->api_version = 1;
   $strongarm->name = 'seckit_clickjacking';
   $strongarm->value = array(
-    'x_frame' => '0',
-    'x_frame_allow_from' => '',
+    'x_frame' => '3',
+    'x_frame_allow_from' => 'http://optimizely.com',
     'js_css_noscript' => 0,
     'noscript_message' => 'Sorry, you need to enable JavaScript to visit this website.',
   );


### PR DESCRIPTION
We turned clickjacking protection because we thought it doesn't work, but it turned out that it's only Chrome and Safari that doesn't support `Allow-from` value of this header:
![image](https://cloud.githubusercontent.com/assets/672669/11186435/5bc4ef10-8c8a-11e5-872b-c13069d44a6b.png)
See https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options

Related #5392, #5742.
