### PR TITLE
Adds hotmodule toggle to custom settings

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -759,7 +759,8 @@ function dosomething_campaign_add_shipment_form_vars($node) {
  * @return bool
  */
 function dosomething_campaign_is_hot_module($vars) {
-  if (isset($vars['field_high_season'])) {
+  $hot_module_enabled = dosomething_helpers_get_variable('node', $vars['nid'], 'hot_module_enabled');
+  if (isset($vars['field_high_season']) && $hot_module_enabled) {
     $today = dosomething_campaign_set_est_timezone(new DateTime());
     $start_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value']), TRUE);
     $end_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value2']), TRUE, TRUE);
@@ -861,7 +862,8 @@ function dosomething_campaign_is_active($node) {
   * @return bool
   */
  function dosomething_campaign_is_win_module($vars) {
-  if (isset($vars['field_high_season'])) {
+  $hot_module_enabled = dosomething_helpers_get_variable('node', $vars['nid'], 'hot_module_enabled');
+  if (isset($vars['field_high_season']) && $hot_module_enabled) {
      $today = dosomething_campaign_set_est_timezone(new DateTime());
      $end_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value2']), TRUE, TRUE);
      $win_module_end = dosomething_campaign_set_est_timezone(date_modify(clone $end_date, '+30 days'), TRUE, TRUE);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -760,7 +760,7 @@ function dosomething_campaign_add_shipment_form_vars($node) {
  */
 function dosomething_campaign_is_hot_module($vars) {
   $hot_module_enabled = dosomething_helpers_get_variable('node', $vars['nid'], 'hot_module_enabled');
-  if (isset($vars['field_high_season']) && $hot_module_enabled) {
+  if ($hot_module_enabled && isset($vars['field_high_season'])) {
     $today = dosomething_campaign_set_est_timezone(new DateTime());
     $start_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value']), TRUE);
     $end_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value2']), TRUE, TRUE);

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -134,14 +134,23 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
       ),
     );
   }
+
   // Add goals/progress.
   if (module_exists('dosomething_campaign')) {
+
     $form['goals'] = array(
       '#type' => 'fieldset',
       '#title' => t('Goals Settings'),
       '#collapsible' => TRUE,
       '#collapsed' => TRUE,
     );
+
+    $form['goals']['hot_module_enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => t("Enable Hot Module"),
+      '#default_value' => $vars['hot_module_enabled'],
+    ];
+
     $form['goals']['goal'] = array(
       '#type' => 'textfield',
       '#title' => t('Goal'),
@@ -174,6 +183,7 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
       '#default_value' => variable_get('progress_copy_override'),
       '#description' => t('Add copy here if you’d like to override the default progress copy in the hot module. Note: The default copy changes as progress increases. Override copy is static. If you create override copy, you’ll need to either delete the copy or change it yourself for this text to update.'),
     ];
+
   }
 
   $form['actions'] = array(


### PR DESCRIPTION
#### What's this PR do?

Adds a custom toggle switch to the custom settings of a node under "goals", that is by default off.

If this switch is enabled & the high season is set the hot module & win module will display. 
#### Where should the reviewer start?

Variable created in dosomething_helpers.variables.inc -- after that its used in the dosomething_campaign module.
#### How should this be manually tested?

Set the high season of a campaign to end sometime in the coming days. Verify the hotmodule does not display.
Then go to the campaign custom settings and enable the hotmodule.
Does the hotmodule display now?

Next set the end season date to a few days ago, does the win module display?
Disable the hot module in custom settings, does the win module still display?
#### Any background context you want to provide?

Everything is covered in the issue comments
#### What are the relevant tickets?

Fixes #5827
#### Screenshots (if appropriate)

![screen shot 2015-12-01 at 2 19 14 pm](https://cloud.githubusercontent.com/assets/897368/11511347/a591234a-9836-11e5-9857-b408eb17cf2e.png)
