### PR TITLE
Update to correct logic in passed intro images.

### DIFF
--- a/lib/modules/dosomething/dosomething_image/dosomething_image.module
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.module
@@ -41,12 +41,20 @@ function dosomething_image_get_themed_image($nid, $ratio, $style, $alt = '', $at
   else {
     // Get the path of the themed image.
     $path = dosomething_image_get_themed_image_url($nid, $ratio, $style);
+
+    if (!$path) {
+      return NULL;
+    }
+
     // Set drupal attributes.
     $attributes = drupal_attributes($attributes);
+
     // Construct themed image tag.
     $themed_image =  '<img src="' . check_url($path) . '" alt="' . check_plain($alt) . '"' .  $attributes .'>';
+
     // Store the themed image.
     cache_set('ds_img_' . $nid . '_' . $ratio . '_' . $style, $themed_image, 'cache_dosomething_image');
+    
     return $themed_image;
   }
 }

--- a/lib/modules/dosomething/dosomething_image/dosomething_image.module
+++ b/lib/modules/dosomething/dosomething_image/dosomething_image.module
@@ -29,8 +29,8 @@ function dosomething_image_form_image_node_form_alter(&$form, &$form_state, $for
  * @param array $attributes
  *  Optional - key/value paired array of attributes to add to the image.
  *
- * @return array
- *  A themed image tag with no set height/width.
+ * @return string|null
+ *  A themed image tag with no set height/width or null if no image path.
  */
 function dosomething_image_get_themed_image($nid, $ratio, $style, $alt = '', $attributes = array()) {
   // Attempt to get that image from cache.
@@ -54,7 +54,7 @@ function dosomething_image_get_themed_image($nid, $ratio, $style, $alt = '', $at
 
     // Store the themed image.
     cache_set('ds_img_' . $nid . '_' . $ratio . '_' . $style, $themed_image, 'cache_dosomething_image');
-    
+
     return $themed_image;
   }
 }


### PR DESCRIPTION
Fixes #6150 
#### What's this PR do?

There was a bug that was returning an empty `<img />` tag for the `$intro_image` variable, so the template was thinking there was something there and placing the text to the left column to make room for the image. But since no image was present, it was looking wonky.

This PR updates the logic to return `NULL` if there is no path to an image instead of returning an empty `<img />` tag.
#### Where should the reviewer start?

In the **\* dosomething_image.module*\* file.
#### What are the relevant tickets?
#6150
#### Screenshots

**Before:**
![image](https://cloud.githubusercontent.com/assets/105849/12856497/32d1ac10-cc13-11e5-8fe7-ff1a917c7859.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/105849/12856510/46091d4a-cc13-11e5-9e5e-054328c5b968.png)

---

@DFurnes 

CC @angaither 
