### PR TITLE
fix campaign cache to ensure it clears campaigns when they are updated

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -92,7 +92,7 @@ function dosomething_campaign_load($node, $public = FALSE, $cache = TRUE) {
   // Get the appropriate lang
   $current_lang = dosomething_global_convert_country_to_language(dosomething_global_get_current_prefix());
 
-  if (($cached_node = cache_get('ds_campaign_' . $node->nid ."_". $current_lang, 'cache_dosomething_campaign')) && $cache) {
+  if (($cached_node = cache_get('ds_campaign_' . $node->nid .'_'. $current_lang, 'cache_dosomething_campaign')) && $cache) {
     // If this is accessed via API:
     if ($public) {
       // Add stats property.
@@ -275,7 +275,7 @@ function dosomething_campaign_load($node, $public = FALSE, $cache = TRUE) {
     // Load Creator property.
     dosomething_campaign_load_creator($campaign, $wrapper);
 
-    cache_set('ds_campaign_' . $campaign->nid ."_". $current_lang, $campaign, 'cache_dosomething_campaign', REQUEST_TIME + 60*60*24);
+    cache_set('ds_campaign_' . $campaign->nid .'_'. $current_lang, $campaign, 'cache_dosomething_campaign', REQUEST_TIME + 60*60*24);
 
     // If this is accessed via API:
     if ($public) {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -1239,5 +1239,5 @@ function dosomething_campaign_flush_caches() {
  * Implements hook_node_update()
  */
 function dosomething_campaign_node_update($node) {
-  cache_clear_all('ds_campaign_' . $node->nid, 'cache_dosomething_campaign');
+  cache_clear_all('ds_campaign_' . $node->nid, 'cache_dosomething_campaign', TRUE);
 }


### PR DESCRIPTION
fixes #6013 
fixes #6009 

clears the cache correctly for updates to campaigns

Previously, we were searching strictly for only part of the key in the cache table. Now, we are doing a search for any rows that match the first part of the key, which includes the node ID.
