### PR TITLE
Update to return empty array response for no results in collection requests.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -41,10 +41,9 @@ class CampaignTransformer extends Transformer {
       $total = dosomething_campaign_get_campaign_query_count($filters);
     }
     catch (Exception $error) {
+      // @TODO: Potentially log error to watchdog.
       return [
-        'error' => [
-          'message' => $error->getMessage(),
-        ],
+        'data' => [],
       ];
     }
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -18,7 +18,9 @@ class ReportbackItemTransformer extends ReportbackTransformer {
     }
     catch (Exception $error) {
       // @TODO: Potentially log error to watchdog.
-      return [];
+      return [
+        'data' => [],
+      ];
     }
 
     return [

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -17,11 +17,8 @@ class ReportbackItemTransformer extends ReportbackTransformer {
       $total = $this->getTotalCount($filters);
     }
     catch (Exception $error) {
-      return [
-        'error' => [
-          'message' => $error->getMessage(),
-        ],
-      ];
+      // @TODO: Potentially log error to watchdog.
+      return [];
     }
 
     return [

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -27,11 +27,7 @@ class ReportbackTransformer extends Transformer {
       $reportbacks = services_resource_build_index_list($reportbacks, 'reportbacks', 'id');
     }
     catch (Exception $error) {
-      return [
-        'error' => [
-          'message' => $error->getMessage(),
-        ],
-      ];
+      return [];
     }
 
     return [

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -28,7 +28,9 @@ class ReportbackTransformer extends Transformer {
     }
     catch (Exception $error) {
       // @TODO: Potentially log error to watchdog.
-      return [];
+      return [
+        'data' => [],
+      ];
     }
 
     return [

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -27,6 +27,7 @@ class ReportbackTransformer extends Transformer {
       $reportbacks = services_resource_build_index_list($reportbacks, 'reportbacks', 'id');
     }
     catch (Exception $error) {
+      // @TODO: Potentially log error to watchdog.
       return [];
     }
 


### PR DESCRIPTION
Fixes #6163
#### What's this PR do?

This PR updates responses from the index collection for `/reportbacks` and `/reportback-items` so that if no results is obtained, it responds with an empty array instead of an error object.
#### Where should the reviewer start?

Quick :eyes: on the quick changes.
#### How should this be manually tested?

Pull down branch, try and hit index collection endpoints for `/reportbacks` and `/reportback-items` for something you know shouldn't have results and see if it returns an empty array.
#### What are the relevant tickets?
#6163

_NOTE:_ added a comment about possibly sending the caught error in try catch to `watchdog()` but it would be more ideal to pass along the full query which I couldn't yet without parsing it and stringifying it (which currently is only a method available on the `ApiCache` class. :grimacing: 

---

@DFurnes @aaronschachter 

CC: @angaither 
