### PR TITLE
Unarchive run activity

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.install
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.install
@@ -107,41 +107,4 @@ function dosomething_campaign_run_update_7004() {
       $campaign_node->save();
     }
   }
-=======
- * Moves all signups and reportbacks from run nodes back to the original campaign node.
- */
-function dosomething_campaign_run_update_7003() {
-  $signups = db_query("SELECT n.nid, n.language, n.title, n.created, c.field_campaigns_target_id, s.sid, s.uid, s.nid
-                       FROM node n
-                       INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
-                       INNER JOIN dosomething_signup s on s.nid = n.nid
-                       WHERE n.type = 'campaign_run';");
-
-  foreach ($signups as $signup) {
-    db_update('node')
-      ->fields(array(
-        // change signup node id to campaign id
-        $signup->nid => $signup->field_campaigns_target_id,
-        // change signup run id to campaign run nid
-        $signup->sid => $signup->nid,
-        )
-      )
-      ->execute();
-  }
-
-  $reportbacks = db_query("SELECT n.nid, n.language, n.title, n.created, c.field_campaigns_target_id, rb.rbid, rb.uid, rb.nid
-                           FROM node n
-                           INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
-                           INNER JOIN dosomething_reportback rb on rb.nid = n.nid
-                           WHERE n.type = 'campaign_run';");
-
-  foreach ($reportbacks as $reportback) {
-    db_update('node')
-      ->fields(array(
-        $reportback->nid => $reportback->field_campaigns_target_id,
-        $reportback->rbid => $reportback->nid,
-        )
-      )
-      ->execute
-  }
 }

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.install
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.install
@@ -107,4 +107,41 @@ function dosomething_campaign_run_update_7004() {
       $campaign_node->save();
     }
   }
+=======
+ * Moves all signups and reportbacks from run nodes back to the original campaign node.
+ */
+function dosomething_campaign_run_update_7003() {
+  $signups = db_query("SELECT n.nid, n.language, n.title, n.created, c.field_campaigns_target_id, s.sid, s.uid, s.nid
+                       FROM node n
+                       INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
+                       INNER JOIN dosomething_signup s on s.nid = n.nid
+                       WHERE n.type = 'campaign_run';");
+
+  foreach ($signups as $signup) {
+    db_update('node')
+      ->fields(array(
+        // change signup node id to campaign id
+        $signup->nid => $signup->field_campaigns_target_id,
+        // change signup run id to campaign run nid
+        $signup->sid => $signup->nid,
+        )
+      )
+      ->execute();
+  }
+
+  $reportbacks = db_query("SELECT n.nid, n.language, n.title, n.created, c.field_campaigns_target_id, rb.rbid, rb.uid, rb.nid
+                           FROM node n
+                           INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
+                           INNER JOIN dosomething_reportback rb on rb.nid = n.nid
+                           WHERE n.type = 'campaign_run';");
+
+  foreach ($reportbacks as $reportback) {
+    db_update('node')
+      ->fields(array(
+        $reportback->nid => $reportback->field_campaigns_target_id,
+        $reportback->rbid => $reportback->nid,
+        )
+      )
+      ->execute
+  }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -890,7 +890,7 @@ function dosomething_reportback_update_7033() {
 /**
  * Moves all reportbacks from run nodes back to the original campaign node.
  */
-function dosomething_reportback_update_7047() {
+function dosomething_reportback_update_7034() {
   $reportbacks = db_query("SELECT n.nid as campaign_node, n.language, n.title, n.created, c.field_campaigns_target_id, rb.rbid, rb.uid, rb.nid as reportback_node, rb.run_nid
                           FROM node n
                           INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -890,20 +890,21 @@ function dosomething_reportback_update_7033() {
 /**
  * Moves all reportbacks from run nodes back to the original campaign node.
  */
-function dosomething_reportback_update_7036() {
-  $reportbacks = db_query("SELECT n.nid, n.language, n.title, n.created, c.field_campaigns_target_id, rb.rbid, rb.uid, rb.nid as reportback_id, rb.run_nid
-                           FROM node n
-                           INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
-                           INNER JOIN dosomething_reportback rb on rb.nid = n.nid
-                           WHERE n.type = 'campaign_run';");
+function dosomething_reportback_update_7047() {
+  $reportbacks = db_query("SELECT n.nid as campaign_node, n.language, n.title, n.created, c.field_campaigns_target_id, rb.rbid, rb.uid, rb.nid as reportback_node, rb.run_nid
+                          FROM node n
+                          INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
+                          INNER JOIN dosomething_reportback rb on rb.nid = n.nid
+                          WHERE n.type = 'campaign_run';");
 
   foreach ($reportbacks as $reportback) {
     db_update('dosomething_reportback')
       ->fields(array(
         'nid' => $reportback->field_campaigns_target_id,
-        'run_nid' => $reportback->nid,
+        'run_nid' => $reportback->campaign_node,
         )
       )
+      ->condition('nid', $reportback->reportback_node)
       ->execute();
   }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -885,11 +885,12 @@ function dosomething_reportback_update_7033() {
   if (!db_index_exists($table, 'run_nid')) {
     db_add_index($table, 'run_nid', ['run_nid']);
   }
+}
 
-=======
+/**
  * Moves all reportbacks from run nodes back to the original campaign node.
  */
-function dosomething_reportback_update_7033() {
+function dosomething_reportback_update_7036() {
   $reportbacks = db_query("SELECT n.nid, n.language, n.title, n.created, c.field_campaigns_target_id, rb.rbid, rb.uid, rb.nid as reportback_id, rb.run_nid
                            FROM node n
                            INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
@@ -897,7 +898,7 @@ function dosomething_reportback_update_7033() {
                            WHERE n.type = 'campaign_run';");
 
   foreach ($reportbacks as $reportback) {
-    db_update('campaign_run')
+    db_update('dosomething_reportback')
       ->fields(array(
         'nid' => $reportback->field_campaigns_target_id,
         'run_nid' => $reportback->nid,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -901,7 +901,7 @@ function dosomething_reportback_update_7034() {
     db_update('dosomething_reportback')
       ->fields(array(
         'nid' => $reportback->field_campaigns_target_id,
-        'run_nid' => $reportback->campaign_node,
+        'run_nid' => '0',
         )
       )
       ->condition('nid', $reportback->reportback_node)

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -886,4 +886,23 @@ function dosomething_reportback_update_7033() {
     db_add_index($table, 'run_nid', ['run_nid']);
   }
 
+=======
+ * Moves all reportbacks from run nodes back to the original campaign node.
+ */
+function dosomething_reportback_update_7033() {
+  $reportbacks = db_query("SELECT n.nid, n.language, n.title, n.created, c.field_campaigns_target_id, rb.rbid, rb.uid, rb.nid as reportback_id, rb.run_nid
+                           FROM node n
+                           INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
+                           INNER JOIN dosomething_reportback rb on rb.nid = n.nid
+                           WHERE n.type = 'campaign_run';");
+
+  foreach ($reportbacks as $reportback) {
+    db_update('campaign_run')
+      ->fields(array(
+        'nid' => $reportback->field_campaigns_target_id,
+        'run_nid' => $reportback->nid,
+        )
+      )
+      ->execute();
+  }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -605,7 +605,6 @@ function dosomething_signup_update_7021() {
         'nid' => $signup->field_campaigns_target_id,
         // change signup run id to 0 (TODO:later we'll change back to change to campaign run nid)
         'run_nid' => '0',
-        // 'run_nid' => $signup->campaign_node,
         )
       )
       ->condition('nid', $signup->signup_node)

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -625,26 +625,3 @@ function dosomething_signup_update_7022() {
     db_add_unique_key($table, 'uid-nid-run_nid', ['uid', 'nid', 'run_nid']);
   }
 }
-
-/**
- * Moves all signups from run nodes back to the original campaign node.
- */
-function dosomething_signup_update_7026() {
-  $signups = db_query("SELECT n.nid, n.language, n.title, n.created, c.field_campaigns_target_id, s.sid, s.uid, s.nid as signup_id, s.run_nid
-                       FROM node n
-                       INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
-                       INNER JOIN dosomething_signup s on s.nid = n.nid
-                       WHERE n.type = 'campaign_run';");
-
-  foreach ($signups as $signup) {
-    db_update('dosomething_signup')
-      ->fields(array(
-        // change signup node id to campaign id
-        'nid' => $signup->field_campaigns_target_id,
-        // change signup run id to campaign run nid
-        'run_nid' => $signup->nid,
-        )
-      )
-      ->execute();
-  }
-}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -629,7 +629,7 @@ function dosomething_signup_update_7022() {
 /**
  * Moves all signups from run nodes back to the original campaign node.
  */
-function dosomething_signup_update_7030() {
+function dosomething_signup_update_7023() {
   $signups = db_query("SELECT n.nid as campaign_node, n.language, n.title, n.created, c.field_campaigns_target_id, s.sid, s.uid, s.nid as signup_node, s.run_nid
                        FROM node n
                        INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -591,7 +591,7 @@ function dosomething_signup_update_7020() {
 /**
  * Adds campaign run nid column to the dosomething_signup table.
  */
-function dosomething_signup_update_7021() {
+function dosomething_signup_update_7023() {
   $tbl_name = 'dosomething_signup';
   // Load schema to get table definition.
   $schema = dosomething_signup_schema();
@@ -626,8 +626,8 @@ function dosomething_signup_update_7022() {
 =======
  * Moves all signups from run nodes back to the original campaign node.
  */
-function dosomething_signup_update_7023() {
-  $signups = db_query("SELECT n.nid, n.language, n.title, n.created, c.field_campaigns_target_id, s.sid, s.uid, s.nid
+function dosomething_signup_update_7033() {
+  $signups = db_query("SELECT n.nid, n.language, n.title, n.created, c.field_campaigns_target_id, s.sid, s.uid, s.nid as signup_id, s.run_nid
                        FROM node n
                        INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
                        INNER JOIN dosomething_signup s on s.nid = n.nid
@@ -637,9 +637,9 @@ function dosomething_signup_update_7023() {
     db_update('dosomething_signup')
       ->fields(array(
         // change signup node id to campaign id
-        $signup->nid => $signup->field_campaigns_target_id,
+        'nid' => $signup->field_campaigns_target_id,
         // change signup run id to campaign run nid
-        $signup->sid => $signup->nid,
+        'run_nid' => $signup->nid,
         )
       )
       ->execute();

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -589,22 +589,27 @@ function dosomething_signup_update_7020() {
 }
 
 /**
- * Adds campaign run nid column to the dosomething_signup table.
+ * Moves all signups from run nodes back to the original campaign node.
  */
-function dosomething_signup_update_7023() {
-  $tbl_name = 'dosomething_signup';
-  // Load schema to get table definition.
-  $schema = dosomething_signup_schema();
-  // New field to add.
-  $field_name = 'run_nid';
-  // If the field doesn't exist already:
-  if (!db_field_exists($tbl_name, $field_name)) {
-    // Add it per the schema field definition.
-    db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
-  }
+function dosomething_signup_update_7021() {
+  $signups = db_query("SELECT n.nid as campaign_node, n.language, n.title, n.created, c.field_campaigns_target_id, s.sid, s.uid, s.nid as signup_node, s.run_nid
+                       FROM node n
+                       INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
+                       INNER JOIN dosomething_signup s on s.nid = n.nid
+                       WHERE n.type = 'campaign_run';");
 
-  // Move run_nid colum after nid.
-  db_query("ALTER TABLE dosomething_signup MODIFY COLUMN run_nid int AFTER nid;");
+  foreach ($signups as $signup) {
+    db_update('dosomething_signup')
+      ->fields(array(
+        // change signup node id to campaign id
+        'nid' => $signup->field_campaigns_target_id,
+        // change signup run id to campaign run nid
+        'run_nid' => $signup->campaign_node,
+        )
+      )
+      ->condition('nid', $signup->signup_node)
+      ->execute();
+  }
 }
 
 /**
@@ -627,25 +632,20 @@ function dosomething_signup_update_7022() {
 }
 
 /**
- * Moves all signups from run nodes back to the original campaign node.
+ * Adds campaign run nid column to the dosomething_signup table.
  */
 function dosomething_signup_update_7023() {
-  $signups = db_query("SELECT n.nid as campaign_node, n.language, n.title, n.created, c.field_campaigns_target_id, s.sid, s.uid, s.nid as signup_node, s.run_nid
-                       FROM node n
-                       INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
-                       INNER JOIN dosomething_signup s on s.nid = n.nid
-                       WHERE n.type = 'campaign_run';");
-
-  foreach ($signups as $signup) {
-    db_update('dosomething_signup')
-      ->fields(array(
-        // change signup node id to campaign id
-        'nid' => $signup->field_campaigns_target_id,
-        // change signup run id to campaign run nid
-        'run_nid' => $signup->campaign_node,
-        )
-      )
-      ->condition('nid', $signup->signup_node)
-      ->execute();
+  $tbl_name = 'dosomething_signup';
+  // Load schema to get table definition.
+  $schema = dosomething_signup_schema();
+  // New field to add.
+  $field_name = 'run_nid';
+  // If the field doesn't exist already:
+  if (!db_field_exists($tbl_name, $field_name)) {
+    // Add it per the schema field definition.
+    db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
   }
+
+  // Move run_nid colum after nid.
+  db_query("ALTER TABLE dosomething_signup MODIFY COLUMN run_nid int AFTER nid;");
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -623,5 +623,25 @@ function dosomething_signup_update_7022() {
 
   if (!db_index_exists($table, 'uid-nid-run_nid')) {
     db_add_unique_key($table, 'uid-nid-run_nid', ['uid', 'nid', 'run_nid']);
+=======
+ * Moves all signups from run nodes back to the original campaign node.
+ */
+function dosomething_signup_update_7023() {
+  $signups = db_query("SELECT n.nid, n.language, n.title, n.created, c.field_campaigns_target_id, s.sid, s.uid, s.nid
+                       FROM node n
+                       INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
+                       INNER JOIN dosomething_signup s on s.nid = n.nid
+                       WHERE n.type = 'campaign_run';");
+
+  foreach ($signups as $signup) {
+    db_update('dosomething_signup')
+      ->fields(array(
+        // change signup node id to campaign id
+        $signup->nid => $signup->field_campaigns_target_id,
+        // change signup run id to campaign run nid
+        $signup->sid => $signup->nid,
+        )
+      )
+      ->execute();
   }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -603,8 +603,9 @@ function dosomething_signup_update_7021() {
       ->fields(array(
         // change signup node id to campaign id
         'nid' => $signup->field_campaigns_target_id,
-        // change signup run id to campaign run nid
-        'run_nid' => $signup->campaign_node,
+        // change signup run id to 0 (TODO:later we'll change back to change to campaign run nid)
+        'run_nid' => '0',
+        // 'run_nid' => $signup->campaign_node,
         )
       )
       ->condition('nid', $signup->signup_node)

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -625,3 +625,27 @@ function dosomething_signup_update_7022() {
     db_add_unique_key($table, 'uid-nid-run_nid', ['uid', 'nid', 'run_nid']);
   }
 }
+
+/**
+ * Moves all signups from run nodes back to the original campaign node.
+ */
+function dosomething_signup_update_7030() {
+  $signups = db_query("SELECT n.nid as campaign_node, n.language, n.title, n.created, c.field_campaigns_target_id, s.sid, s.uid, s.nid as signup_node, s.run_nid
+                       FROM node n
+                       INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
+                       INNER JOIN dosomething_signup s on s.nid = n.nid
+                       WHERE n.type = 'campaign_run';");
+
+  foreach ($signups as $signup) {
+    db_update('dosomething_signup')
+      ->fields(array(
+        // change signup node id to campaign id
+        'nid' => $signup->field_campaigns_target_id,
+        // change signup run id to campaign run nid
+        'run_nid' => $signup->campaign_node,
+        )
+      )
+      ->condition('nid', $signup->signup_node)
+      ->execute();
+  }
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -623,10 +623,13 @@ function dosomething_signup_update_7022() {
 
   if (!db_index_exists($table, 'uid-nid-run_nid')) {
     db_add_unique_key($table, 'uid-nid-run_nid', ['uid', 'nid', 'run_nid']);
-=======
+  }
+}
+
+/**
  * Moves all signups from run nodes back to the original campaign node.
  */
-function dosomething_signup_update_7033() {
+function dosomething_signup_update_7026() {
   $signups = db_query("SELECT n.nid, n.language, n.title, n.created, c.field_campaigns_target_id, s.sid, s.uid, s.nid as signup_id, s.run_nid
                        FROM node n
                        INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id


### PR DESCRIPTION
#### What does this PR do?

Un-archives run activity and moves all signups and reportbacks from run nodes back to the original campaign node. 
#### How should this be tested?

First run the 

`SELECT n.nid as campaign_node, n.language, n.title, n.created, c.field_campaigns_target_id, rb.rbid, rb.uid, rb.nid as reportback_node, rb.run_nid
FROM node n
INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
INNER JOIN dosomething_reportback rb on rb.nid = n.nid
WHERE n.type = 'campaign_run';` 

and 

`SELECT n.nid as campaign_node, n.language, n.title, n.created, c.field_campaigns_target_id, s.sid, s.uid, s.nid as signup_node, s.run_nid
FROM node n
INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
INNER JOIN dosomething_signup s on s.nid = n.nid
WHERE n.type = 'campaign_run';`

in sequel pro. Here, all `run_nid`s should be 0.

In your vagrant box, run `drush updb -y` in dosomething@dev:/var/www/dev.dosomething.org/html$. 

Reload the `dosomething_signup` and `dosomething_reportbacks` tables and `nid`s and `run_nid`s should be updated. All campaigns should be updated so their `nid`= a campaign id (e.g. Comeback Clothes 362) and `run_nid` = a campaign nid (e.g. Comeback Clothes 1227). 
#### What are the relevant tickets?

Fixes #5995 
