### PR TITLE
Switch permalink to use facebook feed dialog

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -540,10 +540,13 @@ function dosomething_reportback_view_entity($entity) {
     $share_text = token_replace(t(variable_get('dosomething_campaign_permalink_confirmation_owners_social_network_copy')), array('node' => $node));
     $share_text = str_replace('[node:issue]', strtolower($node->issue['name']), $share_text);
 
-
     $share_types = array(
       'facebook' => array(
-        'type' => 'default',
+        'type' => 'feed_dialog',
+        'parameters' => array(
+          'picture' => $file->getImageURL('480x480'),
+          'caption' => $node->call_to_action,
+        ),
       ),
       'twitter' => array(
         'tweet' => htmlspecialchars_decode($share_text, ENT_QUOTES) . " ",


### PR DESCRIPTION
#### What's this PR do?

Switch the type of share we use for the Facebook share functionality on permalink pages. The feed dialog allows us to customize the data that is shared manually, without depending on meta tags. This helps us get around Facebook scraping and caching issues on these pages that get created on the fly. 
#### Any background context you want to provide?

Was working on manually forcing facebook to crawl these pages using their API, but that has the potential to block the page from loading. This approach allows us to have more custom functionality for the facebook share, but only when the user actually clicks the facebook share button.
#### What are the relevant tickets?

Fixes #5096 
