### PR TITLE
adds updates to signups and reportbacks to set run IDs to 0

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -902,7 +902,6 @@ function dosomething_reportback_update_7033() {
      db_update('dosomething_reportback')
        ->fields(array(
          'nid' => $reportback->field_campaigns_target_id,
-         'run_nid' => '0',
          )
        )
        ->condition('nid', $reportback->reportback_node)

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -887,3 +887,25 @@ function dosomething_reportback_update_7033() {
   }
 
 }
+
+  /**
+  * Moves all reportbacks from run nodes back to the original campaign node.
+  */
+ function dosomething_reportback_update_7034() {
+   $reportbacks = db_query("SELECT n.nid as campaign_node, n.language, n.title, n.created, c.field_campaigns_target_id, rb.rbid, rb.uid, rb.nid as reportback_node, rb.run_nid
+                           FROM node n
+                           INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
+                           INNER JOIN dosomething_reportback rb on rb.nid = n.nid
+                           WHERE n.type = 'campaign_run';");
+
+   foreach ($reportbacks as $reportback) {
+     db_update('dosomething_reportback')
+       ->fields(array(
+         'nid' => $reportback->field_campaigns_target_id,
+         'run_nid' => '0',
+         )
+       )
+       ->condition('nid', $reportback->reportback_node)
+       ->execute();
+   }
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -625,3 +625,27 @@ function dosomething_signup_update_7022() {
     db_add_unique_key($table, 'uid-nid-run_nid', ['uid', 'nid', 'run_nid']);
   }
 }
+
+/**
+ * Moves all signups from run nodes back to the original campaign node.
+ */
+function dosomething_signup_update_7023() {
+  $signups = db_query("SELECT n.nid as campaign_node, n.language, n.title, n.created, c.field_campaigns_target_id, s.sid, s.uid, s.nid as signup_node, s.run_nid
+                       FROM node n
+                       INNER JOIN field_data_field_campaigns c on n.nid = c.entity_id
+                       INNER JOIN dosomething_signup s on s.nid = n.nid
+                       WHERE n.type = 'campaign_run';");
+
+  foreach ($signups as $signup) {
+    db_update('dosomething_signup')
+      ->fields(array(
+        // change signup node id to campaign id
+        'nid' => $signup->field_campaigns_target_id,
+        // change signup run id to 0 (TODO:later we'll change back to change to campaign run nid)
+        'run_nid' => '0',
+        )
+      )
+      ->condition('nid', $signup->signup_node)
+      ->execute();
+  }
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -641,8 +641,6 @@ function dosomething_signup_update_7023() {
       ->fields(array(
         // change signup node id to campaign id
         'nid' => $signup->field_campaigns_target_id,
-        // change signup run id to 0 (TODO:later we'll change back to change to campaign run nid)
-        'run_nid' => '0',
         )
       )
       ->condition('nid', $signup->signup_node)


### PR DESCRIPTION
#### What does this PR do?

Cleans up PR #6056 and sets `run_nid`s to `0`. 
#### How should this be manually tested?

See #6056 
#### What are the relevant tickets?
#6056
