### PR TITLE
tracking reportback errors

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -372,7 +372,9 @@ function dosomething_reportback_form_validate_file($form, &$form_state) {
 
   // If this is a new reportback form, file is mandatory.
   elseif ($form_state['values']['rbid'] == 0) {
-    ga('send', 'event', 'Reportback', 'no image uploaded');
+    $ga = new Elements_Tools_Serversideanalytics();
+    $ga->setEvent('send', 'event', 'Reportback', 'no image uploaded');
+    $ga->createEvent();
     form_set_error('reportback_item', t('Please upload an image.'));
   }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -370,9 +370,7 @@ function dosomething_reportback_form_validate_file($form, &$form_state) {
   }
   // If this is a new reportback form, file is mandatory.
   elseif ($form_state['values']['rbid'] == 0) {
-    $ga = new Elements_Tools_Serversideanalytics();
-    $ga->setEvent('send', 'event', 'Reportback', 'no image uploaded');
-    $ga->createEvent();
+    dosomething_helpers_add_analytics_event('Reportback', 'image file too large');
     form_set_error('reportback_item', t('Please upload an image.'));
   }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -368,9 +368,11 @@ function dosomething_reportback_form_validate_file($form, &$form_state) {
       form_set_error('reportback_item', t('There was an error. Please try again.'));
     }
   }
+
+
   // If this is a new reportback form, file is mandatory.
   elseif ($form_state['values']['rbid'] == 0) {
-    stathat_send_ez_count('drupal - Reportback - please upload an image', 1);
+    ga('send', 'event', 'Reportback', 'no image uploaded');
     form_set_error('reportback_item', t('Please upload an image.'));
   }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -368,8 +368,6 @@ function dosomething_reportback_form_validate_file($form, &$form_state) {
       form_set_error('reportback_item', t('There was an error. Please try again.'));
     }
   }
-
-
   // If this is a new reportback form, file is mandatory.
   elseif ($form_state['values']['rbid'] == 0) {
     $ga = new Elements_Tools_Serversideanalytics();

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -370,6 +370,7 @@ function dosomething_reportback_form_validate_file($form, &$form_state) {
   }
   // If this is a new reportback form, file is mandatory.
   elseif ($form_state['values']['rbid'] == 0) {
+    stathat_send_ez_count('drupal - Reportback - please upload an image', 1);
     form_set_error('reportback_item', t('Please upload an image.'));
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUpload.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUpload.js
@@ -75,6 +75,7 @@ define(function(require) {
       }
 
       if (!_this.validFileSize(files)) {
+        ga('send', 'event', 'Reportback', 'image file too large');
         _this.showError(_this.sizeError);
 
         return;
@@ -387,6 +388,7 @@ define(function(require) {
       }
       // Show user an error if they upload an image that is too small.
       else {
+        ga('send', 'event', 'Reportback', 'image too small');
         _this.showError(_this.dimensionsError);
       }
     };

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUpload.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUpload.js
@@ -75,7 +75,9 @@ define(function(require) {
       }
 
       if (!_this.validFileSize(files)) {
-        ga('send', 'event', 'Reportback', 'image file too large');
+        if (typeof ga !== 'undefined' && ga !== null) {
+          ga('send', 'event', 'Reportback', 'image file too large');
+        }
         _this.showError(_this.sizeError);
 
         return;
@@ -388,7 +390,9 @@ define(function(require) {
       }
       // Show user an error if they upload an image that is too small.
       else {
-        ga('send', 'event', 'Reportback', 'image too small');
+        if (typeof ga !== 'undefined' && ga !== null) {
+          ga('send', 'event', 'Reportback', 'image too small');
+        }
         _this.showError(_this.dimensionsError);
       }
     };


### PR DESCRIPTION
fixes #4027 

image file size too big + image dimensions too small:
-these are in ImageUpload.js because that is where those checks actually occur (aka before the form is submitted)
-the calls to ga are definitely in the right places, but I'm not 100% sure the parameters are what we want them to be

no image uploaded:
-this is in dosomething_reportback.forms.inc because we only check for that when the user clicks submit, so there is no way to check for this in the js file
-less certain about the php syntax for ga, but this seems to follow what I could find online
-I am not sure if drupal gets mad at this or not, as I can't get it to throw this error on my machine (when I click submit without an image, it just scrolls up?)
