### PR TITLE
Fixes end date in campaign headings

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -763,7 +763,6 @@ function dosomething_campaign_is_hot_module($vars) {
     $today = dosomething_campaign_set_est_timezone(new DateTime());
     $start_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value']), TRUE);
     $end_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value2']), TRUE, TRUE);
-    $end_date->setTime(23, 59, 59);
 
     // Hot module is only enabled when variable is set, high season dates exist and there is still days left.
     if (!empty($vars['field_high_season']) && (($start_date < $today)  && ($today < $end_date))) {

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -417,7 +417,6 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
 
     // Construct the proper end date text
     $end_date = new DateTime($vars['field_high_season'][0]['value2']);
-    // $vars['campaign_end_date'] = $end_date->format('F') . ' ' . $end_date->format('j') . $end_date->format('S');
     $vars['campaign_end_date'] = $end_date->format('F jS');
 
     // Set campaign headings.

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -417,7 +417,8 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
 
     // Construct the proper end date text
     $end_date = new DateTime($vars['field_high_season'][0]['value2']);
-    $vars['campaign_end_date'] = $end_date->format('F') . ' ' . $end_date->format('j') . $end_date->format('S');
+    // $vars['campaign_end_date'] = $end_date->format('F') . ' ' . $end_date->format('j') . $end_date->format('S');
+    $vars['campaign_end_date'] = $end_date->format('F jS');
 
     // Set campaign headings.
     $vars['campaign_headings'] = theme('campaign_headings', $vars);

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -415,8 +415,13 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
     // Add $campaign_scholarship variable.
     paraneue_dosomething_preprocess_node_campaign_scholarship($vars);
 
+    // Construct the proper end date text
+    $end_date = new DateTime($vars['field_high_season'][0]['value2']);
+    $vars['campaign_end_date'] = $end_date->format('F') . ' ' . $end_date->format('j') . $end_date->format('S');
+
     // Set campaign headings.
     $vars['campaign_headings'] = theme('campaign_headings', $vars);
+
     // If creator property has been set:
     if ($creator = $campaign->creator) {
       // Pass $campaign->creator array to the campaign_creator theme function.

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/partials/campaign-headings.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/partials/campaign-headings.tpl.php
@@ -3,6 +3,6 @@
 
 <?php if (isset($campaign->end_date) && $campaign->status != 'closed'): ?>
   <p class="header__date">
-    <?php print t('Ends @end_date', ['@end_date' => date('F d', $campaign->end_date)]); ?>
+    <?php print t('Ends ' . $campaign_end_date); ?>
   </p>
 <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/partials/campaign-headings.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/partials/campaign-headings.tpl.php
@@ -3,6 +3,6 @@
 
 <?php if (isset($campaign->end_date) && $campaign->status != 'closed'): ?>
   <p class="header__date">
-    <?php print t('Ends ' . $campaign_end_date); ?>
+    <?php print t('Ends @end_date', ['@end_date' => $campaign_end_date]); ?>
   </p>
 <?php endif; ?>


### PR DESCRIPTION
#### What's this PR do?

Fixes the end date in the campaign heading
#### Where should the reviewer start?

preprocess.inc
#### How should this be manually tested?

Does the end date in the heading always match the hot module & config setting? 
(Try in multiple timezones)
#### Any background context you want to provide?

This template/preprocess logic was using pre-hotmodule logic which breaks with timezone stuff. 

Also see the comments I left in the files
#### What are the relevant tickets?

Fixes #5582 (Again.)
#### Screenshots (if appropriate)

America/New York
![screen shot 2015-12-01 at 3 20 58 pm](https://cloud.githubusercontent.com/assets/897368/11513041/2dbd28d8-983f-11e5-8aed-35b67fd0ab48.png)

Pacific/Honolulu
![screen shot 2015-12-01 at 3 21 50 pm](https://cloud.githubusercontent.com/assets/897368/11513059/4a7c14ca-983f-11e5-858d-0a85acb068a0.png)

Australia
![screen shot 2015-12-01 at 3 22 37 pm](https://cloud.githubusercontent.com/assets/897368/11513088/6c10130c-983f-11e5-82b4-13f3ec251e00.png)

UTC
![screen shot 2015-12-01 at 3 22 52 pm](https://cloud.githubusercontent.com/assets/897368/11513090/6fa07d86-983f-11e5-8184-5ea21bead27a.png)
