### PR TITLE
Add run id as a join to signup table view.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.info
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.info
@@ -14,4 +14,4 @@ features[user_permission][] = view any signup
 features[views_view][] = node_signups
 files[] = dosomething_signup.test
 files[] = includes/dosomething_signup.inc
-mtime = 1428597800
+mtime = 1453755345

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.views_default.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.views_default.inc
@@ -76,6 +76,11 @@ function dosomething_signup_views_default_views() {
   $handler->display->display_options['relationships']['uid']['field'] = 'uid';
   $handler->display->display_options['relationships']['uid']['label'] = 'User';
   $handler->display->display_options['relationships']['uid']['required'] = TRUE;
+  /* Relationship: Entity Reference: Referenced Entity */
+  $handler->display->display_options['relationships']['field_current_run_target_id']['id'] = 'field_current_run_target_id';
+  $handler->display->display_options['relationships']['field_current_run_target_id']['table'] = 'field_data_field_current_run';
+  $handler->display->display_options['relationships']['field_current_run_target_id']['field'] = 'field_current_run_target_id';
+  $handler->display->display_options['relationships']['field_current_run_target_id']['relationship'] = 'nid';
   /* Field: Signups: Signup sid */
   $handler->display->display_options['fields']['sid']['id'] = 'sid';
   $handler->display->display_options['fields']['sid']['table'] = 'dosomething_signup';
@@ -101,6 +106,12 @@ function dosomething_signup_views_default_views() {
   $handler->display->display_options['fields']['mail']['field'] = 'mail';
   $handler->display->display_options['fields']['mail']['relationship'] = 'uid';
   $handler->display->display_options['fields']['mail']['link_to_user'] = 'user';
+  /* Field: Content: Nid */
+  $handler->display->display_options['fields']['nid_1']['id'] = 'nid_1';
+  $handler->display->display_options['fields']['nid_1']['table'] = 'node';
+  $handler->display->display_options['fields']['nid_1']['field'] = 'nid';
+  $handler->display->display_options['fields']['nid_1']['relationship'] = 'field_current_run_target_id';
+  $handler->display->display_options['fields']['nid_1']['label'] = 'Run NID';
   /* Field: Signups: Signup source */
   $handler->display->display_options['fields']['source']['id'] = 'source';
   $handler->display->display_options['fields']['source']['table'] = 'dosomething_signup';
@@ -181,6 +192,30 @@ function dosomething_signup_views_default_views() {
     8 => 0,
     9 => 0,
   );
+  /* Filter criterion: Content: Nid */
+  $handler->display->display_options['filters']['nid']['id'] = 'nid';
+  $handler->display->display_options['filters']['nid']['table'] = 'node';
+  $handler->display->display_options['filters']['nid']['field'] = 'nid';
+  $handler->display->display_options['filters']['nid']['relationship'] = 'field_current_run_target_id';
+  $handler->display->display_options['filters']['nid']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['nid']['expose']['operator_id'] = 'nid_op';
+  $handler->display->display_options['filters']['nid']['expose']['label'] = 'Run NID';
+  $handler->display->display_options['filters']['nid']['expose']['operator'] = 'nid_op';
+  $handler->display->display_options['filters']['nid']['expose']['identifier'] = 'nid';
+  $handler->display->display_options['filters']['nid']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+    6 => 0,
+    7 => 0,
+    8 => 0,
+    9 => 0,
+    10 => 0,
+    11 => 0,
+    12 => 0,
+    13 => 0,
+  );
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');
@@ -209,11 +244,13 @@ function dosomething_signup_views_default_views() {
     t('Displaying @start - @end of @total'),
     t('Node'),
     t('User'),
+    t('Content entity referenced from field_current_run'),
     t('Signup sid'),
     t('.'),
     t('Submitted'),
     t('Uid'),
     t('E-mail'),
+    t('Run NID'),
     t('Source'),
     t('All'),
     t('Signups: %1'),


### PR DESCRIPTION
Expose that field to allow different things to be input.

cc @deadlybutter 
view setup 
![](https://i.imgur.com/HRa5vyO.png)

what it looks like
![screen shot 2016-01-25 at 4 05 27 pm](https://cloud.githubusercontent.com/assets/645205/12564531/b71e546c-c37d-11e5-874e-b3691723cb19.png)

since stage doesn't have language/multiple runs I don't know what this will do if there's more than one run for a node. 

Refs #6007
