### PR TITLE
Adds specific deadline to hotmodule stat card

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -628,7 +628,10 @@ function dosomething_campaign_get_scholarship($nid) {
  *  Formatted time (e.g. "4 days left")
  */
 function dosomething_campaign_get_hot_time_left($node, &$vars = NULL) {
-  $timing = dosomething_campaign_get_goals_times($vars);
+  if (!isset($node) && !isset($vars)) {
+    return;
+  }
+  $timing = dosomething_campaign_get_goals_times($vars ?: $node);
   $today = $timing['today'];
   $end_date = $timing['end_date'];
   $difference = $today->diff($end_date, true);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -628,12 +628,16 @@ function dosomething_campaign_get_scholarship($nid) {
  *  Formatted time (e.g. "4 days left")
  */
 function dosomething_campaign_get_hot_time_left($node, &$vars = NULL) {
-  if (!isset($node) && !isset($vars)) {
-    return;
+  if (!isset($vars) && !isset($vars['hm_today'])) {
+    $timing = dosomething_campaign_get_goals_times($node);
+
+    if (!isset($timing)) {
+      return;
+    }
   }
-  $timing = dosomething_campaign_get_goals_times($vars ?: $node);
-  $today = $timing['today'];
-  $end_date = $timing['end_date'];
+
+  $today = $vars['hm_today'] ?: $timing['today'];
+  $end_date = $vars['hm_end_date'] ?: $timing['end_date'];
   $difference = $today->diff($end_date, true);
   $days_left = $difference->d;
   $hours_left = $difference->h + ($days_left * 24);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -628,8 +628,9 @@ function dosomething_campaign_get_scholarship($nid) {
  *  Formatted time (e.g. "4 days left")
  */
 function dosomething_campaign_get_hot_time_left($node, &$vars = NULL) {
-  $today = isset($vars['hm_today']) ? $vars['hm_today'] : dosomething_campaign_set_est_timezone(new DateTime());
-  $end_date = $vars['hm_end_date'];
+  $timing = dosomething_campaign_get_goals_times($vars);
+  $today = $timing['today'];
+  $end_date = $timing['end_date'];
   $difference = $today->diff($end_date, true);
   $days_left = $difference->d;
   $hours_left = $difference->h + ($days_left * 24);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -763,12 +763,14 @@ function dosomething_campaign_is_hot_module(&$vars) {
   if ($hot_module_enabled && isset($vars['field_high_season'])) {
     $today = dosomething_campaign_set_est_timezone(new DateTime());
     $start_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value']), TRUE);
+    $unmodified_end_date = new DateTime($vars['field_high_season'][0]['value2']);
     $end_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value2']), TRUE, TRUE);
 
     // Set the values to the vars array, so we don't need to do the math again.
     $vars['hm_today'] = $today;
     $vars['hm_start_date'] = $start_date;
     $vars['hm_end_date'] = $end_date;
+    $vars['hm_readable_end_date'] = $unmodified_end_date->format('F jS h') . ':' . $unmodified_end_date->format('i T');
 
     // Hot module is only enabled when variable is set, high season dates exist and there is still days left.
     if (!empty($vars['field_high_season']) && (($start_date < $today)  && ($today < $end_date))) {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -762,19 +762,16 @@ function dosomething_campaign_is_hot_module(&$vars) {
   $hot_module_enabled = dosomething_helpers_get_variable('node', $vars['nid'], 'hot_module_enabled');
   if ($hot_module_enabled && isset($vars['field_high_season'])) {
     date_default_timezone_set('EST');
-    $today = dosomething_campaign_set_est_timezone(new DateTime());
-    $start_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value']), TRUE);
-    $unmodified_end_date = new DateTime($vars['field_high_season'][0]['value2']);
-    $end_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value2']), TRUE, TRUE);
+    $timing = dosomething_campaign_get_goals_times($vars);
 
     // Set the values to the vars array, so we don't need to do the math again.
-    $vars['hm_today'] = $today;
-    $vars['hm_start_date'] = $start_date;
-    $vars['hm_end_date'] = $end_date;
-    $vars['hm_readable_end_date'] = $unmodified_end_date->format('F jS h') . ':' . $unmodified_end_date->format('ia T');
+    $vars['hm_today'] = $timing['today'];
+    $vars['hm_start_date'] = $timing['start_date'];
+    $vars['hm_end_date'] = $timing['end_date'];
+    $vars['hm_readable_end_date'] = $timing['unmodified_end_date']->format('F jS h') . ':' . $timing['unmodified_end_date']->format('ia T');
 
     // Hot module is only enabled when variable is set, high season dates exist and there is still days left.
-    if (!empty($vars['field_high_season']) && (($start_date < $today)  && ($today < $end_date))) {
+    if (!empty($vars['field_high_season']) && (($timing['start_date'] < $timing['today'])  && ($timing['today'] < $timing['end_date']))) {
       return TRUE;
     }
   }
@@ -908,6 +905,16 @@ function dosomething_campaign_set_est_timezone($date, $add_four = FALSE, $end_of
     $date->setTime(23, 59, 59);
   }
   return $date;
+}
+
+function dosomething_campaign_get_goals_times($node) {
+  $timing = [
+    "today" => dosomething_campaign_set_est_timezone(new DateTime()),
+    "start_date" => dosomething_campaign_set_est_timezone(new DateTime($node['field_high_season'][0]['value']), TRUE),
+    "unmodified_end_date" => new DateTime($node['field_high_season'][0]['value2']),
+    "end_date" => dosomething_campaign_set_est_timezone(new DateTime($node['field_high_season'][0]['value2']), TRUE, TRUE)
+  ];
+  return $timing;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -761,6 +761,7 @@ function dosomething_campaign_add_shipment_form_vars($node) {
 function dosomething_campaign_is_hot_module(&$vars) {
   $hot_module_enabled = dosomething_helpers_get_variable('node', $vars['nid'], 'hot_module_enabled');
   if ($hot_module_enabled && isset($vars['field_high_season'])) {
+    date_default_timezone_set('EST');
     $today = dosomething_campaign_set_est_timezone(new DateTime());
     $start_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value']), TRUE);
     $unmodified_end_date = new DateTime($vars['field_high_season'][0]['value2']);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -869,7 +869,6 @@ function dosomething_campaign_is_active($node) {
   $hot_module_enabled = dosomething_helpers_get_variable('node', $vars['nid'], 'hot_module_enabled');
   $win_module_enabled = variable_get('dosomething_campaign_enable_win_module', NULL);
   if ($win_module_enabled == 1 && isset($vars['field_high_season']) && $hot_module_enabled) {
-    date_default_timezone_set('EST');
     $timing = dosomething_campaign_get_goals_times($vars);
 
     // Set the values to the vars array, so we don't need to do the math again.
@@ -920,11 +919,13 @@ function dosomething_campaign_get_goals_times($node) {
   if (!isset($node)) {
     return NULL;
   }
+  date_default_timezone_set('EST');
+  $high_season = is_array($node) ? $node['field_high_season'] : $node->field_high_season;
   $timing = [
-    "today" => dosomething_campaign_set_est_timezone(new DateTime()),
-    "start_date" => dosomething_campaign_set_est_timezone(new DateTime($node['field_high_season'][0]['value']), TRUE),
-    "unmodified_end_date" => new DateTime($node['field_high_season'][0]['value2']),
-    "end_date" => dosomething_campaign_set_est_timezone(new DateTime($node['field_high_season'][0]['value2']), TRUE, TRUE)
+    "today" => new DateTime(),
+    "start_date" => new DateTime($high_season[0]['value']),
+    "unmodified_end_date" => new DateTime($high_season[0]['value2']),
+    "end_date" => new DateTime($high_season[0]['value2']),
   ];
   return $timing;
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -874,7 +874,7 @@ function dosomething_campaign_is_active($node) {
     $vars['hm_today'] = $timing['today'];
     $vars['hm_end_date'] = $timing['end_date'];
 
-    $win_module_end = dosomething_campaign_set_est_timezone(date_modify(clone $timing['end_date'], '+30 days'), TRUE, TRUE);
+    $win_module_end = $timing['win_module_end'];
 
     // Win module is only enabled when variable is set, high season dates exist and there is still days left.
     if (!empty($vars['field_high_season']) && (($timing['end_date'] < $timing['today'])  && ($timing['today'] < $win_module_end))) {
@@ -926,7 +926,7 @@ function dosomething_campaign_get_goals_times($node) {
     return NULL;
   }
   date_default_timezone_set('EST');
-  $high_season = is_array($node) ? $node['field_high_season'] : $node->field_high_season[LANGUAGE_NONE];
+  $high_season = is_array($node) ? $node['field_high_season'] : $node->field_high_season[$node->language];
   if($high_season == NULL) {
     return NULL;
   }
@@ -934,6 +934,7 @@ function dosomething_campaign_get_goals_times($node) {
     "today" => new DateTime(),
     "start_date" => new DateTime($high_season[0]['value']),
     "end_date" => new DateTime($high_season[0]['value2']),
+    "win_module_end" => date_modify(new DateTime($high_season[0]['value2']), '+30 days'),
   ];
   return $timing;
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -867,16 +867,21 @@ function dosomething_campaign_is_active($node) {
   */
  function dosomething_campaign_is_win_module($vars) {
   $hot_module_enabled = dosomething_helpers_get_variable('node', $vars['nid'], 'hot_module_enabled');
-  if (isset($vars['field_high_season']) && $hot_module_enabled) {
-     $today = dosomething_campaign_set_est_timezone(new DateTime());
-     $end_date = dosomething_campaign_set_est_timezone(new DateTime($vars['field_high_season'][0]['value2']), TRUE, TRUE);
-     $win_module_end = dosomething_campaign_set_est_timezone(date_modify(clone $end_date, '+30 days'), TRUE, TRUE);
-     $vars['hm_today'] = $today;
-     $vars['hm_end_date'] = $end_date;
-     // Win module is only enabled when variable is set, high season dates exist and there is still days left.
-     if (variable_get('dosomething_campaign_enable_win_module', NULL) == 1 && !empty($vars['field_high_season']) && (($end_date < $today)  && ($today < $win_module_end))) {
-       return TRUE;
-     }
+  $win_module_enabled = variable_get('dosomething_campaign_enable_win_module', NULL);
+  if ($win_module_enabled == 1 && isset($vars['field_high_season']) && $hot_module_enabled) {
+    date_default_timezone_set('EST');
+    $timing = dosomething_campaign_get_goals_times($vars);
+
+    // Set the values to the vars array, so we don't need to do the math again.
+    $vars['hm_today'] = $timing['today'];
+    $vars['hm_end_date'] = $timing['end_date'];
+
+    $win_module_end = dosomething_campaign_set_est_timezone(date_modify(clone $timing['end_date'], '+30 days'), TRUE, TRUE);
+
+    // Win module is only enabled when variable is set, high season dates exist and there is still days left.
+    if (!empty($vars['field_high_season']) && (($timing['end_date'] < $timing['today'])  && ($timing['today'] < $win_module_end))) {
+      return TRUE;
+    }
    }
    return FALSE;
  }
@@ -907,7 +912,14 @@ function dosomething_campaign_set_est_timezone($date, $add_four = FALSE, $end_of
   return $date;
 }
 
+/**
+ * Returns array of date times ofor the given campaign node
+ *
+ */
 function dosomething_campaign_get_goals_times($node) {
+  if (!isset($node)) {
+    return NULL;
+  }
   $timing = [
     "today" => dosomething_campaign_set_est_timezone(new DateTime()),
     "start_date" => dosomething_campaign_set_est_timezone(new DateTime($node['field_high_season'][0]['value']), TRUE),

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -761,14 +761,13 @@ function dosomething_campaign_add_shipment_form_vars($node) {
 function dosomething_campaign_is_hot_module(&$vars) {
   $hot_module_enabled = dosomething_helpers_get_variable('node', $vars['nid'], 'hot_module_enabled');
   if ($hot_module_enabled && isset($vars['field_high_season'])) {
-    date_default_timezone_set('EST');
     $timing = dosomething_campaign_get_goals_times($vars);
 
     // Set the values to the vars array, so we don't need to do the math again.
     $vars['hm_today'] = $timing['today'];
     $vars['hm_start_date'] = $timing['start_date'];
     $vars['hm_end_date'] = $timing['end_date'];
-    $vars['hm_readable_end_date'] = $timing['unmodified_end_date']->format('F jS h') . ':' . $timing['unmodified_end_date']->format('ia T');
+    $vars['hm_readable_end_date'] = $timing['end_date']->format('F jS h') . ':' . $timing['end_date']->format('ia T');
 
     // Hot module is only enabled when variable is set, high season dates exist and there is still days left.
     if (!empty($vars['field_high_season']) && (($timing['start_date'] < $timing['today'])  && ($timing['today'] < $timing['end_date']))) {
@@ -914,17 +913,26 @@ function dosomething_campaign_set_est_timezone($date, $add_four = FALSE, $end_of
 /**
  * Returns array of date times ofor the given campaign node
  *
+ * @param Object or Array
+ *    vars array or node object to pull from
+ *
+ * @return array $timing
+ *    today - The current day
+ *    start_date - The day the campaign starts
+ *    end_date - The day the campaign ends
  */
 function dosomething_campaign_get_goals_times($node) {
   if (!isset($node)) {
     return NULL;
   }
   date_default_timezone_set('EST');
-  $high_season = is_array($node) ? $node['field_high_season'] : $node->field_high_season;
+  $high_season = is_array($node) ? $node['field_high_season'] : $node->field_high_season[LANGUAGE_NONE];
+  if($high_season == NULL) {
+    return NULL;
+  }
   $timing = [
     "today" => new DateTime(),
     "start_date" => new DateTime($high_season[0]['value']),
-    "unmodified_end_date" => new DateTime($high_season[0]['value2']),
     "end_date" => new DateTime($high_season[0]['value2']),
   ];
   return $timing;

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -771,7 +771,7 @@ function dosomething_campaign_is_hot_module(&$vars) {
     $vars['hm_today'] = $today;
     $vars['hm_start_date'] = $start_date;
     $vars['hm_end_date'] = $end_date;
-    $vars['hm_readable_end_date'] = $unmodified_end_date->format('F jS h') . ':' . $unmodified_end_date->format('i T');
+    $vars['hm_readable_end_date'] = $unmodified_end_date->format('F jS h') . ':' . $unmodified_end_date->format('ia T');
 
     // Hot module is only enabled when variable is set, high season dates exist and there is still days left.
     if (!empty($vars['field_high_season']) && (($start_date < $today)  && ($today < $end_date))) {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -247,7 +247,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
   $start_date = $vars['hm_start_date'];
   $end_date = $vars['hm_end_date'];
   $readable_end_date = $vars['hm_readable_end_date'];
-  $time_left = dosomething_campaign_get_hot_time_left($vars);
+  $time_left = dosomething_campaign_get_hot_time_left(NULL, $vars);
 
   //Calculate progress goal & copy
   $goal = dosomething_helpers_get_variable('node', $vars['nid'], 'goal');

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -247,7 +247,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
   $start_date = $vars['hm_start_date'];
   $end_date = $vars['hm_end_date'];
   $readable_end_date = $vars['hm_readable_end_date'];
-  $time_left = dosomething_campaign_get_hot_time_left($node, $vars);
+  $time_left = dosomething_campaign_get_hot_time_left($vars);
 
   //Calculate progress goal & copy
   $goal = dosomething_helpers_get_variable('node', $vars['nid'], 'goal');

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -359,6 +359,7 @@ function dosomething_campaign_preprocess_hot_module(&$vars, &$wrapper) {
     'author_image' => (isset($vars['author_image'])) ? $vars['author_image'] : NULL,
     'share_copy' => $share_copy,
     'share_bar' => $share_bar,
+    'exact_end_date' => $readable_end_date,
   );
 
   $vars['hot_module'] = theme('hot_module_block', $hot_module_variables);

--- a/lib/modules/dosomething/dosomething_campaign/theme/hot-module.tpl.php
+++ b/lib/modules/dosomething/dosomething_campaign/theme/hot-module.tpl.php
@@ -15,7 +15,7 @@
         <div class="stat-card__chart">
           <canvas class="js-progress-chart" width="280" height="200" data-goal="<?php print $goal; ?>"></canvas>
         </div>
-        <div class="stat-card__end">
+        <div class="stat-card__deadline">
           <p><?php print t("Deadline for reaching to goal is") ?></p>
           <p><?php print $exact_end_date ?></p>
         </div>

--- a/lib/modules/dosomething/dosomething_campaign/theme/hot-module.tpl.php
+++ b/lib/modules/dosomething/dosomething_campaign/theme/hot-module.tpl.php
@@ -16,7 +16,7 @@
           <canvas class="js-progress-chart" width="280" height="200" data-goal="<?php print $goal; ?>"></canvas>
         </div>
         <div class="stat-card__deadline">
-          <p><?php print t("Deadline for reaching to goal is") ?></p>
+          <p><?php print t('Deadline for reaching the goal is') ?></p>
           <p><?php print $exact_end_date ?></p>
         </div>
       </div>

--- a/lib/modules/dosomething/dosomething_campaign/theme/hot-module.tpl.php
+++ b/lib/modules/dosomething/dosomething_campaign/theme/hot-module.tpl.php
@@ -15,6 +15,10 @@
         <div class="stat-card__chart">
           <canvas class="js-progress-chart" width="280" height="200" data-goal="<?php print $goal; ?>"></canvas>
         </div>
+        <div class="stat-card__end">
+          <p><?php print t("Deadline for reaching to goal is") ?></p>
+          <p><?php print $exact_end_date ?></p>
+        </div>
       </div>
 
       <div class="author-callout">

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_stat-card.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_stat-card.scss
@@ -41,4 +41,13 @@ $dark-blue: #0081BC;
     border: solid 2px $light-gray;
     border-top: 0;
   }
+
+  .stat-card__deadline {
+    color: $med-gray;
+    margin: $base-spacing 0;
+
+    p {
+      margin-top: 0;
+    }
+  }
 }


### PR DESCRIPTION
#### What's this PR do?

Adds a specific deadline to the hot module stat card stating the end date time pm/am and timezone 
Also fixes hm_readable_end_date

Also covers this PR https://github.com/DoSomething/phoenix/pull/5934
#### How should this be manually tested?

Currently on Thor, heres an example https://thor.dosomething.org/us/campaigns/smiles-soldiers

otherwise test if the hot module is outputting correctly 
#### Any background context you want to provide?

For some reason the PHP decided to do formatting in GMT, this caused confusion because of all our settings are defaulted to UTC. The solution was date_default_timeszone_set("EST") as I saw on PHP.net http://php.net/manual/en/function.date.php#refsect1-function.date-examples
#### What are the relevant tickets?

Fixes #5922 
Fixes #5917  
#### Screenshots (if appropriate)

![screen shot 2015-12-10 at 1 20 58 pm](https://cloud.githubusercontent.com/assets/897368/11724354/9255b7a2-9f41-11e5-96b9-3b7c2bb10261.png)
![screen shot 2015-12-10 at 1 22 20 pm](https://cloud.githubusercontent.com/assets/897368/11724355/9255f226-9f41-11e5-9379-38d369a81f74.png)

This is what it looks like as an Australian user normally 1 day ahead of the US/East (Date in backend is the 15th) 
![screen shot 2015-12-10 at 2 24 09 pm](https://cloud.githubusercontent.com/assets/897368/11725852/c98aded4-9f49-11e5-80fa-513722f37aa7.png)
# DONT MERGE YET
