### PR TITLE
Makes sure that all node edit links are prefixed 

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -97,7 +97,7 @@ function dosomething_global_init() {
     return;
   }
 
-  // Handle translation redirects for authenticated and anonymous users whe n
+  // Handle translation redirects for authenticated and anonymous users when
   // they request bare (Global English) URLs to nodes.
   //
   // Passing 'noredirect=1' will defeat the redirect.

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -566,7 +566,9 @@ function dosomething_global_redirect_node_edit($node, $user_language) {
     $new_url = str_replace(' ', '', '/node/' . $node->nid . '/edit/' . $lang_append);
     drupal_goto($new_url);
   }
-  else if (empty(dosomething_global_get_current_prefix()) && !empty($prefix)) {
+  // If the page has no prefix, add one
+  else if (dosomething_global_get_current_prefix() === '' && !empty($prefix)) {
+    // Add prefix to the current path
     drupal_goto($prefix . '/' . current_path());
   }
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -566,7 +566,7 @@ function dosomething_global_redirect_node_edit($node, $user_language) {
     $new_url = str_replace(' ', '', '/node/' . $node->nid . '/edit/' . $lang_append);
     drupal_goto($new_url);
   }
-  else if (dosomething_global_get_current_prefix() == '' && $prefix != '') {
+  else if (empty(dosomething_global_get_current_prefix()) && !empty($prefix)) {
     drupal_goto($prefix . '/' . current_path());
   }
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -97,7 +97,7 @@ function dosomething_global_init() {
     return;
   }
 
-  // Handle translation redirects for authenticated and anonymous users when
+  // Handle translation redirects for authenticated and anonymous users whe n
   // they request bare (Global English) URLs to nodes.
   //
   // Passing 'noredirect=1' will defeat the redirect.
@@ -561,8 +561,14 @@ function dosomething_global_redirect_node_edit($node, $user_language) {
     // Append the user language
     $lang_append = $new_translation_prefix . $user_language;
 
+    // Make sure there is a prefix
+    $prefix = '/node/';
+    if (dosomething_global_get_current_prefix() == '') {
+      $prefix = '/' . dosomething_global_get_prefix_for_language($user_language) . $prefix;
+    }
+
     // Build complete URL and redirect
-    $new_url = str_replace(' ', '', '/node/' . $node->nid . '/edit/' . $lang_append);
+    $new_url = str_replace(' ', '', $prefix . $node->nid . '/edit/' . $lang_append);
     drupal_goto($new_url);
   }
 }

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -552,6 +552,7 @@ function dosomething_global_get_language($account, stdClass $node = NULL, $respe
 function dosomething_global_redirect_node_edit($node, $user_language) {
   // Load the languages being used
   $src_language = $node->language;
+  $prefix = dosomething_global_get_prefix_for_language($user_language);
 
   // If we're not working on a translation, no need to re-direct.
   if ($src_language != $user_language) {
@@ -561,15 +562,12 @@ function dosomething_global_redirect_node_edit($node, $user_language) {
     // Append the user language
     $lang_append = $new_translation_prefix . $user_language;
 
-    // Make sure there is a prefix
-    $prefix = '/node/';
-    if (dosomething_global_get_current_prefix() == '') {
-      $prefix = '/' . dosomething_global_get_prefix_for_language($user_language) . $prefix;
-    }
-
     // Build complete URL and redirect
-    $new_url = str_replace(' ', '', $prefix . $node->nid . '/edit/' . $lang_append);
+    $new_url = str_replace(' ', '', '/node/' . $node->nid . '/edit/' . $lang_append);
     drupal_goto($new_url);
+  }
+  else if (dosomething_global_get_current_prefix() == '' && $prefix != '') {
+    drupal_goto($prefix . '/' . current_path());
   }
 }
 


### PR DESCRIPTION
#### What's this PR do?

Makes sure that the correct prefix is applied to node edit pages
#### How should this be manually tested?

Can you click/goto global edit links, and then view the page without error? 
What about normal edit links?
#### Any background context you want to provide?

The node edit logic never cared about prefixes as they aren't required for the correct node edit page. The implications of this however are the cause of #5952 
#### What are the relevant tickets?

Fixes #5952 
