### PR TITLE
Updating Services to disable API endpoints no longer in use.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -10,4 +10,4 @@ features[ctools][] = services:services:3
 features[ctools][] = views:views_default:3.0
 features[features_api][] = api:2
 features[services_endpoint][] = drupalapi
-mtime = 1447955638
+mtime = 1448767165

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -72,11 +72,6 @@ function dosomething_api_default_services_endpoint() {
           'enabled' => '1',
         ),
       ),
-      'relationships' => array(
-        'gallery' => array(
-          'enabled' => '1',
-        ),
-      ),
       'targeted_actions' => array(
         'signup' => array(
           'enabled' => '1',
@@ -130,16 +125,6 @@ function dosomething_api_default_services_endpoint() {
     'reportbacks' => array(
       'operations' => array(
         'retrieve' => array(
-          'enabled' => '1',
-        ),
-        'index' => array(
-          'enabled' => '1',
-        ),
-      ),
-    ),
-    'signups' => array(
-      'operations' => array(
-        'create' => array(
           'enabled' => '1',
         ),
         'index' => array(


### PR DESCRIPTION
Refs #6033
Refs #6096
#### What's this PR do?

This PR begins the first steps in the above 2 issues, to remove the deprecated endpoints from being accessible via Services. They are no longer in use, or otherwise were never used so best to kill them! :hocho: 
#### Where should the reviewer start?

Take a look at the Feature and make sure it looks right.
#### How should this be manually tested?

Pull down and run a Feature revert. Check the Services endpoints in the CMS and see if the respective items no longer have little checkmarks next to them!
#### Any background context you want to provide?

The `/campaigns/gallery.json` endpoint was only used in the Campaign Action page gallery, but that has since been changed to use the new `/reportback-items` endpoint.

The `/signups` endpoint was used for some testing and then scrapped for moving signup stuff for mobile app to the Northstar API.
#### What are the relevant tickets?
#6033
#6096

---

@angaither 

CC: @DFurnes @aaronschachter 
