### PR TITLE
Adds campaign run nid to signups and reportbacks

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -326,8 +326,8 @@ function dosomething_reportback_form_submit($form, &$form_state) {
 
   $campaign = node_load($values['nid']);
   global $user;
-  $language = dosomething_global_get_language($user, $campaign);
-  $values['run_nid'] = $campaign->field_current_run[$language][0]['target_id'];
+  $language_code = dosomething_global_get_language($user, $campaign);
+  $values['run_nid'] = $campaign->field_current_run[$language_code][0]['target_id'];
 
   // If username field is set, this is an admin form.
   $is_admin_form = isset($form_state['values']['username']);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -324,6 +324,11 @@ function dosomething_reportback_form_validate($form, &$form_state) {
 function dosomething_reportback_form_submit($form, &$form_state) {
   $values = $form_state['values'];
 
+  $campaign = node_load($values['nid']);
+  global $user;
+  $language = dosomething_global_get_language($user, $campaign);
+  $values['run_nid'] = $campaign->field_current_run[$language][0]['target_id'];
+
   // If username field is set, this is an admin form.
   $is_admin_form = isset($form_state['values']['username']);
   // Load uid by selected username.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -325,8 +325,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
   $values = $form_state['values'];
 
   $campaign = node_load($values['nid']);
-  global $user;
-  $language_code = dosomething_global_get_language($user, $campaign);
+  $language_code = $language_code = $campaign->language;
   $values['run_nid'] = $campaign->field_current_run[$language_code][0]['target_id'];
 
   // If username field is set, this is an admin form.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -725,6 +725,7 @@ function dosomething_reportback_set_properties(&$entity, $values) {
   $properties = array(
     'uid',
     'nid',
+    'run_nid',
     'quantity',
     'why_participated',
     'num_participants',

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -217,8 +217,8 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
   // @todo: If campaign is unpublished and non-staff $uid, return error.
 
   $campaign = node_load($nid);
-  $language = dosomething_global_get_language($user, $campaign);
-  $run_nid = $campaign->field_current_run[$language][0]['target_id'];
+  $language_code = dosomething_global_get_language($user, $campaign);
+  $run_nid = $campaign->field_current_run[$language_code][0]['target_id'];
 
   $values = array(
     'nid' => $nid,

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -206,8 +206,8 @@ function dosomething_signup_get_query_source() {
  *   The sid of the newly inserted signup, or FALSE if error.
  */
 function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp = NULL) {
+  global $user;
   if ($uid == NULL) {
-    global $user;
     $uid = $user->uid;
   }
   // If a signup already exists, exit.
@@ -216,9 +216,14 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
   // @todo: If the campaign is closed, return error.
   // @todo: If campaign is unpublished and non-staff $uid, return error.
 
+  $campaign = node_load($nid);
+  $language = dosomething_global_get_language($user, $campaign);
+  $run_nid = $campaign->field_current_run[$language][0]['target_id'];
+
   $values = array(
     'nid' => $nid,
     'uid' => $uid,
+    'run_nid' => $run_nid,
     'source'=> $source,
     'timestamp' => $timestamp,
   );

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -206,10 +206,11 @@ function dosomething_signup_get_query_source() {
  *   The sid of the newly inserted signup, or FALSE if error.
  */
 function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp = NULL) {
-  global $user;
   if ($uid == NULL) {
+    global $user;
     $uid = $user->uid;
   }
+
   // If a signup already exists, exit.
   if (dosomething_signup_exists($nid, $uid)) { return FALSE; }
 
@@ -217,7 +218,7 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
   // @todo: If campaign is unpublished and non-staff $uid, return error.
 
   $campaign = node_load($nid);
-  $language_code = dosomething_global_get_language($user, $campaign);
+  $language_code = $campaign->language;
   $run_nid = $campaign->field_current_run[$language_code][0]['target_id'];
 
   $values = array(


### PR DESCRIPTION
#### What's this PR do?

Adds campaign run nid to signups and reportbacks
(Did not touch the API)
#### How should this be manually tested?

Is the campaign run NID filled out in signups/reportbacks when you do those respective things? 
#### What are the relevant tickets?

Fixes #6008 
