### PR TITLE
Do not wrap Birthday field title in h4

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -315,7 +315,7 @@ function paraneue_dosomething_form_user_profile_after_build($form, &$form_state)
   $form['value']['date']['#attributes']['data-validate'] = 'birthday';
   $form['value']['date']['#attributes']['data-validate-required'] = '';
   $form['value']['date']['#title_display'] = 'before';
-  $form['value']['date']['#title'] = '<h4>' . t('Birthday') . '</h4>';
+  $form['value']['date']['#title'] = t('Birthday');
   $form['#title'] = '';
   unset($form['value']['date']['#description']);
   return $form;


### PR DESCRIPTION
#### What's this PR do?

Removes the `h4` around the title of the Birthday field. Not sure why it was there. 

![garfield](https://cloud.githubusercontent.com/assets/1700409/11641417/283f3f10-9d06-11e5-9685-37aa98ee3461.gif)
#### What are the relevant tickets?

Fixes #5868 

![newsroom-fixtheinternet](https://cloud.githubusercontent.com/assets/1700409/11641505/8aa93e30-9d06-11e5-8e96-e7cb667c1691.gif)
