### PR TITLE
Adds globe update functionality

### DIFF
--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.admin.inc
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.admin.inc
@@ -48,5 +48,12 @@ function dosomething_settings_admin_config_form($form, &$form_state) {
     '#default_value' => variable_get($var_name),
   );
 
+  $var_name = 'dosomething_settings_realtimefeed_update_url';
+  $form['dashboard'][$var_name] = array(
+    '#type' => 'textfield',
+    '#title' => t('Update URL for lobby dashboard'),
+    '#default_value' => variable_get($var_name),
+  );
+
   return system_settings_form($form);
 }

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
@@ -23,6 +23,25 @@ function dosomething_settings_menu() {
   return $items;
 }
 
+function dosomething_settings_init() {
+  // We don't need to redirect cli request, such as drush.
+  if (drupal_is_cli()) {
+    return;
+  }
+
+  $update_url = variable_get('dosomething_settings_realtimefeed_update_url');
+  if (!empty($update_url)) {
+    $data = ['code' => dosomething_settings_get_geo_country_code()];
+    $response = drupal_http_request($update_url, array(
+       'method' => 'POST',
+       'data' => json_encode($data),
+       'max_redirects' => 0,
+       'headers' => array('Content-Type' => 'application/json', 'Accept' => 'application/json'))
+     );
+  }
+
+}
+
 /**
  * Determines whether current site is an international affiliate.
  *

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
@@ -24,7 +24,7 @@ function dosomething_settings_menu() {
 }
 
 function dosomething_settings_init() {
-  // We don't need to redirect cli request, such as drush.
+  // We don't need to track cli request, such as drush.
   if (drupal_is_cli()) {
     return;
   }

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.module
@@ -23,25 +23,6 @@ function dosomething_settings_menu() {
   return $items;
 }
 
-function dosomething_settings_init() {
-  // We don't need to track cli request, such as drush.
-  if (drupal_is_cli()) {
-    return;
-  }
-
-  $update_url = variable_get('dosomething_settings_realtimefeed_update_url');
-  if (!empty($update_url)) {
-    $data = ['code' => dosomething_settings_get_geo_country_code()];
-    $response = drupal_http_request($update_url, array(
-       'method' => 'POST',
-       'data' => json_encode($data),
-       'max_redirects' => 0,
-       'headers' => array('Content-Type' => 'application/json', 'Accept' => 'application/json'))
-     );
-  }
-
-}
-
 /**
  * Determines whether current site is an international affiliate.
  *

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -19,6 +19,19 @@ function paraneue_dosomething_preprocess_html(&$vars) {
   $vars['is_affiliate'] = dosomething_settings_is_affiliate();
   $member_count = dosomething_user_get_member_count(TRUE);
   $vars['head_title'] = token_replace($vars['head_title'], ['member-count-readable' => $member_count]);
+
+  $update_url = variable_get('dosomething_settings_realtimefeed_update_url');
+  if (!empty($update_url)) {
+    drupal_add_js(
+      array('dosomethingSetting' =>
+        array(
+          'globeUrl' => $update_url,
+          'countryCode' => dosomething_settings_get_geo_country_code(),
+        )
+      ),
+      'setting'
+    );
+  }
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/js/app.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/app.js
@@ -45,13 +45,14 @@ $(document).ready(function() {
    * it exists on the page, and short-circuiting if not.
    */
 
+  // Ping the dashboard with my location
+  Globe.init();
+
   // Initialize analytics.
   Analytics.init();
 
   // Initialize the donation form on the donate page.
   Donate.init();
-
-  Globe.init();
 
   // Initialize the campaign finder on the homepage.
   Finder.init();

--- a/lib/themes/dosomething/paraneue_dosomething/js/app.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/app.js
@@ -28,6 +28,7 @@ import Tile from 'patterns/Tile';
 import Analytics from 'utilities/Analytics';
 import Share from 'utilities/Share';
 import ShowMore from 'utilities/ShowMore';
+import Globe from 'utilities/Globe';
 
 // Load validation rules
 import 'validators/auth';
@@ -49,6 +50,8 @@ $(document).ready(function() {
 
   // Initialize the donation form on the donate page.
   Donate.init();
+
+  Globe.init();
 
   // Initialize the campaign finder on the homepage.
   Finder.init();

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Globe.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Globe.js
@@ -1,0 +1,12 @@
+import $ from 'jquery';
+import setting from './Setting';
+
+function init() {
+  const globeUpdateUrl = setting('dosomethingSetting.globeUrl');
+  if (globeUpdateUrl !== undefined) {
+    const countryCode = setting('dosomethingSetting.countryCode');
+    $.post(globeUpdateUrl, {code: countryCode});
+  }
+}
+
+export default { init };


### PR DESCRIPTION
#### What's this PR do?

Adds some code in dosomething settings that updates the lobby dashboard everytime someone hits the site. Why? FOR UPDATING THIS NIFTY GLOBE OF COURSE!

![screen shot 2015-11-20 at 4 26 06 pm](https://cloud.githubusercontent.com/assets/897368/11312324/6c590f34-8fa3-11e5-974b-dad3293a23fd.png)

It also adds in a new config variable to the dosomething_settings admin page. If this is blank the functionality will be disabled. Otherwise it contains the URL to ping for the lobby dashboard.
#### How should this be manually tested?

Deploy this (globe) branch to Thor. Set the setting in dosomething settings to http://lobby.dosomething.org/services/drupal

Go to http://lobby.dosomething.org/module/static and watch bubbles appear!
#### Any background context you want to provide?

I think this is fabulous.

It's currently live on Thor at the time I'm writing this if you'd like to see it work. Otherwise follow the instructions above ^
