### PR TITLE
Campaign class updates

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -190,6 +190,7 @@ abstract class Transformer {
     $output = [
       'id' => isset($data->id) ? $data->id : $data->nid,
       'title' => $data->title,
+      'campaign_runs' => $data->campaign_runs,
     ];
 
     // If an instance of Campaign class, then there is much
@@ -204,11 +205,15 @@ abstract class Transformer {
 
         $output['updated_at'] = $data->updated_at;
 
+        $output['status'] = $data->status ? $data->status : 'active';
+
         $output['time_commitment'] = $data->time_commitment;
 
         // $output['type'] = $data->type; //@TODO: Should type be included? Consider there is an SMS Campaign type...
 
-        $output['status'] = $data->status ? $data->status : 'active';
+        $output['language'] = $data->language;
+
+        $output['translations'] = $data->translations;
 
         foreach ($data->cover_image as $key => $image) {
           if (!is_null($image)) {

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -134,7 +134,7 @@ class Campaign {
       $this->variables = dosomething_helpers_get_variables('node', $this->id);
       $this->title = $data->title;
       $this->display = $display;
-      $this->campaign_runs = $this->getCampaignRuns();
+      $this->campaign_runs = $this->getCampaignRuns($this->id);
 
       if ($display === 'full') {
         $this->tagline = $this->getTagline();
@@ -217,8 +217,23 @@ class Campaign {
   /**
    * Get all Campaign Run for this Campaign.
    */
-  protected function getCampaignRuns() {
-    return NULL;
+  protected function getCampaignRuns($id) {
+    if (!$this->node->field_current_run) {
+      return NULL;
+    }
+
+    $runs = [
+      'current' => [],
+      'past' => [],
+    ];
+
+    foreach ($this->node->field_current_run as $key => $value) {
+      $runs['current'][$key]['id'] = dosomething_helpers_extract_field_data($this->node->field_current_run, $key);
+    }
+
+    // @TODO: Figure out how to grab past runs
+
+    return $runs;
   }
 
   /**
@@ -603,14 +618,13 @@ class Campaign {
     $translationData = $this->node->translations;
     $translations = [
       'original' => dosomething_helpers_isset($translationData->original),
-      'data' => [],
     ];
 
     if (isset($translationData->data)) {
       foreach ($translationData->data as $key => $value) {
         $prefix = dosomething_global_get_prefix_for_language($key);
 
-        $translations['data'][$key] = [
+        $translations[$key] = [
           'language_code' => $key,
           'prefix' => !empty($prefix) ? $prefix : NULL,
         ];

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -13,6 +13,9 @@ class Campaign {
   public $updated_at;
   public $status;
   public $type;
+  public $language;
+  public $translations;
+  public $campaign_runs;
   public $time_commitment;
   public $cover_image;
   public $scholarship;
@@ -96,6 +99,24 @@ class Campaign {
     }
 
     return $campaigns;
+  }
+
+  /**
+   * Return node data for this campaign instance.
+   *
+   * @return mixed
+   */
+  public function getNodeData() {
+    return $this->node;
+  }
+
+  /**
+   * Return variables data for this campaign instance.
+   *
+   * @return mixed
+   */
+  public function getVariablesData() {
+    return $this->variables;
   }
 
   /**

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -134,9 +134,7 @@ class Campaign {
       $this->variables = dosomething_helpers_get_variables('node', $this->id);
       $this->title = $data->title;
       $this->display = $display;
-      $this->campaign_runs = [
-        'active_run' => NULL,
-      ];
+      $this->campaign_runs = $this->getCampaignRuns();
 
       if ($display === 'full') {
         $this->tagline = $this->getTagline();
@@ -144,6 +142,8 @@ class Campaign {
         $this->updated_at = $data->changed;
         $this->status = $this->getStatus();
         $this->type = $this->getType();
+        $this->language = $this->getLanguage();
+        $this->translations = $this->getTranslations();
         $this->time_commitment = $this->getTimeCommitment();
 
         $this->cover_image = [
@@ -212,6 +212,13 @@ class Campaign {
     }
 
     return $data;
+  }
+
+  /**
+   * Get all Campaign Run for this Campaign.
+   */
+  protected function getCampaignRuns() {
+    return NULL;
   }
 
   /**
@@ -362,6 +369,18 @@ class Campaign {
     }
 
     return NULL;
+  }
+
+  /**
+   * Get language data.
+   */
+  protected function getLanguage() {
+    $languagePrefix = dosomething_helpers_isset($this->node->language, 'en');
+
+    return [
+      'prefix' => $languagePrefix,
+      'language_code' => dosomething_global_convert_country_to_language($languagePrefix),
+    ];
   }
 
   /**
@@ -573,6 +592,32 @@ class Campaign {
     }
 
     return $timing;
+  }
+
+  /**
+   * Get translations data for this Campaign.
+   *
+   * @TODO: potentially add extra useful info for each translation (full country name, etc?)
+   */
+  protected function getTranslations() {
+    $translationData = $this->node->translations;
+    $translations = [
+      'original' => dosomething_helpers_isset($translationData->original),
+      'data' => [],
+    ];
+
+    if (isset($translationData->data)) {
+      foreach ($translationData->data as $key => $value) {
+        $prefix = dosomething_global_get_prefix_for_language($key);
+
+        $translations['data'][$key] = [
+          'language_code' => $key,
+          'prefix' => !empty($prefix) ? $prefix : NULL,
+        ];
+      }
+    }
+
+    return $translations;
   }
 
   /**

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -9,13 +9,13 @@ class Campaign {
   public $title;
   public $display;
   public $tagline;
+  public $campaign_runs;
   public $created_at;
   public $updated_at;
   public $status;
   public $type;
   public $language;
   public $translations;
-  public $campaign_runs;
   public $time_commitment;
   public $cover_image;
   public $scholarship;
@@ -134,6 +134,9 @@ class Campaign {
       $this->variables = dosomething_helpers_get_variables('node', $this->id);
       $this->title = $data->title;
       $this->display = $display;
+      $this->campaign_runs = [
+        'active_run' => NULL,
+      ];
 
       if ($display === 'full') {
         $this->tagline = $this->getTagline();

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -707,7 +707,7 @@ function dosomething_helpers_get_campaign_status($start_date, $end_date) {
  * @return
  *  Returns the campaigns node in the correct language or false.
 */
-function dosomething_helpers_get_campaign_run($nid, $user = NULL) {
+function dosomething_helpers_get_current_campaign_run_for_user($nid, $user = NULL) {
   // Setup variables
   $node = node_load($nid);
   if (!isset($user)) {

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -723,7 +723,7 @@ function dosomething_helpers_get_campaign_run($nid, $user = NULL) {
     $node_language = $node->language;
     $run_nid = dosomething_helpers_extract_field_data($node->field_current_run, $node_language);
 
-    // Reutrn NULL if the campaign doesnt have a run nid
+    // Return NULL if the campaign doesn't have a run nid
     if (!isset($run_nid)) {
       return FALSE;
     }


### PR DESCRIPTION
Refs #5991
Refs #6054
#### What's this PR do?

Foundation work that will benefit resolving the above issues. This PR expands on the `Campaign` class to add properties for `language`, `translation`, and `campaign_runs`. This information is also now available via the API.
#### Where should the reviewer start?

Start with the **Campaign.php** file and then move onto the **Transformer.php**.
#### How should this be manually tested?

Pull down branch, clear cache and hit the API asking for a few specific campaigns and see if the new properties show up.
#### Any background context you want to provide?

@joe I updated the name of `dosomething_helpers_get_campaign_run()` to `dosomething_helpers_get_current_campaign_run_for_user()` to more accurately reflect the purpose of the function. Based on work I did for this PR, it seems like there will be other such functions that are similar but don't rely on need for user's language.
#### What are the relevant tickets?
#5991
#6054

---

@DFurnes @angaither 

cc: @deadlybutter @jonuy 
