### PR TITLE
Clear cache for API when a campaign is updated.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
+++ b/lib/modules/dosomething/dosomething_api/includes/ApiCache.php
@@ -6,14 +6,14 @@ class ApiCache {
    * Clear a specified item from cache.
    *
    * @param  mixed  $id
-   * @param  mixed  $endpoint
+   * @param  mixed  $action
    * @param  mixed  $parameters
    * @return bool
    */
-  function clear($id = NULL, $endpoint = NULL, $parameters = NULL) {
+  function clear($id = NULL, $action = NULL, $parameters = NULL) {
     if (!$id) {
-      if ($endpoint && $parameters) {
-        $id = $this->generate_id($endpoint, $parameters);
+      if ($action && $parameters) {
+        $id = $this->generate_id($action, $parameters);
       }
       else {
         return FALSE;
@@ -28,12 +28,12 @@ class ApiCache {
   /**
    * Get data from cache based on id from endpoint and URL parameters.
    *
-   * @param  string  $endpoint  Type of resource based on endpoint.
-   * @param  array   $parameters  The URL parameters passed that define the request.
+   * @param  string  $action
+   * @param  array   $parameters
    * @return mixed
    */
-  public function get($endpoint, $parameters) {
-    $id = $this->generate_id($endpoint, $parameters);
+  public function get($action, $parameters) {
+    $id = $this->generate_id($action, $parameters);
 
     $cache = cache_get($id, 'cache_dosomething_api');
 
@@ -57,18 +57,18 @@ class ApiCache {
   /**
    * Set data in cache for 24 hours with id based on endpoint and URL parameters.
    *
-   * @param  string  $endpoint
+   * @param  string  $action
    * @param  array   $parameters
    * @param  mixed   $data
    * @param  mixed   $expiration
    * @return bool
    */
-  public function set($endpoint, $parameters, $data, $expiration = NULL) {
+  public function set($action, $parameters, $data, $expiration = NULL) {
     if (!dosomething_helpers_convert_string_to_boolean($parameters['cache'])) {
       return FALSE;
     }
 
-    $id = $this->generate_id($endpoint, $parameters);
+    $id = $this->generate_id($action, $parameters);
 
     if (is_bool($expiration) && $expiration === FALSE) {
       $expiration = CACHE_PERMANENT;
@@ -88,14 +88,14 @@ class ApiCache {
   /**
    * Generate an id from resource endpoint type and URL parameters.
    *
-   * @param  string  $endpoint
+   * @param  string  $action
    * @param  array   $parameters
    * @return string
    */
-  private function generate_id($endpoint, $parameters) {
+  private function generate_id($action, $parameters) {
     unset($parameters['cache']);
 
-    return $endpoint . '_api_request' . $this->stringify($parameters);
+    return $action . '_api_request' . $this->stringify($parameters);
   }
 
   /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -1261,6 +1261,8 @@ function dosomething_campaign_flush_caches() {
  * Implements hook_node_update()
  */
 function dosomething_campaign_node_update($node) {
-  $campaignController = new CampaignController;
-  $campaignController->update($node->nid);
+  if ($node->type === 'campaign') {
+    $campaignController = new CampaignController;
+    $campaignController->update($node->nid);
+  }
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -1261,5 +1261,6 @@ function dosomething_campaign_flush_caches() {
  * Implements hook_node_update()
  */
 function dosomething_campaign_node_update($node) {
-  cache_clear_all('ds_campaign_' . $node->nid, 'cache_dosomething_campaign', TRUE);
+  $campaignController = new CampaignController;
+  $campaignController->update($node->nid);
 }

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignController.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignController.php
@@ -2,6 +2,15 @@
 
 class CampaignController {
 
-  // @TODO: handle main app controller-y things such as CRUD in here.
+  /**
+   * Update the specified Campaign in storage.
+   *
+   * @param  int  $id
+   * @return void
+   */
+  function update($id) {
+    cache_clear_all('campaigns_api_request', 'cache_dosomething_api', TRUE);
+    cache_clear_all('ds_campaign_' . $id, 'cache_dosomething_campaign', TRUE);
+  }
 
 }

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignController.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignController.php
@@ -9,7 +9,7 @@ class CampaignController {
    * @return void
    */
   function update($id) {
-    cache_clear_all('campaigns_api_request', 'cache_dosomething_api', TRUE);
+    cache_clear_all('campaigns_index_api_request', 'cache_dosomething_api', TRUE);
     cache_clear_all('ds_campaign_' . $id, 'cache_dosomething_campaign', TRUE);
   }
 

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -22,13 +22,13 @@ class CampaignTransformer extends Transformer {
 
     $cache = new ApiCache;
 
-    $campaigns = $cache->get('campaigns', $parameters);
+    $campaigns = $cache->get('campaigns_index', $parameters);
 
     try {
       if (!$campaigns) {
         $campaigns = Campaign::find($filters, 'full');
 
-        $cache->set('campaigns', $parameters, $campaigns);
+        $cache->set('campaigns_index', $parameters, $campaigns);
       }
       else {
         $campaigns = $campaigns->data;


### PR DESCRIPTION
Fixes #6125
#### What's this PR do?

This does a general clear of any campaign data in cache for the API. This also puts into use the CampaignController class that has been sitting idle. Might become more useful down the line.

I tested this a bunch of times to make sure that the API cache cleared when a campaign is updated. One thing to keep in mind, right now the API returns campaign and associated data for the made node, and includes info on what translations are available, but does not return a specific translations data to you. So you might change a field in the `us` version (with a campaign that also has a global version), but the API doesn't reflect it... while the cache _DID_ get cleared, the API is actually only showing you the field data for the main node (likely global). Just a caveat to keep in mind if it seems like the data didn't change!
#### Where should the reviewer start?

Minor updates; just check the two files :)
#### Any background context you want to provide?

I added the use of the `CampaignController` because it could start coming in handy. We have one for some of the other resources available through the API (mostly because they are entities and entities has it's own controller class you need to extend).

---

@angaither @DFurnes 
