### PR TITLE
Upgrade Optimizely module to 2.18

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -154,7 +154,7 @@ projects[oauth][subdir] = "contrib"
 projects[oauth][patch][] = "https://www.drupal.org/files/issues/oauth-OAuth-PHP-library-Authorization-Header-parameters-separator-2328685-1.patch"
 
 ; Optimizely
-projects[optimizely][version] = "2.14"
+projects[optimizely][version] = "2.18"
 projects[optimizely][subdir] = "contrib"
 
 ; Pathauto


### PR DESCRIPTION
Fixes #5799 

In preparation for the Optimizely 7.x-3.x release, upgrade the Optimizely module to the latest 7.x-2.x (7.x-2.18) release. Changes from the `7.x-2.14` to `7.x-2.18` releases are:

```
- Issue #2584933: Optimizely suggests no protocol in HTML snippet by dremy
- Issue #2577193: Increase Optimizely Snippet's Load Priority by SeeWatson
- Issue #2564383: Unable to save Url with parameters by richardcanoe
- Started cleanup of code formatting as suggested by SeeWatson in issue #2581409
- Issue 2342389: Enable/disable checkbox is not working
- Issue: 2330675 - Broken links on Account Info tab
Link to Optimizely site to purchase upgrade to Optimizely was broken.
Applied patch supplied by tz_earl
- Issue: 2324367 - Remove unnecessary .DS_Store files
Applied patch supplied by tz_earl
- Issue: 2323041 - OptimizelyTestPageSnippetTestCase fails in multiple ways.
Didn't apply patch as related code was fixed / enhanced but still provided
commit credit as the solution was still helpful. Applied patch supplied by tz_earl
- Issue: 2303917 - Default project can be deleted with manual url
Added check and related "Default project can not be deleted." error message
to prevent project ID 1 from being sent to delete functionality.
- Issue: 2304545 - Path not displayed in error messages
Added htmlentities formatting to path values when displaying errors.
- Issue 2306399 - Warning: Illegal string offset '#value'
Removed ['#value'] in 'project-row-' . $element[$key]['#project_code']['#value']
and $element[$key]['#oid']['#value'].
```
