### PR TITLE
Current Run JS toggle

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
@@ -793,7 +793,7 @@ function dosomething_campaign_field_default_field_instances() {
     'entityconnect_unload_edit' => 0,
     'field_name' => 'field_current_run',
     'label' => 'Current Run',
-    'required' => 1,
+    'required' => 0,
     'settings' => array(
       'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
@@ -184,4 +184,4 @@ features[variable][] = node_preview_campaign
 features[variable][] = node_submitted_campaign
 features[variable][] = pathauto_node_campaign_pattern
 features[views_view][] = campaigns_by_term
-mtime = 1452007310
+mtime = 1452026855

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -43,6 +43,10 @@ function dosomething_campaign_form_campaign_node_form_alter(&$form, &$form_state
       $filtered_options[$run->entity_id] = $all_options[$run->entity_id];
     }
 
+    // Add empty option to the options array. Helps to ensure that the user
+    // explicity chooses a campaign instead of defaulting to the first option
+    // in the list.
+    $filtered_options = array("_none" => "- None -") + $filtered_options;
     $form['field_current_run'][$language]['#options'] = $filtered_options;
   }
 }

--- a/lib/modules/dosomething/dosomething_campaign/js/campaign_node_form.js
+++ b/lib/modules/dosomething/dosomething_campaign/js/campaign_node_form.js
@@ -42,5 +42,46 @@
         }
       });
     }
+
+    $('.vertical-tab-button a').click(function() {
+      if ($('.vertical-tabs-panes').find('#edit-options:visible').length !== 0)
+      {
+        togglePublish();
+      }
+    });
+
+    $('select[name*="field_current_run"]').change(function() {
+      togglePublish();
+    });
+
+    function togglePublish() {
+      $currentRun = $( "select[name*='field_current_run']" ).val();
+      if ($currentRun === '_none') {
+        displayPublish(false);
+      } else {
+        displayPublish(true);
+      }
+    }
+
+    function displayPublish(state) {
+      var $publishContainer = $('.node-form-options');
+      var $publishOption = $('.form-item-status');
+
+      if (state) {
+        var $error = $publishContainer.find('.error');
+        if ($error.length) {
+          $error.remove();
+        }
+        $publishOption.find('#edit-status').removeAttr('disabled');
+        $publishOption.find('.option').css('color', '#333333');
+      } else {
+        if (!$publishContainer.find('.error').length) {
+          var $error = $('<div class="messages error">Please select a <a href="#edit-field-current-run">campaign run</a> in order to publish this campaign.</div>');
+          $publishContainer.prepend($error);
+        }
+        $publishOption.find('#edit-status').attr('disabled','disabled');
+        $publishOption.find('.option').css('color', 'gray');
+      }
+    }
   });
 }(jQuery));

--- a/lib/modules/dosomething/dosomething_campaign/js/campaign_node_form.js
+++ b/lib/modules/dosomething/dosomething_campaign/js/campaign_node_form.js
@@ -76,7 +76,7 @@
         $publishOption.find('.option').css('color', '#333333');
       } else {
         if (!$publishContainer.find('.error').length) {
-          var $error = $('<div class="messages error">Please select a <a href="#edit-field-current-run">campaign run</a> in order to publish this campaign.</div>');
+          var $error = $('<div class="messages error">Please select a <a href="#edit-field-current-run">campaign run</a> in order to change publish state.</div>');
           $publishContainer.prepend($error);
         }
         $publishOption.find('#edit-status').attr('disabled','disabled');


### PR DESCRIPTION
#### What's this PR do?

Disable the publish option on campaign nodes if no campaign run is selected. Now that we handle the requirement of the current run field with JS, this PR also reverts required option on that field from the database.

**Campaign run selected:**
<img width="214" alt="screen shot 2016-01-07 at 10 06 49 am" src="https://cloud.githubusercontent.com/assets/1700409/12173715/67e1d8e8-b526-11e5-8001-52e470d2226a.png">

Gravy.

**Campaign run not selected:**

<img width="935" alt="screen shot 2016-01-07 at 10 07 36 am" src="https://cloud.githubusercontent.com/assets/1700409/12173727/852b9826-b526-11e5-9b42-66face6a8302.png">

Do not pass go.
#### How should this be manually tested?

On a campaign node edit form, if `- None -` is selected on the current run field, then when you go to publish or change the published state of a campaign, you should see an error message. But, if you select a campaign run, you should be able to do what you need to do.
#### What are the relevant tickets?

Fixes #5994 

@DoSomething/front-end @angaither 
