### PR TITLE
Adds special char decoding to user profile titles

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess.inc
@@ -681,7 +681,7 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
     foreach ($doing as $delta => $value) {
       $image = dosomething_image_get_themed_image($value['nid_image'], 'landscape', '400x400');
       $item = array(
-        'title' => $value['link'],
+        'title' => htmlspecialchars_decode($value['link'], ENT_QUOTES),
         'image' => $image,
         'description' => $value['call_to_action'],
         'url' => dosomething_global_node_url($value['nid'], $language, 'prove'),
@@ -710,7 +710,7 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
       $url = dosomething_global_url('node/' . $reportback->nid);
       $content = array(
         'url' => $url,
-        'title' => $reportback->node_title,
+        'title' => htmlspecialchars_decode($reportback->node_title, ENT_QUOTES),
         'image' => $img,
         'description' => $impact,
       );


### PR DESCRIPTION
#### What's this PR do?

Adds special char decoding to user profile titles
#### How should this be manually tested?

Do campaign titles with special chars (quotes, etc) render normally on the user profile?
#### Any background context you want to provide?

https://github.com/DoSomething/phoenix/pull/1694/files
#### What are the relevant tickets?

Fixes #5818 
