### PR TITLE
Fixes broken endpoint when no parameters passed.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -18,14 +18,14 @@ class CampaignTransformer extends Transformer {
    * @return array
    */
   public function index($parameters) {
+    $filters = $this->setFilters($parameters);
+
     $cache = new ApiCache;
 
     $campaigns = $cache->get('campaigns', $parameters);
 
     try {
       if (!$campaigns) {
-        $filters = $this->setFilters($parameters);
-
         $campaigns = Campaign::find($filters, 'full');
 
         $cache->set('campaigns', $parameters, $campaigns);


### PR DESCRIPTION
Fixes #6044
#### What's this PR do?

Turns out I had moved the  variable generation inside a scoped logic block; if the logic didn't pass then the variable wasn't set and it's being used a little farther down in the code so it needs to be set regardless. Moved it up and out of the logic block. Works fine now.
#### Where should the reviewer start?

Just take a look at where I moved the variable definition to :)
#### What are the relevant tickets?
#6044

---

@DFurnes @aaronschachter @angaither 

cc: @jonuy 
