### PR TITLE
Center "add your photo here" text

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
@@ -270,14 +270,14 @@
   }
 
   > .message-callout {
-    bottom: 0;
+    bottom: 25px;
     left: 50%;
     margin-left: -130px;
     position: absolute;
     width: 240px;
 
     @include media($medium) {
-      bottom: 50px;
+      bottom: 25%;
     }
   }
 


### PR DESCRIPTION
#### What's this PR do?

Updates the spacing on the "add your photo here" text so that it stays centered across different viewports.

Updates this: 

<img width="464" alt="screen shot 2016-02-05 at 11 43 00 am" src="https://cloud.githubusercontent.com/assets/1700409/12852602/c5bdc614-cbfd-11e5-974f-449e3aee2fd5.png">

To this: 

<img width="470" alt="screen shot 2016-02-05 at 11 42 23 am" src="https://cloud.githubusercontent.com/assets/1700409/12852607/ce9f9b9a-cbfd-11e5-8ddc-6f0461e07d80.png">
#### What are the relevant tickets?

Fixes #5782 

@DoSomething/front-end 
