### PR TITLE
Add support for old campaign runs under the drupal curse

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -694,7 +694,17 @@ function dosomething_helpers_get_campaign_status($start_date, $end_date) {
 
   if (!is_null($end_date)) {
     $end_date = new DateTime($end_date, $tz);
-    $end_date = $end_date->setTime(23,59,59);
+
+    // For runs that have the same start and end date,
+    // check if they should still be active.
+    // This code supports campaign runs that were created before we
+    // added logic to set end dates to NULL if the campaign had no end date.
+    if (($start_date == $end_date) && ($now >= $start_date)) {
+      return 'active';
+    }
+    else {
+      $end_date = $end_date->setTime(23,59,59);
+    }
   }
 
   if ($now >= $start_date) {


### PR DESCRIPTION
#### What's this PR do?

Pull Request #6145 addressed a core Drupal issue that set end dates equal to start dates by default, even if "show end date" was not selected by the admin by setting the end date to NULL explicitly. We then updated the logic to not care about start and end dates that are equal.  

HOWEVER, before this fix was in, there were about 30 runs that had been created and saved that drupal had already done this nonsense for. 

This PR, adds a conditional to `dosomething_helpers_campaign_get_status()` function that first checks if the start and end dates are equal and in the past, in which case the campaign should still be active. 
#### What are the relevant tickets?

Fixes #6144 
