### PR TITLE
adds campaign_run data

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -1,4 +1,4 @@
-  <?php
+<?php
 
 abstract class Transformer {
 

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -1,4 +1,4 @@
-<?php
+  <?php
 
 abstract class Transformer {
 
@@ -414,12 +414,17 @@ abstract class Transformer {
    *   - created_at: (string) Date Signup was created.
    *   - campaign: (string) Campaign Signup belongs to.
    *   - campaign_run: (string) Campaign run Signup belongs to.
+   *   - uri: (string) API URI for Signup data.
    * @return array
    */
-  protected function transformSignup($data) {
+  protected function transformSignup($data, $current) {
     return [
       'id' => $data->id,
       'created_at' => $data->created_at,
+      'campaign_run' => [
+        'id' => $data->campaign_run,
+        'current' => $current,
+      ],
       'uri' => $data->uri,
     ];
   }

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -69,11 +69,7 @@ class SignupTransformer extends Transformer {
     $campaign = (object) $item->campaign;
     $current_run = $campaign->campaign_runs['current']['en']['id'];
 
-    $current = false;
-
-    if ($item->campaign_run == $current_run) {
-      $current = true;
-    }
+    $current = ($item->campaign_run == $current_run);
 
     $data += $this->transformSignup($item, $current);
 

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -66,7 +66,16 @@ class SignupTransformer extends Transformer {
 
     $data = [];
 
-    $data += $this->transformSignup($item);
+    $campaign = (object) $item->campaign;
+    $current_run = $campaign->campaign_runs['current']['en']['id'];
+
+    $current = false;
+
+    if ($item->campaign_run == $current_run) {
+      $current = true;
+    }
+
+    $data += $this->transformSignup($item, $current);
 
     $data['campaign'] = $this->transformCampaign((object) $item->campaign);
 


### PR DESCRIPTION
#### What does this PR do?

Adds the `current_run` the signup is associated with and returns a boolean if the signup's current run is equal to the campaign's current run. 
#### How should this be manually tested?

When hitting `/signup` endpoints, 

```
campaign_run: {
  id: "1772",
  current: true
},
```

should be exposed. 
#### Relevant Tickets

Fixes #6153 
