### PR TITLE
Fixes galleries on campaign collections.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
@@ -137,38 +137,13 @@
   <?php if (!empty($galleries)): ?>
     <section class="container -padded">
       <?php foreach ($galleries as $gallery): ?>
-        <div class="wrapper">
-          <?php if (isset($gallery['title'])): ?>
-            <div class="container__block">
-              <h2 class="inline-sponsor-color"><?php print $gallery['title']; ?></h2>
-            </div>
-          <?php endif; ?>
-
-          <?php if (!empty($gallery['items'])): ?>
-            <ul class="gallery -triad">
-              <?php foreach ($gallery['items'] as $gallery_item): ?>
-                <li class="<?php print $gallery_item['order_class']; ?>">
-                  <div class="figure">
-                    <?php if (isset($gallery_item['image'])): ?>
-                      <div class="figure__media">
-                        <?php print $gallery_item['image']; ?>
-                      </div>
-                    <?php endif; ?>
-
-                    <div class="figure__body">
-                    <?php if (isset($gallery_item['image_title'])): ?>
-                      <h3><?php print $gallery_item['image_title']; ?></h3>
-                    <?php endif; ?>
-                    <?php if (isset($gallery_item['image_description'])): ?>
-                      <?php print $gallery_item['image_description']; ?>
-                    <?php endif; ?>
-                    </div>
-                  </div>
-                </li>
-              <?php endforeach; ?>
-            </ul>
-          <?php endif; ?>
-        </div>
+        <section class="container -padded">
+          <div class="wrapper">
+            <?php if (isset($gallery['markup'])): ?>
+              <?php print $gallery['markup'] ?>
+            <?php endif; ?>
+          </div>
+        </section>
       <?php endforeach; ?>
     </section>
   <?php endif; ?>


### PR DESCRIPTION
#### What's this PR do?
- Fixes galleries on campaign collections.
#### Any background context you want to provide?

Since #5605 galleries on campaign collections are pre-rendered with `dosomething_static_content_preprocess_galleries($vars);` function that returns markup, but `node--campaign_group.tpl.php` still tries to render it by itself as an array of field elements.
I replaced template with [this code](https://github.com/DoSomething/phoenix/blob/9066d50c878dac21db311f392012ac9429814cd5/lib/modules/dosomething/dosomething_static_content/node--static_content.tpl.php#L30-L36).
#### Results

![image](https://cloud.githubusercontent.com/assets/672669/11631192/8874ba9c-9d09-11e5-94be-821bd97dbba8.png)
#### What are the relevant tickets?

Fixes #5901.
