### PR TITLE
Updating show method for RB Item results with some security.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -40,6 +40,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
   public function show($id) {
     try {
       $reportbackItem = ReportbackItem::get($id);
+      $reportbackItem = $this->removeUnauthorizedResults($reportbackItem);
       $reportbackItem = services_resource_build_index_list($reportbackItem, 'reportback-items', 'id');
     }
     catch (Exception $error) {
@@ -126,6 +127,31 @@ class ReportbackItemTransformer extends ReportbackTransformer {
     }
 
     return $statuses;
+  }
+
+  /**
+   * Remove Reportback Items with unauthorized statuses based on user permission.
+   *
+   * @param  array $data
+   * @return mixed
+   * @throws Exception
+   */
+  private function removeUnauthorizedResults($data) {
+    if (user_access('view any reportback')) {
+      return $data;
+    }
+
+    foreach ($data as $index => $item) {
+      if (!in_array($item->status, $this->accessibleStatuses)) {
+        unset($data[$index]);
+      }
+    }
+
+    if (!$data) {
+      throw new Exception('No reportback items data found.');
+    }
+
+    return $data;
   }
 
 }


### PR DESCRIPTION
Refs #5929
#### What's this PR do?

While the index collection of RB Items from the API is now doing a better job of securing content that should not be accessible to anonymous API requests, the show view for a single RB Item was not. This update adds a method to check whether an RB Item returned via requests to `/reportback-items` should be accessible or not. If the anonymous user does not have access to flagged, excluded, and pending items that are specifically requested by their ID, then an exception is thrown and caught via the normal process within the API request cycle.
#### Where should the reviewer start?

In the one file changed, *\* ReportbackItemTransformer.php**.
#### Any background context you want to provide?

Not 100% sure on the naming of method in this PR or in #5953, but good enough for now! :sheep: 
#### What are the relevant tickets?
#5929

---

@DFurnes @angaither 
cc: @jonuy @aaronschachter 
