### PR TITLE
Update to have Reportback class fully load a Campaign class instance.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -147,14 +147,7 @@ class Reportback extends Entity {
     $this->reportback_items = dosomething_helpers_format_data($data->items);
     // @TODO: need to potentially remove this and include language from NS user object instead of global $user
     $this->language = dosomething_helpers_isset($user, 'language', 'en-global');
-    $this->campaign = [
-      'id' => $data->nid,
-      'title' => $data->title,
-      'reportback_info' => [
-        'noun' => $data->noun,
-        'verb' => $data->verb,
-      ],
-    ];
+    $this->campaign = Campaign::get($data->nid);
 
     if ($full) {
       $northstar_response = dosomething_northstar_get_northstar_user($data->uid);


### PR DESCRIPTION
Refs #5991
#### What's this PR do?

This PR updates the Reportback class so it uses the `Campaign::get()` static method to completely load the necessary Campaign data along with the new `campaign_runs`, `language`, and `translations` data.
#### Where should the reviewer start?

Just 1 file! **Reportback.php**
#### Any background context you want to provide?

I was running into some errors since the old method of not fully loading the Campaign was missing vital data that, with the latest updates, the transformation process was now expecting. This should fix that issue moving forward.

---

@angaither 
