### PR TITLE
Allowing custom expiration when setting cache.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -45,6 +45,15 @@ function dosomething_api_ctools_plugin_directory($module, $plugin) {
 }
 
 /**
+ * Implements hook_flush_caches().
+ *
+ * @return array
+ */
+function dosomething_api_flush_caches() {
+  return array('cache_dosomething_api');
+}
+
+/**
  * Implements hook_services_request_postprocess_alter().
  * @deprecated
  * @todo: should remove since nothing is using _node_resource_retrieve callback.

--- a/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
+++ b/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
@@ -35,15 +35,17 @@ class ApiCache {
   public function get($endpoint, $parameters) {
     $id = $this->generate_id($endpoint, $parameters);
 
-    if (!dosomething_helpers_convert_string_to_boolean($parameters['cache'])) {
+    $cache = cache_get($id, 'cache_dosomething_api');
+
+    if ($cache && !dosomething_helpers_convert_string_to_boolean($parameters['cache'])) {
       $this->clear($id);
 
       return FALSE;
     }
 
-    $cache = cache_get($id, 'cache_dosomething_api');
-
-    if ($cache && $cache->expire < REQUEST_TIME) {
+    // Temporary cache expire is equal to -1.
+    // Permanent cache expire is equal to 0.
+    if ($cache && $cache->expire > 0 && $cache->expire < REQUEST_TIME) {
       $this->clear($id);
 
       return FALSE;
@@ -68,10 +70,7 @@ class ApiCache {
 
     $id = $this->generate_id($endpoint, $parameters);
 
-    if (is_null($expiration)) {
-      $expiration = CACHE_TEMPORARY;
-    }
-    elseif (is_bool($expiration) && $expiration === FALSE) {
+    if (is_bool($expiration) && $expiration === FALSE) {
       $expiration = CACHE_PERMANENT;
     }
     elseif (is_int($expiration)) {

--- a/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
+++ b/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
@@ -2,8 +2,6 @@
 
 class ApiCache {
 
-  public $hours_cached = 24;
-
   /**
    * Clear a specified item from cache.
    *
@@ -60,16 +58,30 @@ class ApiCache {
    * @param  string  $endpoint
    * @param  array   $parameters
    * @param  mixed   $data
+   * @param  mixed   $expiration
    * @return bool
    */
-  public function set($endpoint, $parameters, $data) {
-    $id = $this->generate_id($endpoint, $parameters);
-
+  public function set($endpoint, $parameters, $data, $expiration = NULL) {
     if (!dosomething_helpers_convert_string_to_boolean($parameters['cache'])) {
       return FALSE;
     }
 
-    cache_set($id, $data, 'cache_dosomething_api', REQUEST_TIME + (60 * 60 * $this->hours_cached));
+    $id = $this->generate_id($endpoint, $parameters);
+
+    if (is_null($expiration)) {
+      $expiration = CACHE_TEMPORARY;
+    }
+    elseif (is_bool($expiration) && $expiration === FALSE) {
+      $expiration = CACHE_PERMANENT;
+    }
+    elseif (is_int($expiration)) {
+      $expiration = REQUEST_TIME + (60 * 60 * $expiration);
+    }
+    else {
+      $expiration = CACHE_TEMPORARY;
+    }
+
+    cache_set($id, $data, 'cache_dosomething_api', $expiration);
 
     return TRUE;
   }

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -183,7 +183,7 @@ function _campaign_resource_definition() {
  */
 // @TODO: Function will be deprecated and currently only used in soon to be deprecated targeted actions.
 function _campaign_resource_access_alt($op = 'view', $args = array()) {
-  if (DOSOMETHING_REPORTBACK_LOG) {
+  if (DOSOMETHING_REPORTBACK_LOG && $args) {
     watchdog('dosomething_api', '_campaign_resource_access_alt args:' . json_encode($args));
   }
 

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -28,7 +28,7 @@ class CampaignTransformer extends Transformer {
       if (!$campaigns) {
         $campaigns = Campaign::find($filters, 'full');
 
-        $cache->set('campaigns', $parameters, $campaigns);
+        $cache->set('campaigns', $parameters, $campaigns, 2);
       }
       else {
         $campaigns = $campaigns->data;

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -28,7 +28,7 @@ class CampaignTransformer extends Transformer {
       if (!$campaigns) {
         $campaigns = Campaign::find($filters, 'full');
 
-        $cache->set('campaigns', $parameters, $campaigns, 2);
+        $cache->set('campaigns', $parameters, $campaigns);
       }
       else {
         $campaigns = $campaigns->data;


### PR DESCRIPTION
Fixes #6031 
#### What's this PR do?

This updates the `set()` method in the `ApiCache` class so you can pass a custom expiration in hours, `false` to permanently cache, or let it default to a sensible value of temporarily caching until a general cache clear is performed on the app.
#### Where should the reviewer start?

Most of the action is happening in the **ApiCache.php** file.
#### How should this be manually tested?

You can push down the branch, clear cache and load a few `/campaigns` endpoints. Check Redis for the data. Alternatively, I used a series of `watchdog()` calls to help let me know what was going on with the cache, but took them out after otherwise it was going to be too much noise in the DBLog reports. I may add them back later, along with a feature flag to show or hide the logging for test purposes.
#### Any background context you want to provide?

Previously, Campaigns retrieved via the API were getting cached for 24 hours regardless. You could pass `?cache=false` to stop caching the response and also clear the cache for that query. Now that still works, but you can also clear the cache when Drush performs a cache clear or when the cache is manually cleared via the Admin interface.
#### What are the relevant tickets?
#6031

---

@DFurnes @angaither 

CC: @aaronschachter @uy this should help in the future w/ the mobile app as campaign changes are made and you need to retrieve latest data and not needing to send an arbitrary request to the endpoint with `?cache=false` :tada: 
