### PR TITLE
Update to fix up Campaign::get() to return logical data.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_hot_shares/dosomething_campaign_hot_shares.cron.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign_hot_shares/dosomething_campaign_hot_shares.cron.inc
@@ -23,8 +23,8 @@ function dosomething_campaign_hot_shares_cron() {
 
   // Each active campaign, call shell script to create problem share images.
   foreach($results as $result) {
-    $campaign = Campaign::get($result->nid)[0];
-    $node = node_load($result->nid);
+    $campaign = Campaign::get($result->nid);
+    $node = $campaign->getNodeData();
     $count = dosomething_reportback_get_reportback_total_plus_override($result->nid);
     $goal = dosomething_helpers_get_variable('node', $result->nid, 'goal');
     $time_left = dosomething_campaign_get_hot_time_left($node);

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -36,13 +36,15 @@ class Campaign {
    *
    * @param  string|array  $ids  Single id or array of ids of Campaigns to retrieve.
    * @param  string        $display
-   * @return static
+   * @return array|mixed
    * @throws Exception
    */
   public static function get($ids, $display = 'teaser') {
+    $single_campaign = FALSE;
     $campaigns = [];
 
     if (!is_array($ids)) {
+      $single_campaign = TRUE;
       $ids = [$ids];
     }
 
@@ -57,6 +59,10 @@ class Campaign {
       $campaign->build($item, $display);
 
       $campaigns[] = $campaign;
+    }
+
+    if ($single_campaign) {
+      return array_pop($campaigns);
     }
 
     return $campaigns;

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -62,7 +62,7 @@ class CampaignTransformer extends Transformer {
   public function show($id) {
     try {
       $campaign = Campaign::get($id, 'full');
-      $campaign = services_resource_build_index_list($campaign, 'campaigns', 'id');
+      $campaign = array_pop(services_resource_build_index_list([$campaign], 'campaigns', 'id'));
     }
     catch (Exception $error) {
       return [
@@ -73,7 +73,7 @@ class CampaignTransformer extends Transformer {
     }
 
     return [
-      'data' => $this->transform(array_pop($campaign)),
+      'data' => $this->transform($campaign),
     ];
   }
 


### PR DESCRIPTION
Refs #6054
#### What's this PR do?

This is a quick update to the returned data from Campaign::get() static method. It allows passing single string or multiple ids as an array, however if passing a single string it makes it a bit cumbersome to remember to pluck the first item out as the actual data you want to use. This update fixes that so if you pass a single string id, it'll return the Campaign object, if you pass an array of ids it'll return a collection of campaign objects. Related to work for campaign runs, since the **signup** and **reportback** functions are calling `Campaign::get()` in a few areas.
#### Where should the reviewer start?

Review both the **Campaign.php** and **CampaignTransformer.php** files to make sure code looks hunky dory.
#### Any background context you want to provide?

I updated the **dosomething_campaign_hot_shares.cron.inc** file where the call to `Campaign::get()` for a single item is being used.
#### What are the relevant tickets?
#6054

---

@DFurnes 

cc: @jonuy @aaronschachter 
