### PR TITLE
Reportback item status params update

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -49,7 +49,7 @@ function _reportback_item_resource_definition() {
             'optional' => TRUE,
             'type' => 'string',
             'source' => array('param' => 'status'),
-            'default value' => 'approved',
+            'default value' => 'promoted,approved',
           ),
           array(
             'name' => 'count',

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback_item.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback_item.query.inc
@@ -117,11 +117,14 @@ function dosomething_reportback_build_reportback_items_query($params = array()) 
 *    An executed database query object to iterate through.
 */
 function dosomething_reportback_get_reportback_items_query($params) {
+  if ($params['status']) {
+    $statuses = dosomething_reportback_filter_permitted_statuses($params['status']);
 
-  $params['status'] = dosomething_reportback_filter_permitted_statuses($params['status']);
+    if (!$statuses) {
+      return FALSE;
+    }
 
-  if (!$params['status']) {
-    return FALSE;
+    $params['status'] = $statuses;
   }
 
   $query = dosomething_reportback_build_reportback_items_query($params);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback_item.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback_item.query.inc
@@ -117,6 +117,13 @@ function dosomething_reportback_build_reportback_items_query($params = array()) 
 *    An executed database query object to iterate through.
 */
 function dosomething_reportback_get_reportback_items_query($params) {
+
+  $params['status'] = dosomething_reportback_filter_permitted_statuses($params['status']);
+
+  if (!$params['status']) {
+    return FALSE;
+  }
+
   $query = dosomething_reportback_build_reportback_items_query($params);
   $offset = dosomething_helpers_isset($params['offset'], NULL, 0);
   $count = dosomething_helpers_isset($params['count'], NULL, 25);
@@ -130,3 +137,32 @@ function dosomething_reportback_get_reportback_items_query($params) {
   return $result;
 }
 
+
+/**
+ * Filter out requested Reportback Item status based on user permissions.
+ *
+ * @param mixed $data
+ * @return array
+ */
+function dosomething_reportback_filter_permitted_statuses($data) {
+  if (user_access('view any reportback')) {
+    return $data;
+  }
+
+  if (!is_array($data)) {
+    $data = [$data];
+  }
+
+  $restricted = ['pending', 'flagged', 'excluded'];
+
+  $prohibited_values = array_intersect($restricted, $data);
+
+  if ($prohibited_values) {
+    foreach ($prohibited_values as $value) {
+      unset($data[array_search($value, $data)]);
+    }
+  }
+
+  // @TODO: if only one item in array, then just pluck it.
+  return $data;
+}

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback_item.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback_item.query.inc
@@ -142,7 +142,7 @@ function dosomething_reportback_get_reportback_items_query($params) {
  * Filter out requested Reportback Item status based on user permissions.
  *
  * @param mixed $data
- * @return array
+ * @return mixed
  */
 function dosomething_reportback_filter_permitted_statuses($data) {
   if (user_access('view any reportback')) {
@@ -163,6 +163,9 @@ function dosomething_reportback_filter_permitted_statuses($data) {
     }
   }
 
-  // @TODO: if only one item in array, then just pluck it.
+  if (count($data) === 1) {
+    return array_shift($data);
+  }
+
   return $data;
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback_item.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback_item.query.inc
@@ -68,12 +68,11 @@ function dosomething_reportback_build_reportback_items_query($params = array()) 
   }
 
   // Public API properties to expose:
-  $rbf_fields = array('fid', 'caption', 'rbid');
+  $rbf_fields = array('fid', 'caption', 'rbid', 'status');
   $rb_fields = array('created', 'updated', 'quantity', 'uid');
 
   // Staff-only properties to add:
   if (user_access('view any reportback')) {
-    $rbf_fields[] = 'status';
     $rb_fields[] = 'why_participated';
     $rb_fields[] = 'flagged';
   }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -63,12 +63,6 @@ class ReportbackItem extends Entity {
    * @throws Exception
    */
   public static function find(array $filters = []) {
-//    $filters['status'] = $this->filterStatus($filters['status']);
-
-    print_r($filters);
-    die();
-
-
     $reportbackItems = [];
 
     $results = dosomething_reportback_get_reportback_items_query($filters);
@@ -98,7 +92,7 @@ class ReportbackItem extends Entity {
     $northstar_user = (object) [];
 
     $this->id = $data->fid;
-    $this->status = $this->filterStatus($data->status);
+    $this->status = $data->status;
     $this->caption = !empty($data->caption) ? $data->caption : t('DoSomething? Just did!');
     $this->created_at = $data->timestamp;
     $this->media = [
@@ -139,17 +133,6 @@ class ReportbackItem extends Entity {
       'photo' => dosomething_helpers_isset($northstar_user, 'photo'),
       'country' => dosomething_helpers_isset($northstar_user, 'country'),
     ];
-  }
-
-  private function filterStatus($data) {
-    print_r($data);
-    die();
-
-    return $data;
-  }
-
-  private function query($filters) {
-    return dosomething_reportback_get_reportback_items_query($filters);
   }
 
   /**

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -63,6 +63,12 @@ class ReportbackItem extends Entity {
    * @throws Exception
    */
   public static function find(array $filters = []) {
+//    $filters['status'] = $this->filterStatus($filters['status']);
+
+    print_r($filters);
+    die();
+
+
     $reportbackItems = [];
 
     $results = dosomething_reportback_get_reportback_items_query($filters);
@@ -92,7 +98,7 @@ class ReportbackItem extends Entity {
     $northstar_user = (object) [];
 
     $this->id = $data->fid;
-    $this->status = $data->status;
+    $this->status = $this->filterStatus($data->status);
     $this->caption = !empty($data->caption) ? $data->caption : t('DoSomething? Just did!');
     $this->created_at = $data->timestamp;
     $this->media = [
@@ -133,6 +139,17 @@ class ReportbackItem extends Entity {
       'photo' => dosomething_helpers_isset($northstar_user, 'photo'),
       'country' => dosomething_helpers_isset($northstar_user, 'country'),
     ];
+  }
+
+  private function filterStatus($data) {
+    print_r($data);
+    die();
+
+    return $data;
+  }
+
+  private function query($filters) {
+    return dosomething_reportback_get_reportback_items_query($filters);
   }
 
   /**


### PR DESCRIPTION
Fixes #5653
#### What's this PR do?

This PR provides a level of data security based on user permissions. Prior to this PR, all (or some) status types for Reportback Items could be requested by passing a URL parameter `?status=pending,flagged,excluded,promoted,approved` by an anonymous `GET` request. 

This PR updates the API so that if an anonymous user is requested restricted statuses of `pending`, `flagged` or `excluded`, those types get filtered out and the request responds with no items and an error response or just providing `promoted` and/or `approved` items (depending if those were also requested). Now only admin users have access to request those status types.

This PR also updates the default `status` value to be both `promoted` and `approved`.
#### Where should the reviewer start?

The main logic happens in **dosomething_reportback_item.query.inc**
#### How should this be manually tested?

If you want, pull down the branch and then hit the `/reportback_items` endpoint and pass some restricted statuses in query URL parameters while in incognito browser mode and see if any results show up that shouldn't.

---

@aaronschachter 

cc: @angaither @jonuy 
