### PR TITLE
Fix for missing CTAs on Fact pages.

### DIFF
--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
@@ -73,6 +73,8 @@ function dosomething_fact_page_theme($existing, $type, $theme, $path) {
  * Implements hook_preprocess_node().
  */
 function dosomething_fact_page_preprocess_node(&$vars) {
+  $supported_languages = dosomething_global_get_language_prefix_list();
+
   if ($vars['type'] == 'fact_page') {
     $template_vars = array(
       'text' => array(
@@ -92,9 +94,12 @@ function dosomething_fact_page_preprocess_node(&$vars) {
         $field = $vars["field_{$label}"];
 
         if (isset($field) && !empty($field)) {
-          if (array_key_exists('en', $field)) {
-            $field = $field['en'];
+          $prefix = array_keys($field)[0];
+
+          if (!is_int($prefix) && in_array($prefix, $supported_languages)) {
+            $field = $field[$prefix];
           }
+
           $field = $field[0];
 
           switch ($key) {
@@ -110,6 +115,7 @@ function dosomething_fact_page_preprocess_node(&$vars) {
             default:
               break;
           }
+
         }
 
       }

--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
@@ -96,6 +96,8 @@ function dosomething_fact_page_preprocess_node(&$vars) {
         if (isset($field) && !empty($field)) {
           $prefix = array_keys($field)[0];
 
+          // Depending on language availability, the data we need to grab
+          // may be nested in an associated array using a language prefix.
           if (!is_int($prefix) && in_array($prefix, $supported_languages)) {
             $field = $field[$prefix];
           }

--- a/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
+++ b/lib/modules/dosomething/dosomething_fact_page/dosomething_fact_page.module
@@ -74,7 +74,6 @@ function dosomething_fact_page_theme($existing, $type, $theme, $path) {
  */
 function dosomething_fact_page_preprocess_node(&$vars) {
   if ($vars['type'] == 'fact_page') {
-    $content = $vars['content'];
     $template_vars = array(
       'text' => array(
         'subtitle',
@@ -90,22 +89,29 @@ function dosomething_fact_page_preprocess_node(&$vars) {
 
     foreach ($template_vars as $key => $labels) {
       foreach ($labels as $label) {
-        $field = "field_{$label}";
-          if (isset($content[$field])) {
+        $field = $vars["field_{$label}"];
+
+        if (isset($field) && !empty($field)) {
+          if (array_key_exists('en', $field)) {
+            $field = $field['en'];
+          }
+          $field = $field[0];
+
           switch ($key) {
             case 'text':
-                $vars[$label] = $content[$field][0]['#markup'];
+                $vars[$label] = t($field['value']);
               break;
             case 'image':
-              $vars[$label] = dosomething_image_get_themed_image($vars[$field][0]['entity']->nid, 'landscape', '550x300', $label);
-            break;
+              $vars[$label] = dosomething_image_get_themed_image($field['target_id'], 'landscape', '550x300', $label);
+              break;
             case 'link':
-              $vars[$label] = l($content[$field][0]['#element']['title'], $content[$field][0]['#element']['url'], array('attributes' => array('class' => 'button')));
-            break;
+              $vars[$label] = l($field['title'], $field['url'], ['attributes' => ['class' => 'button']]);
+              break;
             default:
               break;
           }
         }
+
       }
     }
 

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -542,6 +542,22 @@ function dosomething_global_get_language($account, stdClass $node = NULL, $respe
 }
 
 /**
+ * Return an array containing only the list of language
+ * prefixes supported.
+ *
+ * @return array
+ */
+function dosomething_global_get_language_prefix_list() {
+  $prefixes = [];
+
+  foreach(language_list() as $language) {
+    $prefixes[] = $language->language;
+  }
+
+  return $prefixes;
+}
+
+/**
  * Handles redirecting the node edit page to proper translation
  *
  * @param $node

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -110,7 +110,7 @@ function dosomething_helpers_delete_test_nodes() {
  * @param array $field Nested array of field data.
  * @param string $language Language selection, defaults to Drupal constant for "undefined".
  *
- * @return array|null
+ * @return mixed|null
  */
 function dosomething_helpers_extract_field_data($field, $language = LANGUAGE_NONE) {
   if (isset($field) && !empty($field)) {


### PR DESCRIPTION
Fixes #5941 
#### What's this PR do?

At some point the expected ['content'] array data changed and no longer houses the CTA information (along with Fact page images), so the Fact page template was breaking on both CTA content and image content. The solution involved adding a bit of new logic to account for  information as well as adjusting where the data was being retrieved from. It now refers to the data in the main  array.#### What's this PR do?
#### Where should the reviewer start?

The fix mostly happens in the **dosomething_fact_page.module** so that's probs a good place to :eyes: 
#### How should this be manually tested?

We can do a push to Thor and check to make sure all is hunky dory again!
#### Any background context you want to provide?

Tried a few different approaches but this seemed to be the most feasible. I had originally intended to use `dosomething_helpers_extract_field_data()` which worked for most of the fields but threw a wrench with getting the CTA link data, and also when the arrays were structured differently depending on whether it was a US or Global url :rage2: 
#### What are the relevant tickets?
#5941

---

@angaither
