### PR TITLE
Reportback items filters method

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -63,9 +63,9 @@ function _reportback_item_resource_definition() {
             'name' => 'random',
             'description' => 'Boolean to indicate whether to retrieve reportback items in random order.',
             'optional' => TRUE,
-            'type' => 'int',
+            'type' => 'boolean',
             'source' => array('param' => 'random'),
-            'default value' => 0,
+            'default value' => FALSE,
           ),
           array(
             'name' => 'page',

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -7,20 +7,22 @@ class ReportbackItemTransformer extends ReportbackTransformer {
    * @return array
    */
   public function index($parameters) {
-    $filters = [
-      'nid' => dosomething_helpers_format_data($parameters['campaigns']),
-      'status' => dosomething_helpers_format_data($parameters['status']),
-      'count' => (int) $parameters['count'] ?: 25,
-      'page' => (int) $parameters['page'],
-    ];
+    $filters = $this->setFilters($parameters);
 
-    $filters['offset'] = $this->setOffset($filters['page'], $filters['count']);
-
-    // @TODO: Logic update!
-    // Not ideal that this is NULL instead of FALSE but due to how logic happens in original query function. It should be updated!
-    // Logic currently checks for isset() instead of just boolean, so won't change until endpoints switched.
-    $filters['random'] = $parameters['random'] === 'true' ? TRUE : NULL;
-    $filters['load_user'] = $parameters['load_user'] === 'true' ? TRUE : NULL;
+//    $filters = [
+//      'nid' => dosomething_helpers_format_data($parameters['campaigns']),
+//      'status' => dosomething_helpers_format_data($parameters['status']),
+//      'count' => (int) $parameters['count'] ?: 25,
+//      'page' => (int) $parameters['page'],
+//    ];
+//
+//    $filters['offset'] = $this->setOffset($filters['page'], $filters['count']);
+//
+//    // @TODO: Logic update!
+//    // Not ideal that this is NULL instead of FALSE but due to how logic happens in original query function. It should be updated!
+//    // Logic currently checks for isset() instead of just boolean, so won't change until endpoints switched.
+//    $filters['random'] = $parameters['random'] === 'true' ? TRUE : NULL;
+//    $filters['load_user'] = $parameters['load_user'] === 'true' ? TRUE : NULL;
 
     try {
       $reportbackItems = ReportbackItem::find($filters);
@@ -84,6 +86,32 @@ class ReportbackItemTransformer extends ReportbackTransformer {
     $data['user'] = $this->transformUser((object) $item->user);
 
     return $data;
+  }
+
+  /**
+   * Set the filters based on request URL parameters.
+   *
+   * @param array $parameters
+   * @return array
+   */
+  private function setFilters($parameters) {
+    $filters = [
+      'nid' => dosomething_helpers_format_data($parameters['campaigns']),
+      'status' => dosomething_helpers_format_data($parameters['status']),
+      'count' => (int) $parameters['count'] ?: 25,
+      'page' => (int) $parameters['page'],
+      'random' => dosomething_helpers_convert_string_to_boolean($parameters['random']),
+      'load_user' => dosomething_helpers_convert_string_to_boolean($parameters['load_user']),
+    ];
+
+    $filters['offset'] = $this->setOffset($filters['page'], $filters['count']);
+
+    // Unset False boolean values that affect the query builder.
+    if (!$filters['random']) {
+      unset($filters['random']);
+    }
+
+    return $filters;
   }
 
 }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -9,21 +9,6 @@ class ReportbackItemTransformer extends ReportbackTransformer {
   public function index($parameters) {
     $filters = $this->setFilters($parameters);
 
-//    $filters = [
-//      'nid' => dosomething_helpers_format_data($parameters['campaigns']),
-//      'status' => dosomething_helpers_format_data($parameters['status']),
-//      'count' => (int) $parameters['count'] ?: 25,
-//      'page' => (int) $parameters['page'],
-//    ];
-//
-//    $filters['offset'] = $this->setOffset($filters['page'], $filters['count']);
-//
-//    // @TODO: Logic update!
-//    // Not ideal that this is NULL instead of FALSE but due to how logic happens in original query function. It should be updated!
-//    // Logic currently checks for isset() instead of just boolean, so won't change until endpoints switched.
-//    $filters['random'] = $parameters['random'] === 'true' ? TRUE : NULL;
-//    $filters['load_user'] = $parameters['load_user'] === 'true' ? TRUE : NULL;
-
     try {
       $reportbackItems = ReportbackItem::find($filters);
       $reportbackItems = services_resource_build_index_list($reportbackItems, 'reportback-items', 'id');

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -76,7 +76,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
   /**
    * Set the filters based on request URL parameters.
    *
-   * @param array $parameters
+   * @param  array $parameters
    * @return array
    */
   private function setFilters($parameters) {

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -103,7 +103,7 @@ class ReportbackTransformer extends Transformer {
     $filters = [
       'nid' => dosomething_helpers_format_data($parameters['campaigns']),
       'status' => dosomething_helpers_format_data($parameters['status']),
-      'count' => $parameters['count'] ?: 25,
+      'count' => (int) $parameters['count'] ?: 25,
       'random' => dosomething_helpers_convert_string_to_boolean($parameters['random']),
       'load_user' => dosomething_helpers_convert_string_to_boolean($parameters['load_user']),
       'flagged' => dosomething_helpers_convert_string_to_boolean($parameters['flagged']),


### PR DESCRIPTION
#### What's this PR do?

This PR takes a similar approach to the update done with ReportbackTransformer for the setFilters() method added there. Helps clean up code and abstract parameter processing to a separate method.
#### Where should the reviewer start?

In the **ReportbackItemTransformer.php** changes.
#### How should this be manually tested?

Hit a few of the `/reportback-items` endpoints

---

@DFurnes 

cc: @angaither @jonuy 
