### PR TITLE
Fixes reportback cron

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
@@ -34,4 +34,18 @@ function dosomething_reportback_cron() {
         ))
       ->execute();
   }
+
+  $results = db_query("SELECT n.nid, SUM(rb.quantity) as total
+                       FROM node n
+                       INNER JOIN field_data_field_campaign_status s on n.nid = s.entity_id AND n.language = s.language
+                       INNER JOIN dosomething_reportback rb on n.nid = rb.nid
+                       WHERE n.type = 'campaign'
+                       AND s.field_campaign_status_value = 'active'
+                       AND rb.flagged = 0
+                       GROUP BY n.nid;");
+
+  // Updated reportback counts accordingly.
+  foreach ($results as $result) {
+    dosomething_helpers_set_variable('node', $result->nid, 'sum_rb_all_quantity', (int) $result->total);
+  }  
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
@@ -9,7 +9,7 @@
  * Implements hook_cron().
  */
 function dosomething_reportback_cron() {
-  // Get all reportbacks for the current run updated in the past hour.
+  // Query for the total quantity for all active campaigns, for the current run
   $results = db_query("SELECT n.nid, SUM(rb.quantity) as total, run.field_current_run_target_id as run_nid
                        FROM node n
                        INNER JOIN field_data_field_campaign_status s on n.nid = s.entity_id AND n.language = s.language
@@ -35,7 +35,7 @@ function dosomething_reportback_cron() {
       ->execute();
   }
 
-  // Get all reportbacks updated in the past hour.
+  // Query for the total quantity for all active campaigns, for all the runs
   $results = db_query("SELECT n.nid, SUM(rb.quantity) as total
                        FROM node n
                        INNER JOIN field_data_field_campaign_status s on n.nid = s.entity_id AND n.language = s.language

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
@@ -9,7 +9,7 @@
  * Implements hook_cron().
  */
 function dosomething_reportback_cron() {
-  // Get all reportbacks updated in the past hour.
+  // Get all reportbacks for the current run updated in the past hour.
   $results = db_query("SELECT n.nid, SUM(rb.quantity) as total, run.field_current_run_target_id as run_nid
                        FROM node n
                        INNER JOIN field_data_field_campaign_status s on n.nid = s.entity_id AND n.language = s.language
@@ -35,6 +35,7 @@ function dosomething_reportback_cron() {
       ->execute();
   }
 
+  // Get all reportbacks updated in the past hour.
   $results = db_query("SELECT n.nid, SUM(rb.quantity) as total
                        FROM node n
                        INNER JOIN field_data_field_campaign_status s on n.nid = s.entity_id AND n.language = s.language
@@ -47,5 +48,5 @@ function dosomething_reportback_cron() {
   // Updated reportback counts accordingly.
   foreach ($results as $result) {
     dosomething_helpers_set_variable('node', $result->nid, 'sum_rb_all_quantity', (int) $result->total);
-  }  
+  }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.cron.inc
@@ -10,13 +10,15 @@
  */
 function dosomething_reportback_cron() {
   // Get all reportbacks updated in the past hour.
-  $results = db_query("SELECT n.nid, SUM(rb.quantity) as total
+  $results = db_query("SELECT n.nid, SUM(rb.quantity) as total, run.field_current_run_target_id as run_nid
                        FROM node n
-                       INNER JOIN field_data_field_campaign_status s on n.nid = s.entity_id
+                       INNER JOIN field_data_field_campaign_status s on n.nid = s.entity_id AND n.language = s.language
                        INNER JOIN dosomething_reportback rb on n.nid = rb.nid
+                       INNER JOIN field_data_field_current_run run on n.nid = run.entity_id
                        WHERE n.type = 'campaign'
                        AND s.field_campaign_status_value = 'active'
                        AND rb.flagged = 0
+                       AND rb.run_nid = run.field_current_run_target_id
                        GROUP BY n.nid;");
 
   // Updated reportback counts accordingly.


### PR DESCRIPTION
#### What's this PR do?

Fixes the reportback cron so

1) The quantity is no longer r \* t (r= reportback total, t= # of translations)
2) The quantity is specific to the run
#### How should this be manually tested?

Use this query on a DB with :hankey: data

```
SELECT n.nid, SUM(rb.quantity) as total, run.field_current_run_target_id as run_nid
FROM node n
INNER JOIN field_data_field_campaign_status s on n.nid = s.entity_id AND n.language = s.language
INNER JOIN dosomething_reportback rb on n.nid = rb.nid
INNER JOIN field_data_field_current_run run on n.nid = run.entity_id
WHERE n.type = 'campaign'
AND s.field_campaign_status_value = 'active'
AND rb.flagged = 0
AND rb.run_nid = run.field_current_run_target_id
GROUP BY n.nid
```

Some of the values should be inflated based on the # of translations for that node. 

Run the cron in this PR and re-run that ^ query. Are the values back to normal? Check the dosomething_reportback_progress_log table...
#### Any background context you want to provide?

See the comments in the issue.
#### What are the relevant tickets?

Fixes #6004 
#### Screenshots

The reportback log progress table ordered by timestamp, after running cron. Notice the top one is correct "118".
<img width="291" alt="screen shot 2016-01-25 at 4 12 30 pm" src="https://cloud.githubusercontent.com/assets/897368/12564781/1f42dce2-c37f-11e5-8077-339877acd2d8.png">

This was the query beforehand saying it should be 118.
<img width="213" alt="screen shot 2016-01-25 at 4 12 38 pm" src="https://cloud.githubusercontent.com/assets/897368/12564779/1f3f2fb6-c37f-11e5-84c5-80820f040ce4.png">

Proof it should be 118. (100 + 17 + 1, one of them is flagged)
<img width="1053" alt="screen shot 2016-01-25 at 4 16 00 pm" src="https://cloud.githubusercontent.com/assets/897368/12564780/1f3f499c-c37f-11e5-8af9-6f75634b2c4f.png">
