### PR TITLE
Add campaign run id to signup and reportback tables

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -870,11 +870,7 @@ function dosomething_reportback_update_7032() {
     // Add it per the schema field definition.
     db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
   }
-}
 
-/**
- * Move run_nid column after nid in the dosomething_reportback table.
- */
-function dosomething_reportback_update_7033() {
+  // Move run_nid colum after nid.
   db_query("ALTER TABLE dosomething_reportback MODIFY COLUMN run_nid int AFTER nid;");
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -30,6 +30,12 @@ function dosomething_reportback_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'run_nid' => array(
+        'description' => 'The campaign run that the reportback is tied to.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
       'created' => array(
         'description' => 'The Unix timestamp when the reportback was created.',
         'type' => 'int',
@@ -848,4 +854,20 @@ function dosomething_reportback_update_7030(&$sandbox) {
  */
 function dosomething_reportback_update_7031(&$sandbox) {
   _dosomething_reportback_retroactive_rb_fix_flagged();
+}
+
+/**
+ * Adds campaign run nid column to the dosomething_reportback table.
+ */
+function dosomething_signup_update_7032() {
+  $tbl_name = 'dosomething_reportback';
+  // Load schema to get table definition.
+  $schema = dosomething_reportback_schema();
+  // New field to add.
+  $field_name = 'run_nid';
+  // If the field doesn't exist already:
+  if (!db_field_exists($tbl_name, $field_name)) {
+    // Add it per the schema field definition.
+    db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
+  }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -30,6 +30,12 @@ function dosomething_reportback_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'run_nid' => array(
+        'description' => 'The campaign run that the reportback is tied to.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
       'created' => array(
         'description' => 'The Unix timestamp when the reportback was created.',
         'type' => 'int',
@@ -854,10 +860,21 @@ function dosomething_reportback_update_7031(&$sandbox) {
  * Adds campaign run nid column to the dosomething_reportback table.
  */
 function dosomething_reportback_update_7032() {
-  db_query("ALTER TABLE dosomething_reportback
-            ADD run_nid int
-            DEFAULT 0
-            NOT NULL
-            COMMENT 'The campaign run that the reportback is tied to.'
-            AFTER nid;");
+  $tbl_name = 'dosomething_reportback';
+  // Load schema to get table definition.
+  $schema = dosomething_reportback_schema();
+  // New field to add.
+  $field_name = 'run_nid';
+  // If the field doesn't exist already:
+  if (!db_field_exists($tbl_name, $field_name)) {
+    // Add it per the schema field definition.
+    db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
+  }
+}
+
+/**
+ * Move run_nid column after nid in the dosomething_reportback table.
+ */
+function dosomething_reportback_update_7033() {
+  db_query("ALTER TABLE dosomething_reportback MODIFY COLUMN run_nid int AFTER nid;");
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -30,12 +30,6 @@ function dosomething_reportback_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
-      'run_nid' => array(
-        'description' => 'The campaign run that the reportback is tied to.',
-        'type' => 'int',
-        'not null' => TRUE,
-        'default' => 0,
-      ),
       'created' => array(
         'description' => 'The Unix timestamp when the reportback was created.',
         'type' => 'int',
@@ -859,15 +853,11 @@ function dosomething_reportback_update_7031(&$sandbox) {
 /**
  * Adds campaign run nid column to the dosomething_reportback table.
  */
-function dosomething_signup_update_7032() {
-  $tbl_name = 'dosomething_reportback';
-  // Load schema to get table definition.
-  $schema = dosomething_reportback_schema();
-  // New field to add.
-  $field_name = 'run_nid';
-  // If the field doesn't exist already:
-  if (!db_field_exists($tbl_name, $field_name)) {
-    // Add it per the schema field definition.
-    db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
-  }
+function dosomething_reportback_update_7032() {
+  db_query("ALTER TABLE dosomething_reportback
+            ADD run_nid int
+            DEFAULT 0
+            NOT NULL
+            COMMENT 'The campaign run that the reportback is tied to.'
+            AFTER nid;");
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -601,11 +601,7 @@ function dosomething_signup_update_7021() {
     // Add it per the schema field definition.
     db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
   }
-}
 
-/**
- * Move run_nid column after nid in the dosomething_signup table.
- */
-function dosomething_signup_update_7022() {
+  // Move run_nid colum after nid.
   db_query("ALTER TABLE dosomething_signup MODIFY COLUMN run_nid int AFTER nid;");
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -30,12 +30,6 @@ function dosomething_signup_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
-      'run_nid' => array(
-        'description' => 'The campaign run that the user has signed up for.',
-        'type' => 'int',
-        'not null' => TRUE,
-        'default' => 0,
-      ),
       'timestamp' => array(
         'description' => 'The Unix timestamp when the signup was submitted.',
         'type' => 'int',
@@ -591,14 +585,10 @@ function dosomething_signup_update_7020() {
  * Adds campaign run nid column to the dosomething_signup table.
  */
 function dosomething_signup_update_7021() {
-  $tbl_name = 'dosomething_signup';
-  // Load schema to get table definition.
-  $schema = dosomething_signup_schema();
-  // New field to add.
-  $field_name = 'run_nid';
-  // If the field doesn't exist already:
-  if (!db_field_exists($tbl_name, $field_name)) {
-    // Add it per the schema field definition.
-    db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
-  }
+  db_query("ALTER TABLE dosomething_signup
+            ADD run_nid int
+            DEFAULT 0
+            NOT NULL
+            COMMENT 'The campaign run that the user has signed up for.'
+            AFTER nid;");
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -30,6 +30,12 @@ function dosomething_signup_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'run_nid' => array(
+        'description' => 'The campaign run that the user has signed up for.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
       'timestamp' => array(
         'description' => 'The Unix timestamp when the signup was submitted.',
         'type' => 'int',
@@ -579,4 +585,20 @@ function dosomething_signup_update_7020() {
   $new_name = 'dosomething_signup_us_mobile_opt_in_path_user_register';
   variable_set($new_name, variable_get($old_name));
   variable_del($old_name);
+}
+
+/**
+ * Adds campaign run nid column to the dosomething_signup table.
+ */
+function dosomething_signup_update_7021() {
+  $tbl_name = 'dosomething_signup';
+  // Load schema to get table definition.
+  $schema = dosomething_signup_schema();
+  // New field to add.
+  $field_name = 'run_nid';
+  // If the field doesn't exist already:
+  if (!db_field_exists($tbl_name, $field_name)) {
+    // Add it per the schema field definition.
+    db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
+  }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -30,6 +30,12 @@ function dosomething_signup_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'run_nid' => array(
+        'description' => 'The campaign run that the user has signed up for.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
       'timestamp' => array(
         'description' => 'The Unix timestamp when the signup was submitted.',
         'type' => 'int',
@@ -585,10 +591,21 @@ function dosomething_signup_update_7020() {
  * Adds campaign run nid column to the dosomething_signup table.
  */
 function dosomething_signup_update_7021() {
-  db_query("ALTER TABLE dosomething_signup
-            ADD run_nid int
-            DEFAULT 0
-            NOT NULL
-            COMMENT 'The campaign run that the user has signed up for.'
-            AFTER nid;");
+  $tbl_name = 'dosomething_signup';
+  // Load schema to get table definition.
+  $schema = dosomething_signup_schema();
+  // New field to add.
+  $field_name = 'run_nid';
+  // If the field doesn't exist already:
+  if (!db_field_exists($tbl_name, $field_name)) {
+    // Add it per the schema field definition.
+    db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
+  }
+}
+
+/**
+ * Move run_nid column after nid in the dosomething_signup table.
+ */
+function dosomething_signup_update_7022() {
+  db_query("ALTER TABLE dosomething_signup MODIFY COLUMN run_nid int AFTER nid;");
 }


### PR DESCRIPTION
#### What's this PR do?

Adds a new `run_id` column to the `dosomething_reportback` and `dosomething_signup` tables.
#### How should this be manually tested?

Run update hooks and then take a look at the db to make sure the new columns are added.
#### What are the relevant tickets?

Fixes #5990 
