### PR TITLE
Fixes missing campaign title in reportback mergevars.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -867,6 +867,13 @@ function dosomething_reportback_mbp_request($entity) {
       } else {
         $title = $node->title;
       }
+    } else {
+      watchdog(
+        'dosomething_reportback',
+        'Node !nid !nid not found for reportback fid !fid.',
+        ['!nid' => $entity->nid, '!fid' => $entity->fid],
+        WATCHDOG_WARNING
+      );
     }
 
     $params = array(

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -879,10 +879,8 @@ function dosomething_reportback_mbp_request($entity) {
       'impact_number' => $entity->quantity,
       'impact_noun' => $entity->noun,
       'image_markup' => $image_markup,
+      'campaign_language' => !empty($node->language) ? $node->language : DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE,
     );
-    if (!empty($node->language)) {
-      $params['campaign_language'] = $node->language;
-    }
 
     if (module_exists('dosomething_mbp')) {
       dosomething_mbp_request('campaign_reportback', $params);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -856,21 +856,34 @@ function dosomething_reportback_mbp_request($entity) {
 
   if (module_exists('dosomething_user')) {
     $account = user_load($entity->uid);
+    $node = node_load($entity->nid);
+    $language = dosomething_global_get_language($account, $node);
+
+    $title = $entity->node_title;
+    if ($node) {
+      // Get node title, normal for collections, translatable for campaigns.
+      if (isset($node->title_field)) {
+        $title = $wrapper->language($language)->title_field->value();
+      } else {
+        $title = $node->title;
+      }
+    }
+
     $params = array(
       'email' => $account->mail,
       'uid' => $account->uid,
       'first_name' => dosomething_user_get_field('field_first_name', $account),
-      'campaign_title' => $entity->node_title,
+      'campaign_title' => $title,
       'event_id' => $entity->nid,
       'impact_verb' => $entity->verb,
       'impact_number' => $entity->quantity,
       'impact_noun' => $entity->noun,
       'image_markup' => $image_markup,
     );
-    $node = node_load($entity->nid);
-    if ($node) {
+    if (!empty($node->language)) {
       $params['campaign_language'] = $node->language;
     }
+
     if (module_exists('dosomething_mbp')) {
       dosomething_mbp_request('campaign_reportback', $params);
     }


### PR DESCRIPTION
#### What's this PR do?

So I think this should fix title in email, sent to a user, which reported back with Mobile App or SMS:
![image](https://cloud.githubusercontent.com/assets/672669/12274875/a1758e9e-b975-11e5-8216-737bc6eda1c8.png)
#### How should this be manually tested?
- Signup for the campaign via SMS mobile: 38383, "Wired" : 
- Start flow: "TECH"
- Go through steps, "1", "2", "3", "4"
- report back: "EMOJI"
  - "Y" to confirm submitting images
- Send image
- Answer 3 report back questions
- Produces report back email with empty campaign title (details / example above).
#### Any background context you want to provide?

See #5985, #5870.
#### What are the relevant tickets?

Fixes #5872.
