### PR TITLE
Updating Campaign class language/translation methods.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -394,13 +394,16 @@ class Campaign {
 
   /**
    * Get language data.
+   *
+   * @return array
    */
   protected function getLanguage() {
-    $languagePrefix = dosomething_helpers_isset($this->node->language, 'en');
+    $language = dosomething_helpers_isset($this->node->language);
+    $prefix = dosomething_global_get_prefix_for_language($language);
 
     return [
-      'prefix' => $languagePrefix,
-      'language_code' => dosomething_global_convert_country_to_language($languagePrefix),
+      'language_code' => dosomething_global_convert_country_to_language($prefix),
+      'prefix' => !empty($prefix) ? $prefix : NULL,
     ];
   }
 
@@ -618,6 +621,7 @@ class Campaign {
   /**
    * Get translations data for this Campaign.
    *
+   * @return array
    * @TODO: potentially add extra useful info for each translation (full country name, etc?)
    */
   protected function getTranslations() {


### PR DESCRIPTION
Fixes #6071
#### What's this PR do?

Turns out I was using the incorrect function from global module for extracting the language prefix for the specified language of a Campaign. This PR updates the functions used.
#### Where should the reviewer start?

In the Campaign class file where the methods were updated.
#### How should this be manually tested?

Hit the Campaigns endpoint and check the `language` and `translations` properties.
#### What are the relevant tickets?
#6071
