### PR TITLE
Fixes undefined property notices on the campaings page.

### DIFF
--- a/lib/modules/dosomething/dosomething_search/dosomething_search.module
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.module
@@ -286,8 +286,12 @@ function dosomething_search_views_pre_render(&$view) {
   if ($view->name == 'explore_campaigns') {
   foreach ($view->result as $key => $result) {
       // Decode campaign title and campaign call to action, make sure to include single quotes!
-      $view->result[$key]->label = htmlspecialchars_decode($result->label, ENT_QUOTES);
-      $view->result[$key]->sm_field_call_to_action[0] = htmlspecialchars_decode($result->sm_field_call_to_action[0], ENT_QUOTES);
+      if (!empty($result->label)) {
+        $view->result[$key]->label = htmlspecialchars_decode($result->label, ENT_QUOTES);
+      }
+      if (!empty($result->sm_field_call_to_action[0])) {
+        $view->result[$key]->sm_field_call_to_action[0] = htmlspecialchars_decode($result->sm_field_call_to_action[0], ENT_QUOTES);
+      }
     }
   }
 }


### PR DESCRIPTION
Just fixes the undefined property notices.

<img width="968" alt="screen shot 2016-01-04 at 7 50 51 pm" src="https://cloud.githubusercontent.com/assets/672669/12096236/9b1f340a-b31c-11e5-906d-ebfc8e90ca26.png">

```
Notice: Undefined property: stdClass::$sm_field_call_to_action in dosomething_search_views_pre_render() (line 290 of /var/www/dev.dosomething.org/lib/modules/dosomething/dosomething_search/dosomething_search.module).
```
