### PR TITLE
Update campaign status timing logic

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -1280,8 +1280,8 @@ function dosomething_campaign_node_validate($node, $form, &$form_state) {
     if ($current_run_id !== $submitted_current_run) {
       // Get the dates of the run.
       $new_run = entity_metadata_wrapper('node', $submitted_current_run);
-      $start_date = new DateTime($new_run->language($language)->field_run_date->value()['value']);
-      $end_date = new DateTime($new_run->language($language)->field_run_date->value()['value2']);
+      $start_date = $new_run->language($language)->field_run_date->value()['value'];
+      $end_date = $new_run->language($language)->field_run_date->value()['value2'];
       // Update the campaign status.
       $status = dosomething_helpers_get_campaign_status($start_date, $end_date);
       $form_state['values']['field_campaign_status'][$language][0]['value'] = $status;

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.cron.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.cron.inc
@@ -27,11 +27,10 @@ function dosomething_campaign_run_cron() {
     // Load the current run.
     $run = node_load($result->current_run);
     // Get the start and end dates.
-    $start = new DateTime($run->field_run_date[$result->language][0]['value']);
-    // The generated runs don't have end dates set, but when runs are created manually,
-    // if an end date isn't speficied, the start and end dates will be the same.
-    // So we emulate this here.
-    $end = (!$run->field_run_date[$result->language][0]['value2']) ? $start : new DateTime($run->field_run_date[$result->language][0]['value2']);
+    $start = $run->field_run_date[$result->language][0]['value'];
+    $end = $run->field_run_date[$result->language][0]['value2'];
+
+    // Store the status on the campagin node.
     $status = dosomething_helpers_get_campaign_status($start, $end);
     $campaign = entity_metadata_wrapper('node', $result->campaign_nid);
     $campaign->language($result->language)->field_campaign_status = $status;

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -302,8 +302,8 @@ function dosomething_campaign_run_node_submit($node, $form, &$form_state) {
     // Get language of the translation being submittted.
     $language = $form_state['entity_translation']['form_langcode'];
     // Grab the run dates the user just entered;
-    $start_date = new DateTime($form_state['values']['field_run_date'][$language][0]['value']);
-    $end_date = new DateTime($form_state['values']['field_run_date'][$language][0]['value2']);
+    $start_date = $form_state['values']['field_run_date'][$language][0]['value'];
+    $end_date = $form_state['values']['field_run_date'][$language][0]['value2'];
     $status = dosomething_helpers_get_campaign_status($start_date, $end_date);
 
     // Just get the first campaign this is tied to. While we allow for multiple campaigns to be selected per campaign run, only one should be selected.

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -681,13 +681,21 @@ function dosomething_helpers_unset_array_keys(array $array = [], array $keys = [
 /**
  * Determines active or closed status based on start and end dates of a campaign run.
  *
- * @param datetime $start_date
- * @param datetime $end_date
+ * @param string $start_date
+ * @param string $end_date
  *
  * @return string 'active' or 'closed' based on timing logic.
  */
 function dosomething_helpers_get_campaign_status($start_date, $end_date) {
-  $now = new DateTime();
+  // Create DateTime objects in EST.
+  $tz = new DateTimeZone('America/New_York');
+  $now = new DateTime('now', $tz);
+  $start_date = new DateTime($start_date, $tz);
+
+  if (!is_null($end_date)) {
+    $end_date = new DateTime($end_date, $tz);
+    $end_date = $end_date->setTime(23,59,59);
+  }
 
   //@TODO - Remove check that start date = end date when #6123 is done.
   if ((is_null($end_date) && $now >= $start_date) || ($start_date == $end_date && $now >= $start_date) || ($now >= $start_date && $now <= $end_date)) {


### PR DESCRIPTION
#### What's this PR do?

Makes updates to the campaign timing logic: 
- Updated `dosomething_helpers_get_campaign_status()` to take in date strings instead of datetime objects. This way we can easily ensure the datetime object is created in EST which is the timezone all time comparisons should be based in.
- Add a timestamp to the end date that ensures we compare the current date and time to the end of the day on the end date. i.e. Runs set to end today, 2/3/15, don't really end until after 11:59pm.
#### Where should the reviewer start?

 `dosomething_helpers_get_campaign_status()` is the main logic that was updated and then I just updated instances where we were passing datetime objects to that function to just pass the raw string.
#### What are the relevant tickets?

Fixes #6058 
