### PR TITLE
Adds error handling and watchdog noticing to both scripts

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.drush.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.drush.inc
@@ -66,7 +66,12 @@ function drush_dosomething_reportback_ds_reportback_run_nid_fix() {
           // one we've now discovered.
           $rb = reportback_load($result->rbid);
           $rb->run_nid = $run->run_nid;
-          entity_save('reportback', $rb);
+          try {
+            entity_save('reportback', $rb);
+          }
+          catch (Exception $e) {
+            watchdog('dosomething_reportback', $e->getMessage(), array($result->rbid));
+          }
         }
       }
       // IF the end date doesnt exist we apply this logic to every reportback
@@ -84,7 +89,12 @@ function drush_dosomething_reportback_ds_reportback_run_nid_fix() {
           // one we've now discovered.
           $rb = reportback_load($result->rbid);
           $rb->run_nid = $run->run_nid;
-          entity_save('reportback', $rb);
+          try {
+            entity_save('reportback', $rb);
+          }
+          catch (Exception $e) {
+            watchdog('dosomething_reportback', $e->getMessage(), array($result->rbid));
+          }
         }
       }
     }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.drush.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.drush.inc
@@ -59,7 +59,12 @@ function drush_dosomething_signup_ds_signup_run_nid_fix() {
           // one we've now discovered.
           $s = signup_load($result->sid);
           $s->run_nid = $run->run_nid;
-          entity_save('signup', $s);
+          try {
+            entity_save('signup', $s);
+          }
+          catch (Exception $e) {
+            watchdog('dosomething_signup', $e->getMessage(), array($result->sid));
+          }
         }
       }
       // IF the end date doesnt exist we apply this logic to every signup
@@ -77,7 +82,12 @@ function drush_dosomething_signup_ds_signup_run_nid_fix() {
           // one we've now discovered.
           $s = signup_load($result->sid);
           $s->run_nid = $run->run_nid;
-          entity_save('signup', $s);
+          try {
+            entity_save('signup', $s);
+          }
+          catch (Exception $e) {
+            watchdog('dosomething_signup', $e->getMessage(), array($result->sid));
+          }
         }
       }
     }


### PR DESCRIPTION
We are experiencing some SQL errors which is resulting in large batches of reportbacks not being updated. This PR adds a try catch to make sure the script continues running and we watchdog any rbid/sid's that throw this error to allow for further investigation
