### PR TITLE
Fixes downloads not showing and spamming error

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -87,6 +87,9 @@
 function dosomething_campaign_load($node, $public = FALSE) {
   if ($node->type != 'campaign') { return FALSE; }
 
+  // Get the appropriate lang
+  $current_lang = dosomething_global_convert_country_to_language(dosomething_global_get_current_prefix());
+
   // Set the image src ratio and styles.
   $image_src_ratio = 'square';
   $image_src_style = '300x300';
@@ -207,7 +210,7 @@ function dosomething_campaign_load($node, $public = FALSE) {
 
   $campaign->downloads = NULL;
   if (!empty($node->field_downloads)) {
-    foreach ($node->field_downloads[LANGUAGE_NONE] as $file) {
+    foreach ($node->field_downloads[$current_lang] as $file) {
       $campaign->downloads[] = array(
         'url' => file_create_url($file['uri']),
         'description' => $file['description'],

--- a/lib/modules/dosomething/dosomething_home/dosomething_home.module
+++ b/lib/modules/dosomething/dosomething_home/dosomething_home.module
@@ -33,7 +33,7 @@ function dosomething_home_preprocess_node(&$vars) {
         $nid = $campaign;
       }
       $node = node_load($nid);
-      $lang_code = dosomething_global_get_language($user, $node);
+      $lang_code = dosomething_global_get_language($user, $node, FALSE);
 
       // Grab all tiles attributes.
       $tiles = array();


### PR DESCRIPTION
#### What's this PR do?
- Fixes the downloads not displaying on campaign pages
- Fixes one of those annoying spamming errors
#### How should this be manually tested?

Do the downloads show in Plan It! now?
#### Any background context you want to provide?

Language NONE was still in use (re: campaign helpers).

In the home module bug, the dosomething_global_get_language logic wasnt running because it was respecting the URL first (hence the third FALSE parameter I added)
#### What are the relevant tickets?

Fixes #5915 

I dont think theres an issue for the random spam bug
