### PR TITLE
Addition of campaign language and country to signup params

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -10,6 +10,12 @@ define('TRANSLATABLE_TYPES', 'static_content,campaign,home');
 // Default language: Global English
 define('DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE', 'en-global');
 
+// Default country code
+// https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+// Used for transactional messaging in dosomething_mbp for default template name
+// of non-affiliate counties.
+define('DOSOMETHING_GLOBAL_DEFAULT_COUNTRY_CODE', 'XG');
+
 /**
  * Implements hook_init().
  */

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -113,12 +113,26 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
   if (isset($params['user_language'])) {
     $payload['user_language'] = $params['user_language'];
   }
+  if (isset($params['campaign_language'])) {
+    $payload['campaign_language'] = $params['campaign_language'];
+  }
+  if (isset($params['campaign_country'])) {
+    $payload['campaign_country'] = $params['campaign_country'];
+  }
 
-  // If email template wasn't set before, get standart template name.
+  // If email template wasn't set use request details to define template name.
   if (!empty($params['email_template'])) {
     $payload['email_template'] = $params['email_template'];
-  } else {
-    $payload['email_template'] = dosomething_mbp_get_template_name($origin, $params['user_language']);
+  }
+  else {
+    $template_language = NULL;
+    if (isset($params['campaign_language'])) {
+      $template_language = $params['campaign_language'];
+    }
+    elseif (isset($params['user_language'])) {
+      $template_language = $params['user_language'];
+    }
+    $payload['email_template'] = dosomething_mbp_get_template_name($origin, $template_language);
   }
 
   // Payload specific to each transaction type.
@@ -199,11 +213,12 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
  *   $payload - Composed values ready to be sent as a message payload.
  */
 function dosomething_mbp_get_common_campaign_payload(&$payload, $params) {
-  $payload['subscribed']        = 1;
-  $payload['event_id']          = $params['event_id'];
+  $payload['subscribed'] = 1;
+  $payload['event_id']   = $params['event_id'];
 
   if (isset($params['campaign_language'])) {
     $payload['campaign_language'] = $params['campaign_language'];
+    $payload['campaign_country'] = $params['campaign_country'];
   }
 
   $payload['email_tags'][] = $params['event_id'];
@@ -235,18 +250,17 @@ function dosomething_mbp_get_common_campaign_payload(&$payload, $params) {
  *
  * @param string $event_name
  *   Example: "campaign_signup", "password_reset", etc
- * @param string $user_language
- *   The user language setting as defined by dosomething_settings_get_geo_country_code() and
- *   dosomething_global_convert_country_to_language().
+ * @param string $language
+ *   The language setting that the message template should use.
  *
  * @return string
  *   Name of Mandrill template to use for transactional message.
  */
-function dosomething_mbp_get_template_name($event_name, $user_language = NULL) {
-  if (isset($user_langauge)) {
-    $country_code = dosomething_global_convert_language_to_country($user_language);
+function dosomething_mbp_get_template_name($event_name, $language = NULL) {
+  if (isset($langauge)) {
+    $country_code = dosomething_global_convert_language_to_country($language);
     if ($country_code == NULL) {
-      $country_code = 'US';
+      $country_code = 'GL';
     }
   }
   else {

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -260,7 +260,7 @@ function dosomething_mbp_get_template_name($event_name, $language = NULL) {
   if (isset($langauge)) {
     $country_code = dosomething_global_convert_language_to_country($language);
     if ($country_code == NULL) {
-      $country_code = 'XG';
+      $country_code = DOSOMETHING_GLOBAL_DEFAULT_COUNTRY_CODE;
     }
   }
   else {

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -28,7 +28,7 @@ function dosomething_mbp_menu() {
  * @param string $origin
  *   Where the message request came from.
  * @param array $params
- *   Optional keyed array of data to build payload from.
+ *   (optional) Keyed array of data to build payload from.
  *
  * @return bool
  *   The status of the request.
@@ -88,7 +88,7 @@ function dosomething_mbp_request($origin, $params = NULL) {
  *   Where the message request came from that's used to determine what the
  *   payload should be.
  * @param array $params
- *   Optional keyed array of data to build payload from.
+ *   (optional) Keyed array of data to build payload from.
  *
  * @return array
  *   $payload - Composed values ready to be sent as a message payload.
@@ -251,7 +251,7 @@ function dosomething_mbp_get_common_campaign_payload(&$payload, $params) {
  * @param string $event_name
  *   Example: "campaign_signup", "password_reset", etc
  * @param string $language
- *   The language setting that the message template should use.
+ *   (optional) Language setting used to define the message template name.
  *
  * @return string
  *   Name of Mandrill template to use for transactional message.

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -260,7 +260,7 @@ function dosomething_mbp_get_template_name($event_name, $language = NULL) {
   if (isset($langauge)) {
     $country_code = dosomething_global_convert_language_to_country($language);
     if ($country_code == NULL) {
-      $country_code = 'GL';
+      $country_code = 'XG';
     }
   }
   else {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -557,19 +557,24 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
   if (!($node->type == 'campaign' || $node->type == 'campaign_group')) {
     return FALSE;
   }
+  if (module_exists('dosomething_global')) {
+    list($user_language, $user_country) = dosomething_global_user_details($account);
+    $campaign_language = dosomething_global_get_current_prefix();
+    $campaign_country_code = dosomething_global_convert_language_to_country($campaign_language);
+  }
+
   $wrapper = entity_metadata_wrapper('node', $node);
   $language = dosomething_global_get_language($account, $node);
   $url_options = array(
-    'language' => $language,
+    'language' => $campaign_language,
     'absolute' => TRUE,
     'query' => array(
       'source' => 'node/' . $node->nid,
     ),
   );
-  $campaign_link = dosomething_global_url('node/' . $nid, $url_options);
+  $campaign_link = dosomething_global_url('node/' . $node->nid, $url_options);
 
   // Get node title, normal for collections, translatable for campaigns.
-  $title = '';
   if (isset($node->title_field)) {
     $title = $wrapper->language($language)->title_field->value();
   } else {
@@ -583,9 +588,11 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     'mobile' => dosomething_user_get_field('field_mobile', $account),
     'event_id' => $node->nid,
     'campaign_title' => $title,
-    'campaign_link' => dosomething_global_url('node/' . $node->nid, $url_options),
-    'user_language' => $language,
-    'campaign_language' => $node->language,
+    'campaign_link' => $campaign_link,
+    'user_language' => $user_language,
+    'user_country' => $user_country,
+    'campaign_language' => $campaign_language,
+    'campaign_country' => $campaign_country_code,
   );
 
   // Don't subscribe 26+ yo users for Mobile Commons.
@@ -612,7 +619,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
  */
 function dosomething_signup_get_mbp_params_campaign(&$params, $wrapper) {
   if ($wrapper->type->value() == 'campaign') {
-    $content = $wrapper->language($params['user_language']);
+    $content = $wrapper->language($params['campaign_language']);
     $params['call_to_action'] = $content->field_call_to_action->value();
     $params['step_one'] = $content->field_pre_step_header->value();
     $params['step_two'] = DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER;


### PR DESCRIPTION
Fixes #5685 
- #5685 (Fixes Campaign signups)

Adds `campaign_language` and `campaign_country` to $params sent to Message Broker request for campaign signups.

**Testing**: The payload produced by the `dosomething_mbp.module` before sending a message to Message Broker. Note the `CAMPAIGN_TITLE` and  `email_template` ("Please Don't Break Anything" & "mb-campaign-signup-US") are based on the `campaign _language` ("en") not the `user_language` ("en-global"):

**Example** - Global user signing up for US campaign. Expect campaign language rather than user language to define the language->country for the template name and the language of the `merge_var` content.

```
Array
(
    [activity] => campaign_signup
    [email] => dlee+update-test98@dosomething.org
    [uid] => 1705551
    [merge_vars] => Array
        (
            [MEMBER_COUNT] => 3.5 million
            [FNAME] => Test
            [CAMPAIGN_TITLE] => Please Don't Break Anything
            [CAMPAIGN_LINK] => http://dev.dosomething.org:8888/us/campaigns/global-please-dont-break-anything?source=node/1691
            [CALL_TO_ACTION] => Everything works
            [STEP_ONE] => Do Header
            [STEP_TWO] => Snap a Pic
            [STEP_THREE] => do this after
        )

    [user_country] => IS
    [user_language] => en-global
    [campaign_language] => en
    [campaign_country] => US
    [email_template] => mb-campaign-signup-US
    [subscribed] => 1
    [event_id] => 1691
    [email_tags] => Array
        (
            [0] => 1691
            [1] => drupal_campaign_signup
        )

)
```
