### PR TITLE
Changes a ways session is initialized in `dosomething_global_init()`

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -19,7 +19,7 @@ function dosomething_global_init() {
     return;
   }
 
-  drupal_session_start();
+  drupal_session_initialize();
 
   if (!empty($_SESSION['dosomething_global_redirected'])) {
     $_SESSION['dosomething_global_redirected'] = FALSE;


### PR DESCRIPTION
#### What's this PR do?
- Changes a ways session is initialized in `dosomething_global_init()`
#### How should this be manually tested?

See #5924
#### Any background context you want to provide?

I wasn't able to reproduce it locally, but I think this might fix it.
`drupal_session_initialize()` looks more safe than `drupal_session_start()`.
#### What are the relevant tickets?

Proposes a fix for #5924.
