### PR TITLE
Removing old code to request reportbacks query.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1098,41 +1098,29 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
 /**
  * Returns Reportbacks query result to loop through.
  *
- * @param array $params
+ * @param  array  $params
  *   An associative array of conditions to filter by.
- *   @see dosomething_reportback_build_reportbacks_query()
- * @param int $count
- *   Number of Reportbacks to return.
- * @param int $start
- *   Which Reportbacks to start with. If present, $start and $count are used together
- *   to create a LIMIT clause for selecting Reportbacks. This could be used to do paging.
+ *  - nid (string|array)
+ *  - status (string|array)
+ *  - count (int)
+ *  - offset (int)
+ *  - random (bool)
+ *  - load_user (bool)
  * @return object
  *   An executed database query object to iterate through.
  */
-function dosomething_reportback_get_reportbacks_query_result($params = array(), $count = 25, $start = 0) {
+function dosomething_reportback_get_reportbacks_query($params) {
   $query = dosomething_reportback_build_reportbacks_query($params);
+  $offset = dosomething_helpers_isset($params['offset'], NULL, 0);
+  $count = dosomething_helpers_isset($params['count'], NULL, 25);
 
   if ($count && $count !== 'all') {
-    $query->range($start, $count);
+    $query->range($offset, $count);
   }
 
   $result = $query->execute()->fetchAll();
 
   return $result;
-}
-
-
-/**
- * Function to replace dosomething_reportback_get_reportbacks_query_result()
- * to reduce number of parameters and keep them with single $params array, but for
- * now acting as a go between.
- *
- * @param array $params
- * @return object
- * @TODO: replace dosomething_reportback_get_reportbacks_query_result()
- */
-function dosomething_reportback_get_reportbacks_query($params) {
-  return dosomething_reportback_get_reportbacks_query_result($params, $params['count']);
 }
 
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1100,6 +1100,7 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
  *
  * @param  array  $params
  *   An associative array of conditions to filter by.
+ *  - rbid (string)
  *  - nid (string|array)
  *  - status (string|array)
  *  - count (int)

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -87,7 +87,7 @@ class Reportback extends Entity {
    */
   public static function get($ids) {
     $reportbacks = [];
-    $results = dosomething_reportback_get_reportbacks_query_result(['rbid' => $ids]);
+    $results = dosomething_reportback_get_reportbacks_query(['rbid' => $ids]);
 
     if (!$results) {
       throw new Exception('No reportback data found.');


### PR DESCRIPTION
Fixes #4701
#### What's this PR do?

This updates just wraps up the removal of the reportbacks query result function that was not as useful for the API because it required passing too many parameters, and the new funciton allows passing an array of parameters.
#### Where should the reviewer start?

Just take a gander at the code and make sure it looks right.
#### How should this be manually tested?

If you so desire you can pull down the code and do a couple hits to the `/reportback.json` endpoint and make sure you're still getting data.
#### Any background context you want to provide?

This code was set up ahead of time during the development of the API to allow removal of the old function, so shouldn't cause problems with this update.
#### What are the relevant tickets?
#4701

---

@angaither 
cc: @jonuy 
