### PR TITLE
There's an additional `days` attribute on the diff.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -639,11 +639,11 @@ function dosomething_campaign_get_hot_time_left($node, &$vars = NULL) {
   $today = $vars['hm_today'] ?: $timing['today'];
   $end_date = $vars['hm_end_date'] ?: $timing['end_date'];
   $difference = $today->diff($end_date, true);
-  $days_left = $difference->d;
+  $days_left = $difference->days;
   $hours_left = $difference->h + ($days_left * 24);
 
   if ($hours_left > 48) {
-    $time_left = t($difference->d . ' days left');
+    $time_left = t($days_left . ' days left');
   }
   else {
     $time_left = t($hours_left . ' hours left');


### PR DESCRIPTION
Using that will not ignore the month the campaign ends.
Fixes #5856

instead of calculating how many days in that month and adding it all together, the `days` does that for you
![image](https://cloud.githubusercontent.com/assets/645205/11666009/41f5fa9a-9db8-11e5-8736-9cfb1e5195b0.png)
