### PR TITLE
Reportback status security refactor

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback_item.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback_item.query.inc
@@ -117,14 +117,8 @@ function dosomething_reportback_build_reportback_items_query($params = array()) 
 *    An executed database query object to iterate through.
 */
 function dosomething_reportback_get_reportback_items_query($params) {
-  if (isset($params['status'])) {
-    $statuses = dosomething_reportback_filter_permitted_statuses($params['status']);
-
-    if (!$statuses) {
+  if (isset($params['status']) && !$params['status']) {
       return FALSE;
-    }
-
-    $params['status'] = $statuses;
   }
 
   $query = dosomething_reportback_build_reportback_items_query($params);
@@ -138,37 +132,4 @@ function dosomething_reportback_get_reportback_items_query($params) {
   $result = $query->execute()->fetchAll();
 
   return $result;
-}
-
-
-/**
- * Filter out requested Reportback Item status based on user permissions.
- *
- * @param mixed $data
- * @return mixed
- */
-function dosomething_reportback_filter_permitted_statuses($data) {
-  if (user_access('view any reportback')) {
-    return $data;
-  }
-
-  if (!is_array($data)) {
-    $data = [$data];
-  }
-
-  $restricted = ['pending', 'flagged', 'excluded'];
-
-  $prohibited_values = array_intersect($restricted, $data);
-
-  if ($prohibited_values) {
-    foreach ($prohibited_values as $value) {
-      unset($data[array_search($value, $data)]);
-    }
-  }
-
-  if (count($data) === 1) {
-    return array_shift($data);
-  }
-
-  return $data;
 }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -46,6 +46,7 @@ class ReportbackItem extends Entity {
     }
 
     foreach($results as $item) {
+      // check whether user has permission to view
       $reportbackItem = new static;
       $reportbackItem->build($item, TRUE);
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -46,7 +46,6 @@ class ReportbackItem extends Entity {
     }
 
     foreach($results as $item) {
-      // check whether user has permission to view
       $reportbackItem = new static;
       $reportbackItem->build($item, TRUE);
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -10,7 +10,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
    */
   public function index($parameters) {
     $filters = $this->setFilters($parameters);
-    
+
     try {
       $reportbackItems = ReportbackItem::find($filters);
       $reportbackItems = services_resource_build_index_list($reportbackItems, 'reportback-items', 'id');

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -99,4 +99,9 @@ class ReportbackItemTransformer extends ReportbackTransformer {
     return $filters;
   }
 
+
+  private function securingFilters() {
+
+  }
+
 }


### PR DESCRIPTION
Fixes #5874
#### What's this PR do?

The logic to remove restricted statuses has been switched around from being in the **dosomething_reportback_item.query.inc** file to being a private method of the `ReportbackItemTransformer` class. The security measures in place are really only being used by the API, and this also allows for securing the filters earlier on in the transformation process, rather than later when it hits the query builder, allowing the need to process the filters only once instead of multiple times. 

These changes were also required for how the totals are calculated and relying on accurate use of the RB item statuses along with pagination for the gallery.
#### Where should the reviewer start?

Most of the magic is happening in the **ReportbackItemTransformer.php**.
#### What are the relevant tickets?
#5874

---

@DFurnes @angaither 

cc: @jonuy @aaronschachter 
