### PR TITLE
Update to allow viewing unreviewed RBs if admin.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
@@ -55,11 +55,11 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
     }
   }
 
-  if (!isset($params['flagged'])) {
-    $query->condition('rb.flagged', 0);
-  }
-  else {
-    if (!$params['flagged']) {
+  if (isset($params['flagged'])) {
+    if ($params['flagged']) {
+      $query->condition('rb.flagged', 1);
+    }
+    else {
       $query->condition('rb.flagged', 0);
     }
   }
@@ -135,10 +135,8 @@ function dosomething_reportback_filter_flagged_reportbacks($params) {
     return $params;
   }
 
-  // Unset False boolean values that affect the query builder.
-  if (isset($params['flagged'])) {
-    unset($params['flagged']);
-  }
+  // Only show reviewed and/or un-flagged Reportbacks.
+  $params['flagged'] = FALSE;
 
   return $params;
 }

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -153,7 +153,7 @@ class Reportback extends Entity {
     $this->updated_at = $data->updated;
     $this->quantity = (int) $data->quantity;
     $this->why_participated = dosomething_helpers_isset($data, 'why_participated');
-    $this->flagged = (bool) dosomething_helpers_isset($data, 'flagged', FALSE);
+    $this->flagged = $this->getFlag($data->flagged);
     $this->reportback_items = dosomething_helpers_format_data($data->items);
     // @TODO: need to potentially remove this and include language from NS user object instead of global $user
     $this->language = dosomething_helpers_isset($user, 'language', 'en-global');
@@ -176,6 +176,21 @@ class Reportback extends Entity {
       'photo' => dosomething_helpers_isset($northstar_user, 'photo'),
       'country' => dosomething_helpers_isset($northstar_user, 'country'),
     ];
+  }
+
+  /**
+   * Get the flagging status for Reportback.
+   *
+   * @param  $flag
+   * @return mixed|null
+   */
+  protected function getFlag($flag) {
+    if (is_null($flag)) {
+      return NULL;
+    }
+    else {
+      return dosomething_helpers_convert_string_to_boolean($flag);
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes DoSomething/northstar#279
#### What's this PR do?

This PR allows admins to retrieve unreviewed and/or flagged Reportbacks when requesting from `/reportbacks/:id` endpoint. Also updates the assignment of the `flagged` property on the Reportback class so it will now indicate `null` if a RB has not been reviewed, and `FALSE` if not flagged and `TRUE` if flagged, as opposed to just the latter two.
#### Where should the reviewer start?

Check out the query edits and see if it makes sense!
#### Any background context you want to provide?

This only works for the _show_ endpoint and doesn't work for the index collection endpoint. We would need to do some further work to allow unreviewed RBs to show if querying via the `/reportbacks` index collection endpoint do the the array of params that need to be accounted for (ie: such as the `status` param).
#### What are the relevant tickets?

DoSomething/northstar#279

---

@DFurnes @aaronschachter 

CC: @angaither 
