### PR TITLE
Update status on campaign save

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -1263,3 +1263,26 @@ function dosomething_campaign_flush_caches() {
 function dosomething_campaign_node_update($node) {
   cache_clear_all('ds_campaign_' . $node->nid, 'cache_dosomething_campaign', TRUE);
 }
+
+/**
+ * Implements hook_node_validate()
+ */
+function dosomething_campaign_node_validate($node, $form, &$form_state) {
+  if ($node->type == 'campaign') {
+    $language = $form_state['entity_translation']['form_langcode'];
+    $values = $form_state['values'];
+
+    $current_run_id = $form['#node']->field_current_run[$language][0]['target_id'];
+    $submitted_current_run = $values['field_current_run'][$language][0]['target_id'];
+
+    if ($current_run_id !== $submitted_current_run) {
+      $new_run = entity_metadata_wrapper('node', $submitted_current_run);
+      // @TODO -- Extract into function.
+      $start_date = new DateTime($new_run->language($language)->field_run_date->value()['value']);
+      $end_date = new DateTime($new_run->language($language)->field_run_date->value()['value2']);
+      $status = dosomething_helpers_get_campaign_status($start_date, $end_date);
+      // -- end function.
+      $form_state['values']['field_campaign_status'][$language][0]['value'] = $status;
+    }
+  }
+}

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -1281,7 +1281,7 @@ function dosomething_campaign_node_validate($node, $form, &$form_state) {
       // Get the dates of the run.
       $new_run = entity_metadata_wrapper('node', $submitted_current_run);
       $start_date = new DateTime($new_run->language($language)->field_run_date->value()['value']);
-      $end_date = new DateTime($new_run->language($language)->field_run_date->value()['value2']);
+      $end_date = (!$new_run->language($language)->field_run_date->value()['value2']) ? $start_date : new DateTime($new_run->language($language)->field_run_date->value()['value2']);
       // Update the campaign status.
       $status = dosomething_helpers_get_campaign_status($start_date, $end_date);
       $form_state['values']['field_campaign_status'][$language][0]['value'] = $status;

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -1281,7 +1281,7 @@ function dosomething_campaign_node_validate($node, $form, &$form_state) {
       // Get the dates of the run.
       $new_run = entity_metadata_wrapper('node', $submitted_current_run);
       $start_date = new DateTime($new_run->language($language)->field_run_date->value()['value']);
-      $end_date = (!$new_run->language($language)->field_run_date->value()['value2']) ? $start_date : new DateTime($new_run->language($language)->field_run_date->value()['value2']);
+      $end_date = new DateTime($new_run->language($language)->field_run_date->value()['value2']);
       // Update the campaign status.
       $status = dosomething_helpers_get_campaign_status($start_date, $end_date);
       $form_state['values']['field_campaign_status'][$language][0]['value'] = $status;

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -1269,19 +1269,21 @@ function dosomething_campaign_node_update($node) {
  */
 function dosomething_campaign_node_validate($node, $form, &$form_state) {
   if ($node->type == 'campaign') {
+    // Get the language of the translation being submitted.
     $language = $form_state['entity_translation']['form_langcode'];
-    $values = $form_state['values'];
 
+    // Get the current run set in the db and the one the user submitted.
+    // so we can see if it has changed.
     $current_run_id = $form['#node']->field_current_run[$language][0]['target_id'];
-    $submitted_current_run = $values['field_current_run'][$language][0]['target_id'];
+    $submitted_current_run = $form_state['values']['field_current_run'][$language][0]['target_id'];
 
     if ($current_run_id !== $submitted_current_run) {
+      // Get the dates of the run.
       $new_run = entity_metadata_wrapper('node', $submitted_current_run);
-      // @TODO -- Extract into function.
       $start_date = new DateTime($new_run->language($language)->field_run_date->value()['value']);
       $end_date = new DateTime($new_run->language($language)->field_run_date->value()['value2']);
+      // Update the campaign status.
       $status = dosomething_helpers_get_campaign_status($start_date, $end_date);
-      // -- end function.
       $form_state['values']['field_campaign_status'][$language][0]['value'] = $status;
     }
   }

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -299,15 +299,16 @@ function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$fo
  */
 function dosomething_campaign_run_node_submit($node, $form, &$form_state) {
   if ($node->type == 'campaign_run') {
+    // Get language of the translation being submittted.
     $language = $form_state['entity_translation']['form_langcode'];
-    // @TODO -- Extracted into function.
+    // Grab the run dates the user just entered;
     $start_date = new DateTime($form_state['values']['field_run_date'][$language][0]['value']);
     $end_date = (!$form_state['values']['field_run_date'][$language][0]['value2']) ? $start_date : new DateTime($form_state['values']['field_run_date'][$language][0]['value2']);
     $status = dosomething_helpers_get_campaign_status($start_date, $end_date);
-    // -- end extraction.
 
     // Just get the first campaign this is tied to. While we allow for multiple campaigns to be selected per campaign run, only one should be selected.
     $campaign = $form_state['values']['field_campaigns'][$language][0];
+    // Update the campaign's status.
     $campaign = entity_metadata_wrapper('node', $campaign['target_id']);
     $current_run = $campaign->language($language)->field_current_run->value();
     if ($current_run->nid == $form_state['values']['nid']) {

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -325,4 +325,18 @@ function dosomething_campaign_run_node_presave($node) {
       }
     }
   }
+
+  if ($node->type == 'campaign') {
+    $current_runs = $node->field_current_run;
+
+    foreach ($current_runs as $language => $run) {
+      // Load the current run.
+      $current_run = node_load($run[0]['target_id']);
+      // Get the start and end dates.
+      $start = new DateTime($current_run->field_run_date[$language][0]['value']);
+      $end = (!$current_run->field_run_date[$language][0]['value2']) ? $start : new DateTime($current_run->field_run_date[$language][0]['value2']);
+      $status = dosomething_helpers_get_campaign_status($start, $end);
+      $node->field_campaign_status[$language][0]['value'] = $status;
+    }
+  }
 }

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -298,12 +298,12 @@ function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$fo
  * Implements hook_node_submit()
  */
 function dosomething_campaign_run_node_submit($node, $form, &$form_state) {
-  if ($node->type == 'campaign_run') {
+  if ($node->type == 'campaign_run' && isset($form_state['entity_translation'])) {
     // Get language of the translation being submittted.
     $language = $form_state['entity_translation']['form_langcode'];
     // Grab the run dates the user just entered;
     $start_date = new DateTime($form_state['values']['field_run_date'][$language][0]['value']);
-    $end_date = (!$form_state['values']['field_run_date'][$language][0]['value2']) ? $start_date : new DateTime($form_state['values']['field_run_date'][$language][0]['value2']);
+    $end_date = new DateTime($form_state['values']['field_run_date'][$language][0]['value2']);
     $status = dosomething_helpers_get_campaign_status($start_date, $end_date);
 
     // Just get the first campaign this is tied to. While we allow for multiple campaigns to be selected per campaign run, only one should be selected.

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -294,49 +294,25 @@ function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$fo
   drupal_add_css(drupal_get_path('module', 'dosomething_campaign_run') . '/campaign_run_node.css');
 }
 
-/*
- * When campaign run nodes are saved, this hook updates the campaign status field on campaign nodes
- * based on the campaign run dates.
- *
- * Implements hook_node_presave().
+/**
+ * Implements hook_node_submit()
  */
-function dosomething_campaign_run_node_presave($node) {
+function dosomething_campaign_run_node_submit($node, $form, &$form_state) {
   if ($node->type == 'campaign_run') {
-    $run_campaigns = $node->field_campaigns;
-    $run_dates = $node->field_run_date;
+    $language = $form_state['entity_translation']['form_langcode'];
+    // @TODO -- Extracted into function.
+    $start_date = new DateTime($form_state['values']['field_run_date'][$language][0]['value']);
+    $end_date = (!$form_state['values']['field_run_date'][$language][0]['value2']) ? $start_date : new DateTime($form_state['values']['field_run_date'][$language][0]['value2']);
+    $status = dosomething_helpers_get_campaign_status($start_date, $end_date);
+    // -- end extraction.
 
-    // Determine the active and closed state for each translation of the run_date field
-    foreach ($run_dates as $lang => $date) {
-      $start = new DateTime($date[0]['value']);
-      $end = new DateTime($date[0]['value2']);
-      $status = dosomething_helpers_get_campaign_status($start, $end);
-      $run_campaigns = $node->field_campaigns[$lang];
-
-      // Update the campaign status field on each campaign node tied to this run,
-      // if it is set as the current run.
-      // There could be multiple campaigns per campaign run. Probably not, but we do allow for it.
-      foreach ($run_campaigns as $campaign) {
-        $campaign_node = entity_metadata_wrapper('node', $campaign['target_id']);
-        $current_run = $campaign_node->field_current_run->value();
-        if ($current_run->nid == $node->nid) {
-          $campaign_node->language($lang)->field_campaign_status = $status;
-          $campaign_node->save();
-        }
-      }
-    }
-  }
-
-  if ($node->type == 'campaign') {
-    $current_runs = $node->field_current_run;
-
-    foreach ($current_runs as $language => $run) {
-      // Load the current run.
-      $current_run = node_load($run[0]['target_id']);
-      // Get the start and end dates.
-      $start = new DateTime($current_run->field_run_date[$language][0]['value']);
-      $end = (!$current_run->field_run_date[$language][0]['value2']) ? $start : new DateTime($current_run->field_run_date[$language][0]['value2']);
-      $status = dosomething_helpers_get_campaign_status($start, $end);
-      $node->field_campaign_status[$language][0]['value'] = $status;
+    // Just get the first campaign this is tied to. While we allow for multiple campaigns to be selected per campaign run, only one should be selected.
+    $campaign = $form_state['values']['field_campaigns'][$language][0];
+    $campaign = entity_metadata_wrapper('node', $campaign['target_id']);
+    $current_run = $campaign->language($language)->field_current_run->value();
+    if ($current_run->nid == $form_state['values']['nid']) {
+      $campaign->language($language)->field_campaign_status = $status;
+      $campaign->save();
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -689,7 +689,8 @@ function dosomething_helpers_unset_array_keys(array $array = [], array $keys = [
 function dosomething_helpers_get_campaign_status($start_date, $end_date) {
   $now = new DateTime();
 
-  if (($start_date == $end_date && $now >= $start_date) || ($now >= $start_date && $now <= $end_date)) {
+  //@TODO - Remove check that start date = end date when #6123 is done.
+  if ((is_null($end_date) && $now >= $start_date) || ($start_date == $end_date && $now >= $start_date) || ($now >= $start_date && $now <= $end_date)) {
     return 'active';
   }
   else {


### PR DESCRIPTION
### What's this PR do?

Updates the campaign status when someone changes the campaign run on campaign nodes. 

Also, updated the hooks I was using to update the campaign status on campaign run node save to use `hook_node_submit` so we can more reliably get the values that had just been submitted by the user. 
#### Where should the reviewer start?

Start at `dosomething_campaign.module` where I use `hook_node_validate()` to get the form state of the campaign node that is submitted and allows me to update the value of fields before the form actually gets submitted. This is where we update the status. 
#### What are the relevant tickets?

Fixes #6052 
