### PR TITLE
Issue5685 campaign_language and campaign_country to Message Broker transactional requeues

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -740,20 +740,11 @@ function dosomething_global_user_details($account = NULL) {
  *    Details about the user account:
  *      - language
  *      - country_code
- *      - title
  */
 function dosomething_global_campaign_details($node) {
 
   $language = $node->language;
   $country_code = dosomething_global_convert_language_to_country($language);
 
-  // Get node title, normal for collections, translatable for campaigns.
-  $wrapper = entity_metadata_wrapper('node', $node);
-  if (isset($node->title_field)) {
-    $title = $wrapper->language($language)->title_field->value();
-  } else {
-    $title = $node->title;
-  }
-
-  return array($language, $country_code, $title);
+  return array($language, $country_code);
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -730,21 +730,3 @@ function dosomething_global_user_details($account = NULL) {
 
   return array($language, $country_code);
 }
-
-/**
- *  Lookup global related details about a campaign:
- *  - language
- *  - country_code
- *
- *  @return array
- *    Details about the user account:
- *      - language
- *      - country_code
- */
-function dosomething_global_campaign_details($node) {
-
-  $language = $node->language;
-  $country_code = dosomething_global_convert_language_to_country($language);
-
-  return array($language, $country_code);
-}

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -730,3 +730,30 @@ function dosomething_global_user_details($account = NULL) {
 
   return array($language, $country_code);
 }
+
+/**
+ *  Lookup global related details about a campaign:
+ *  - language
+ *  - country_code
+ *
+ *  @return array
+ *    Details about the user account:
+ *      - language
+ *      - country_code
+ *      - title
+ */
+function dosomething_global_campaign_details($node) {
+
+  $language = $node->language;
+  $country_code = dosomething_global_convert_language_to_country($language);
+
+  // Get node title, normal for collections, translatable for campaigns.
+  $wrapper = entity_metadata_wrapper('node', $node);
+  if (isset($node->title_field)) {
+    $title = $wrapper->language($language)->title_field->value();
+  } else {
+    $title = $node->title;
+  }
+
+  return array($language, $country_code, $title);
+}

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -113,12 +113,24 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
   if (isset($params['user_language'])) {
     $payload['user_language'] = $params['user_language'];
   }
+  if (isset($params['campaign_language'])) {
+    $payload['campaign_language'] = $params['campaign_language'];
+  }
+  if (isset($params['campaign_country'])) {
+    $payload['campaign_country'] = $params['campaign_country'];
+  }
 
-  // If email template wasn't set before, get standart template name.
+  // If email template wasn't set use request details to define template name.
   if (!empty($params['email_template'])) {
     $payload['email_template'] = $params['email_template'];
   } else {
-    $payload['email_template'] = dosomething_mbp_get_template_name($origin, $params['user_language']);
+    if (isset($params['campaign_language'])) {
+      $template_language = $params['campaign_language'];
+    }
+    elseif (isset($params['user_language'])) {
+      $template_language = $params['user_language'];
+    }
+    $payload['email_template'] = dosomething_mbp_get_template_name($origin, $template_language);
   }
 
   // Payload specific to each transaction type.
@@ -204,6 +216,7 @@ function dosomething_mbp_get_common_campaign_payload(&$payload, $params) {
 
   if (isset($params['campaign_language'])) {
     $payload['campaign_language'] = $params['campaign_language'];
+    $payload['campaign_country'] = $params['campaign_country'];
   }
 
   $payload['email_tags'][] = $params['event_id'];
@@ -235,18 +248,18 @@ function dosomething_mbp_get_common_campaign_payload(&$payload, $params) {
  *
  * @param string $event_name
  *   Example: "campaign_signup", "password_reset", etc
- * @param string $user_language
- *   The user language setting as defined by dosomething_settings_get_geo_country_code() and
- *   dosomething_global_convert_country_to_language().
+ * @param string $language
+ *   The language setting that the message template should use.
  *
  * @return string
  *   Name of Mandrill template to use for transactional message.
  */
-function dosomething_mbp_get_template_name($event_name, $user_language = NULL) {
-  if (isset($user_langauge)) {
-    $country_code = dosomething_global_convert_language_to_country($user_language);
+function dosomething_mbp_get_template_name($event_name, $language = NULL) {
+
+  if (isset($language)) {
+    $country_code = dosomething_global_convert_language_to_country($language);
     if ($country_code == NULL) {
-      $country_code = 'US';
+      $country_code = 'GL';
     }
   }
   else {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -557,10 +557,11 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
   if (!($node->type == 'campaign' || $node->type == 'campaign_group')) {
     return FALSE;
   }
-  $wrapper = entity_metadata_wrapper('node', $node);
-  $user_language = dosomething_global_get_user_language();
-  // Note use of $respect_url = TRUE to use language of campaign signup
-  $campaign_language = dosomething_global_get_language($account, $node, TRUE);
+  if (module_exists('dosomething_global')) {
+    list($user_language, $user_country) = dosomething_global_user_details($account);
+    list($campaign_language, $campaign_country_code, $campaign_title) = dosomething_global_campaign_details($node);
+  }
+
   $url_options = array(
     'language' => $campaign_language,
     'absolute' => TRUE,
@@ -568,15 +569,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
       'source' => 'node/' . $node->nid,
     ),
   );
-  $campaign_link = dosomething_global_url('node/' . $nid, $url_options);
-
-  // Get node title, normal for collections, translatable for campaigns.
-  $title = '';
-  if (isset($node->title_field)) {
-    $title = $wrapper->language($campaign_language)->title_field->value();
-  } else {
-    $title = $node->title;
-  }
+  $campaign_link = dosomething_global_url('node/' . $node->nid, $url_options);
 
   $params = array(
     'email' => $account->mail,
@@ -584,10 +577,12 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     'first_name' => dosomething_user_get_field('field_first_name', $account),
     'mobile' => dosomething_user_get_field('field_mobile', $account),
     'event_id' => $node->nid,
-    'campaign_title' => $title,
-    'campaign_link' => dosomething_global_url('node/' . $node->nid, $url_options),
+    'campaign_title' => $campaign_title,
+    'campaign_link' => $campaign_link,
     'user_language' => $user_language,
+    'user_country' => $user_country,
     'campaign_language' => $campaign_language,
+    'campaign_country' => $campaign_country_code,
   );
 
   // Don't subscribe 26+ yo users for Mobile Commons.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -614,7 +614,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
  */
 function dosomething_signup_get_mbp_params_campaign(&$params, $wrapper) {
   if ($wrapper->type->value() == 'campaign') {
-    $content = $wrapper->language($params['user_language']);
+    $content = $wrapper->language($params['campaign_language']);
     $params['call_to_action'] = $content->field_call_to_action->value();
     $params['step_one'] = $content->field_pre_step_header->value();
     $params['step_two'] = DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER;

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -559,7 +559,8 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
   }
   if (module_exists('dosomething_global')) {
     list($user_language, $user_country) = dosomething_global_user_details($account);
-    list($campaign_language, $campaign_country_code) = dosomething_global_campaign_details($node);
+    $campaign_language = dosomething_global_get_current_prefix();
+    $campaign_country_code = dosomething_global_convert_language_to_country($campaign_language);
   }
 
   $wrapper = entity_metadata_wrapper('node', $node);

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -558,9 +558,11 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     return FALSE;
   }
   $wrapper = entity_metadata_wrapper('node', $node);
-  $language = dosomething_global_get_language($account, $node);
+  $user_language = dosomething_global_get_user_language();
+  // Note use of $respect_url = TRUE to use language of campaign signup
+  $campaign_language = dosomething_global_get_language($account, $node, TRUE);
   $url_options = array(
-    'language' => $language,
+    'language' => $campaign_language,
     'absolute' => TRUE,
     'query' => array(
       'source' => 'node/' . $node->nid,
@@ -571,7 +573,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
   // Get node title, normal for collections, translatable for campaigns.
   $title = '';
   if (isset($node->title_field)) {
-    $title = $wrapper->language($language)->title_field->value();
+    $title = $wrapper->language($campaign_language)->title_field->value();
   } else {
     $title = $node->title;
   }
@@ -584,7 +586,8 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     'event_id' => $node->nid,
     'campaign_title' => $title,
     'campaign_link' => dosomething_global_url('node/' . $node->nid, $url_options),
-    'user_language' => $language,
+    'user_language' => $user_language,
+    'campaign_language' => $campaign_language,
   );
 
   // Don't subscribe 26+ yo users for Mobile Commons.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -559,9 +559,10 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
   }
   if (module_exists('dosomething_global')) {
     list($user_language, $user_country) = dosomething_global_user_details($account);
-    list($campaign_language, $campaign_country_code, $campaign_title) = dosomething_global_campaign_details($node);
+    list($campaign_language, $campaign_country_code) = dosomething_global_campaign_details($node);
   }
 
+  $wrapper = entity_metadata_wrapper('node', $node);
   $url_options = array(
     'language' => $campaign_language,
     'absolute' => TRUE,
@@ -570,6 +571,12 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     ),
   );
   $campaign_link = dosomething_global_url('node/' . $node->nid, $url_options);
+  // Get node title, normal for collections, translatable for campaigns.
+  if (isset($node->title_field)) {
+    $title = $wrapper->language($language)->title_field->value();
+  } else {
+    $title = $node->title;
+  }
 
   $params = array(
     'email' => $account->mail,
@@ -577,7 +584,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     'first_name' => dosomething_user_get_field('field_first_name', $account),
     'mobile' => dosomething_user_get_field('field_mobile', $account),
     'event_id' => $node->nid,
-    'campaign_title' => $campaign_title,
+    'campaign_title' => $title,
     'campaign_link' => $campaign_link,
     'user_language' => $user_language,
     'user_country' => $user_country,


### PR DESCRIPTION
- #5685 (Fixes Campaign signups only)

Adds `campaign_language` and `campaign_country` to $params sent to Message Broker request for campaign signups.

**Testing**: The payload produced by the `dosomething_mbp.module` before sending a message to Message Broker. Note the `CAMPAIGN_TITLE` and  `email_template` ("Please Don't Break Anything" & "mb-campaign-signup-US") are based on the `campaign _language` ("en") not the `user_language` ("en-global"):

**Example** - Global user signing up for US campaign. Expect campaign language rather than user language to define the language->country for the template name and the language of the `merge_var` content.

```
Array
(
    [activity] => campaign_signup
    [email] => dlee+update-test98@dosomething.org
    [uid] => 1705551
    [merge_vars] => Array
        (
            [MEMBER_COUNT] => 3.5 million
            [FNAME] => Test
            [CAMPAIGN_TITLE] => Please Don't Break Anything
            [CAMPAIGN_LINK] => http://dev.dosomething.org:8888/us/campaigns/global-please-dont-break-anything?source=node/1691
            [CALL_TO_ACTION] => Everything works
            [STEP_ONE] => Do Header
            [STEP_TWO] => Snap a Pic
            [STEP_THREE] => do this after
        )

    [user_country] => IS
    [user_language] => en-global
    [campaign_language] => en
    [campaign_country] => US
    [email_template] => mb-campaign-signup-US
    [subscribed] => 1
    [event_id] => 1691
    [email_tags] => Array
        (
            [0] => 1691
            [1] => drupal_campaign_signup
        )

)
```
