### PR TITLE
Switches to days only in hot module

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -634,12 +634,7 @@ function dosomething_campaign_get_hot_time_left($node, &$vars = NULL) {
   $days_left = $difference->d;
   $hours_left = $difference->h + ($days_left * 24);
 
-  if ($days_left >= 8) {
-    $readable_end_date = $end_date->format('F jS');
-    $vars['hm_readable_end_date'] = $readable_end_date;
-    $time_left = t('Ends ' . $readable_end_date);
-  }
-  elseif ($hours_left > 48) {
+  if ($hours_left > 48) {
     $time_left = t($difference->d . ' days left');
   }
   else {


### PR DESCRIPTION
#### What's this PR do?

IT CHANGES THE WORLD, FOREVER.

THE END DATE, IS GONE. ONLY DAYS REMAIN!
#### How should this be manually tested?

Does an "end date" show up in the hot module, or just a lot of days? 
#### Any background context you want to provide?

Fantini said it sounded like a good idea.
#### What are the relevant tickets?

Fixes #5922 
#### Screenshots (if appropriate)

![screen shot 2015-12-08 at 2 04 55 pm](https://cloud.githubusercontent.com/assets/897368/11665303/afec33e2-9db4-11e5-89e2-3fb987ea85ad.png)
