### PR TITLE
Adds run nid to reportbacks and signups

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -893,5 +893,6 @@ function dosomething_reportback_update_7033() {
 function dosomething_reportback_update_7034(&$sandbox) {
   db_query("UPDATE dosomething_reportback as rb
             INNER JOIN field_data_field_current_run as run on rb.nid = run.entity_id
-            SET rb.run_nid = field_current_run_target_id");
+            SET rb.run_nid = field_current_run_target_id
+            WHERE rb.run_id = 0");
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -886,4 +886,11 @@ function dosomething_reportback_update_7033() {
     db_add_index($table, 'run_nid', ['run_nid']);
   }
 
+/**
+ * Makes sure all reportbacks have a run nid
+ */
+function dosomething_reportback_update_7034(&$sandbox) {
+  db_query("UPDATE dosomething_reportback as rb
+            INNER JOIN field_data_field_current_run as run on rb.nid = run.entity_id
+            SET rb.run_nid = field_current_run_target_id");
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -885,6 +885,7 @@ function dosomething_reportback_update_7033() {
   if (!db_index_exists($table, 'run_nid')) {
     db_add_index($table, 'run_nid', ['run_nid']);
   }
+}
 
 /**
  * Makes sure all reportbacks have a run nid

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -894,6 +894,6 @@ function dosomething_reportback_update_7034(&$sandbox) {
   db_query("UPDATE dosomething_reportback as rb
             INNER JOIN field_data_field_current_run as run on rb.nid = run.entity_id
             SET rb.run_nid = field_current_run_target_id
-            WHERE rb.run_id = 0
+            WHERE rb.run_nid = 0
             OR rb.run_nid IS NULL");
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -894,5 +894,6 @@ function dosomething_reportback_update_7034(&$sandbox) {
   db_query("UPDATE dosomething_reportback as rb
             INNER JOIN field_data_field_current_run as run on rb.nid = run.entity_id
             SET rb.run_nid = field_current_run_target_id
-            WHERE rb.run_id = 0");
+            WHERE rb.run_id = 0
+            OR rb.run_nid IS NULL");
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -625,3 +625,12 @@ function dosomething_signup_update_7022() {
     db_add_unique_key($table, 'uid-nid-run_nid', ['uid', 'nid', 'run_nid']);
   }
 }
+
+/*
+ * Makes sure all signups have a run nid
+ */
+function dosomething_signup_update_7023(&$sandbox) {
+  db_query("UPDATE dosomething_signup as s
+            INNER JOIN field_data_field_current_run as run on s.nid = run.entity_id
+            SET s.run_nid = field_current_run_target_id");
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -632,5 +632,6 @@ function dosomething_signup_update_7022() {
 function dosomething_signup_update_7023(&$sandbox) {
   db_query("UPDATE dosomething_signup as s
             INNER JOIN field_data_field_current_run as run on s.nid = run.entity_id
-            SET s.run_nid = field_current_run_target_id");
+            SET s.run_nid = field_current_run_target_id
+            WHERE s.run_nid = 0");
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -633,5 +633,6 @@ function dosomething_signup_update_7023(&$sandbox) {
   db_query("UPDATE dosomething_signup as s
             INNER JOIN field_data_field_current_run as run on s.nid = run.entity_id
             SET s.run_nid = field_current_run_target_id
-            WHERE s.run_nid = 0");
+            WHERE s.run_nid = 0
+            OR s.run_nid IS NULL");
 }


### PR DESCRIPTION
## DONT MERGE!
## @sbsmith86 is doing work that must run before this does (#5981)
#### What's this PR do?

Adds the current run nid to the reportback and signup 
#### How should this be manually tested?

For reportbacks, run this query after the update hook runs. There shouldn't be any run nid's with 0 left.

```
SELECT dosomething_reportback.run_nid, field_data_field_current_run.field_current_run_target_id
                    FROM dosomething_reportback
                    INNER JOIN field_data_field_current_run
                    ON dosomething_reportback.nid = field_data_field_current_run.entity_id
```

Same thing but for signups.

```
SELECT dosomething_signup.run_nid, field_data_field_current_run.field_current_run_target_id
                    FROM dosomething_signup
                    INNER JOIN field_data_field_current_run
                    ON dosomething_signup.nid = field_data_field_current_run.entity_id
```
#### What are the relevant tickets?

Fixes #6014  
#### Screenshots

Reportbacks 
![screen shot 2016-01-12 at 2 17 18 pm](https://cloud.githubusercontent.com/assets/897368/12275320/83f73346-b93d-11e5-8611-e8361f30ece9.png)
![screen shot 2016-01-12 at 2 21 59 pm](https://cloud.githubusercontent.com/assets/897368/12275319/83f53e88-b93d-11e5-9b1d-aba2bd139781.png)

Signups
![screen shot 2016-01-12 at 3 13 28 pm](https://cloud.githubusercontent.com/assets/897368/12275618/157a65b2-b93f-11e5-8b7b-e03174cb2426.png)
