### PR TITLE
Drupal dependency fixes

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -4,17 +4,23 @@
  * Code for the dosomething_api feature.
  */
 
+module_load_include('php', 'dosomething_campaign', 'includes/CampaignTransformer');
+module_load_include('php', 'dosomething_kudos', 'includes/KudosTransformer');
+module_load_include('php', 'dosomething_reportback', 'includes/ReportbackTransformer');
+module_load_include('php', 'dosomething_reportback', 'includes/ReportbackItemTransformer');
+module_load_include('php', 'dosomething_signup', 'includes/SignupTransformer');
+
 include_once 'dosomething_api.features.inc';
 include_once 'includes/Transformer.php';
 include_once 'includes/ApiCache.php';
 include_once 'resources/campaign_resource.inc';
+include_once 'resources/kudos_resource.inc';
 include_once 'resources/member_resource.inc';
 include_once 'resources/reportback_resource.inc';
 include_once 'resources/reportback_item_resource.inc';
 include_once 'resources/reportback_file_resource.inc';
-include_once 'resources/kudos_resource.inc';
-include_once 'resources/term_resource.inc';
 include_once 'resources/signup_resource.inc';
+include_once 'resources/term_resource.inc';
 
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -4,7 +4,6 @@
  * Code for the dosomething_campaign feature.
  */
 
-module_load_include('php', 'dosomething_api', 'includes/Transformer');
 module_load_include('php', 'dosomething_api', 'includes/ApiCache');
 
 include_once 'dosomething_campaign.features.inc';

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -1,5 +1,7 @@
 <?php
 
+module_load_include('php', 'dosomething_api', 'includes/Transformer');
+
 class CampaignTransformer extends Transformer {
 
   /**

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.info
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.info
@@ -4,3 +4,6 @@ core = 7.x
 package = DoSomething
 version = 7.x-0.3
 dependencies[] = entity
+dependencies[] = dosomething_api
+dependencies[] = dosomething_helpers
+

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -4,6 +4,8 @@
  * Module file for DoSomething Kudos functionality.
  */
 
+module_load_include('php', 'dosomething_api', 'includes/ApiCache');
+
 include_once 'includes/Kudos.php';
 include_once 'includes/KudosController.php';
 include_once 'includes/KudosTransformer.php';

--- a/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
@@ -1,4 +1,6 @@
-  <?php
+<?php
+
+module_load_include('php', 'dosomething_api', 'includes/Transformer');
 
 class KudosTransformer extends Transformer {
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -5,7 +5,7 @@
  */
 define('DOSOMETHING_REPORTBACK_LOG', variable_get('dosomething_reportback_log') ? TRUE : FALSE);
 
-module_load_include('inc', 'dosomething_api', 'dosomething_api.module');
+module_load_include('php', 'dosomething_api', 'includes/ApiCache');
 
 include_once 'dosomething_reportback.features.inc';
 include_once 'dosomething_reportback.forms.inc';

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -1,8 +1,7 @@
 <?php
 
-/**
- * Reportback Transformer Class
- */
+module_load_include('php', 'dosomething_api', 'includes/Transformer');
+
 class ReportbackTransformer extends Transformer {
 
   /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.info
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.info
@@ -7,6 +7,7 @@ dependencies[] = entity
 dependencies[] = dosomething_api
 dependencies[] = dosomething_campaign
 dependencies[] = dosomething_helpers
+dependencies[] = dosomething_reportback
 dependencies[] = features
 dependencies[] = views
 features[ctools][] = views:views_default:3.0

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -6,6 +6,8 @@
 define('DOSOMETHING_SIGNUP_LOG_MOBILECOMMONS', variable_get('dosomething_signup_log_mobilecommons') ? TRUE : FALSE);
 define('DOSOMETHING_SIGNUP_LOG_SIGNUPS', variable_get('dosomething_signup_log_signups') ? TRUE : FALSE);
 
+module_load_include('php', 'dosomething_api', 'includes/ApiCache');
+
 include_once 'dosomething_signup.features.inc';
 include_once 'dosomething_signup.forms.inc';
 include_once 'dosomething_signup.signup_data_form.inc';

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -1,8 +1,7 @@
 <?php
 
-/**
- * Signup Transformer Class
- */
+module_load_include('php', 'dosomething_api', 'includes/Transformer');
+
 class SignupTransformer extends Transformer {
 
   /**


### PR DESCRIPTION
Fixes #6160
#### What's this PR do?

This PR addresses some fixes to potentially help with dependency issues when Drupal is bootstrapping itself and grabbing dependencies for modules that live as files in other modules. So basically aiming to fix INCEPTION!
#### Where should the reviewer start?

Just take a look at the **[Resource]Transformer.php** files and the **dosomething_[resource].module** files and make sure the specified dependencies seem correct. Also check out the **dosomething_[resource].info** files, since some of those were updated too.
#### How should this be manually tested?

Well, if you really want to, get ready to go grab some :bread: and make a sandwich, cause it'll take a while. You'll need to pull down this branch, then wipe you local _shiz_ and do a `ds build --install` and a `ds pull stage --db` making sure there isn't a ton of red :rotating_light: errors about **Transformer** related classes not being found, etc.

You could also hit a few of the Phoenix endpoints to test and make sure the API is still returning responses :smile_cat: 
#### What are the relevant tickets?
#6160

---

@aaronschachter @angaither @chloealee @DFurnes 
