### PR TITLE
Fixes node redirect after signup

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -691,7 +691,8 @@ function dosomething_user_authentication_submit($form, &$form_state) {
   }
   elseif (isset($nid)) {
     // Redirect to campaign node on reportback permalink pages.
-    $form_state['redirect'] = drupal_get_path_alias('node/' . $nid);
+    global $user;
+    $form_state['redirect'] = dosomething_global_node_url($nid, $user->language);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -660,6 +660,8 @@ function dosomething_user_login_submit($form, &$form_state) {
  * more sensible redirects post-login.
  */
 function dosomething_user_authentication_submit($form, &$form_state) {
+  global $user;
+
   // If there's a hidden nid, sign the user up for a campaign.
   if (isset($form['nid']['#value'])) {
     $nid = $form['nid']['#value'];
@@ -675,7 +677,7 @@ function dosomething_user_authentication_submit($form, &$form_state) {
         dosomething_signup_user_presignup($nid);
       }
       else {
-        dosomething_signup_user_signup($nid, NULL, $source);
+        dosomething_signup_user_signup($nid, $user, $source);
       }
     }
   }
@@ -691,7 +693,6 @@ function dosomething_user_authentication_submit($form, &$form_state) {
   }
   elseif (isset($nid)) {
     // Redirect to campaign node on reportback permalink pages.
-    global $user;
     $form_state['redirect'] = dosomething_global_node_url($nid, $user->language);
   }
 }


### PR DESCRIPTION
#### What's this PR do?

Fixes the form['redirect'] when a user signs up / logs in on a node.
#### How should this be manually tested?

As a global user, go to campaign, sign up. Are you still on the global node or did you get redirected to /us/ ?
#### Any background context you want to provide?

Previous system for constructing the URL neglected language.
#### What are the relevant tickets?

Fixes #5792 

cc: @namimody this is that bug the GB users are experiencing 
