### PR TITLE
comments in ->type to expose type in response

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -211,7 +211,7 @@ abstract class Transformer {
 
         $output['time_commitment'] = $data->time_commitment;
 
-        // $output['type'] = $data->type; //@TODO: Should type be included? Consider there is an SMS Campaign type...
+        $output['type'] = $data->type;
 
         foreach ($data->cover_image as $key => $image) {
           if (!is_null($image)) {


### PR DESCRIPTION
#### What does this PR do?

Exposes campaign type in API response.
#### How should this be manually tested?

Make sure a regular campaign endpoint displays `type: "campaign"` in API response and SMS game returns `type: "sms_game"` in response. 

Comeback Clothes endpoint: http://dev.dosomething.org:8888/api/v1/campaigns/362
Science Sleuth endpoint: http://dev.dosomething.org:8888/api/v1/campaigns/1269
#### What are the relevant tickets?

Fixes #6069 
