### PR TITLE
Turn of xml enpdoints in the api.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -10,4 +10,4 @@ features[ctools][] = services:services:3
 features[ctools][] = views:views_default:3.0
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
-mtime = 1444941925
+mtime = 1447955638

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -22,18 +22,18 @@ function dosomething_api_default_services_endpoint() {
   $endpoint->server_settings = array(
     'formatters' => array(
       'json' => TRUE,
-      'xml' => TRUE,
       'bencode' => FALSE,
       'jsonp' => FALSE,
       'php' => FALSE,
+      'xml' => FALSE,
       'yaml' => FALSE,
     ),
     'parsers' => array(
       'application/json' => TRUE,
       'application/x-www-form-urlencoded' => TRUE,
-      'application/xml' => TRUE,
       'application/vnd.php.serialized' => FALSE,
       'application/x-yaml' => FALSE,
+      'application/xml' => FALSE,
       'multipart/form-data' => FALSE,
       'text/xml' => FALSE,
     ),


### PR DESCRIPTION
You can't sit with us.
![](http://imagesmtv-a.akamaihd.net/uri/mgid:file:http:shared:mtv.com/news/wp-content/uploads/2015/02/5h-gretchen-wieners-1423872856.gif)
Fixes #4462
