### PR TITLE
Fix campaign view based on status

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -856,8 +856,12 @@ function dosomething_campaign_is_pitch_page($node) {
  * @return bool
  */
 function dosomething_campaign_is_closed($node) {
-  if (isset($node->field_campaign_status[LANGUAGE_NONE][0]['value'])) {
-    return $node->field_campaign_status[LANGUAGE_NONE][0]['value'] == 'closed';
+  // Get the language.
+  global $user;
+  $language = dosomething_global_get_language($user, $node);
+
+  if (isset($node->field_campaign_status[$language][0]['value'])) {
+    return $node->field_campaign_status[$language][0]['value'] == 'closed';
   }
   return FALSE;
 }


### PR DESCRIPTION
#### What's this PR do?

Fixes an issue where the campaign closed/active state wasn't being reflected on the node view. So closed campaigns were still showing the active view instead of the closed state. The issue arose because we made the campaign status field translatable, so now we have to grab the value based on the current language instead of the default undefined drupal language. 
#### Where should the reviewer start?

`dosomething_campaign.module`
#### How should this be manually tested?

Set a campaign translation to closed by updating the run dates on it's current run (in the same language) to be in the past, then go to view the campaign. You should see the closed state. Set the dates to be current and the campaign status should switch to active and when you view the campaign, you should see it in it's active state.
#### What are the relevant tickets?

Fixes #6057 
### Note: don't merge until after #5959 is compete. See @mikefantini's comment on the relevant ticket.
