### PR TITLE
display problem statement even if no translation for current language

### DIFF
--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -75,6 +75,10 @@ function dosomething_fact_get_facts_data($node, $field_names) {
     if ($field_data) {
       if (array_key_exists($language, $field_data)) {
         $entity = dosomething_fact_get_entity($field_data, $language);
+       } else {
+        //if we do not have a translation for the current user's language, get language of user that created the reportback
+        $alpha_language = $node->language;
+        $entity = dosomething_fact_get_entity($field_data, $alpha_language);
       }
 
       if (isset($field_data[0]['entity']) && is_object($field_data[0]['entity'])) {

--- a/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
+++ b/lib/modules/dosomething/dosomething_fact/dosomething_fact.module
@@ -75,10 +75,10 @@ function dosomething_fact_get_facts_data($node, $field_names) {
     if ($field_data) {
       if (array_key_exists($language, $field_data)) {
         $entity = dosomething_fact_get_entity($field_data, $language);
-       } else {
-        //if we do not have a translation for the current user's language, get language of user that created the reportback
-        $alpha_language = $node->language;
-        $entity = dosomething_fact_get_entity($field_data, $alpha_language);
+       }
+      else {
+        // If we do not have a translation for the current user's language, get language of user that created the reportback
+        $entity = dosomething_fact_get_entity($field_data, $node->language);
       }
 
       if (isset($field_data[0]['entity']) && is_object($field_data[0]['entity'])) {


### PR DESCRIPTION
Fixes #5684 

If we do not have a translation for the current user's language, get language of user that created the reportback and get the campaign facts (including problem statement) based on that.

Testing:
- create a reportback for a campaign that doesn't have translations for every language
- view the reportback (reportback/{reportback #}) from one of the languages that the campaign doesn't have translations for (make sure you clear the cache before this step to make sure it is working)
- you should see the same thing as if you view the reportback from the language in which it was created

![image](https://cloud.githubusercontent.com/assets/4240292/12271563/c200a5a0-b929-11e5-9677-28be02e2120e.png)

The user who created this reportback has language english, and it is being viewed from global english. There was no translation for global english, so it pulled up the english version.

CC: @namimody 
