### PR TITLE
Update to add more whitespace around elements on static & fact pages.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/fact/node--fact_page.tpl.php
@@ -55,15 +55,17 @@
   <?php endif; ?>
 
   <?php if (isset($call_to_action)): ?>
-    <div class="cta">
-      <div class="wrapper">
-        <h2 class="cta__message"><?php print $call_to_action; ?></h2>
-        <?php print $cta_link; ?>
+    <div class="container -padded">
+      <div class="cta">
+        <div class="wrapper">
+          <h2 class="cta__message"><?php print $call_to_action; ?></h2>
+          <?php print $cta_link; ?>
+        </div>
       </div>
     </div>
   <?php endif; ?>
 
-  <section class="container">
+  <section class="container -padded">
     <div class="wrapper">
       <div class="container__block with-lists">
         <?php if (isset($second_fact_group)): ?>
@@ -91,10 +93,12 @@
   </section>
 
   <?php if (isset($call_to_action)): ?>
-    <div class="cta">
-      <div class="wrapper">
-        <h2 class="cta__message"><?php print $call_to_action; ?></h2>
-        <?php print $cta_link; ?>
+    <div class="container">
+      <div class="cta">
+        <div class="wrapper">
+          <h2 class="cta__message"><?php print $call_to_action; ?></h2>
+          <?php print $cta_link; ?>
+        </div>
       </div>
     </div>
   <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/static_content/node--static_content.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/static_content/node--static_content.tpl.php
@@ -15,7 +15,7 @@
   <?php //print $variables['header']; ?>
 
   <?php if (isset($intro)): ?>
-    <section class="container">
+    <section class="container -padded">
       <div class="wrapper">
       <?php if(isset($intro_image) || isset($intro_video)): ?>
         <?php /** There's an image, so show two columns. */ ?>
@@ -52,12 +52,14 @@
   <?php endif; ?>
 
   <?php if (isset($call_to_action)): ?>
-    <div class="cta">
-      <div class="wrapper">
-        <h2 class="cta__message"><?php print $call_to_action; ?></h2>
-        <?php print $cta_link; ?>
+    <section class="container -padded">
+      <div class="cta">
+        <div class="wrapper">
+          <h2 class="cta__message"><?php print $call_to_action; ?></h2>
+          <?php print $cta_link; ?>
+        </div>
       </div>
-    </div>
+    </section>
   <?php endif; ?>
 
 


### PR DESCRIPTION
Fixes #6023 
#### What's this PR do?

This PR finds the whitespace and adds it back in for both static and fact pages.
#### Where should the reviewer start?

In the two template files that were adjusted.
#### What are the relevant tickets?
#6023

**Before:**
![image](https://cloud.githubusercontent.com/assets/105849/12857766/05b0109e-cc1a-11e5-9214-f066853ade14.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/105849/12857779/15437e92-cc1a-11e5-9ac3-6ba1f8000cb8.png)

---

@DFurnes 

cc: @angaither @deadlybutter 
