### PR TITLE
Set run date to NULL

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -294,6 +294,29 @@ function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$fo
   drupal_add_css(drupal_get_path('module', 'dosomething_campaign_run') . '/campaign_run_node.css');
 }
 
+/*
+ * Implements hook_node_validate()
+ *
+ * On the run date field on campaign run nodes, we want to store the end date as NULL
+ * if the user doesn't choose to "show end date" on the form.
+ * This is needed to overwrite default drupal behavior that stores the start date in the end date
+ * if the user doesn't specify one explicity.
+ *
+ * See https://www.drupal.org/node/874322 for more on this issue.
+ */
+function dosomething_campaign_run_node_validate($node, $form, &$form_state) {
+  if ($node->type == 'campaign_run') {
+    foreach ($form_state['values']['field_run_date'] as $lang => $run_date) {
+      // The show_date key will only be available on the language key
+      // that correlates to the translation being saved,
+      // so we need to check for it's existence and it's value.
+      if (isset($run_date[0]['show_todate']) && $run_date[0]['show_todate'] == 0) {
+        $form_state['values']['field_run_date'][$lang][0]['value2'] = NULL;
+      }
+    }
+  }
+}
+
 /**
  * Implements hook_node_submit()
  */

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -697,9 +697,13 @@ function dosomething_helpers_get_campaign_status($start_date, $end_date) {
     $end_date = $end_date->setTime(23,59,59);
   }
 
-  //@TODO - Remove check that start date = end date when #6123 is done.
-  if ((is_null($end_date) && $now >= $start_date) || ($start_date == $end_date && $now >= $start_date) || ($now >= $start_date && $now <= $end_date)) {
-    return 'active';
+  if ($now >= $start_date) {
+    if (is_null($end_date) || $now <= $end_date) {
+      return 'active';
+    }
+    else {
+      return 'closed';
+    }
   }
   else {
     return 'closed';


### PR DESCRIPTION
#### What's this PR do?

Overwrites some dumb drupal logic that sets the end date to the start date even if you don't choose "show end date" on the run date field on campaign run nodes. Now, If a user doesn't select "show run date" we will store the end date as `NULL`

Also updates `dosomething_helpers_get_campaign_status()` to account for the fact that we no longer have equal start and end dates 1) Because the end date will always be set to just before midnight so start and end dates won't be the same. 2) Because the end date will be NULL. 
#### Where should the reviewer start?

here probably: `dosomething_campaign_run_node_validate()`;
#### What are the relevant tickets?

Fixes #6144 
Fixes #6123 
