### PR TITLE
Use old international implementation of country codes.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -15,7 +15,7 @@ include_once 'dosomething_user.theme.inc';
  */
 function dosomething_user_preprocess_page(&$vars) {
   $school_api_endpoint = variable_get('dosomething_user_school_api_endpoint', 'http://lofischools.herokuapp.com/search');
-  $date_format = (dosomething_settings_get_geo_country_code() === 'US') ? 'MM/DD/YYYY' : 'DD/MM/YYYY';
+  $date_format = (dosomething_settings_get_affiliate_country_code() === 'US') ? 'MM/DD/YYYY' : 'DD/MM/YYYY';
 
   drupal_add_js(
     array('dosomethingUser' =>


### PR DESCRIPTION
#### Changes

Rather than using the new Fastly country code function, which doesn't exist on international (and wouldn't make sense there), we'll just use the old "multisite" version that uses the country setting.

For review: @sergii-tkachenko 
/cc @sheyd 
