### PR TITLE
Fixes infobar for global users

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -362,17 +362,17 @@ function paraneue_dosomething_add_info_bar(&$vars) {
   }
 
   if (module_exists('dosomething_global')) {
-    $country_prefix = dosomething_global_get_current_prefix();
+    $country_code = dosomething_settings_get_geo_country_code();
 
-    if ($country_prefix) {
+    if ($country_code) {
       $country_contact_emails = array(
         'br' => 'ajuda@dosomething.org',
         'mx' => 'ayuda@dosomething.org',
       );
 
       // For the countries in $country_contact_emails, use a contact email address instead of zendesk form.
-      if (array_key_exists($country_prefix, $country_contact_emails)) {
-        $info_bar_vars['contact_us_email'] = '<a href="mailto:' . $country_contact_emails[$country_prefix] .'">'. $country_contact_emails[$country_prefix] . '</a>';
+      if (array_key_exists($country_code, $country_contact_emails)) {
+        $info_bar_vars['contact_us_email'] = '<a href="mailto:' . $country_contact_emails[$country_code] .'">'. $country_contact_emails[$country_code] . '</a>';
       // All other countries get the zendesk form.
       }
       else {

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
@@ -33,4 +33,3 @@
   </div>
 </footer>
 <?php endif; ?>
-


### PR DESCRIPTION
#### What's this PR do?

Switches out prefix usage for country code in the info bar preprocess 
#### How should this be manually tested?

Do global users now have the zendesk help?
#### Any background context you want to provide?

The logic was not executing for global users because a global user has no prefix, and thats what this logic was looking for.
#### What are the relevant tickets?

Fixes #5832 
