### PR TITLE
add link to FAQs in contact us modal

### DIFF
--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -147,9 +147,10 @@ function dosomething_zendesk_form($form, &$form_state, $entity = NULL)  {
     '#required' => TRUE,
     '#title' => t(variable_get('dosomething_zendesk_form_body_label')),
   );
-  //check if FAQs exist
-  //if so, array_push '#description' => 'Check out our <a href="#" data-modal-href="#modal-faq">FAQs</a> first', onto $form['body']
-
+  // Add link to FAQs if they exist
+  if(isset(dosomething_campaign_load($entity)->faq)) {
+    $form['body']['#description'] = 'Check out our <a href="#" data-modal-href="#modal-faq">FAQs</a> first';
+  }
 
   $form['submit'] = array(
     '#type' => 'submit',

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -147,6 +147,10 @@ function dosomething_zendesk_form($form, &$form_state, $entity = NULL)  {
     '#required' => TRUE,
     '#title' => t(variable_get('dosomething_zendesk_form_body_label')),
   );
+  //check if FAQs exist
+  //if so, array_push '#description' => 'Check out our <a href="#" data-modal-href="#modal-faq">FAQs</a> first', onto $form['body']
+
+
   $form['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Submit'),

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -147,11 +147,6 @@ function dosomething_zendesk_form($form, &$form_state, $entity = NULL)  {
     '#required' => TRUE,
     '#title' => t(variable_get('dosomething_zendesk_form_body_label')),
   );
-  // Add link to FAQs if they exist
-  if(isset(dosomething_campaign_load($entity)->faq)) {
-    $form['body']['#description'] = 'Check out our <a href="#" data-modal-href="#modal-faq">FAQs</a> first';
-  }
-
   $form['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Submit'),

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -79,6 +79,11 @@ function paraneue_dosomething_add_info_bar(&$vars) {
     }
     else {
       $zendesk_form_header = t(variable_get('dosomething_zendesk_form_header'));
+      if(isset($vars['field_faq']))
+        $info_bar_vars['FAQs'] = true;
+      else
+        $info_bar_vars['FAQs'] = false;
+
       $info_bar_vars['zendesk_form_header'] = $zendesk_form_header;
 
       if (isset($vars['zendesk_form'])) {

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -79,7 +79,7 @@ function paraneue_dosomething_add_info_bar(&$vars) {
     }
     else {
       $zendesk_form_header = t(variable_get('dosomething_zendesk_form_header'));
-      $info_bar_vars['FAQs'] = isset($vars['field_faq']);
+      $info_bar_vars['faqs'] = isset($vars['field_faq']);
       $info_bar_vars['zendesk_form_header'] = $zendesk_form_header;
 
       if (isset($vars['zendesk_form'])) {

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -79,11 +79,7 @@ function paraneue_dosomething_add_info_bar(&$vars) {
     }
     else {
       $zendesk_form_header = t(variable_get('dosomething_zendesk_form_header'));
-      if(isset($vars['field_faq']))
-        $info_bar_vars['FAQs'] = true;
-      else
-        $info_bar_vars['FAQs'] = false;
-
+      $info_bar_vars['FAQs'] = isset($vars['field_faq']);
       $info_bar_vars['zendesk_form_header'] = $zendesk_form_header;
 
       if (isset($vars['zendesk_form'])) {

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
@@ -22,10 +22,10 @@
         <div data-modal id="modal-contact-form" class="modal--contact" role="dialog">
           <h2 class="heading -banner"><?php print t('Contact Us'); ?></h2>
           <div class="modal__block">
-            <?php if($FAQs): ?>
-              <?php $zendesk_form_header = $zendesk_form_header . '<p>Or get your question answered right away by first <a href="#" data-modal-href="#modal-faq">checking our FAQs</a>  which are updated regularly.</p>'; ?>
-            <?php endif; ?>
             <p><?php print $zendesk_form_header; ?></p>
+            <?php if($FAQs): ?>
+              <p>Or get your question answered right away by first <a href="#" data-modal-href="#modal-faq">checking our FAQs</a>  which are updated regularly.</p>
+            <?php endif; ?>
           </div>
           <div class="modal__block">
             <?php print render($zendesk_form); ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
@@ -23,7 +23,7 @@
           <h2 class="heading -banner"><?php print t('Contact Us'); ?></h2>
           <div class="modal__block">
             <p><?php print $zendesk_form_header; ?></p>
-            <?php if($FAQs): ?>
+            <?php if($faqs): ?>
               <p>Or get your question answered right away by first <a href="#" data-modal-href="#modal-faq">checking our FAQs</a>  which are updated regularly.</p>
             <?php endif; ?>
           </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
@@ -22,6 +22,9 @@
         <div data-modal id="modal-contact-form" class="modal--contact" role="dialog">
           <h2 class="heading -banner"><?php print t('Contact Us'); ?></h2>
           <div class="modal__block">
+            <?php if($FAQs): ?>
+              <?php $zendesk_form_header = $zendesk_form_header . '<p>Or get your question answered right away by first <a href="#" data-modal-href="#modal-faq">checking our FAQs</a>  which are updated regularly.</p>'; ?>
+            <?php endif; ?>
             <p><?php print $zendesk_form_header; ?></p>
           </div>
           <div class="modal__block">


### PR DESCRIPTION
Fixes #6062

Zendesk Contact Us modal at the bottom of campaign pages now includes a link to the FAQs for that campaign if they exist. 

If there are FAQs:
![image](https://cloud.githubusercontent.com/assets/4240292/12597779/a01fdd62-c454-11e5-9018-8f6a66d55135.png)

If there aren't FAQs:
![image](https://cloud.githubusercontent.com/assets/4240292/12597801/b4853428-c454-11e5-8bba-8de412bd421f.png)

The link opens the FAQ modal which is unchanged.

cc: @mikefantini 
