### PR TITLE
Preventing unpublished nodes being indexed in solr

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -26,6 +26,7 @@ projects[apachesolr_confgen][subdir] = "contrib"
 ; Apachesolr Multilingual
 projects[apachesolr_multilingual][version] = "1.3"
 projects[apachesolr_multilingual][subdir] = "contrib"
+projects[apachesolr_multilingual][patch][] = https://www.drupal.org/files/issues/apachesolr_multilingual-unpub-translations-2616388-1.patch
 
 ; Apachesolr Views
 projects[apachesolr_views][version] = "1.0-beta2"


### PR DESCRIPTION
#### What does this PR do?
- Fetches a patch submitted to D.O. to prevent the apachesolr_multilingual module from indexing unpublished translations.
#### Any background context you want to provide?

Preventing unpublished translations from being indexed should fix several problems. There isn't currently a mechanism to filter out unpublished translations from Solr results in the Finder or in search, so this is the best option to ensure that all code that relies on Solr functions properly.
#### How should this be tested?

Rebuild phoenix, then delete and reindex Solr to make sure no unpublished translations show up in the index.
#### What are the relevant tickets?

Fixes #5570
