### PR TITLE
Fix the campaign run cron job

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.cron.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.cron.inc
@@ -10,24 +10,24 @@
  * Implements hook_cron().
  */
 function dosomething_campaign_run_cron() {
-  // Get all campaign runs and the start and end date for each translation of the run date field.
-  $results = db_query("SELECT campaign_run.entity_id as campaign_run_nid,
-                              run_date.field_run_date_value as start_date,
-                              run_date.field_run_date_value2 as end_date,
-                              run_date.language,
-                              campaigns.field_campaigns_target_id as campaign_nid
-                       FROM entity_translation as campaign_run
-                       INNER JOIN field_data_field_run_date as run_date
-                          ON campaign_run.entity_id = run_date.entity_id
-                          AND campaign_run.language = run_date.language
-                       INNER JOIN field_data_field_campaigns as campaigns
-                          ON campaign_run.entity_id = campaigns.entity_id
-                          AND campaigns.language = run_date.language;");
-
+  $results = db_query("SELECT campaign.entity_id as campaign_nid, campaign.language, current_run.field_current_run_target_id as current_run, current_run.language as current_run_language
+                      FROM entity_translation as campaign
+                      INNER JOIN node ON node.nid = campaign.entity_id
+                      LEFT JOIN field_data_field_current_run as current_run
+                        ON campaign.entity_id = current_run.entity_id
+                        AND campaign.language = current_run.language
+                      WHERE node.type = 'campaign'
+                      AND campaign.entity_type = 'node';");
   // Update the campaign status of the campaign node.
   foreach ($results as $result) {
-    $start = new DateTime($result->start_date);
-    $end = new DateTime($result->end_date);
+    // Load the current run.
+    $run = node_load($result->current_run);
+    // Get the start and end dates.
+    $start = new DateTime($run->field_run_date[$result->language][0]['value']);
+    // The generated runs don't have end dates set, but when runs are created manually,
+    // if an end date isn't speficied the start and end dates will be the same.
+    // So we emulate this here.
+    $end = (!$run->field_run_date[$result->language][0]['value2']) ? $start : new DateTime($run->field_run_date[$result->language][0]['value2']);
     $status = dosomething_helpers_get_campaign_status($start, $end);
     $campaign = entity_metadata_wrapper('node', $result->campaign_nid);
     $campaign->language($result->language)->field_campaign_status = $status;

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.cron.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.cron.inc
@@ -10,7 +10,11 @@
  * Implements hook_cron().
  */
 function dosomething_campaign_run_cron() {
-  $results = db_query("SELECT campaign.entity_id as campaign_nid, campaign.language, current_run.field_current_run_target_id as current_run, current_run.language as current_run_language
+  // Get each translation of all campaigns and their current run.
+  $results = db_query("SELECT campaign.entity_id as campaign_nid,
+                              campaign.language,
+                              current_run.field_current_run_target_id as current_run,
+                              current_run.language as current_run_language
                       FROM entity_translation as campaign
                       INNER JOIN node ON node.nid = campaign.entity_id
                       LEFT JOIN field_data_field_current_run as current_run
@@ -25,7 +29,7 @@ function dosomething_campaign_run_cron() {
     // Get the start and end dates.
     $start = new DateTime($run->field_run_date[$result->language][0]['value']);
     // The generated runs don't have end dates set, but when runs are created manually,
-    // if an end date isn't speficied the start and end dates will be the same.
+    // if an end date isn't speficied, the start and end dates will be the same.
     // So we emulate this here.
     $end = (!$run->field_run_date[$result->language][0]['value2']) ? $start : new DateTime($run->field_run_date[$result->language][0]['value2']);
     $status = dosomething_helpers_get_campaign_status($start, $end);


### PR DESCRIPTION
#### What's this PR do?

Updates the cron job that sets campaign status based on campaign run dates so that we do it based on the campaign's current run. Before, we were setting the status for every run in the system. But not all runs are current. 
#### What are the relevant tickets?

Fixes #6105 (background info in that ticket)
