### PR TITLE
Reportback api multiple ids

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
@@ -1,104 +1,104 @@
 <?php
 
 function _reportback_resource_definition() {
-  $reportback_resource = array();
-  $reportback_resource['reportbacks'] = array(
-    'operations' => array(
+  $reportback_resource = [];
+  $reportback_resource['reportbacks'] = [
+    'operations' => [
 
-      'retrieve' => array(
+      'retrieve' => [
         'help' => 'Retrieve a specified reportback.',
-        'file' => array(
+        'file' => [
           'type' => 'inc',
           'module' => 'dosomething_api',
           'name' => 'resources/reportback_resource'
-        ),
+        ],
         'callback' => '_reportback_resource_retrieve',
-        'args' => array(
-          array(
+        'args' => [
+          [
             'name' => 'rbid',
             'description' => 'The rbid of the reportback to retrieve.',
             'optional' => FALSE,
             'type' => 'int',
-            'source' => array('path' => 0),
-          ),
-        ),
+            'source' => ['path' => 0],
+          ],
+        ],
         'access callback' => '_reportback_resource_access',
-        'access arguments' => array('view'),
-      ),
+        'access arguments' => ['view'],
+      ],
 
-      'index' => array(
+      'index' => [
         'help' => 'List all reportbacks.',
-        'file' => array(
+        'file' => [
           'type' => 'inc',
           'module' => 'dosomething_api',
           'name' => 'resources/reportback_resource'
-        ),
+        ],
         'callback' => '_reportback_resource_index',
-        'args' => array(
-          array(
+        'args' => [
+          [
             'name' => 'campaigns',
             'description' => 'The ids of specified campaigns to get reportbacks.',
             'optional' => TRUE,
             'type' => 'string',
-            'source' => array('param' => 'campaigns'),
+            'source' => ['param' => 'campaigns'],
             'default value' => NULL,
-          ),
-          array(
+          ],
+          [
             'name' => 'status',
             'description' => 'Comma delimited list of reportback statuses to collect reportbacks for.',
             'optional' => TRUE,
             'type' => 'string',
-            'source' => array('param' => 'status'),
+            'source' => ['param' => 'status'],
             'default value' => 'promoted,approved',
-          ),
-          array(
+          ],
+          [
             'name' => 'count',
             'description' => 'The number of reportbacks to retrieve.',
             'optional' => TRUE,
             'type' => 'string',
-            'source' => array('param' => 'count'),
+            'source' => ['param' => 'count'],
             'default value' => 25,
-          ),
-          array(
+          ],
+          [
             'name' => 'random',
             'description' => 'Boolean to indicate whether to retrieve reportbacks in random order.',
             'optional' => TRUE,
             'type' => 'boolean',
-            'source' => array('param' => 'random'),
+            'source' => ['param' => 'random'],
             'default value' => FALSE,
-          ),
-          array(
+          ],
+          [
             'name' => 'page',
             'description' => 'The zero-based index of the page to get, defaults to 0.',
             'optional' => TRUE,
             'type' => 'int',
-            'source' => array('param' => 'page'),
+            'source' => ['param' => 'page'],
             'default value' => 1,
-          ),
-          array(
+          ],
+          [
             'name' => 'load_user',
             'description' => 'Boolean to indicate whether to make call to northstar to retrieve full user data.',
             'optional' => TRUE,
             'type' => 'boolean',
-            'source' => array('param' => 'load_user'),
+            'source' => ['param' => 'load_user'],
             'default value' => FALSE,
-          ),
-          array(
+          ],
+          [
             'name' => 'flagged',
             'description' => 'Boolean to indicate whether to also retrieve flagged reportbacks.',
             'optional' => TRUE,
             'type' => 'boolean',
-            'source' => array('param' => 'flagged'),
+            'source' => ['param' => 'flagged'],
             'default value' => FALSE,
-          ),
-        ),
+          ],
+        ],
         'access callback' => '_reportback_resource_access',
-        'access arguments' => array('index'),
-      ),
+        'access arguments' => ['index'],
+      ],
 
-    ),
+    ],
 
-  );
+  ];
 
   return $reportback_resource;
 }
@@ -125,7 +125,7 @@ function _reportback_resource_access($op) {
 
 
 function _reportback_resource_index($campaigns, $status, $count, $random, $page, $load_user, $flagged) {
-  $parameters =  array(
+  $parameters =  [
     'campaigns' => $campaigns,
     'status' => $status,
     'count' => $count,
@@ -133,7 +133,7 @@ function _reportback_resource_index($campaigns, $status, $count, $random, $page,
     'page' => $page,
     'load_user' => $load_user,
     'flagged' => $flagged,
-  );
+  ];
 
   $reportbacks = new ReportbackTransformer;
   return $reportbacks->index($parameters);

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
@@ -36,6 +36,14 @@ function _reportback_resource_definition() {
         'callback' => '_reportback_resource_index',
         'args' => [
           [
+            'name' => 'ids',
+            'description' => 'Retrieve reportbacks based on specific node ids.',
+            'optional' => TRUE,
+            'type' => 'string',
+            'source' => ['param' => 'ids'],
+            'default value' => NULL,
+          ],
+          [
             'name' => 'campaigns',
             'description' => 'The ids of specified campaigns to get reportbacks.',
             'optional' => TRUE,
@@ -55,7 +63,7 @@ function _reportback_resource_definition() {
             'name' => 'count',
             'description' => 'The number of reportbacks to retrieve.',
             'optional' => TRUE,
-            'type' => 'string',
+            'type' => 'int',
             'source' => ['param' => 'count'],
             'default value' => 25,
           ],
@@ -123,9 +131,22 @@ function _reportback_resource_access($op) {
   return FALSE;
 }
 
-
-function _reportback_resource_index($campaigns, $status, $count, $random, $page, $load_user, $flagged) {
+/**
+ * Retrieve and show index list response of reportbacks requested.
+ *
+ * @param  string  $ids
+ * @param  string  $campaigns
+ * @param  string  $status
+ * @param  int     $count
+ * @param  bool    $random
+ * @param  int     $page
+ * @param  bool    $load_user
+ * @param  bool    $flagged
+ * @return array
+ */
+function _reportback_resource_index($ids, $campaigns, $status, $count, $random, $page, $load_user, $flagged) {
   $parameters =  [
+    'ids' => $ids,
     'campaigns' => $campaigns,
     'status' => $status,
     'count' => $count,
@@ -135,12 +156,10 @@ function _reportback_resource_index($campaigns, $status, $count, $random, $page,
     'flagged' => $flagged,
   ];
 
-  $reportbacks = new ReportbackTransformer;
-  return $reportbacks->index($parameters);
+  return (new ReportbackTransformer)->index($parameters);
 }
 
 
 function _reportback_resource_retrieve($rbid) {
-  $reportbacks = new ReportbackTransformer;
-  return $reportbacks->show($rbid);
+  return (new ReportbackTransformer)->show($rbid);
 }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -5,7 +5,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
   private $accessibleStatuses = ['promoted', 'approved'];
 
   /**
-   * @param array $parameters Any parameters obtained from query string.
+   * @param  array $parameters Any parameters obtained from query string.
    * @return array
    */
   public function index($parameters) {
@@ -34,7 +34,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
   /**
    * Display the specified resource.
    *
-   * @param string $id Resource id.
+   * @param  string $id Resource id.
    * @return array
    */
   public function show($id) {
@@ -59,7 +59,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
   /**
    * Transform data and build out response.
    *
-   * @param object $item Single object of retrieved data.
+   * @param  object $item Single object of retrieved data.
    * @return array
    */
   protected function transform($item) {

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -101,6 +101,7 @@ class ReportbackTransformer extends Transformer {
    */
   private function setFilters($parameters) {
     $filters = [
+      'rbid' => dosomething_helpers_format_data($parameters['ids']),
       'nid' => dosomething_helpers_format_data($parameters['campaigns']),
       'status' => dosomething_helpers_format_data($parameters['status']),
       'count' => (int) $parameters['count'] ?: 25,


### PR DESCRIPTION
Refs #5859
#### What's this PR do?

This update allows for passing specified IDs as a comma separated list to the `/reportbacks` endpoint via the `url` parameter and thus collect a curated list of multiple Reportbacks with all their Reportback Items in tow. Also did a bit of file cleanup to update array syntax :tada: 
#### Where should the reviewer start?

At **reportback_resource.inc** and follow the breadcrumb trail from there... :bread: 
#### Any background context you want to provide?

This came about from a question related to #5859, regarding getting all reportbacks for a user, along with the respective list of reportback items. If we have a list of Reportback IDs for a user, we can then use this update to request them all in one call.

For example:

```
api/v1/reportbacks?ids=3419,3465,3052
```
#### What are the relevant tickets?
#5859

---

@DFurnes @angaither 
cc: @jonuy @aaronschachter 
