### PR TITLE
Removing old code to request reportback-items query.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -73,7 +73,6 @@ function dosomething_api_services_request_postprocess_alter($controller, $args, 
  *
  * @param array $params
  *   Parameters to pass to the Reportback Files query.
- *   @see dosomething_reportback_get_reportback_files_query_result().
  * @param int $count
  *   Number of Reportback Files to return.
  * @param int $start
@@ -96,7 +95,10 @@ function dosomething_api_get_reportback_files($params, $count = 25, $start = 0) 
   );
   $user_input = array('caption', 'why_participated');
 
-  $results = dosomething_reportback_get_reportback_files_query_result($params, $count, $start);
+  $params['offset'] = $start;
+  $params['count'] = $count;
+
+  $results = dosomething_reportback_get_reportback_items_query($params);
   $result = services_resource_build_index_list($results, 'reportback_files', 'fid');
 
   foreach ($result as &$record) {

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -115,26 +115,6 @@ abstract class Transformer {
 
 
   /**
-   * Retrieve Reportback Items by the specified id(s).
-   *
-   * @param  string  $ids Comma separated list of Reportback Item ids.
-   * @return array
-   * @deprecated since version... because I said so!
-   * @TODO: Remove.
-   */
-  protected function getReportbackItems($ids) {
-    $filters = array(
-      'fid' => $this->formatData($ids),
-    );
-
-    // Obtaining all Reportback items.
-    $query = dosomething_reportback_get_reportback_files_query_result($filters, 'all');
-
-    return services_resource_build_index_list($query, 'reportback-items', 'fid');
-  }
-
-
-  /**
    * Get metadata for pagination of response data.
    *
    * @param  int     $total Complete total number of items found.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -671,8 +671,9 @@ function dosomething_campaign_preprocess_closed_reportback_gallery(&$vars, $styl
   $params = array(
     'nid' => $vars['nid'],
     'status' => 'promoted',
+    'count' => $num_items,
   );
-  $result = dosomething_reportback_get_reportback_files_query_result($params, $num_items);
+  $result = dosomething_reportback_get_reportback_items_query($params);
 
   // Loop through gallery_vars to only output what we need for theming:
   foreach ($result as $delta => $item) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -143,12 +143,16 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
       $page_size = $limit;
     }
   }
-  // Display reportback forms in asc order.
+
   $params['order'] = 'asc';
+  $params['count'] = $page_size;
+
   // Get the DatabaseQuery to loop through.
-  $result = dosomething_reportback_get_reportback_files_query_result($params, $page_size);
+  $result = dosomething_reportback_get_reportback_items_query($params);
+
   // Get the total number of results.
   $total = dosomething_reportback_get_reportback_files_query_count($params);
+
   // If it's zero, reset the count variables.
   if (!$total) {
     $total = dosomething_reportback_get_reportback_files_query_count($params, $reset = TRUE);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1223,44 +1223,33 @@ function dosomething_reportback_get_reportback_files_query($params = array()) {
 
 
 /**
- * Returns Reportback Files query result to loop through.
+ * Returns Reportback Items query result to loop through.
  *
- * @param array $params
+ * @param  array  $params
  *   An associative array of conditions to filter by.
- *   @see dosomething_reportback_get_reportback_files_query()
- * @param int $count
- *   Number of Reportback Files to return.
- * @param int $start
- *   Which RB File to start with. If present, $start and $count are used together
- *   to create a LIMIT clause for selecting RB Files. This could be used to do paging.
- *
+ *  - fid (string)
+ *  - nid (string|array)
+ *  - status (string|array)
+ *  - count (int)
+ *  - page (int)
+ *  - offset (int)
+ *  - random (bool)
+ *  - load_user (bool)
  * @return object
- *   An executed database query object to iterate through.
+ *    An executed database query object to iterate through.
  */
-function dosomething_reportback_get_reportback_files_query_result($params = array(), $count = 25, $start = 0) {
+function dosomething_reportback_get_reportback_items_query($params) {
   $query = dosomething_reportback_get_reportback_files_query($params);
+  $offset = dosomething_helpers_isset($params['offset'], NULL, 0);
+  $count = dosomething_helpers_isset($params['count'], NULL, 25);
 
   if ($count && $count !== 'all') {
-    $query->range($start, $count);
+    $query->range($offset, $count);
   }
 
   $result = $query->execute()->fetchAll();
 
   return $result;
-}
-
-
-/**
- * Function to replace dosomething_reportback_get_reportback_files_query_result()
- * to reduce number of parameters and keep them with single $params array, but for
- * now acting as a go between.
- *
- * @param array $params
- * @return object
- * @TODO: replace dosomething_reportback_get_reportback_files_query_result()
- */
-function dosomething_reportback_get_reportback_items_query($params) {
-  return dosomething_reportback_get_reportback_files_query_result($params, $params['count'], $params['offset']);
 }
 
 
@@ -1272,9 +1261,6 @@ function dosomething_reportback_get_reportback_items_query($params) {
  * @param bool $reset
  *   If TRUE, run SQL count query.
  *   If FALSE, use the Helper count variable if exists.
- *
- * @see dosomething_reportback_get_reportback_files_query().
- *
  * @return int
  */
 function dosomething_reportback_get_reportback_files_query_count($params, $reset = FALSE) {

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -42,7 +42,7 @@ class ReportbackItem extends Entity {
   public static function get($ids) {
     $reportbackItems = [];
 
-    $results = dosomething_reportback_get_reportback_files_query_result(['fid' => $ids]);
+    $results = dosomething_reportback_get_reportback_items_query(['fid' => $ids]);
 
     if (!$results) {
       throw new Exception('No reportback items data found.');

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -324,9 +324,10 @@ function paraneue_dosomething_get_themed_reportbacks_by_status($campaign_id, $st
   $params = array();
   $params['nid'] = $campaign_id;
   $params['status'] = $status;
+  $params['count'] = $count;
   $params['random'] = $random;
 
-  $reportback_results = dosomething_reportback_get_reportback_files_query_result($params, $count);
+  $reportback_results = dosomething_reportback_get_reportback_items_query($params);
 
   $admin_access = user_access('view any reportback');
 


### PR DESCRIPTION
Fixes #4702
#### What's this PR do?

This updates just wraps up the removal of the reportback-items query result function that was not as useful for the API because it required passing too many parameters, and the new function allows passing an array of parameters.
#### Where should the reviewer start?

Just take a gander at the code and make sure it looks right.
#### How should this be manually tested?

If you so desire you can pull down the code and do a couple hits to the `/reportback-items` endpoint and make sure you're still getting data.
#### Any background context you want to provide?

This code was set up ahead of time during the development of the API to allow removal of the old function, so shouldn't cause problems with this update.
#### What are the relevant tickets?
#4702

---

@angaither 
cc: @jonuy 
