### PR TITLE
Adds session var to user redirect

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -93,6 +93,7 @@ function dosomething_global_init() {
   //
   // Passing 'noredirect=1' will defeat the redirect.
   if ($user_variables['is_user_page'] && !$user_variables['is_login_page'] && !$node_variables['node_no_redirect']) {
+    $_SESSION['dosomething_global_redirected'] = TRUE;
     drupal_goto($url_variables['url_path_prefix'] . '/' . current_path());
     return;
   }


### PR DESCRIPTION
Quick fix for login/logout going into a redirect loop for global users.

This is happening for the same reason campaign global nodes go into redirect loops (well used too) which is why the session fix also works for this.
