### PR TITLE
returns all missing information

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -229,8 +229,7 @@ abstract class Transformer {
 
         $output['solutions'] = $data->solutions;
 
-        $output['pre_step_header'] = $data->pre_step_header;
-        $output['promoting_tips'] = $data->promoting_tips;
+        $output['pre_step'] = $data->pre_step;
 
         $output['latest_news'] = $data->latest_news;
 

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -201,8 +201,6 @@ abstract class Transformer {
 
       // Show all properties for "full" display.
       if ($data->display === 'full') {
-        // print_r($data);
-        // die();
         $output['tagline'] = $data->tagline;
 
         $output['created_at'] = $data->created_at;

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -201,6 +201,8 @@ abstract class Transformer {
 
       // Show all properties for "full" display.
       if ($data->display === 'full') {
+        // print_r($data);
+        // die();
         $output['tagline'] = $data->tagline;
 
         $output['created_at'] = $data->created_at;
@@ -228,6 +230,11 @@ abstract class Transformer {
         $output['facts']['sources'] = $data->facts['sources'] ? $data->facts['sources'] : NULL;
 
         $output['solutions'] = $data->solutions;
+
+        $output['pre_step_header'] = $data->pre_step_header;
+        $output['promoting_tips'] = $data->promoting_tips;
+
+        $output['latest_news'] = $data->latest_news;
 
         $output['causes'] = $data->causes;
 

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -22,7 +22,7 @@ class Campaign {
   public $staff_pick;
   public $facts;
   public $solutions;
-  public $pre_step_header;
+  public $pre_step;
   public $promoting_tips;
   public $latest_news;
   public $causes;
@@ -173,8 +173,7 @@ class Campaign {
         $solution_data = $this->getSolutionData();
         $this->solutions = $solution_data;
 
-        $this->pre_step_header = $this->getPreStepHeader();
-        $this->promoting_tips = $this->getPromotingTips();
+        $this->pre_step = $this->getPreStepInfo();
         $this->latest_news = $this->getLatestNews();
 
         $this->causes = $this->getCauses();
@@ -470,25 +469,16 @@ class Campaign {
   }
 
   /**
-   * Get campaign's pre-step header.
+   * Get campaign's pre-step header and caption.
    *
    * @return array
    */
-  protected function getPreStepHeader() {
-    return [
-      'pre_step_header' => dosomething_helpers_extract_field_data($this->node->field_pre_step_header),
-    ];
-  }
+  protected function getPreStepInfo() {
+    $pre_step = [];
+    $pre_step['header'] = (dosomething_helpers_extract_field_data($this->node->field_pre_step_header));
+    $pre_step['copy'] = (dosomething_helpers_extract_field_data($this->node->field_pre_step_copy));
 
-  /**
-   * Get campaign's promoting tips.
-   *
-   * @return array
-   */
-  protected function getPromotingTips() {
-    return [
-      'promoting_tips' => dosomething_helpers_extract_field_data($this->node->field_promoting_tips),
-    ];
+    return $pre_step;
   }
 
   /**

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -22,6 +22,9 @@ class Campaign {
   public $staff_pick;
   public $facts;
   public $solutions;
+  public $pre_step_header;
+  public $promoting_tips;
+  public $latest_news;
   public $causes;
   public $action_types;
   public $issue;
@@ -169,6 +172,10 @@ class Campaign {
 
         $solution_data = $this->getSolutionData();
         $this->solutions = $solution_data;
+
+        $this->pre_step_header = $this->getPreStepHeader();
+        $this->promoting_tips = $this->getPromotingTips();
+        $this->latest_news = $this->getLatestNews();
 
         $this->causes = $this->getCauses();
 
@@ -408,6 +415,17 @@ class Campaign {
   }
 
   /**
+   * Get campaign's latest news.
+   *
+   * @return array
+   */
+  protected function getLatestNews() {
+    return [
+      'latest_news' => dosomething_helpers_extract_field_data($this->node->field_latest_news_copy),
+    ];
+  }
+
+  /**
    * Get MailChimp data.
    *
    * @return array
@@ -449,6 +467,28 @@ class Campaign {
       }
 
       return $timing;
+  }
+
+  /**
+   * Get campaign's pre-step header.
+   *
+   * @return array
+   */
+  protected function getPreStepHeader() {
+    return [
+      'pre_step_header' => dosomething_helpers_extract_field_data($this->node->field_pre_step_header),
+    ];
+  }
+
+  /**
+   * Get campaign's promoting tips.
+   *
+   * @return array
+   */
+  protected function getPromotingTips() {
+    return [
+      'promoting_tips' => dosomething_helpers_extract_field_data($this->node->field_promoting_tips),
+    ];
   }
 
   /**

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -23,7 +23,6 @@ class Campaign {
   public $facts;
   public $solutions;
   public $pre_step;
-  public $promoting_tips;
   public $latest_news;
   public $causes;
   public $action_types;


### PR DESCRIPTION
#### What does this PR do?

Returns missing information needed for weekly digest email message by Message Broker for `/api/v1/campaigns/:nid` endpoint. 
#### Where should the reviewer start?

`Campaign.php` then to `Transformer.php`
#### How should this be manually tested?

Make sure `/api/v1/campaigns/:nid` endpoint has returns information for `pre_step_header`, `promoting_tips`, and `latest_news`. Use http://dev.dosomething.org:8888/api/v1/campaigns/362 to check Comeback Clothes. 
#### Notes

Not sure if the labels `pre_step_header` and `promoting_tips` are the most intuitive. Would it make more sense to change these to `during_tips_header` and `during_tips_copy` or even separate into 

```
-during_tips: {
  - header: "Run Your Drive!", 
  - copy: {
      raw: "Make flyers with the nearest drop-off box location. Put them on trash cans so people recycle     their clothes instead of throwing them away.",
formatted: "<p>Make flyers with the nearest drop-off box location. Put them on trash cans so people recycle their clothes instead of throwing them away.</p> "
}
```

Also, sometimes `latest_news` will return `null`. Is this okay for when using to populate content the email digest?
cc: @DeeZone 
#### What are the relevant tickets?

Fixes #6077 
