### PR TITLE
Fixes get_hot_time_left to unblock cron

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -629,7 +629,7 @@ function dosomething_campaign_get_scholarship($nid) {
  */
 function dosomething_campaign_get_hot_time_left($node, &$vars = NULL) {
   $today = isset($vars['hm_today']) ? $vars['hm_today'] : dosomething_campaign_set_est_timezone(new DateTime());
-  $end_date = $vars['hm_end_date'];
+  $end_date = isset($vars['hm_end_date']) ? $vars['hm_end_date'] : dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value2']), TRUE, TRUE);
   $difference = $today->diff($end_date, true);
   $days_left = $difference->d;
   $hours_left = $difference->h + ($days_left * 24);


### PR DESCRIPTION
#### What's this PR do?

The $end_date in get_home_time_left() had no default option if hm_end_date was NULL, unline $today which did. Just applied the same style of logic.
#### How should this be manually tested?

Does cron run?
#### What are the relevant tickets?

Fixes #5917 
