### PR TITLE
Updating database schema for ds_signups & ds_reportbacks

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -92,9 +92,13 @@ function dosomething_reportback_schema() {
       ),
     ),
     'primary key' => array('rbid'),
+    'unique keys' => array(
+      'rbid-uid-nid-run_nid' => array('rbid', 'uid', 'nid', 'run_nid'),
+    ),
     'indexes' => array(
       'uid' => array('uid'),
       'nid' => array('nid'),
+      'run_nid' => array('run_nid'),
     ),
   );
   $schema['dosomething_reportback_log'] = array(
@@ -873,4 +877,19 @@ function dosomething_reportback_update_7032() {
 
   // Move run_nid colum after nid.
   db_query("ALTER TABLE dosomething_reportback MODIFY COLUMN run_nid int AFTER nid;");
+}
+
+/**
+ * Adds unique key and index for Campaign Run data to the dosomething_reportback table.
+ */
+function dosomething_reportback_update_7033() {
+  $table = 'dosomething_reportback';
+
+  if (!db_index_exists($table, 'run_nid')) {
+    db_add_index($table, 'run_nid', ['run_nid']);
+  }
+
+  if (!db_index_exists($table, 'rbid-uid-nid-run_nid')) {
+    db_add_unique_key($table, 'rbid-uid-nid-run_nid', ['rbid', 'uid', 'nid', 'run_nid']);
+  }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -92,9 +92,6 @@ function dosomething_reportback_schema() {
       ),
     ),
     'primary key' => array('rbid'),
-    'unique keys' => array(
-      'rbid-uid-nid-run_nid' => array('rbid', 'uid', 'nid', 'run_nid'),
-    ),
     'indexes' => array(
       'uid' => array('uid'),
       'nid' => array('nid'),
@@ -880,7 +877,7 @@ function dosomething_reportback_update_7032() {
 }
 
 /**
- * Adds unique key and index for Campaign Run data to the dosomething_reportback table.
+ * Adds index for Campaign Run data to the dosomething_reportback table.
  */
 function dosomething_reportback_update_7033() {
   $table = 'dosomething_reportback';
@@ -889,7 +886,4 @@ function dosomething_reportback_update_7033() {
     db_add_index($table, 'run_nid', ['run_nid']);
   }
 
-  if (!db_index_exists($table, 'rbid-uid-nid-run_nid')) {
-    db_add_unique_key($table, 'rbid-uid-nid-run_nid', ['rbid', 'uid', 'nid', 'run_nid']);
-  }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -67,11 +67,12 @@ function dosomething_signup_schema() {
     ),
     'primary key' => array('sid'),
     'unique keys' => array(
-      'uid-nid' => array('uid', 'nid'),
+      'uid-nid-run_nid' => array('uid', 'nid', 'run_nid'),
     ),
     'indexes' => array(
       'uid' => array('uid'),
       'nid' => array('nid'),
+      'run_nid' => array('run_nid'),
     ),
   );
   $schema['dosomething_signup_data_form'] = array(
@@ -604,4 +605,23 @@ function dosomething_signup_update_7021() {
 
   // Move run_nid colum after nid.
   db_query("ALTER TABLE dosomething_signup MODIFY COLUMN run_nid int AFTER nid;");
+}
+
+/**
+ * Adds unique key and index for Campaign Run data to the dosomething_signup table.
+ */
+function dosomething_signup_update_7022() {
+  $table = 'dosomething_signup';
+
+  if (db_index_exists($table, 'uid-nid')) {
+    db_drop_unique_key($table, 'uid-nid');
+  }
+
+  if (!db_index_exists($table, 'run_nid')) {
+    db_add_index($table, 'run_nid', ['run_nid']);
+  }
+
+  if (!db_index_exists($table, 'uid-nid-run_nid')) {
+    db_add_unique_key($table, 'uid-nid-run_nid', ['uid', 'nid', 'run_nid']);
+  }
 }


### PR DESCRIPTION
Refs #5993
#### What's this PR do?

This updates the run_nid on both dosomething_signup and dosomething_reportback tables to act as an index and a combination unique key.
#### Where should the reviewer start?

In the respective _**.install_\* files for each DB schema.
#### How should this be manually tested?

Take a gander and confirm this all looks alright and makes sense. You can test it by pulling it down and running `drush updb` to have the database changes take place. Then take a look at the DB and make sure the indexes and keys are updated for the **dosomething_signup** and **dosomething_reportback** table structures.
#### What are the relevant tickets?
#5993

---

@angaither 
