### PR TITLE
Updating pot file.

### DIFF
--- a/pots/paraneue_dosomething.pot
+++ b/pots/paraneue_dosomething.pot
@@ -615,6 +615,14 @@ msgstr ""
 msgid "Just double checking!"
 msgstr ""
 
+#: DoSomething/validation
+msgid "Did you mean"
+msgstr ""
+
+#: DoSomething/validation
+msgid "Fix it!"
+msgstr ""
+
 #: includes/auth/register.inc
 msgid "Looks good!"
 msgstr ""


### PR DESCRIPTION
Fixes #5759
#### What's this PR do?

This PR adds some additional terms missing from the POT file in the **paraneue_dosomething.pot** file. The terms are also now imported into POEditor.
#### Where should the reviewer start?

:eyes: on the updates.
#### What are the relevant tickets?
#5759

---

@angaither 
