### PR TITLE
Add drush disable command to ds pull stage

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -485,6 +485,9 @@ function pull_db {
       echo "Reindexing Solr..."
       drush solr-mark-all && drush solr-index
 
+      echo "Disabling Optimizely module on staging."
+      drush dis optimizely
+
     else
       echo "Pulling down the db from ${alias[1]} staging"
       drush -y sql-sync @ds.${alias[1]}.staging @ds.${alias[1]}.dev

--- a/bin/ds
+++ b/bin/ds
@@ -470,6 +470,9 @@ function pull_db {
       echo "Reverting features..."
       drush -y fra
 
+      echo "Disabling Optimizely module on staging."
+      drush dis optimizely
+
       echo "Clearing cache..."
       drush cc all
 
@@ -484,9 +487,6 @@ function pull_db {
 
       echo "Reindexing Solr..."
       drush solr-mark-all && drush solr-index
-
-      echo "Disabling Optimizely module on staging."
-      drush dis optimizely
 
     else
       echo "Pulling down the db from ${alias[1]} staging"


### PR DESCRIPTION
Fixes #1507 

The Optimizely module needs to be disabled in staging builds to prevent it from running Javascript based tests. 
- `ds pull stage` triggers `pull_db if [[ ${alias[0]} == "stage" ]`

Using `drush`, disable the Optimizely module.
