### PR TITLE
Signup function updates

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -191,6 +191,8 @@ abstract class Transformer {
       'id' => isset($data->id) ? $data->id : $data->nid,
       'title' => $data->title,
       'campaign_runs' => $data->campaign_runs,
+      'language' => $data->language,
+      'translations' => $data->translations,
     ];
 
     // If an instance of Campaign class, then there is much
@@ -210,10 +212,6 @@ abstract class Transformer {
         $output['time_commitment'] = $data->time_commitment;
 
         // $output['type'] = $data->type; //@TODO: Should type be included? Consider there is an SMS Campaign type...
-
-        $output['language'] = $data->language;
-
-        $output['translations'] = $data->translations;
 
         foreach ($data->cover_image as $key => $image) {
           if (!is_null($image)) {

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -93,8 +93,8 @@ function _member_resource_definition() {
       'password_reset_url' => array(
         'help' => 'Gets the user password reset URL.',
         'file' => array(
-          'type' => 'inc', 
-          'module' => 'dosomething_api', 
+          'type' => 'inc',
+          'module' => 'dosomething_api',
           'name' => 'resources/member_resource',
         ),
         'args' => array(
@@ -105,12 +105,12 @@ function _member_resource_definition() {
             'type' => 'int',
             'description' => 'The uid of the user whose password reset url we are getting',
           ),
-        ),        
+        ),
         'callback' => '_member_resource_reset',
         'access callback' => '_member_resource_access',
         'access arguments' => array('password_reset_url'),
-      ), 
-    ),   
+      ),
+    ),
   );
   return $member_resource;
 }
@@ -267,7 +267,7 @@ function _member_resource_get_activity($uid, $nid = NULL) {
  */
 function _member_resource_get_activity_result($uid, $nid) {
   $result = new StdClass();
-  if ($sid = dosomething_signup_exists($nid, $uid)) {
+  if ($sid = dosomething_signup_exists($nid, NULL, $uid)) {
     $signup = signup_load($sid);
     $result->sid = $signup->sid;
     $result->nid = $signup->nid;

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -141,6 +141,8 @@ class Campaign {
       $this->title = $data->title;
       $this->display = $display;
       $this->campaign_runs = $this->getCampaignRuns($this->id);
+      $this->language = $this->getLanguage();
+      $this->translations = $this->getTranslations();
 
       if ($display === 'full') {
         $this->tagline = $this->getTagline();
@@ -148,8 +150,6 @@ class Campaign {
         $this->updated_at = $data->changed;
         $this->status = $this->getStatus();
         $this->type = $this->getType();
-        $this->language = $this->getLanguage();
-        $this->translations = $this->getTranslations();
         $this->time_commitment = $this->getTimeCommitment();
 
         $this->cover_image = [

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -62,7 +62,8 @@ class CampaignTransformer extends Transformer {
   public function show($id) {
     try {
       $campaign = Campaign::get($id, 'full');
-      $campaign = array_pop(services_resource_build_index_list([$campaign], 'campaigns', 'id'));
+      $campaign = services_resource_build_index_list([$campaign], 'campaigns', 'id');
+      $campaign = array_pop($campaign);
     }
     catch (Exception $error) {
       return [

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -26,7 +26,10 @@ function dosomething_global_init() {
   }
 
   $languages = language_list();
-  if (empty($languages[DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE])) {
+
+  $global_lang_code = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
+
+  if (empty($languages[$global_lang_code])) {
     watchdog('dosomething_global', "Can't load %lang language",
       array('%lang' => $global_lang_code), WATCHDOG_ERROR);
     return;

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -700,37 +700,40 @@ function dosomething_helpers_get_campaign_status($start_date, $end_date) {
 /**
  * Gets the current run for a given campaign nid and user.
  *
- * @param int $nid
- * @param object $user
- *  (optional) Will default to global $user if not supplied
- *
- * @return
- *  Returns the campaigns node in the correct language or false.
+ * @param  int     $nid
+ * @param  object  $user
+ * @param  object  $campaign
+ * @return bool|mixed  Returns the campaigns node in the correct language or false.
+ * @throws Exception
 */
-function dosomething_helpers_get_current_campaign_run_for_user($nid, $user = NULL) {
-  // Setup variables
-  $node = node_load($nid);
+function dosomething_helpers_get_current_campaign_run_for_user($nid, $user = NULL, $campaign = NULL) {
+  if (!isset($campaign)) {
+    $campaign = Campaign::get($nid);
+  }
+
   if (!isset($user)) {
     global $user;
   }
 
-  // First check if we have a run in the user lang
-  $user_language = dosomething_global_get_language($user, $node);
-  $run_nid = dosomething_helpers_extract_field_data($node->field_current_run, $user_language);
+  $node = $campaign->getNodeData();
 
-  // If not try the nodes source language
-  if (!isset($run_nid)) {
-    $node_language = $node->language;
-    $run_nid = dosomething_helpers_extract_field_data($node->field_current_run, $node_language);
+  // First check if we have a run in the user lang
+  $userLanguage = dosomething_global_get_language($user, $node);
+  $runId = dosomething_helpers_isset($campaign->campaign_runs['current'], $userLanguage);
+
+  // If not try the Campaign's source language
+  if (!isset($runId)) {
+    $campaignLanguage = $campaign->language['language_code'];
+    $runId = dosomething_helpers_isset($campaign->campaign_runs['current'], $campaignLanguage);
 
     // Return NULL if the campaign doesn't have a run nid
-    if (!isset($run_nid)) {
-      return FALSE;
+    if (!isset($runId)) {
+      return NULL;
     }
   }
 
-  // Load the run.
+  // Load the run and return it.
   // For some reason this also loads the proper translation, for both anonymous users and authed. I can't explain it.
-  $run = node_load($run_nid);
-  return $run;
+  // @TODO: may want to investigate how it loads the proper translation...
+  return node_load($runId);
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -719,15 +719,15 @@ function dosomething_helpers_get_current_campaign_run_for_user($nid, $user = NUL
 
   // First check if we have a run in the user lang
   $userLanguage = dosomething_global_get_language($user, $node);
-  $runId = dosomething_helpers_isset($campaign->campaign_runs['current'], $userLanguage);
+  $run = dosomething_helpers_isset($campaign->campaign_runs['current'], $userLanguage);
 
   // If not try the Campaign's source language
-  if (!isset($runId)) {
+  if (!isset($run)) {
     $campaignLanguage = $campaign->language['language_code'];
-    $runId = dosomething_helpers_isset($campaign->campaign_runs['current'], $campaignLanguage);
+    $run = dosomething_helpers_isset($campaign->campaign_runs['current'], $campaignLanguage);
 
     // Return NULL if the campaign doesn't have a run nid
-    if (!isset($runId)) {
+    if (!isset($run)) {
       return NULL;
     }
   }
@@ -735,5 +735,5 @@ function dosomething_helpers_get_current_campaign_run_for_user($nid, $user = NUL
   // Load the run and return it.
   // For some reason this also loads the proper translation, for both anonymous users and authed. I can't explain it.
   // @TODO: may want to investigate how it loads the proper translation...
-  return node_load($runId);
+  return node_load($run->id);
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -735,5 +735,5 @@ function dosomething_helpers_get_current_campaign_run_for_user($nid, $user = NUL
   // Load the run and return it.
   // For some reason this also loads the proper translation, for both anonymous users and authed. I can't explain it.
   // @TODO: may want to investigate how it loads the proper translation...
-  return node_load($run->id);
+  return node_load($run['id']);
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -253,14 +253,14 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
 /**
  * Delete a user signup.
  *
- * @param int $nid
- *   The node nid of the signup record to be deleted.
- * @param int $uid
- *   Optional - the user uid of signup record to be deleted.
- *   If not given, uses global $user->uid.
+ * @param  int   $nid
+ * @param  null  $runId
+ * @param  null  $uid
+ * @return bool
  */
-function dosomething_signup_delete_signup($nid, $uid = NULL) {
-  $sid = dosomething_signup_exists($nid, $uid);
+function dosomething_signup_delete_signup($nid, $runId = NULL, $uid = NULL) {
+  $sid = dosomething_signup_exists($nid, $runId, $uid);
+
   try {
     if ($sid) {
       entity_delete('signup', $sid);
@@ -268,8 +268,9 @@ function dosomething_signup_delete_signup($nid, $uid = NULL) {
     return TRUE;
   }
   catch (Exception $e) {
-    watchdog('dosomething_signup', $e, array(), WATCHDOG_ERROR);
+    watchdog('dosomething_signup', $e, [], WATCHDOG_ERROR);
   }
+
   return FALSE;
 }
 
@@ -867,11 +868,12 @@ function dosomething_signup_presignup_create($nid) {
 /**
  * Checks if a pre-signup exists for given $nid for global $user.
  *
- * @return bool
+ * @param  int  $nid
+ * @return mixed
  */
 function dosomething_signup_presignup_exists($nid) {
   global $user;
-  return dosomething_signup_exists($nid, $user->uid, $presignup = TRUE);
+  return dosomething_signup_exists($nid, NULL, $user->uid, $presignup = TRUE);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -206,28 +206,31 @@ function dosomething_signup_get_query_source() {
  *   The sid of the newly inserted signup, or FALSE if error.
  */
 function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp = NULL) {
-  if ($uid == NULL) {
-    global $user;
+  global $user;
+
+  if (!isset($uid)) {
     $uid = $user->uid;
   }
 
+  // @TODO: If the campaign is closed, return error.
+  // @TODO: If campaign is unpublished and non-staff $uid, return error.
+
+  $campaign = Campaign::get($nid);
+  $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $user, $campaign);
+
   // If a signup already exists, exit.
-  if (dosomething_signup_exists($nid, $uid)) { return FALSE; }
-
-  // @todo: If the campaign is closed, return error.
-  // @todo: If campaign is unpublished and non-staff $uid, return error.
-
-  $campaign = node_load($nid);
-  $language_code = $campaign->language;
-  $run_nid = $campaign->field_current_run[$language_code][0]['target_id'];
+  if (dosomething_signup_exists($nid, $run->nid, $uid)) {
+    return FALSE;
+  }
 
   $values = array(
     'nid' => $nid,
     'uid' => $uid,
-    'run_nid' => $run_nid,
+    'run_nid' => $run->nid,
     'source'=> $source,
     'timestamp' => $timestamp,
   );
+
   try {
     // Create a signup entity.
     $entity = entity_create('signup', $values);
@@ -273,36 +276,48 @@ function dosomething_signup_delete_signup($nid, $uid = NULL) {
 /**
  * Checks if a signup record exists.
  *
- * @param int $nid
+ * @param  int  $nid
  *   The node nid of the signup record to check.
- * @param int $uid
+ * @param  int  $runId
+ *   The run nid of the signup record to check.
+ * @param  int  $uid
  *   Optional - the user uid of signup record to check.
  *   If not given, uses global $user->uid.
- * @param string $presignup
+ * @param  string  $presignup
  *   Optional - If true, query the presignups table, not regular signups.
- *
  * @return mixed
  *   The sid of signup exists, FALSE if it doesn't exist.
  */
-function dosomething_signup_exists($nid, $uid = NULL, $presignup = FALSE) {
-  if ($uid == NULL) {
+function dosomething_signup_exists($nid, $runId = NULL, $uid = NULL, $presignup = FALSE) {
+  if (!isset($runId)) {
+    $run = dosomething_helpers_get_current_campaign_run_for_user($nid);
+    $runId = $run->nid;
+  }
+
+  if (!isset($uid)) {
     global $user;
     $uid = $user->uid;
   }
+
   $signup_tbl = 'dosomething_signup';
+
   if ($presignup) {
     $signup_tbl = 'dosomething_signup_presignup';
   }
+
   $result = db_select($signup_tbl, 's')
     ->condition('uid', $uid)
     ->condition('nid', $nid)
+    ->condition('run_nid', $runId)
     ->fields('s', array('sid'))
     ->execute();
   $sid = $result->fetchField(0);
+
   // If a sid was found, return it.
   if (is_numeric($sid)) {
     return $sid;
   }
+
   // Otherwise return FALSE.
   return FALSE;
 }


### PR DESCRIPTION
Refs #6054
#### What's this PR do?

This PR updates all the signup related functions `dosomething_signup_create()`, `dosomething_signup_delete_signup()`, `dosomething_signup_exists()` and whatever other signup functions call these functions to make sure we now take account of the Campaign Run ID, and pass/accept the right arguments within these functions.
#### Where should the reviewer start?

Probably best to go by [commit order](https://github.com/DoSomething/phoenix/pull/6066/commits) to see the updates in a logical order.
#### How should this be manually tested?

Try signing up for a campaign with an account that isn't signed up for said Campaign. Then check the `dosomething_signup` table in the database, sort by **timestamp** and see if that latest signup has an actual `run_nid` filled in!
#### Any background context you want to provide?

I also updated the `dosomething_helpers_get_current_campaign_run_for_user()` function to use the `Campaign::get(:id)` method when loading a campaign/node data. Trying to move towards using the static method to load the data so that there it complete parity between loading Campaigns in the DS App backend or for the API (same source of data!).
#### What are the relevant tickets?
#6054

---

@angaither @DFurnes 

CC: @deadlybutter 
