### PR TITLE
Adds temp fix to dosomething_global_get_language

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -512,6 +512,10 @@ function dosomething_global_get_language($account, stdClass $node = NULL, $respe
     }
   }
 
+  if (!isset($account->language)) {
+    $account->language = dosomething_global_convert_country_to_language(dosomething_settings_get_geo_country_code());
+  }
+
   if (is_object($node)) {
     // If there is a published translation for the node in the user's language, use it.
     if ($node->translations->data{$account->language}['status']) {


### PR DESCRIPTION
#### What's this PR do?

if no account language is set (anonymous user) then we should temporarily set one based on the country. 

in the future this will be based on the browser lang (see https://github.com/DoSomething/phoenix/pull/5733 )
#### How should this be manually tested?

Go to an MX or BR homepage (as a anonymous user from that country). Copy the link from a campaign tile. Check that its correctly prefixed / aliased for MX or BR.
#### Any background context you want to provide?

This was failing because there was no lang set for anon users
#### What are the relevant tickets?

Fixes #5814  
