### PR TITLE
Makes sure we dont add a slash if the prefix ix blank

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -614,7 +614,7 @@ function dosomething_global_redirect_node($user_lang, $node, $redirect_status) {
     drupal_exit();
     return;
   }
-  
+
   $_SESSION['dosomething_global_redirected'] = TRUE;
   drupal_goto(dosomething_global_node_url($node->nid, $user_lang));
 }
@@ -663,11 +663,11 @@ function dosomething_global_node_url($nid, $language, $fragment = NULL) {
   if (isset($fragment)) {
     $raw_url .= '#' . $fragment;
   }
-  $alias = dosomething_global_get_prefix_for_language($language);
-  if (!empty($alias)) {
-    $alias .= '/';
+  $prefix = dosomething_global_get_prefix_for_language($language);
+  if (!empty($prefix)) {
+    $prefix .= '/';
   }
-  return $GLOBALS['base_url'] . '/' . $alias . drupal_get_path_alias($raw_url, $language);
+  return $GLOBALS['base_url'] . '/' . $prefix . drupal_get_path_alias($raw_url, $language);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -614,12 +614,9 @@ function dosomething_global_redirect_node($user_lang, $node, $redirect_status) {
     drupal_exit();
     return;
   }
+  
   $_SESSION['dosomething_global_redirected'] = TRUE;
-  // Might be overly formal: We could pull 'node/nid' from the current
-  // request. This is in case of the unlikely (impossible?) event that
-  // a translated version of this node has a different entity ID.
-  $target_path = sprintf('node/%s', $target_node['entity_id']);
-  drupal_goto(url($target_path, array('language' => $languages[$language])), array(), $redirect_status);
+  drupal_goto(dosomething_global_node_url($node->nid, $user_lang));
 }
 
 /**
@@ -666,7 +663,11 @@ function dosomething_global_node_url($nid, $language, $fragment = NULL) {
   if (isset($fragment)) {
     $raw_url .= '#' . $fragment;
   }
-  return $GLOBALS['base_url'] . '/' . dosomething_global_get_prefix_for_language($language) . '/' . drupal_get_path_alias($raw_url, $language);
+  $alias = dosomething_global_get_prefix_for_language($language);
+  if (!empty($alias)) {
+    $alias .= '/';
+  }
+  return $GLOBALS['base_url'] . '/' . $alias . drupal_get_path_alias($raw_url, $language);
 }
 
 /**


### PR DESCRIPTION
Also cleans up the node redirect logic to the same standard as everything else. I don't think we have an issue for this and it's blocking deploy. 
