### PR TITLE
Api reportback flagged parameter

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
@@ -49,7 +49,7 @@ function _reportback_resource_definition() {
             'optional' => TRUE,
             'type' => 'string',
             'source' => array('param' => 'status'),
-            'default value' => 'approved',
+            'default value' => 'promoted,approved',
           ),
           array(
             'name' => 'count',
@@ -63,9 +63,9 @@ function _reportback_resource_definition() {
             'name' => 'random',
             'description' => 'Boolean to indicate whether to retrieve reportbacks in random order.',
             'optional' => TRUE,
-            'type' => 'int',
+            'type' => 'boolean',
             'source' => array('param' => 'random'),
-            'default value' => 0,
+            'default value' => FALSE,
           ),
           array(
             'name' => 'page',
@@ -77,10 +77,18 @@ function _reportback_resource_definition() {
           ),
           array(
             'name' => 'load_user',
-            'description' => 'Flag to indicate whether to make call to northstar to retrieve full user data.',
+            'description' => 'Boolean to indicate whether to make call to northstar to retrieve full user data.',
             'optional' => TRUE,
             'type' => 'boolean',
             'source' => array('param' => 'load_user'),
+            'default value' => FALSE,
+          ),
+          array(
+            'name' => 'flagged',
+            'description' => 'Boolean to indicate whether to also retrieve flagged reportbacks.',
+            'optional' => TRUE,
+            'type' => 'boolean',
+            'source' => array('param' => 'flagged'),
             'default value' => FALSE,
           ),
         ),
@@ -116,7 +124,7 @@ function _reportback_resource_access($op) {
 }
 
 
-function _reportback_resource_index($campaigns, $status, $count, $random, $page, $load_user) {
+function _reportback_resource_index($campaigns, $status, $count, $random, $page, $load_user, $flagged) {
   $parameters =  array(
     'campaigns' => $campaigns,
     'status' => $status,
@@ -124,6 +132,7 @@ function _reportback_resource_index($campaigns, $status, $count, $random, $page,
     'random' => $random,
     'page' => $page,
     'load_user' => $load_user,
+    'flagged' => $flagged,
   );
 
   $reportbacks = new ReportbackTransformer;

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
@@ -55,6 +55,15 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
     }
   }
 
+  if (!isset($params['flagged'])) {
+    $query->condition('rb.flagged', 0);
+  }
+  else {
+    if (!$params['flagged']) {
+      $query->condition('rb.flagged', 0);
+    }
+  }
+
   // Public API properties to expose:
   $rb_fields = array('rbid', 'created', 'updated', 'quantity', 'uid');
 
@@ -71,6 +80,7 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
 
   $query->groupBy('rb.rbid');
 
+  // @TODO: After campaign gallery changes, update this condition to: isset($params['random']) && $params['random']
   if (isset($params['random'])) {
     $query->orderRandom();
   }
@@ -94,10 +104,13 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
  *  - offset (int)
  *  - random (bool)
  *  - load_user (bool)
+ *  - flagged (bool)
  * @return object
  *   An executed database query object to iterate through.
  */
 function dosomething_reportback_get_reportbacks_query($params) {
+  $params = dosomething_reportback_filter_flagged_reportbacks($params);
+
   $query = dosomething_reportback_build_reportbacks_query($params);
   $offset = dosomething_helpers_isset($params['offset'], NULL, 0);
   $count = dosomething_helpers_isset($params['count'], NULL, 25);
@@ -109,5 +122,25 @@ function dosomething_reportback_get_reportbacks_query($params) {
   $result = $query->execute()->fetchAll();
 
   return $result;
+}
+
+
+/**
+ * Filter out requested flagged Reportbacks based on user permissions.
+ *
+ * @param  array  $params
+ * @return mixed
+ */
+function dosomething_reportback_filter_flagged_reportbacks($params) {
+  if (user_access('view any reportback')) {
+    return $params;
+  }
+
+  // Unset False boolean values that affect the query builder.
+  if ($params['flagged']) {
+    unset($params['flagged']);
+  }
+
+  return $params;
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -119,9 +119,8 @@ class Reportback extends Entity {
 
     foreach($results as $item) {
       // @TODO: remove need for passing variable for constructor check.
-      $load_user = dosomething_helpers_isset($filters['load_user'], NULL, FALSE);
       $reportback = new static(['ignore' => true]);
-      $reportback->build($item, $load_user);
+      $reportback->build($item, $filters['load_user']);
 
       $reportbacks[] = $reportback;
     }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -27,7 +27,6 @@ class ReportbackTransformer extends Transformer {
     return $total;
   }
 
-
   /**
    * @param array $parameters Any parameters obtained from query string.
    * @return array
@@ -51,7 +50,6 @@ class ReportbackTransformer extends Transformer {
       'data' => $this->transformCollection($reportbacks),
     ];
   }
-
 
   /**
    * Display the specified resource.
@@ -77,7 +75,6 @@ class ReportbackTransformer extends Transformer {
     ];
   }
 
-
   /**
    * Transform data and build out response.
    *
@@ -95,7 +92,6 @@ class ReportbackTransformer extends Transformer {
 
     return $data;
   }
-
 
   /**
    * Set the filters based on request URL parameters.

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -27,22 +27,13 @@ class ReportbackTransformer extends Transformer {
     return $total;
   }
 
+
   /**
    * @param array $parameters Any parameters obtained from query string.
    * @return array
    */
   public function index($parameters) {
-    $filters = [
-      'nid' => dosomething_helpers_format_data($parameters['campaigns']),
-      'status' => dosomething_helpers_format_data($parameters['status']),
-      'count' => $parameters['count'] ?: 25,
-    ];
-
-    // @TODO: Logic update!
-    // Not ideal that this is NULL instead of FALSE but due to how logic happens in original query function. It should be updated!
-    // Logic currently checks for isset() instead of just boolean, so won't change until endpoints switched.
-    $filters['random'] = $parameters['random'] === 'true' ? TRUE : NULL;
-    $filters['load_user'] = $parameters['load_user'] === 'true' ? TRUE : NULL;
+    $filters = $this->setFilters($parameters);
 
     try {
       $reportbacks = Reportback::find($filters);
@@ -60,6 +51,7 @@ class ReportbackTransformer extends Transformer {
       'data' => $this->transformCollection($reportbacks),
     ];
   }
+
 
   /**
    * Display the specified resource.
@@ -85,6 +77,7 @@ class ReportbackTransformer extends Transformer {
     ];
   }
 
+
   /**
    * Transform data and build out response.
    *
@@ -101,6 +94,31 @@ class ReportbackTransformer extends Transformer {
     $data['user'] = $this->transformUser((object) $item->user);
 
     return $data;
+  }
+
+
+  /**
+   * Set the filters based on request URL parameters.
+   *
+   * @param  array  $parameters
+   * @return array
+   */
+  private function setFilters($parameters) {
+    $filters = [
+      'nid' => dosomething_helpers_format_data($parameters['campaigns']),
+      'status' => dosomething_helpers_format_data($parameters['status']),
+      'count' => $parameters['count'] ?: 25,
+      'random' => dosomething_helpers_convert_string_to_boolean($parameters['random']),
+      'load_user' => dosomething_helpers_convert_string_to_boolean($parameters['load_user']),
+      'flagged' => dosomething_helpers_convert_string_to_boolean($parameters['flagged']),
+    ];
+
+    // Unset False boolean values that affect the query builder.
+    if (!$filters['random']) {
+      unset($filters['random']);
+    }
+
+    return $filters;
   }
 
 }


### PR DESCRIPTION
Fixes #5879
#### What's this PR do?

This PR updates the `/reportbacks` endpoint so that flagged reportbacks are not returned in any anonymous `GET` requests to the API. It also adds a new `flagged` URL parameter to the `/reportbacks` endpoint so that if an admin wants to retrieve both flagged and not flagged reportbacks, they can pass `flagged=true` as a URL parameter in the request (can also set it to `false` but that behaves as the default of not passing the parameter).
#### Where should the reviewer start?

Start at **reportback_resource.inc** where the new URL parameter is added to Services module.
#### How should this be manually tested?

Pull down the branch, make sure to `drush cc all` to clear the cache and have Services register the new `flagged` URL parameter. Then hit a few `/reportback` endpoints as both an admin/anonymous user, passing `?flagged=true` or `?flagged=false` or omitting it entirely and confirm expected results!
#### What are the relevant tickets?
#5879

---

@aaronschachter @DFurnes 

cc: @jonuy @angaither @chloealee 
