### PR TITLE
Use global english URL for image URLs so there is no country prefix

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -325,7 +325,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
   $goal_copy = number_format($goal, 0, '', ',') . " " . strtolower($vars['reportback_noun_verb']) . " by " . $readable_end_date;
 
   // Create the image path to the hot module share image generated for the node.
-  $base_url = url(base_path(), array('absolute'=> TRUE));
+  $base_url = url(base_path(), array('absolute'=> TRUE, 'language' => 'en-global'));
   $hot_share_image = $base_url . 'sites/default/files/images/hot-' . $vars['nid'] . '.png';
 
   $share_types = array(


### PR DESCRIPTION
#### What's this PR do?

Before a country prefix was being appended to the base url used to find the hot share image. This resulted in an incorrect url and the image was not able to be found. ex:

`http://dev.dosomething.org:8888/ussites/default/files/images/hot-1283.png` 

This PR uses the global english url for the hot share image URLs so that a country prefix doesn't get appended.

`http://dev.dosomething.org:8888/sites/default/files/images/hot-1283.png`
#### What are the relevant tickets?

Fixes #5752 
