### PR TITLE
Add a script to remove zero and null duplicate signup rows.

### DIFF
--- a/scripts/remove-null-zero-duplicate-signups.php
+++ b/scripts/remove-null-zero-duplicate-signups.php
@@ -21,6 +21,7 @@ foreach ($duplicates as $duplicate) {
       // Remove that row.
       db_delete('dosomething_signup')->condition('sid', $sid)->execute();
       echo 'removed row: ' . $sid . "\n";
+      watchdog('dosomething_signup', 'removed : @sid' , [$sid]);
     }
   }
 }

--- a/scripts/remove-null-zero-duplicate-signups.php
+++ b/scripts/remove-null-zero-duplicate-signups.php
@@ -7,11 +7,11 @@
  *
  */
 
-$duplicates = db_query("SELECT s.uid, s.nid, group_concat(s.sid) as sids, group_concat(ifnull(s.run_nid, 0)) as run_nids, COUNT(*) c
+$duplicates = db_query('SELECT s.uid, s.nid, group_concat(s.sid) as sids, group_concat(ifnull(s.run_nid, 0)) as run_nids, COUNT(*) c
                         FROM dosomething_signup s
                         GROUP BY s.uid, s.nid
                         HAVING c > 1
-                        ORDER BY s.nid;");
+                        ORDER BY s.nid;');
 
 foreach ($duplicates as $duplicate) {
   $sids = explode(',', $duplicate->sids);
@@ -20,7 +20,7 @@ foreach ($duplicates as $duplicate) {
     if ($run_nids[$key] == 0) {
       // Remove that row.
       db_delete('dosomething_signup')->condition('sid', $sid)->execute();
-      echo "removed row: " . $sid . "\n";
+      echo 'removed row: ' . $sid . "\n";
     }
   }
 }

--- a/scripts/remove-null-zero-duplicate-signups.php
+++ b/scripts/remove-null-zero-duplicate-signups.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * Script to remove duplicate rows in the dosomething_signup table with null or zero values
+ * in the run_nid col.
+ *
+ * drush --script-path=../scripts/ php-script remove-null-zero-duplicate-signups.php
+ *
+ */
+
+$duplicates = db_query("SELECT s.uid, s.nid, group_concat(s.sid) as sids, group_concat(ifnull(s.run_nid, 0)) as run_nids, COUNT(*) c
+                        FROM dosomething_signup s
+                        GROUP BY s.uid, s.nid
+                        HAVING c > 1
+                        ORDER BY s.nid;");
+
+foreach ($duplicates as $duplicate) {
+  $sids = explode(',', $duplicate->sids);
+  $run_nids = explode(',', $duplicate->run_nids);
+  foreach ($sids as $key => $sid) {
+    if ($run_nids[$key] == 0) {
+      // Remove that row.
+      db_delete('dosomething_signup')->condition('sid', $sid)->execute();
+      echo "removed row: " . $sid . "\n";
+    }
+  }
+}


### PR DESCRIPTION
First pass at removing duplicates. 
This removes signups where the user has two records for the same node, and one of them is zero or null. it removes that row. 

Refs #6095

I tested this with a copy of the prod data and it removes the duplicate rows down to ~250
