### PR TITLE
Updating form output for school finder modal.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -314,14 +314,6 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     '#suffix' => '</p></div>',
   );
 
-  // Container for form elements
-  $form['elements'] = array(
-    '#type' => 'container',
-    '#attributes' => array(
-      'class' => array('modal__block'),
-    ),
-  );
-
   // If we are collecting User address:
   if ($config['collect_user_address']) {
     dosomething_user_address_form_element($form['elements'], $form_state);
@@ -448,7 +440,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       ),
     ),
   );
-
+  
   return $form;
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -314,6 +314,14 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     '#suffix' => '</p></div>',
   );
 
+  // Container for form elements
+  $form['elements'] = array(
+    '#type' => 'container',
+    '#attributes' => array(
+      'class' => array('modal__block'),
+    ),
+  );
+
   // If we are collecting User address:
   if ($config['collect_user_address']) {
     dosomething_user_address_form_element($form['elements'], $form_state);
@@ -440,6 +448,12 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       ),
     ),
   );
+
+  // @todo Hacky solution to deal with form elements when no elements added and eliminate empty container added.
+  // @see https://github.com/DoSomething/phoenix/pull/5809
+  if (count($form['elements']) <= 10) {
+    unset($form['elements']);
+  }
   
   return $form;
 }


### PR DESCRIPTION
Fixes #5788
#### What's this PR do?

There was an additional form wrapper for elements that did not contian any markup or content but was still being output as an empty div with styled padding which was causing the extra spacing.
#### Where should the reviewer start?

Quick :eyes: on the one file changed.
#### Any background context you want to provide?

@DFurnes do you happen to know if something gets otherwise populated into the `elements` container in some other version of the school finder modal (if there is one) that I might not be accounting for?
#### What are the relevant tickets?
#5788

---

@DFurnes 

cc: @angaither 
