### PR TITLE
change isset to !empty

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -79,7 +79,7 @@ function paraneue_dosomething_add_info_bar(&$vars) {
     }
     else {
       $zendesk_form_header = t(variable_get('dosomething_zendesk_form_header'));
-      $info_bar_vars['faqs'] = isset($vars['field_faq']);
+      $info_bar_vars['faqs'] = !empty($vars['field_faq']);
       $info_bar_vars['zendesk_form_header'] = $zendesk_form_header;
 
       if (isset($vars['zendesk_form'])) {


### PR DESCRIPTION
Fixes #6149 

Change from checking if the FAQ array exists to checking if there are any actual FAQs in there. Last time the main example I was looking at did not have this array unless there were FAQs, but I guess that is not always the case.

To test:

As both an admin and regular user, click "Contact Us" for a variety of campaigns both with and without FAQs. There should only be a link to FAQs if the campaign has them.

cc: @mikefantini, @DFurnes 
