### PR TITLE
Uses campaign run title on user profile

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -555,11 +555,13 @@ function dosomething_campaign_get_campaigns_doing($uid = NULL) {
  *   The image size to return.
  * @param string $source
  *   (optional) The signup source to append to the campaign query string.
+ * @param bool $use_run_title
+ *    Override the campaign title with the campaign run.
  *
  * @return array
  *   An array of variables.
  */
-function dosomething_campaign_get_campaign_block_vars($nid, $image_size = '740x480', $source = NULL) {
+function dosomething_campaign_get_campaign_block_vars($nid, $image_size = '740x480', $source = NULL, $use_run_title = FALSE) {
   $node = node_load($nid);
   $clc = dosomething_helpers_get_current_language_content_code();
 
@@ -581,7 +583,12 @@ function dosomething_campaign_get_campaign_block_vars($nid, $image_size = '740x4
   if (!empty($node->field_call_to_action)) {
     $cta = $node->field_call_to_action[$clc][0]['value'];
   }
+
   $title = $node->title_field[$clc][0]['safe_value'];
+  if ($use_run_title) {
+    $campaign_run = node_load($node->field_current_run[$language][0]['target_id']);
+    $title = $campaign_run->title;
+  }
 
   return array(
     'nid' => $nid,

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
@@ -48,7 +48,7 @@ function dosomething_user_preprocess_user_profile(&$variables) {
   }
   else {
     foreach ($doing as $nid) {
-      $variables['doing'][] = dosomething_campaign_get_campaign_block_vars($nid);
+      $variables['doing'][] = dosomething_campaign_get_campaign_block_vars($nid, '740x480', NULL, TRUE);
     }
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc
@@ -30,6 +30,11 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
     // Theme each reportback and create an array.
     foreach ($reportbacks as $delta => $rbid) {
       $reportback = reportback_load((int) $rbid);
+
+      $campaign = node_load($reportback->nid);
+      $node_language = dosomething_global_get_language($user, $campaign);
+      $campaign_run = node_load($campaign->field_current_run[$node_language][0]['target_id']);
+
       $impact = $reportback->quantity . ' ' . $reportback->noun . ' ' . $reportback->verb;
       if (user_access('view any reportback')) {
         // Link to the full reportback entity view.
@@ -43,7 +48,7 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
       $url = dosomething_global_url('node/' . $reportback->nid);
       $content = array(
         'url' => $url,
-        'title' => htmlspecialchars_decode($reportback->node_title, ENT_QUOTES),
+        'title' => htmlspecialchars_decode($campaign_run->title, ENT_QUOTES),
         'image' => $img,
         'description' => $impact,
       );
@@ -54,4 +59,3 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
   // Theme a gallery of reportbacks, and give the user profile template access to it.
   $vars['reportback_gallery'] = paraneue_dosomething_get_gallery($reportback_items, 'duo', array(), TRUE);
 }
-


### PR DESCRIPTION
#### What's this PR do?

Updates the user profile to use the _current_ campaign run title for reportbacks \* "doing"
Adds a campaign run override option to the get_campaign_block_vars
#### How should this be manually tested?

Does the campaign override title, override the campaign title, on the user profile page?
#### What are the relevant tickets?

Fixes #5975 
#### Questions:

This won't work a year from now when a campaign relaunches. If my profile currently says "space jam 2015", it will say "space jam 2016" when it relaunches because its based on the **current run** of the campaign. I'm not sure how to relate a reportback item to a previous campaign run? @angaither @sergii-tkachenko ?

**don't merge until the question is resolved!**
