### PR TITLE
Fixing a few DBLog related notices.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
@@ -112,8 +112,8 @@ function dosomething_reportback_get_reportbacks_query($params) {
   $params = dosomething_reportback_filter_flagged_reportbacks($params);
 
   $query = dosomething_reportback_build_reportbacks_query($params);
-  $offset = dosomething_helpers_isset($params['offset'], NULL, 0);
-  $count = dosomething_helpers_isset($params['count'], NULL, 25);
+  $offset = dosomething_helpers_isset($params, 'offset', 0);
+  $count = dosomething_helpers_isset($params, 'count', 25);
 
   if ($count && $count !== 'all') {
     $query->range($offset, $count);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback_item.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback_item.query.inc
@@ -117,7 +117,7 @@ function dosomething_reportback_build_reportback_items_query($params = array()) 
 *    An executed database query object to iterate through.
 */
 function dosomething_reportback_get_reportback_items_query($params) {
-  if ($params['status']) {
+  if (isset($params['status'])) {
     $statuses = dosomething_reportback_filter_permitted_statuses($params['status']);
 
     if (!$statuses) {
@@ -128,8 +128,8 @@ function dosomething_reportback_get_reportback_items_query($params) {
   }
 
   $query = dosomething_reportback_build_reportback_items_query($params);
-  $offset = dosomething_helpers_isset($params['offset'], NULL, 0);
-  $count = dosomething_helpers_isset($params['count'], NULL, 25);
+  $offset = dosomething_helpers_isset($params, 'offset', 0);
+  $count = dosomething_helpers_isset($params, 'count', 25);
 
   if ($count && $count !== 'all') {
     $query->range($offset, $count);


### PR DESCRIPTION
#### What's this PR do?

@joe saw a bunch of PHP notices being thrown and alerted me to issues with the query builder functions for RB and RB items. This PR fixes a few issues with how I was using my own `dosomething_helpers_isset()` function @_@ Since passing an array to the function, need to separate the key we're looking for as the second argument passed to the function.

![image](https://cloud.githubusercontent.com/assets/105849/11600177/0d9a59d4-9a99-11e5-8718-9f8f050f8426.png)
#### Where should the reviewer start?

Take a close :mag_right: look at it to make sure I didn't make any more dumb mistakes...

---

@DFurnes @deadlybutter 
