### PR TITLE
Exclude reportback items parameter

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -1,96 +1,104 @@
 <?php
 
 function _reportback_item_resource_definition() {
-  $reportback_item_resource = array();
-  $reportback_item_resource['reportback-items'] = array(
-    'operations' => array(
+  $reportback_item_resource = [];
+  $reportback_item_resource['reportback-items'] = [
+    'operations' => [
 
-      'retrieve' => array(
+      'retrieve' => [
         'help' => 'Retrieve a specified reportback item.',
-        'file' => array(
+        'file' => [
           'type' => 'inc',
           'module' => 'dosomething_api',
           'name' => 'resources/reportback_item_resource',
-        ),
+        ],
         'callback' => '_reportback_item_resource_retrieve',
-        'args' => array(
-          array(
+        'args' => [
+          [
             'name' => 'fid',
             'description' => 'The fid of the reportback item to retrieve.',
             'optional' => FALSE,
             'type' => 'int',
             'source' => array('path' => 0),
-          ),
-        ),
+          ],
+        ],
         'access callback' => '_reportback_item_resource_access',
         'access arguments' => array('view'),
-      ),
+      ],
 
-      'index' => array(
+      'index' => [
         'help' => 'List all reportbacks items.',
-        'file' => array(
+        'file' => [
           'type' => 'inc',
           'module' => 'dosomething_api',
           'name' => 'resources/reportback_item_resource'
-        ),
+        ],
         'callback' => '_reportback_item_resource_index',
-        'args' => array(
-          array(
+        'args' => [
+          [
             'name' => 'campaigns',
             'description' => 'The ids of specified campaigns to get reportback items.',
             'optional' => TRUE,
             'type' => 'string',
             'source' => array('param' => 'campaigns'),
             'default value' => NULL,
-          ),
-          array(
+          ],
+          [
+            'name' => 'exclude',
+            'description' => 'Exclude reportbacks from results based on specific ids.',
+            'optional' => TRUE,
+            'type' => 'string',
+            'source' => ['param' => 'exclude'],
+            'default value' => NULL,
+          ],
+          [
             'name' => 'status',
             'description' => 'Comma delimited list of reportback statuses to collect reportback items for.',
             'optional' => TRUE,
             'type' => 'string',
             'source' => array('param' => 'status'),
             'default value' => 'promoted,approved',
-          ),
-          array(
+          ],
+          [
             'name' => 'count',
             'description' => 'The number of reportback items to retrieve.',
             'optional' => TRUE,
             'type' => 'string',
             'source' => array('param' => 'count'),
             'default value' => 25,
-          ),
-          array(
+          ],
+          [
             'name' => 'random',
             'description' => 'Boolean to indicate whether to retrieve reportback items in random order.',
             'optional' => TRUE,
             'type' => 'boolean',
             'source' => array('param' => 'random'),
             'default value' => FALSE,
-          ),
-          array(
+          ],
+          [
             'name' => 'page',
             'description' => 'The zero-based index of the page to get, defaults to 0.',
             'optional' => TRUE,
             'type' => 'int',
             'source' => array('param' => 'page'),
             'default value' => 1,
-          ),
-         array(
+          ],
+          [
             'name' => 'load_user',
             'description' => 'Flag to indicate whether to make call to northstar to retrieve full user data.',
             'optional' => TRUE,
             'type' => 'boolean',
             'source' => array('param' => 'load_user'),
             'default value' => FALSE,
-          ),
-        ),
+          ],
+        ],
         'access callback' => '_reportback_item_resource_access',
         'access arguments' => array('index'),
-      ),
+      ],
 
-    ),
+    ],
 
-  );
+  ];
 
   return $reportback_item_resource;
 }
@@ -115,10 +123,22 @@ function _reportback_item_resource_access($op) {
   return FALSE;
 }
 
-
-function _reportback_item_resource_index($campaigns, $status, $count, $random, $page, $load_user) {
+/**
+ * Retrieve and show index list response of reportbacks requested.
+ *
+ * @param  string  $campaigns
+ * @param  string  $exclude
+ * @param  string  $status
+ * @param  int     $count
+ * @param  bool    $random
+ * @param  int     $page
+ * @param  bool    $load_user
+ * @return array
+ */
+function _reportback_item_resource_index($campaigns, $exclude, $status, $count, $random, $page, $load_user) {
   $parameters = array(
     'campaigns' => $campaigns,
+    'exclude' => $exclude,
     'status' => $status,
     'count' => $count,
     'random' => $random,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback_item.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback_item.query.inc
@@ -67,6 +67,10 @@ function dosomething_reportback_build_reportback_items_query($params = array()) 
     $query->condition('rb.rbid', $params['rbid']);
   }
 
+  if (isset($params['exclude'])) {
+    $query->condition('rbf.fid', $params['exclude'], 'NOT IN');
+  }
+
   // Public API properties to expose:
   $rbf_fields = array('fid', 'caption', 'rbid', 'status');
   $rb_fields = array('created', 'updated', 'quantity', 'uid');

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -85,6 +85,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
   private function setFilters($parameters) {
     $filters = [
       'nid' => dosomething_helpers_format_data($parameters['campaigns']),
+      'exclude' => dosomething_helpers_format_data($parameters['exclude']),
       'status' => $this->removeUnauthorizedStatuses(dosomething_helpers_format_data($parameters['status'])),
       'count' => (int) $parameters['count'] ?: 25,
       'page' => (int) $parameters['page'],

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -95,6 +95,10 @@ class ReportbackItemTransformer extends ReportbackTransformer {
 
     $filters['offset'] = $this->setOffset($filters['page'], $filters['count']);
 
+    if ($filters['exclude'] && !is_array($filters['exclude'])) {
+      $filters['exclude'] = [$filters['exclude']];
+    }
+
     // Unset False boolean values that affect the query builder.
     if (!$filters['random']) {
       unset($filters['random']);


### PR DESCRIPTION
Fixes #4049
#### What's this PR do?

This PR provides the much needed capacity to _exclude_ certain RB items that are specified, from the result set when doing an index collection request to `/reportback-items`.
#### Where should the reviewer start?

Start at the **reportback_item_resource.inc** file and  go from there.
#### How should this be manually tested?

Try hitting the `/reportback-items` endpoint and pass the new url parameter `?exclude=1234,5678` and make sure those items don't show up in the results.
#### What are the relevant tickets?
#4049

---

@DFurnes @angaither 
cc: @jonuy @aaronschachter 
