### PR TITLE
Translated Problem Share Images

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -127,7 +127,7 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
 
 
     // Create the image path to the problem fact statement image generated for the node.
-    $problem_share_image = $base_url . '/sites/default/files/images/problem-' . $vars['nid'] . '.png';
+    $problem_share_image = $base_url . 'sites/default/files/images/problem-' . $vars['nid'] . '.png';
 
     $share_types = array(
       'facebook' => array(

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -127,7 +127,8 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
 
 
     // Create the image path to the problem fact statement image generated for the node.
-    $problem_share_image = $base_url . 'sites/default/files/images/problem-' . $vars['nid'] . '.png';
+    $country_prefix = (dosomething_global_get_current_prefix()) ? strtoupper(dosomething_global_get_current_prefix()) : 'global';
+    $problem_share_image = $base_url . 'sites/default/files/images/problem-' . $vars['nid'] . '-' . $country_prefix . '.png';
 
     $share_types = array(
       'facebook' => array(

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/create-images.sh
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/create-images.sh
@@ -4,7 +4,7 @@ TEMP_FILE_1=tmp1.png
 TEMP_FILE_2=tmp2.png
 BOLD_FONT_PATH="$1/ProximaNova-Bold.otf"
 REG_FONT_PATH="$1/ProximaNova-Reg.otf"
-FINAL_FILE=$2/images/problem-$3.png
+FINAL_FILE=$2/images/problem-$3-$5.png
 
 convert \
   -size 471x248 \

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/dosomething_campaign_problem_shares.cron.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/dosomething_campaign_problem_shares.cron.inc
@@ -9,14 +9,13 @@
  * Implements hook_cron().
  */
 function dosomething_campaign_problem_shares_cron() {
-  $results = db_query("SELECT n.nid, fn.title as problem
+  $results = db_query("SELECT n.nid, fn.title as problem, fp.language as lang
                        FROM node n
                        INNER JOIN field_data_field_fact_problem fp on n.nid = fp.entity_id
                        INNER JOIN node fn on fp.field_fact_problem_target_id = fn.nid
                        INNER JOIN field_data_field_campaign_status s on n.nid = s.entity_id
                        WHERE n.type ='campaign'
-                       AND s.field_campaign_status_value = 'active'
-                       GROUP BY n.nid;");
+                       AND s.field_campaign_status_value = 'active';");
 
   // Get the relevant paths
   $path = dosomething_helpers_application_path('/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares');
@@ -32,7 +31,9 @@ function dosomething_campaign_problem_shares_cron() {
     }
     $nid = escapeshellarg($result->nid);
     $problem = escapeshellarg($problem);
+    $country_code = dosomething_global_convert_language_to_country($result->lang);
+    $country = ($country_code) ? $country_code : 'global';
     // Call shell script to create the image.
-    shell_exec("/bin/bash $path/create-images.sh $font_path $image_location $nid $problem");
+    shell_exec("/bin/bash $path/create-images.sh $font_path $image_location $nid $problem $country");
   }
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/dosomething_campaign_problem_shares.cron.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_problem_shares/dosomething_campaign_problem_shares.cron.inc
@@ -30,6 +30,7 @@ function dosomething_campaign_problem_shares_cron() {
       $problem = str_replace('%', '%%', $problem);
     }
     $nid = escapeshellarg($result->nid);
+    setlocale(LC_CTYPE, "en_US.UTF-8"); // Ensures that non-ASCII Characters aren't stripped.
     $problem = escapeshellarg($problem);
     $country_code = dosomething_global_convert_language_to_country($result->lang);
     $country = ($country_code) ? $country_code : 'global';


### PR DESCRIPTION
#### What's this PR do?

This PR updates the cron job that creates problem share images so that it runs through each translation of the problem fact field and creates an image with that version of the fact statement. The images that it creates are appended with the country code associated with the language and defaults to 'global' if nothing else. 

Then we find which image to use in the share bar based on what URL prefix is currently being used to get the campaign page.
#### Where should the reviewer start?

The cron job gets updated in `dosomething_campaign_problem_shares.cron.inc`
#### How should this be manually tested?

Going to different versions of a campaign page and making sure you get the correctly translated version of the problem statement image.
#### Any background context you want to provide?

One thing to note is that I didn't translate the "Make a difference" header in the problem share images. So they end up looking like: 

![screen shot 2015-12-07 at 2 04 20 pm](https://cloud.githubusercontent.com/assets/1700409/11636722/78d4b394-9ceb-11e5-996b-4ddd4feaa84c.png)

I can revisit this in a separate issue.
#### What are the relevant tickets?

Fixes #5751 
