### PR TITLE
These runs sure are hot. 

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -320,7 +320,7 @@ function dosomething_signup_exists($nid, $run_nid = NULL, $uid = NULL, $presignu
   // If not see if they are signed up for the campaign without the run.
   // This section is added to test for duplicate signup problems.
   // Refs #6095.
-  if (!is_numeric($sid)) {
+  if (!is_numeric($sid) && !$presignup) {
      $result = db_select('dosomething_signup', 's')
       ->condition('uid', $uid)
       ->condition('nid', $nid)

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -279,7 +279,7 @@ function dosomething_signup_delete_signup($nid, $runId = NULL, $uid = NULL) {
  *
  * @param  int  $nid
  *   The node nid of the signup record to check.
- * @param  int  $runId
+ * @param  int  $run_nid
  *   The run nid of the signup record to check.
  * @param  int  $uid
  *   Optional - the user uid of signup record to check.
@@ -289,12 +289,11 @@ function dosomething_signup_delete_signup($nid, $runId = NULL, $uid = NULL) {
  * @return int|false
  *   The sid of signup exists, FALSE if it doesn't exist.
  */
-function dosomething_signup_exists($nid, $runId = NULL, $uid = NULL, $presignup = FALSE) {
-  if (!isset($runId)) {
+function dosomething_signup_exists($nid, $run_nid = NULL, $uid = NULL, $presignup = FALSE) {
+  if (!isset($run_nid)) {
     $run = dosomething_helpers_get_current_campaign_run_for_user($nid);
-    $runId = $run->nid;
+    $run_nid = $run->nid;
   }
-
   if (!isset($uid)) {
     global $user;
     $uid = $user->uid;
@@ -308,22 +307,42 @@ function dosomething_signup_exists($nid, $runId = NULL, $uid = NULL, $presignup 
       ->execute();
   }
   else {
+    // First check to see if a user has a signup with a run.
     $result = db_select('dosomething_signup', 's')
       ->condition('uid', $uid)
       ->condition('nid', $nid)
-      ->condition('run_nid', $runId)
+      ->condition('run_nid', $run_nid)
       ->fields('s', array('sid'))
       ->execute();
   }
+  $sid = $result->fetchField();
 
-  if (!isset($result)) {
-    return FALSE;
+  // If not see if they are signed up for the campaign without the run.
+  // This section is added to test for duplicate signup problems.
+  // Refs #6095.
+  if (!is_numeric($sid)) {
+     $result = db_select('dosomething_signup', 's')
+      ->condition('uid', $uid)
+      ->condition('nid', $nid)
+      ->fields('s', array('sid'))
+      ->execute();
+      $running_free = TRUE;
   }
-
   $sid = $result->fetchField();
 
   // If a sid was found, return it.
   if (is_numeric($sid)) {
+
+    // If this was a node without a run, add that in.
+    // This section is also added to fix creating duplicate signups.
+    // Refs #6095.
+    if (isset($running_free)) {
+      $query = db_update('dosomething_signup')
+               ->fields(['run_nid' => $run_nid])
+               ->condition('sid', $sid)
+               ->execute();
+    }
+
     return $sid;
   }
 


### PR DESCRIPTION
Update the dosomething_signup_exists function.
This will fix the problem we are having where it appears users are not signed up for a campaign
because the old signup might not have had the correct run attached to it.
This is not a pretty fix, but sometimes that is ok.
Refs #6095
