### PR TITLE
Fill current run field

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -669,13 +669,17 @@ function dosomething_campaign_get_hot_time_left($node, &$vars = NULL) {
 }
 
 /**
- * Get all the campaign runs associated with a node.
+ * Get all the campaign runs associated with a node translation.
  */
-function dosomething_campaign_get_runs($nid) {
+function dosomething_campaign_get_runs($nid, $language) {
   $campaign_runs = db_query("SELECT entity_id
                              FROM field_data_field_campaigns
                              WHERE field_campaigns_target_id = :nid
-                             AND bundle = 'campaign_run';", array(':nid' => $nid))->fetchAll();
+                             AND language = :language
+                             AND bundle = 'campaign_run';", array(
+                              ':nid' => $nid,
+                              ':language' => $language
+                             ))->fetchAll();
 
   return $campaign_runs;
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -670,6 +670,9 @@ function dosomething_campaign_get_hot_time_left($node, &$vars = NULL) {
 
 /**
  * Get all the campaign runs associated with a node translation.
+ *
+ * @param $nid The nid of the node to grab runs for
+ * @param $language The language of the translation to grab runs for.
  */
 function dosomething_campaign_get_runs($nid, $language) {
   $campaign_runs = db_query("SELECT entity_id

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -22,8 +22,6 @@ define('DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER', t('Snap a Pic'));
 function dosomething_campaign_form_campaign_node_form_alter(&$form, &$form_state, $form_id) {
   unset($form['field_active_hours'][LANGUAGE_NONE]['#options']['_none']);
   $form['title']['#description'] = t('Title - i.e. "Protect your Pills", "Birthday Mail", or "Teens for Jeans" <br/><strong> Limit: 20 characters. </strong>');
-  // Add in campaign close info.
-  dosomething_campaign_run_add_campaign_run_info($form, $form_state);
   // Use #after_build to add JS even on validation errors: https://drupal.org/node/1253520#comment-4881588
   $form['#after_build'][] = 'dosomething_campaign_form_campaign_node_form_after_build';
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -22,6 +22,8 @@ define('DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER', t('Snap a Pic'));
 function dosomething_campaign_form_campaign_node_form_alter(&$form, &$form_state, $form_id) {
   unset($form['field_active_hours'][LANGUAGE_NONE]['#options']['_none']);
   $form['title']['#description'] = t('Title - i.e. "Protect your Pills", "Birthday Mail", or "Teens for Jeans" <br/><strong> Limit: 20 characters. </strong>');
+  // Add in campaign close info.
+  dosomething_campaign_run_add_campaign_run_info($form, $form_state);
   // Use #after_build to add JS even on validation errors: https://drupal.org/node/1253520#comment-4881588
   $form['#after_build'][] = 'dosomething_campaign_form_campaign_node_form_after_build';
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -26,26 +26,31 @@ function dosomething_campaign_form_campaign_node_form_alter(&$form, &$form_state
   $form['#after_build'][] = 'dosomething_campaign_form_campaign_node_form_after_build';
 
   $nid = $form['nid']['#value'];
+  $language = $form['field_current_run']['#language'];
+  $all_options = $form['field_current_run'][$language]['#options'];
 
   // If this is an /add/ form then nid won't be set yet.
   if (!is_null($nid)) {
-    $campaign_runs = dosomething_campaign_get_runs($nid);
+    $campaign_runs = dosomething_campaign_get_runs($nid, $language);
   }
 
   // Only show the campaign runs tied to the campaign as options.
-  if (isset($campaign_runs) && !empty($campaign_runs)) {
-    $language = $form['field_current_run']['#language'];
-    $all_options = $form['field_current_run'][$language]['#options'];
-
-    foreach ($campaign_runs as $run) {
-      $filtered_options[$run->entity_id] = $all_options[$run->entity_id];
-    }
-
+  if (isset($campaign_runs)) {
+    $options = $campaign_runs;
     // Add empty option to the options array. Helps to ensure that the user
     // explicity chooses a campaign instead of defaulting to the first option
     // in the list.
-    $filtered_options = array("_none" => "- None -") + $filtered_options;
-    $form['field_current_run'][$language]['#options'] = $filtered_options;
+    $options = array("_none" => "- None -");
+
+    // If there are campaign runs tied to this campaign translation.
+    if (!empty($campaign_runs)) {
+      foreach ($campaign_runs as $run) {
+        $options[$run->entity_id] = $all_options[$run->entity_id];
+      }
+    }
+
+    // Save the options.
+    $form['field_current_run'][$language]['#options'] = $options;
   }
 }
 

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.install
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.install
@@ -78,3 +78,33 @@ function dosomething_campaign_run_update_7003() {
     }
   }
 }
+
+/**
+ * Sets the field_current_run for every campaign.
+ */
+function dosomething_campaign_run_update_7004() {
+  // Get all campaigns.
+  $campaigns = db_query("SELECT campaign.entity_id, campaign.language
+                         FROM entity_translation as campaign
+                         INNER JOIN node ON node.nid = campaign.entity_id
+                         WHERE node.type = 'campaign'
+                         AND campaign.entity_type = 'node';");
+  // Store the current run.
+  foreach($campaigns as $campaign) {
+    // Get the run_nid associated with this campaign and translation.
+    // Note: this just gets the first run_nid associated with the campaign in the result set.
+    $run_nid = db_query("SELECT entity_id
+                         FROM field_data_field_campaigns
+                         WHERE field_campaigns_target_id = :nid
+                         AND bundle = 'campaign_run'
+                         AND language = :lang;", array(
+                          ':nid' => $campaign->entity_id,
+                          ':lang' => $campaign->language))->fetchField(0);
+    // Fill in the field.
+    if ($run_nid) {
+      $campaign_node = entity_metadata_wrapper('node', $campaign->entity_id);
+      $campaign_node->language($campaign->language)->field_current_run = $run_nid;
+      $campaign_node->save();
+    }
+  }
+}

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -255,24 +255,6 @@ function dosomething_campaign_run_get_parent_nid($nid) {
 }
 
 /**
- * Given a campaign form and form state, check to see if there is a campgin run.
- * Adds the campaign run nid to the campaign form.
- *
- * @param array $form
- *  A drupal form array of a campaign node
- * @param array $form_state
- *  A drupal form_state array of a campaign node
- */
-function dosomething_campaign_run_add_campaign_run_info(&$form, &$form_state) {
-  $nid = $form['nid']['#value'];
-  $closed_nid = dosomething_campaign_run_get_closed_run_nid($nid);
-  if (isset($closed_nid)) {
-    $form['field_campaign_status'][LANGUAGE_NONE]['#description'] = t('The current campaign run nid is ' . l($closed_nid, 'node/' . $closed_nid . '/edit'));
-    return $form;
-  }
-}
-
-/**
  * Implements hook_form_NODE_TYPE_alter().
  */
 function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$form_state, $form_id) {

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -212,11 +212,7 @@ function dosomething_campaign_run_preprocess_klout_gallery(&$vars, $nid) {
 }
 
 /**
- * For given campaign $nid, return its closed Campaign Run nid.
- *
- * For now, this just returns a campaign_run node that references the $nid.
- * As we build out multiple runs per campaign, we'll need to add logic
- * to determine sequence.
+ * For given campaign $nid, return its current Campaign Run nid.
  *
  * @param int $nid
  *   A campaign node nid.
@@ -225,13 +221,10 @@ function dosomething_campaign_run_preprocess_klout_gallery(&$vars, $nid) {
  *   Returns the closed campaign_run node $nid if exists, FALSE if not.
  */
 function dosomething_campaign_run_get_closed_run_nid($nid) {
-   // Query field_data_field_campaigns for campaign_run node referencing $nid.
-   $result = db_select('field_data_field_campaigns', 'c')
-    ->fields('c', array('entity_id'))
-    ->condition('field_campaigns_target_id', $nid)
-    ->condition('bundle', 'campaign_run')
-    ->execute();
-  return $result->fetchField(0);
+  $node = entity_metadata_wrapper('node', $nid);
+  if (isset($node->field_current_run)) {
+    return (!is_null($node->field_current_run->value()->nid)) ? $node->field_current_run->value()->nid : FALSE;
+  }
 }
 
 /**
@@ -268,8 +261,9 @@ function dosomething_campaign_run_add_campaign_run_info(&$form, &$form_state) {
   $language = $form['field_current_run']['#language'];
 
   $closed_nid = dosomething_campaign_run_get_closed_run_nid($nid);
-  if (isset($closed_nid)) {
-    $form['field_current_run'][$language]['#description'] = t('The current campaign run nid is ' . l($closed_nid, 'node/' . $closed_nid . '/edit'));
+
+  if ($closed_nid) {
+    $form['field_current_run'][$language]['#description'] = t('The current campaign run nid is ' . l($closed_nid, 'node/' . $closed_nid . '/edit/' . $language));
     return $form;
   }
 }
@@ -284,7 +278,7 @@ function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$fo
   // If the campaign nid is set let's add some help text!
   // This will break when we create MX & BR (and etc) campaign runs. the helpers extract only checks for 'en'
   $campaign_nid = dosomething_helpers_extract_field_data($form['#node']->field_campaigns);
-  if (isset($campaign_nid)) {
+  if ($campaign_nid) {
     // Get totals & language from the campaign.
     $signup_total_members = dosomething_signup_get_signup_total_by_nid($campaign_nid);
     $reportback_quantity = dosomething_reportback_get_reportback_total_by_nid($campaign_nid);

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -255,6 +255,26 @@ function dosomething_campaign_run_get_parent_nid($nid) {
 }
 
 /**
+ * Given a campaign form and form state, check to see if there is a campgin run.
+ * Adds the campaign run nid to the campaign form.
+ *
+ * @param array $form
+ *  A drupal form array of a campaign node
+ * @param array $form_state
+ *  A drupal form_state array of a campaign node
+ */
+function dosomething_campaign_run_add_campaign_run_info(&$form, &$form_state) {
+  $nid = $form['nid']['#value'];
+  $language = $form['field_current_run']['#language'];
+
+  $closed_nid = dosomething_campaign_run_get_closed_run_nid($nid);
+  if (isset($closed_nid)) {
+    $form['field_current_run'][$language]['#description'] = t('The current campaign run nid is ' . l($closed_nid, 'node/' . $closed_nid . '/edit'));
+    return $form;
+  }
+}
+
+/**
  * Implements hook_form_NODE_TYPE_alter().
  */
 function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$form_state, $form_id) {


### PR DESCRIPTION
#### What's this PR do?

Fills the current run field for all campaigns.
#### Where should the reviewer start?

I would go commit by commit. 

[eaaba3f](https://github.com/DoSomething/phoenix/commit/eaaba3ff81fe09457c1101af7ace79d60849cdfa)
Removes the helper text on the campaign node edit form that was showing the user what the current run was. We don't need this anymore, cause we have a field.

[de0238c](https://github.com/DoSomething/phoenix/commit/de0238c1fe8475de30dd6dcdd4e0818e390fe8dd)
Creates the update hook that gets all campaigns, and then fills in the current run field for each translation of that campaign.

[fb9898b](https://github.com/DoSomething/phoenix/commit/fb9898bdd03b051467435870137010ab63aadf5e)
Fixes an issue with the current run field where, if there wasn't a translation of a run, the option was blank. This update fixes it so that if there are campaign runs tied to a campaign translation, only those runs will show. If there are no campaign runs for a campaign translation, nothing will show.
#### How should this be manually tested?

Pull down this branch, run the update hook. If you run this query against the database you shouldn't see any campaign without run_nids tied to them. The only issue I saw was that in my dev, I had closed campaigns that never had runs tied to them. The script that creates runs for campaigns, only does this for `active` campaigns, so runs were never created for them. I am assuming in thor and prod environments, closed campaigns have runs because of the workflow. But just noting this here.

```
SELECT campaign.entity_id as campagin, run.field_current_run_target_id as run_nid
FROM entity_translation as campaign
INNER JOIN node ON campaign.entity_id = node.nid 
LEFT JOIN field_data_field_current_run as run
ON campaign.entity_id = run.entity_id
AND campaign.language = run.language
WHERE node.type = 'campaign'
AND campaign.entity_type = 'node';
```
#### What are the relevant tickets?
#5981
