### PR TITLE
Remove 7x prefix from views limit grouping that caused deploys to fail.

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -251,7 +251,7 @@ projects[views_data_export][version] = "3.0-beta8"
 projects[views_data_export][subdir] = "contrib"
 
 ; Views Grouping Row Limit
-projects[views_limit_grouping][version] = "7.x-1.x-dev"
+projects[views_limit_grouping][version] = "1.x-dev"
 projects[views_limit_grouping][subdir] = "contrib"
 
 ; XML Sitemap


### PR DESCRIPTION
Fixes failing deploying.

`Could not locate views_limit_grouping version 7.x-7.x-1.x-dev.       [error]
