### PR TITLE
Enable caching of single campaign show method.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignController.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignController.php
@@ -9,8 +9,9 @@ class CampaignController {
    * @return void
    */
   function update($id) {
-    cache_clear_all('campaigns_index_api_request', 'cache_dosomething_api', TRUE);
     cache_clear_all('ds_campaign_' . $id, 'cache_dosomething_campaign', TRUE);
+    cache_clear_all('campaigns_show_api_request|id=' . $id, 'cache_dosomething_api');
+    cache_clear_all('campaigns_index_api_request', 'cache_dosomething_api', TRUE);
   }
 
 }

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -60,8 +60,20 @@ class CampaignTransformer extends Transformer {
    * @return array
    */
   public function show($id) {
+    $cache = new ApiCache;
+
+    $campaign = $cache->get('campaigns_show', $id);
+
     try {
-      $campaign = Campaign::get($id, 'full');
+      if (!$campaign) {
+        $campaign = Campaign::get($id, 'full');
+
+        $cache->set('campaigns_show', $id, $campaign);
+      }
+      else {
+        $campaign = $campaign->data;
+      }
+
       $campaign = services_resource_build_index_list([$campaign], 'campaigns', 'id');
       $campaign = array_pop($campaign);
     }


### PR DESCRIPTION
Fixes #6130
#### What's this PR do?

This PR adds the capacity to cache data when requesting a single campaign via the API endpoint for. Also makes sure that the cache is cleared for that specific campaign called via API when the specified campaign is edited via the admin CMS.
#### Where should the reviewer start?

Start at **CampaignTransformer.php**, then head to the changes in the **ApiCache.php** and lastly 
the **CampaignController.php** file.
#### What are the relevant tickets?
#6130

---

@angaither 

cc: @DFurnes @aaronschachter @jonuy 
