### PR TITLE
Fixes Hot Module progress override copy

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -171,7 +171,7 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     $form['goals']['progress_copy_override'] = [
       '#type' => 'textarea',
       '#title' => t('Hot Module progress override copy'),
-      '#default_value' => variable_get('progress_copy_override'),
+      '#default_value' => $vars['progress_copy_override'],
       '#description' => t('Add copy here if you’d like to override the default progress copy in the hot module. Note: The default copy changes as progress increases. Override copy is static. If you create override copy, you’ll need to either delete the copy or change it yourself for this text to update.'),
     ];
   }


### PR DESCRIPTION
#### What's this PR do?

Fixes the Hot Module progress override copy by switching `variable_get` usage `$vars['...']`
#### How should this be manually tested?

Does the content in Hot Module progress override copy (custom settings --> goals) now save correctly?
#### Any background context you want to provide?

see this comment https://github.com/DoSomething/phoenix/issues/5787#issuecomment-157377506
#### What are the relevant tickets?

Fixes #5787 
#### Screenshots (if appropriate)

![screen shot 2015-12-01 at 2 23 30 pm](https://cloud.githubusercontent.com/assets/897368/11511522/9baeaac2-9837-11e5-9de9-055f87a36855.png)

![screen shot 2015-12-01 at 2 26 29 pm](https://cloud.githubusercontent.com/assets/897368/11511525/9e68d242-9837-11e5-9af8-50d38f5ee7ad.png)
