### PR TITLE
Fix facebook sharing

### DIFF
--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -8,6 +8,7 @@
  * Implements hook_preprocess_page().
  */
 function dosomething_metatag_preprocess_page(&$vars) {
+  global $user;
 
   if (!empty($_GET['pass-reset-token'])) {
     // Do not cache pages with reset token set.
@@ -52,11 +53,13 @@ function dosomething_metatag_preprocess_page(&$vars) {
 
   // Add explicit facebook og meta tags to campaign pages.
   if (isset($node) && $node->type == 'campaign') {
+    $langauge_code = dosomething_global_get_language($user, $node);
+
     $facebook_data = array(
       'type' => 'dosomething_facebook:campaign',
       'url' => url(current_path(), array('absolute'=> TRUE)),
       'title' => $node->title,
-      'description' => "Volunteer and take action! " . $node->field_call_to_action[$node->language][0]['value'],
+      'description' => "Volunteer and take action! " . $node->field_call_to_action[$langauge_code][0]['value'],
     );
     dosomething_metatag_add_facebook_tags($facebook_data);
   }
@@ -103,6 +106,7 @@ function dosomething_metatag_get_metatag_image($node = NULL) {
  */
 function dosomething_metatag_add_metatag_image($node = NULL) {
   $image = dosomething_metatag_get_metatag_image($node);
+
   if ($image) {
     // Add social sharing thumbnail meta tag,
     // <link rel="image_src" href="[image]"> into the HEAD.
@@ -128,6 +132,8 @@ function dosomething_metatag_add_metatag_image($node = NULL) {
     );
     drupal_add_html_head($element, 'og:image');
 
+    // Facebook best practices say to add width & height tags
+    // 740x480 is the crop we are using on the images.
     $element = array(
       '#tag' => 'meta',
       '#attributes' => array(
@@ -227,6 +233,7 @@ function dosomething_metatag_get_permalink_vars() {
     'title' => $node->title,
     'description' => $share_copy,
     'image' => $image,
+    // 480x480 is the crop we are using on the images.
     'width' => 480,
     'height' => 480,
   );

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -50,13 +50,20 @@ function dosomething_metatag_preprocess_page(&$vars) {
   // Add relevant image metatags.
   dosomething_metatag_add_metatag_image($node);
 
-  // Explicitly add facebook og tags.
-  dosomething_metatag_add_facebook_tags($node);
+  // Add explicit facebook og meta tags to campaign pages.
+  if (isset($node) && $node->type == 'campaign') {
+    $facebook_data = array(
+      'type' => 'dosomething_facebook:campaign',
+      'url' => url(current_path(), array('absolute'=> TRUE)),
+      'title' => $node->title,
+      'description' => "Volunteer and take action! " . $node->field_call_to_action[$node->language][0]['value'],
+    );
+    dosomething_metatag_add_facebook_tags($facebook_data);
+  }
 
   // Add special share info to the permalink page.
   if (in_array('page__reportback', $vars['theme_hook_suggestions'])) {
     dosomething_metatag_get_permalink_vars();
-
   }
 }
 
@@ -151,57 +158,6 @@ function dosomething_metatag_add_metatag_image($node = NULL) {
   }
 }
 
-function dosomething_metatag_add_facebook_tags($node = NULL) {
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "fb:app_id",
-      "content" => variable_get('dosomething_settings_facebook_app_id', ''),
-    ),
-  );
-
-  drupal_add_html_head($element, 'fb:app_id');
-
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "og:type",
-      "content" => "dosomething_facebook:campaign",
-    ),
-  );
-
-  drupal_add_html_head($element, 'og:type');
-
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "og:url",
-      "content" => url(current_path(), array('absolute'=> TRUE)),
-    ),
-  );
-
-  drupal_add_html_head($element, 'og:url');
-
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "og:title",
-      "content" => $node->title,
-    ),
-  );
-
-  drupal_add_html_head($element, 'og:title');
-
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "og:description",
-      "content" => "Volunteer and take action! " . $node->field_call_to_action[$node->language][0]['value'],
-    ),
-  );
-
-  drupal_add_html_head($element, 'og:description');
-}
 /**
  * Adds twitter, facebook, tumblr share meta tags to permalink page.
  */
@@ -218,6 +174,7 @@ function dosomething_metatag_get_permalink_vars() {
   $share_copy = $node->call_to_action;
   $share_url = url(current_path(), array('absolute' => TRUE, 'query' => array('fid' => $fid)));
 
+  // Twitter.
   $element = array(
     '#tag' => 'meta',
     '#attributes' => array(
@@ -263,6 +220,21 @@ function dosomething_metatag_get_permalink_vars() {
   );
   drupal_add_html_head($element, 'twitter:url');
 
+  // Facebook.
+  $facebook_data = array(
+    'type' => 'dosomething_facebook:campaign',
+    'url' => $share_url,
+    'title' => $node->title,
+    'description' => $share_copy,
+    'image' => $image,
+    'width' => 480,
+    'height' => 480,
+  );
+
+  dosomething_metatag_add_facebook_tags($facebook_data);
+}
+
+function dosomething_metatag_add_facebook_tags($data) {
   $element = array(
     '#tag' => 'meta',
     '#attributes' => array(
@@ -273,53 +245,85 @@ function dosomething_metatag_get_permalink_vars() {
 
   drupal_add_html_head($element, 'fb:app_id');
 
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "og:type",
-      "content" => "dosomething_facebook:campaign",
-    ),
-  );
+  if (array_key_exists('type', $data)) {
+    $element = array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        "property" => "og:type",
+        "content" => $data['type'],
+      ),
+    );
 
-  drupal_add_html_head($element, 'og:type');
+    drupal_add_html_head($element, 'og:type');
+  }
 
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "og:url",
-      "content" => $share_url,
-    ),
-  );
+  if (array_key_exists('url', $data)) {
+    $element = array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        "property" => "og:url",
+        "content" => $data['url'],
+      ),
+    );
 
-  drupal_add_html_head($element, 'og:url');
+    drupal_add_html_head($element, 'og:url');
+  }
 
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "og:title",
-      "content" => $node->title,
-    ),
-  );
+  if (array_key_exists('title', $data)) {
+    $element = array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        "property" => "og:title",
+        "content" => $data['title'],
+      ),
+    );
 
-  drupal_add_html_head($element, 'og:title');
+    drupal_add_html_head($element, 'og:title');
+  }
 
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "og:image",
-      "content" => $image,
-    ),
-  );
+  if (array_key_exists('description', $data)) {
+    $element = array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        "property" => "og:description",
+        "content" => $data['description'],
+      )
+    );
 
-  drupal_add_html_head($element, 'og:image');
+    drupal_add_html_head($element, 'og:description');
+  }
 
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "og:description",
-      "content" => $share_copy,
-    ),
-  );
+  if (array_key_exists('image', $data)) {
+    $element = array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        "property" => "og:image",
+        "content" => $data['image'],
+      )
+    );
 
-  drupal_add_html_head($element, 'og:description');
+    drupal_add_html_head($element, 'og:image');
+  }
+
+  if (array_key_exists('width', $data)) {
+    $element = array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        "property" => "og:image:width",
+        "content" =>  $data['width'],
+      ),
+    );
+    drupal_add_html_head($element, 'og:image:width');
+  }
+
+  if (array_key_exists('height', $data)) {
+    $element = array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        "property" => "og:image:height",
+        "content" =>  $data['height'],
+      ),
+    );
+    drupal_add_html_head($element, 'og:image:height');
+  }
 }

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -234,6 +234,12 @@ function dosomething_metatag_get_permalink_vars() {
   dosomething_metatag_add_facebook_tags($facebook_data);
 }
 
+/*
+ * Add facebook og tags to the page.
+ *
+ * @param array $data
+ *   Array of the content to use for each property.
+ */
 function dosomething_metatag_add_facebook_tags($data) {
   $element = array(
     '#tag' => 'meta',

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -119,7 +119,26 @@ function dosomething_metatag_add_metatag_image($node = NULL) {
         "content" => $image,
       ),
     );
-    drupal_add_html_head($element, 'facebook_share_image');
+    drupal_add_html_head($element, 'og:image');
+
+    $element = array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        "property" => "og:image:width",
+        "content" =>  740,
+      ),
+    );
+    drupal_add_html_head($element, 'og:image:width');
+
+    $element = array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        "property" => "og:image:height",
+        "content" =>  480,
+      ),
+    );
+    drupal_add_html_head($element, 'og:image:height');
+
     // Add the Twitter Image tag into the HEAD.
     $element = array(
       '#tag' => 'meta',
@@ -128,7 +147,7 @@ function dosomething_metatag_add_metatag_image($node = NULL) {
         "content" => $image,
       ),
     );
-    drupal_add_html_head($element, 'twitter_image');
+    drupal_add_html_head($element, 'twitter:image');
   }
 }
 

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -50,6 +50,9 @@ function dosomething_metatag_preprocess_page(&$vars) {
   // Add relevant image metatags.
   dosomething_metatag_add_metatag_image($node);
 
+  // Explicitly add facebook og tags.
+  dosomething_metatag_add_facebook_tags($node);
+
   // Add special share info to the permalink page.
   if (in_array('page__reportback', $vars['theme_hook_suggestions'])) {
     dosomething_metatag_get_permalink_vars();
@@ -129,6 +132,57 @@ function dosomething_metatag_add_metatag_image($node = NULL) {
   }
 }
 
+function dosomething_metatag_add_facebook_tags($node = NULL) {
+  $element = array(
+    '#tag' => 'meta',
+    '#attributes' => array(
+      "property" => "fb:app_id",
+      "content" => variable_get('dosomething_settings_facebook_app_id', ''),
+    ),
+  );
+
+  drupal_add_html_head($element, 'fb:app_id');
+
+  $element = array(
+    '#tag' => 'meta',
+    '#attributes' => array(
+      "property" => "og:type",
+      "content" => "dosomething_facebook:campaign",
+    ),
+  );
+
+  drupal_add_html_head($element, 'og:type');
+
+  $element = array(
+    '#tag' => 'meta',
+    '#attributes' => array(
+      "property" => "og:url",
+      "content" => url(current_path(), array('absolute'=> TRUE)),
+    ),
+  );
+
+  drupal_add_html_head($element, 'og:url');
+
+  $element = array(
+    '#tag' => 'meta',
+    '#attributes' => array(
+      "property" => "og:title",
+      "content" => $node->title,
+    ),
+  );
+
+  drupal_add_html_head($element, 'og:title');
+
+  $element = array(
+    '#tag' => 'meta',
+    '#attributes' => array(
+      "property" => "og:description",
+      "content" => "Volunteer and take action! " . $node->field_call_to_action[$node->language][0]['value'],
+    ),
+  );
+
+  drupal_add_html_head($element, 'og:description');
+}
 /**
  * Adds twitter, facebook, tumblr share meta tags to permalink page.
  */


### PR DESCRIPTION
#### What's this PR do?

Facebook was throwing some warnings: 

![screen shot 2015-12-09 at 5 12 04 pm](https://cloud.githubusercontent.com/assets/1700409/11722400/7acbb4fc-9f36-11e5-8215-57371f7eea2d.png)

They are suggesting that we explicitly add all of the og tags, listed above, on the page. This PR adds them all for campaign pages. Also extracts this logic into a function since we also do it on permalink pages. We should probably add them on all pages, but I'm not sure what all the settings should be for everytype of page. Campaign pages seem to be priority for now. 
#### Where should the reviewer start?

[Start here](https://github.com/DoSomething/phoenix/compare/dev...sbsmith86:fix-facebook-sharing?expand=1#diff-34bae740579fece653f7f7b32b22baa9R54). I set all the Facebook properties and call the new function that adds the tags to the page.
#### Any background context you want to provide?

This probably won't fix anything, but we are seeing issues with Facebook pulling inconsistent data from the page, so I want to clean up these warnings so we can continue and debug the issue. 

However, [I think this issue](https://github.com/DoSomething/phoenix/issues/5936), will fix most of our facebook sharing woes.
#### What are the relevant tickets?

Addresses #5439
#### Screenshots (if appropriate)
