### PR TITLE
campaign status field TAKE 2

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_base.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_base.inc
@@ -138,7 +138,7 @@ function dosomething_campaign_field_default_field_bases() {
       'allowed_values_function' => '',
       'entity_translation_sync' => FALSE,
     ),
-    'translatable' => 0,
+    'translatable' => 1,
     'type' => 'list_text',
   );
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.field_group.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.field_group.inc
@@ -8,7 +8,7 @@
  * Implements hook_field_group_info().
  */
 function dosomething_campaign_field_group_info() {
-  $export = array();
+  $field_groups = array();
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -40,7 +40,7 @@ function dosomething_campaign_field_group_info() {
       ),
     ),
   );
-  $export['group_basic_info|node|campaign|form'] = $field_group;
+  $field_groups['group_basic_info|node|campaign|form'] = $field_group;
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -68,7 +68,7 @@ function dosomething_campaign_field_group_info() {
       'formatter' => 'collapsed',
     ),
   );
-  $export['group_campaign_additional_info|node|campaign|form'] = $field_group;
+  $field_groups['group_campaign_additional_info|node|campaign|form'] = $field_group;
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -96,7 +96,7 @@ function dosomething_campaign_field_group_info() {
       'formatter' => 'collapsed',
     ),
   );
-  $export['group_confirmation|node|campaign|form'] = $field_group;
+  $field_groups['group_confirmation|node|campaign|form'] = $field_group;
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -125,7 +125,7 @@ function dosomething_campaign_field_group_info() {
       'formatter' => 'collapsed',
     ),
   );
-  $export['group_created|node|campaign|form'] = $field_group;
+  $field_groups['group_created|node|campaign|form'] = $field_group;
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -160,7 +160,7 @@ function dosomething_campaign_field_group_info() {
       'formatter' => 'collapsed',
     ),
   );
-  $export['group_do_it|node|campaign|form'] = $field_group;
+  $field_groups['group_do_it|node|campaign|form'] = $field_group;
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -189,7 +189,7 @@ function dosomething_campaign_field_group_info() {
       'formatter' => 'collapsed',
     ),
   );
-  $export['group_incentives|node|campaign|form'] = $field_group;
+  $field_groups['group_incentives|node|campaign|form'] = $field_group;
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -224,7 +224,7 @@ function dosomething_campaign_field_group_info() {
       'formatter' => 'collapsed',
     ),
   );
-  $export['group_know_it|node|campaign|form'] = $field_group;
+  $field_groups['group_know_it|node|campaign|form'] = $field_group;
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -254,7 +254,7 @@ function dosomething_campaign_field_group_info() {
       'formatter' => 'collapsed',
     ),
   );
-  $export['group_location_finder|node|campaign|form'] = $field_group;
+  $field_groups['group_location_finder|node|campaign|form'] = $field_group;
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -283,7 +283,7 @@ function dosomething_campaign_field_group_info() {
       'formatter' => 'collapsed',
     ),
   );
-  $export['group_mobile_app|node|campaign|form'] = $field_group;
+  $field_groups['group_mobile_app|node|campaign|form'] = $field_group;
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -311,7 +311,7 @@ function dosomething_campaign_field_group_info() {
       'formatter' => 'collapsed',
     ),
   );
-  $export['group_partners|node|campaign|form'] = $field_group;
+  $field_groups['group_partners|node|campaign|form'] = $field_group;
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -340,7 +340,7 @@ function dosomething_campaign_field_group_info() {
       'formatter' => 'collapsed',
     ),
   );
-  $export['group_pitch_additional_info|node|campaign|form'] = $field_group;
+  $field_groups['group_pitch_additional_info|node|campaign|form'] = $field_group;
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -374,7 +374,7 @@ function dosomething_campaign_field_group_info() {
       'formatter' => 'collapsed',
     ),
   );
-  $export['group_prep_it|node|campaign|form'] = $field_group;
+  $field_groups['group_prep_it|node|campaign|form'] = $field_group;
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -404,7 +404,7 @@ function dosomething_campaign_field_group_info() {
       'formatter' => 'collapsed',
     ),
   );
-  $export['group_report_back|node|campaign|form'] = $field_group;
+  $field_groups['group_report_back|node|campaign|form'] = $field_group;
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -433,7 +433,7 @@ function dosomething_campaign_field_group_info() {
       'formatter' => 'collapsed',
     ),
   );
-  $export['group_starter_statement|node|campaign|form'] = $field_group;
+  $field_groups['group_starter_statement|node|campaign|form'] = $field_group;
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -468,7 +468,7 @@ function dosomething_campaign_field_group_info() {
       'formatter' => 'collapsed',
     ),
   );
-  $export['group_taxonomy|node|campaign|form'] = $field_group;
+  $field_groups['group_taxonomy|node|campaign|form'] = $field_group;
 
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
@@ -504,7 +504,26 @@ Campaigns that are in high season will have higher priority than non-seasonal ca
       'formatter' => 'collapsed',
     ),
   );
-  $export['group_timing|node|campaign|form'] = $field_group;
+  $field_groups['group_timing|node|campaign|form'] = $field_group;
 
-  return $export;
+  // Translatables
+  // Included for use with string extractors like potx.
+  t('Additional Info');
+  t('Basic Info');
+  t('Confirmation');
+  t('Creator Info');
+  t('Do It');
+  t('Incentives');
+  t('Know It');
+  t('Location Finder');
+  t('Mobile App');
+  t('Pitch Page Additional Info');
+  t('Plan It');
+  t('Prove It');
+  t('Sponsors and Partners');
+  t('Starter Statement');
+  t('Taxonomy and Discovery');
+  t('Timing');
+
+  return $field_groups;
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.info
@@ -184,4 +184,4 @@ features[variable][] = node_preview_campaign
 features[variable][] = node_submitted_campaign
 features[variable][] = pathauto_node_campaign_pattern
 features[views_view][] = campaigns_by_term
-mtime = 1452026855
+mtime = 1452545247

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -54,6 +54,10 @@ function dosomething_campaign_form_campaign_node_form_alter(&$form, &$form_state
     // Save the options.
     $form['field_current_run'][$language]['#options'] = $options;
   }
+
+  // Disable the campaign status field which gets filled programatically based
+  // on campaign run dates.
+  $form['field_campaign_status']['#disabled'] = 1;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.cron.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.cron.inc
@@ -1,0 +1,35 @@
+<?php
+
+
+/**
+ * @file
+ * Provides cron job/drush command for dosomething_campaign_run.module.
+ */
+
+/**
+ * Implements hook_cron().
+ */
+function dosomething_campaign_run_cron() {
+  // Get all campaign runs and the start and end date for each translation of the run date field.
+  $results = db_query("SELECT campaign_run.nid as campaign_run_nid,
+                              run_date.field_run_date_value as start_date,
+                              run_date.field_run_date_value2 as end_date,
+                              run_date.language as language,
+                              campaigns.field_campaigns_target_id as campaign_nid
+                       FROM node as campaign_run
+                       INNER JOIN field_data_field_run_date as run_date
+                          ON campaign_run.nid = run_date.entity_id
+                       INNER JOIN field_data_field_campaigns as campaigns
+                          ON campaign_run.nid = campaigns.entity_id
+                       AND campaigns.language = run_date.language;");
+
+  // Update the campaign status of the campaign node.
+  foreach ($results as $result) {
+    $start = new DateTime($result->start_date);
+    $end = new DateTime($result->end_date);
+    $status = dosomething_helpers_get_campaign_status($start, $end);
+    $campaign = entity_metadata_wrapper('node', $result->campaign_nid);
+    $campaign->language($result->language)->field_campaign_status = $status;
+    $campaign->save();
+  }
+}

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.cron.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.cron.inc
@@ -11,17 +11,18 @@
  */
 function dosomething_campaign_run_cron() {
   // Get all campaign runs and the start and end date for each translation of the run date field.
-  $results = db_query("SELECT campaign_run.nid as campaign_run_nid,
+  $results = db_query("SELECT campaign_run.entity_id as campaign_run_nid,
                               run_date.field_run_date_value as start_date,
                               run_date.field_run_date_value2 as end_date,
-                              run_date.language as language,
+                              run_date.language,
                               campaigns.field_campaigns_target_id as campaign_nid
-                       FROM node as campaign_run
+                       FROM entity_translation as campaign_run
                        INNER JOIN field_data_field_run_date as run_date
-                          ON campaign_run.nid = run_date.entity_id
+                          ON campaign_run.entity_id = run_date.entity_id
+                          AND campaign_run.language = run_date.language
                        INNER JOIN field_data_field_campaigns as campaigns
-                          ON campaign_run.nid = campaigns.entity_id
-                       AND campaigns.language = run_date.language;");
+                          ON campaign_run.entity_id = campaigns.entity_id
+                          AND campaigns.language = run_date.language;");
 
   // Update the campaign status of the campaign node.
   foreach ($results as $result) {

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -5,6 +5,7 @@
  */
 
 include_once 'dosomething_campaign_run.features.inc';
+include_once 'dosomething_campaign_run.cron.inc';
 
 /**
  * Adds loaded closed campaign_run node to the given parent campaign's $vars.
@@ -294,51 +295,30 @@ function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$fo
 }
 
 /*
+ * When campaign run nodes are saved, this hook updates the campaign status field on campaign nodes
+ * based on the campaign run dates.
+ *
  * Implements hook_node_presave().
  */
 function dosomething_campaign_run_node_presave($node) {
   if ($node->type == 'campaign_run') {
     $run_campaigns = $node->field_campaigns;
-    $status = dosomething_campaign_run_get_active_state($node);
+    $run_dates = $node->field_run_date;
 
-    foreach ($run_campaigns as $lang => $campaigns) {
-      // There could be multiple campaigns per language in this field. Probably not, but we do allow for it.
-      foreach ($campaigns as $key => $value) {
-        $campaign_node = entity_metadata_wrapper('node', $value['target_id']);
-        $campaign_node->language($lang)->field_campaign_status = $status[$lang];
+    // Determine the active and closed state for each translation of the run_date field
+    foreach ($run_dates as $lang => $date) {
+      $start = new DateTime($date[0]['value']);
+      $end = new DateTime($date[0]['value2']);
+      $status = dosomething_helpers_get_campaign_status($start, $end);
+      $run_campaigns = $node->field_campaigns[$lang];
+
+      // Update the campaign status field on each campaign node tied to this run.
+      // There could be multiple campaigns per campaign run. Probably not, but we do allow for it.
+      foreach ($run_campaigns as $campaign) {
+        $campaign_node = entity_metadata_wrapper('node', $campaign['target_id']);
+        $campaign_node->language($lang)->field_campaign_status = $status;
         $campaign_node->save();
       }
     }
   }
-}
-
-
-
-// }
-
-/*
- * Determines active or closed status for each translation of field_run_date.
- *
- * @param Object $node
- */
-function dosomething_campaign_run_get_active_state($node) {
-  if (!isset($node->field_run_date)) { return; }
-
-  $run_dates = $node->field_run_date;
-
-  foreach ($run_dates as $lang => $field_date) {
-    $start = new DateTime($field_date[0]['value']);
-    $end = new DateTime($field_date[0]['value2']);
-    $now = new DateTime();
-
-    // If no end date is set, $start and $end will be the same.
-    if (($start == $end && $now >= $start) || ($now >= $start && $now <= $end)) {
-      $status[$lang] = 'active';
-    }
-    else {
-      $status[$lang] = 'closed';
-    }
-  }
-
-  return $status;
 }

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -292,3 +292,53 @@ function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$fo
 
   drupal_add_css(drupal_get_path('module', 'dosomething_campaign_run') . '/campaign_run_node.css');
 }
+
+/*
+ * Implements hook_node_presave().
+ */
+function dosomething_campaign_run_node_presave($node) {
+  if ($node->type == 'campaign_run') {
+    $run_campaigns = $node->field_campaigns;
+    $status = dosomething_campaign_run_get_active_state($node);
+
+    foreach ($run_campaigns as $lang => $campaigns) {
+      // There could be multiple campaigns per language in this field. Probably not, but we do allow for it.
+      foreach ($campaigns as $key => $value) {
+        $campaign_node = entity_metadata_wrapper('node', $value['target_id']);
+        $campaign_node->language($lang)->field_campaign_status = $status[$lang];
+        $campaign_node->save();
+      }
+    }
+  }
+}
+
+
+
+// }
+
+/*
+ * Determines active or closed status for each translation of field_run_date.
+ *
+ * @param Object $node
+ */
+function dosomething_campaign_run_get_active_state($node) {
+  if (!isset($node->field_run_date)) { return; }
+
+  $run_dates = $node->field_run_date;
+
+  foreach ($run_dates as $lang => $field_date) {
+    $start = new DateTime($field_date[0]['value']);
+    $end = new DateTime($field_date[0]['value2']);
+    $now = new DateTime();
+
+    // If no end date is set, $start and $end will be the same.
+    if (($start == $end && $now >= $start) || ($now >= $start && $now <= $end)) {
+      $status[$lang] = 'active';
+    }
+    else {
+      $status[$lang] = 'closed';
+    }
+  }
+
+  return $status;
+}

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -312,12 +312,16 @@ function dosomething_campaign_run_node_presave($node) {
       $status = dosomething_helpers_get_campaign_status($start, $end);
       $run_campaigns = $node->field_campaigns[$lang];
 
-      // Update the campaign status field on each campaign node tied to this run.
+      // Update the campaign status field on each campaign node tied to this run,
+      // if it is set as the current run.
       // There could be multiple campaigns per campaign run. Probably not, but we do allow for it.
       foreach ($run_campaigns as $campaign) {
         $campaign_node = entity_metadata_wrapper('node', $campaign['target_id']);
-        $campaign_node->language($lang)->field_campaign_status = $status;
-        $campaign_node->save();
+        $current_run = $campaign_node->field_current_run->value();
+        if ($current_run->nid == $node->nid) {
+          $campaign_node->language($lang)->field_campaign_status = $status;
+          $campaign_node->save();
+        }
       }
     }
   }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -677,3 +677,22 @@ function dosomething_helpers_unset_array_keys(array $array = [], array $keys = [
 
   return $array;
 }
+
+/**
+ * Determines active or closed status based on start and end dates of a campaign run.
+ *
+ * @param datetime $start_date
+ * @param datetime $end_date
+ *
+ * @return string 'active' or 'closed' based on timing logic.
+ */
+function dosomething_helpers_get_campaign_status($start_date, $end_date) {
+  $now = new DateTime();
+
+  if (($start_date == $end_date && $now >= $start_date) || ($now >= $start_date && $now <= $end_date)) {
+    return 'active';
+  }
+  else {
+    return 'closed';
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
@@ -140,30 +140,30 @@ function paraneue_dosomething_preprocess_page(&$vars) {
       $code = dosomething_global_get_current_country_code();
       $language = dosomething_global_convert_country_to_language($code);
     }
-
-    $field_data = dosomething_helpers_extract_field_data($vars['node']->field_subtitle, $language);
-    if (isset($field_data)) {
-      $header_vars['subtitle'] = $field_data;
-    }
-
-    $field_data = dosomething_helpers_extract_field_data($vars['node']->field_partners, $language);
-    if (isset($field_data)) {
-      $vars['partners'] = dosomething_taxonomy_get_partners_data($field_data);
-      $vars['sponsor_logos'] = paraneue_dosomething_get_sponsor_logos($vars['partners']);
-
-      // Output sponsor, if it exists.
-      if ($vars['sponsor_logos']) {
-        $header_vars['promotions'] = $vars['sponsor_logos'];
-
-        $header_vars['promotions'] = '<div class="promotions">' . $header_vars['promotions'] . '</div>';
+    if (isset($vars['node']->field_subtitle) && isset($vars['node']->field_partners)) {
+      $field_data = dosomething_helpers_extract_field_data($vars['node']->field_subtitle, $language);
+      if (isset($field_data)) {
+        $header_vars['subtitle'] = $field_data;
       }
 
-      // Add class to header if promotions will be included in display.
-      if (isset($vars['promotions'])) {
-        $vars['classes_array'][] = 'has-promotions';
+      $field_data = dosomething_helpers_extract_field_data($vars['node']->field_partners, $language);
+      if (isset($field_data)) {
+        $vars['partners'] = dosomething_taxonomy_get_partners_data($field_data);
+        $vars['sponsor_logos'] = paraneue_dosomething_get_sponsor_logos($vars['partners']);
+
+        // Output sponsor, if it exists.
+        if ($vars['sponsor_logos']) {
+          $header_vars['promotions'] = $vars['sponsor_logos'];
+
+          $header_vars['promotions'] = '<div class="promotions">' . $header_vars['promotions'] . '</div>';
+        }
+
+        // Add class to header if promotions will be included in display.
+        if (isset($vars['promotions'])) {
+          $vars['classes_array'][] = 'has-promotions';
+        }
       }
     }
-
     // Add global header.
     $vars['header'] = theme('header', $header_vars);
   }


### PR DESCRIPTION
#### What's this PR do?
- Disables the campaign status field on campaign nodes so editors can not use it.
- Makes the campaign status field on campaign nodes translatable.
- Adds a presave hook to campaign runs that will update campaign status when a user saves a campaign run node.
- Creates a helper function that takes a start and end date and determines if a campaign is active or not
- Slightly outside of the scope of this issue, but I was getting some preprocess errors on pages without subtitle and partners fields that I fixed up.
- Creates a cron job that updates the campaign status field based on run dates.
#### Where should the reviewer start?

The main business is in these here files, there rest is feature export stuff.

`dosomething_campaign_run.module`
`dosomething_helpers.module`
`dosomething_campaign_run.cron.inc`
#### How should this be manually tested?

Create or edit a campaign run, and run dates, hit save. Go to the campaign you tied the run to, the campaign status field should be disabled, but you should be able to see the current status of the campaign per translation. 

Status would be `active` when the run has a start date and no end date
Status would be `closed` when the run end date is before `now`

The cron job is a bit trickier to test, it really only comes in handy when there is a campaign run dates set in the future or past. The cron job should update the status of the campaign node to closed or active based on the dates without a use having to manually save the campaign run again.
#### Any background context you want to provide?

Campaign runs...amirite?
#### What are the relevant tickets?

Fixes #5989 
