### PR TITLE
Updating vagrant box version to use latest released

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@ Vagrant.configure("2") do |config|
 
   ## Choose your base box
   config.vm.box = "dosomething/phoenix"
-  config.vm.box_version = "1.0.5"
+  config.vm.box_version = "1.0.6"
 
   config.vm.provider "virtualbox" do |v|
     v.customize ["modifyvm", :id, "--memory", 3072]


### PR DESCRIPTION
#### What's this PR do?

This PR updates the version of the `dosomething/phoenix` vagrant box to use the latest released version.
#### Where should the reviewer start?

Just take a :eyes: on quick change.
#### Any background context you want to provide?

I was not sure if there was a specific reason why this wasn't updated. I had tried to `vagrant up` with `v1.0.5` and was running into some weird errors when trying to download the box.

---

@sergii-tkachenko 
cc: @mshmsh5000 @angaither 
