### PR TITLE
Updating install file for dosomething_northstar module.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.install
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.install
@@ -5,10 +5,22 @@
  */
 
 /**
+ * Create a new database table "cache_dosomething_northstar" caching.
  * Implements hook_schema().
  */
-function dosomething_northstar_user_info_schema() {
-  $schema['cache_northstar_user_info'] = drupal_get_schema_unprocessed('dosomething_northstar', 'cache_northstar_user_info');
+function dosomething_northstar_schema() {
+  $schema['cache_dosomething_northstar'] = drupal_get_schema_unprocessed('system', 'cache');
   return $schema;
 }
 
+
+/**
+ * Redundancy if module is already enabled and dosomething_northstar_schema won't run.
+ * Create a new database table "cache_dosomething_northstar" for API request caching.
+ */
+function dosomething_northstar_update_7001() {
+  if (!db_table_exists('cache_dosomething_northstar')) {
+    $schema['cache_dosomething_northstar'] = drupal_get_schema_unprocessed('system', 'cache');
+    db_create_table('cache_dosomething_northstar', $schema['cache_dosomething_northstar']);
+  }
+}

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -134,7 +134,7 @@ function dosomething_northstar_update_user($form_state) {
  * @return object
  */
 function dosomething_northstar_get_northstar_user($id) {
-  $northstar_user_info = cache_get('northstar_user_info_' . $id, 'cache_northstar_user_info');
+  $northstar_user_info = cache_get('northstar_user_info_' . $id, 'cache_dosomething_northstar');
 
   if ($northstar_user_info) {
     $northstar_user_info = $northstar_user_info->data;
@@ -153,7 +153,7 @@ function dosomething_northstar_get_northstar_user($id) {
         $error = sprintf("Error fetching Northstar user data, uid=%d: '%s'", $id, $northstar_user_info->error);
         watchdog_exception('northstar', new Exception($error));
       } else {
-        cache_set('northstar_user_info_' . $id, $northstar_user_info, 'cache_northstar_user_info', REQUEST_TIME + 60*60*24);
+        cache_set('northstar_user_info_' . $id, $northstar_user_info, 'cache_dosomething_northstar', REQUEST_TIME + 60*60*24);
       }
   }
 


### PR DESCRIPTION
Refs #5778
#### What's this PR do?

This PR updates the **dosomething_northstar.install** file to modify how the function to create the caching table is created. The `drupal_get_schema_unprocessed()` function relies on being passed the name of an existing table to grab the schema from it and copy to create a new table with the same schema. The previous code referred to a table that does not exist so the function was likely silently failing.
#### Where should the reviewer start?

Just check the codez changes and make sure it looks correct :)
#### Any background context you want to provide?

While this updates and successfully creates a new `cache_dosomething_northstar` table in the database, it might not really matter since we're using Redis for our caching. However, the redis module overriding caching to put all caching in Redis seems to be broken on **local** development so it is difficult to confirm. @sena and I have chatted a bit about this and need to confirm it is still properly working on our test and prod versions and need to troubleshoot why local is broken.
#### What are the relevant tickets?
#5778 reference to caching related things

---

@angaither 
cc: @chloealee @sheyd 
