### PR TITLE
Trim RB quantity before validating

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -211,7 +211,7 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
       'data-validate' => 'positiveInteger',
       'data-validate-required' => '',
     ),
-    '#element_validate' => array('element_validate_integer_positive'),
+    '#element_validate' => array('dosomething_reportback_validate_quantity'),
     '#title' => t("Total # of @noun @verb", array(
         '@noun' => $entity->noun,
         '@verb' => $entity->verb,
@@ -273,6 +273,20 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
   );
 
   return $form;
+}
+
+/**
+ * Custom validation function for the quantity field so we can trim
+ * values of whitespace before validation is run.
+ */
+function dosomething_reportback_validate_quantity($element, &$form_state) {
+  // Remove whitespace.
+  $value = trim($element['#value']);
+
+  // Implementation of element_validate_integer_positive.
+  if ($value !== '' && (!is_numeric($value) || intval($value) != $value || $value <= 0)) {
+    form_error($element, t('%name must be a positive integer.', array('%name' => $element['#title'])));
+  }
 }
 
 /**


### PR DESCRIPTION
### What's this PR do?

Adds a custom validation function for the quantity field that trims the value of whitespace before validating. 
#### Any background context you want to provide?

Not related, but worth it. 
![97a75bf3b2a](https://cloud.githubusercontent.com/assets/1700409/11222865/e2d46ade-8d3a-11e5-87f5-1c6a0a821cb9.gif)
#### What are the relevant tickets?

An oldie, but goodie: Fixes #2181 
