### PR TITLE
Competition signup prompt v2

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -730,7 +730,9 @@ function dosomething_campaign_add_signup_data_form_vars(&$node) {
   }
 
   // Store the label for the link to the modal.
-  $node->content['signup_data_form_link'] = $config['link_text'];
+  if ($config['link_text']) {
+    $node->content['signup_data_form_link'] = $config['link_text'];
+  }
   // Load signup sid.
   $sid = dosomething_signup_exists($node->nid);
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -578,10 +578,13 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
  * Preprocesses variables for the link to a signup data form.
  */
 function dosomething_campaign_preprocess_signup_data_form(&$vars) {
+  if (isset($vars['content']['signup_data_form'])) {
+      $vars['signup_data_form'] = $vars['content']['signup_data_form'];
+  }
+
   // If the signup data form link is present:
   if (isset($vars['content']['signup_data_form_link'])) {
     $vars['signup_data_form_link'] = $vars['content']['signup_data_form_link'];
-    $vars['signup_data_form'] = $vars['content']['signup_data_form'];
   }
   // If the skip form is present:
   if (isset($vars['content']['skip_signup_data_form'])) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -674,31 +674,17 @@ function dosomething_signup_update_7023() {
   }
 }
 
+
+
 /**
- * Adds competition_signup column to the dosomething_signup_data_form table.
+ * Adds fields to support competitions to the dosomething_signup_data_form table.
  */
 function dosomething_signup_update_7024() {
   $tbl_name = 'dosomething_signup_data_form';
   // Load schema to get table definition.
   $schema = dosomething_signup_schema();
-  // New field to add.
-  $field_name = 'competition_signup';
-  // If the field doesn't exist already:
-  if (!db_field_exists($tbl_name, $field_name)) {
-    // Add it per the schema field definition.
-    db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
-  }
-}
-
-/**
- * Adds submit_text and skip_text columns to the dosomething_signup_data_form table.
- */
-function dosomething_signup_update_7025() {
-  $tbl_name = 'dosomething_signup_data_form';
-  // Load schema to get table definition.
-  $schema = dosomething_signup_schema();
   // New fields to add.
-  $field_names = ['submit_text', 'skip_text'];
+  $field_names = ['submit_text', 'skip_text', 'competition_signup'];
   foreach ($field_names as $name) {
     // If the field doesn't exist already:
     if (!db_field_exists($tbl_name, $name)) {
@@ -711,7 +697,7 @@ function dosomething_signup_update_7025() {
 /**
  * Adds competition column to the dosomething_signup table.
  */
-function dosomething_signup_update_7026() {
+function dosomething_signup_update_7025() {
   $tbl_name = 'dosomething_signup';
   // Load schema to get table definition.
   $schema = dosomething_signup_schema();

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -68,7 +68,6 @@ function dosomething_signup_schema() {
         'description' => 'Boolean indicating if the user signed up to a competition',
         'type' => 'int',
         'not null' => FALSE,
-        'default' => 0,
       ),
     ),
     'primary key' => array('sid'),

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -115,6 +115,20 @@ function dosomething_signup_schema() {
         'not null' => TRUE,
         'default' => '',
       ),
+      'submit_text' => array(
+        'description' => 'The label of the submit button',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'skip_text' => array(
+        'description' => 'The label of the skip button',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ),
       'form_header' => array(
         'description' => 'Form header text',
         'type' => 'varchar',
@@ -667,5 +681,23 @@ function dosomething_signup_update_7024() {
   if (!db_field_exists($tbl_name, $field_name)) {
     // Add it per the schema field definition.
     db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
+  }
+}
+
+/**
+ * Adds submit_text and skip_text columns to the dosomething_signup_data_form table.
+ */
+function dosomething_signup_update_7025() {
+  $tbl_name = 'dosomething_signup_data_form';
+  // Load schema to get table definition.
+  $schema = dosomething_signup_schema();
+  // New fields to add.
+  $field_names = ['submit_text', 'skip_text'];
+  foreach ($field_names as $name) {
+    // If the field doesn't exist already:
+    if (!db_field_exists($tbl_name, $name)) {
+      // Add it per the schema field definition.
+      db_add_field($tbl_name, $name, $schema[$tbl_name]['fields'][$name]);
+    }
   }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -65,9 +65,9 @@ function dosomething_signup_schema() {
         'not null' => FALSE,
       ),
       'competition' => array(
-        'description' => 'Boolean indicating the use signed up to a competition',
+        'description' => 'Boolean indicating if the user signed up to a competition',
         'type' => 'int',
-        'not null' => TRUE,
+        'not null' => FALSE,
         'default' => 0,
       ),
     ),

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -64,6 +64,12 @@ function dosomething_signup_schema() {
         'length' => 255,
         'not null' => FALSE,
       ),
+      'competition' => array(
+        'description' => 'Boolean indicating the use signed up to a competition',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
     ),
     'primary key' => array('sid'),
     'unique keys' => array(
@@ -699,5 +705,21 @@ function dosomething_signup_update_7025() {
       // Add it per the schema field definition.
       db_add_field($tbl_name, $name, $schema[$tbl_name]['fields'][$name]);
     }
+  }
+}
+
+/**
+ * Adds competition column to the dosomething_signup table.
+ */
+function dosomething_signup_update_7026() {
+  $tbl_name = 'dosomething_signup';
+  // Load schema to get table definition.
+  $schema = dosomething_signup_schema();
+  // New field to add.
+  $field_name = 'competition';
+  // If the field doesn't exist already:
+  if (!db_field_exists($tbl_name, $field_name)) {
+    // Add it per the schema field definition.
+    db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
   }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -102,6 +102,12 @@ function dosomething_signup_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'competition_signup' => array(
+        'description' => 'Boolean indicating this is a competition signup form',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
       'link_text' => array(
         'description' => 'The text to display in the link to the form.',
         'type' => 'varchar',
@@ -645,5 +651,21 @@ function dosomething_signup_update_7023() {
       )
       ->condition('nid', $signup->signup_node)
       ->execute();
+  }
+}
+
+/**
+ * Adds competition_signup column to the dosomething_signup_data_form table.
+ */
+function dosomething_signup_update_7024() {
+  $tbl_name = 'dosomething_signup_data_form';
+  // Load schema to get table definition.
+  $schema = dosomething_signup_schema();
+  // New field to add.
+  $field_name = 'competition_signup';
+  // If the field doesn't exist already:
+  if (!db_field_exists($tbl_name, $field_name)) {
+    // Add it per the schema field definition.
+    db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
   }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -68,10 +68,10 @@ function dosomething_signup_node_signup_data_form($form, &$form_state, $node) {
     '#default_value' => $values['required'],
     '#description' => t('If checked, the form modal will be displayed after the user first signs up.'),
   );
-  $form[$fieldset]['config'][$prefix . 'required_competition_signup'] = array(
+  $form[$fieldset]['config'][$prefix . 'competition_signup'] = array(
     '#type' => 'checkbox',
     '#title' => t('Competition Signup'),
-    '#default_value' => $values['required_competition_signup'],
+    '#default_value' => $values['competition_signup'],
     '#description' => t('If checked, when the user submits this form, they will be entered into a competition'),
   );
   $form[$fieldset]['config'][$prefix . 'required_allow_skip'] = array(
@@ -252,6 +252,7 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
         'status' => $values[$prefix . 'status'],
         'required' => $values[$prefix . 'required'],
         'required_allow_skip' => $values[$prefix . 'required_allow_skip'],
+        'competition_signup' => $values[$prefix . 'competition_signup'],
         'link_text' => $values[$prefix . 'link_text'],
         'form_header' => $values[$prefix . 'form_header'],
         'form_copy' => $values[$prefix . 'form_copy'],

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -458,7 +458,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     '#suffix' => '</div></div>',
   );
 
-  $submit_label = ($config['submit_text']) ? $config['submit_text'] : 'Submit';
+  $submit_label = ($config['submit_text']) ? t($config['submit_text']) : t('Submit');
   $form['actions']['submit'] = array(
     '#type' => 'submit',
     '#value' => $submit_label,
@@ -533,7 +533,7 @@ function dosomething_signup_user_signup_data_form_validate_school($form, &$form_
  */
 function dosomething_signup_user_skip_signup_data_form($form, &$form_state, $signup) {
   $config = dosomething_signup_get_signup_data_form_info($signup->nid);
-  $skip_label = ($config['skip_text']) ? $config['skip_text'] : 'Skip';
+  $skip_label = ($config['skip_text']) ? t($config['skip_text']) : t('Skip');
 
   $form['#attributes']['class'] = array('form-actions');
   $form['sid'] = array(

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -230,11 +230,6 @@ function dosomething_signup_node_signup_data_form_validate(&$form, &$form_state)
   $prefix = 'signup_data_form_';
   // If signup data form is enabled:
   if ($values[$prefix . 'status'] == 1) {
-    // Link text is mandatory.
-    $link_text = $prefix . 'link_text';
-    if (empty($values[$link_text])) {
-      form_set_error($link_text, t('Signup Data Form Link text is mandatory.'));
-    }
     // Confirm_msg is mandatory.
     $confirm_msg = $prefix . 'confirm_msg';
     if (empty($values[$confirm_msg])) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -506,7 +506,7 @@ function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
     dosomething_user_save_school_id($values['school_id']);
   }
   // Update signup record.
-  dosomething_signup_update_signup_data($values);
+  dosomething_signup_update_signup_data($values, $config);
   // Display the signup_data_form's confirm_msg field.
   drupal_set_message($config['confirm_msg']);
 }
@@ -559,7 +559,7 @@ function dosomething_signup_user_skip_signup_data_form($form, &$form_state, $sig
  */
 function dosomething_signup_user_skip_signup_data_form_submit($form, &$form_state) {
   // Update signup record with response = 0.
-  dosomething_signup_update_signup_data($form_state['values'], 0);
+  dosomething_signup_update_signup_data($form_state['values'], NULL, 0);
 }
 
 /**
@@ -570,7 +570,7 @@ function dosomething_signup_user_skip_signup_data_form_submit($form, &$form_stat
  * @param int $response
  *   If 0, the user chose to skip the form. Else, should be 1.
  */
-function dosomething_signup_update_signup_data($values, $response = 1) {
+function dosomething_signup_update_signup_data($values, $config = NULL, $response = 1) {
   try {
     // Load the signup entity to update.
     $entity = signup_load($values['sid']);
@@ -580,6 +580,10 @@ function dosomething_signup_update_signup_data($values, $response = 1) {
     if ($response) {
       if (isset($values['why_signedup'])) {
         $entity->why_signedup = $values['why_signedup'];
+      }
+
+      if ($config['competition_signup']) {
+        $entity->competition = 1;
       }
     }
     $entity->save();

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -68,6 +68,12 @@ function dosomething_signup_node_signup_data_form($form, &$form_state, $node) {
     '#default_value' => $values['required'],
     '#description' => t('If checked, the form modal will be displayed after the user first signs up.'),
   );
+  $form[$fieldset]['config'][$prefix . 'required_competition_signup'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Competition Signup'),
+    '#default_value' => $values['required_competition_signup'],
+    '#description' => t('If checked, when the user submits this form, they will be entered into a competition'),
+  );
   $form[$fieldset]['config'][$prefix . 'required_allow_skip'] = array(
     '#type' => 'checkbox',
     '#title' => t('Allow skip'),

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -110,6 +110,18 @@ function dosomething_signup_node_signup_data_form($form, &$form_state, $node) {
     '#default_value' => $values['link_text'],
     '#description' => t('This is label of the link in "Stuff You Need" which opens the form modal.'),
   );
+  $form[$fieldset]['config'][$prefix . 'submit_text'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Submit Button Text'),
+    '#default_value' => $values['submit_text'],
+    '#description' => t('This will be used as the label of the submit button.'),
+  );
+  $form[$fieldset]['config'][$prefix . 'skip_text'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Skip button text'),
+    '#default_value' => $values['skip_text'],
+    '#description' => t('This will be used as the lable of the skip button.'),
+  );
   $form[$fieldset]['config'][$prefix . 'form_header'] = array(
     '#type' => 'textfield',
     '#title' => t('Form header'),
@@ -254,6 +266,8 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
         'required_allow_skip' => $values[$prefix . 'required_allow_skip'],
         'competition_signup' => $values[$prefix . 'competition_signup'],
         'link_text' => $values[$prefix . 'link_text'],
+        'submit_text' => $values[$prefix . 'submit_text'],
+        'skip_text' => $values[$prefix . 'skip_text'],
         'form_header' => $values[$prefix . 'form_header'],
         'form_copy' => $values[$prefix . 'form_copy'],
         'form_submitted_copy' => $values[$prefix . 'form_submitted_copy'],
@@ -444,9 +458,10 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     '#suffix' => '</div></div>',
   );
 
+  $submit_label = ($config['submit_text']) ? $config['submit_text'] : 'Submit';
   $form['actions']['submit'] = array(
     '#type' => 'submit',
-    '#value' => t('Submit'),
+    '#value' => $submit_label,
     '#attributes' => array(
       'class' => array(
         'button',
@@ -517,6 +532,9 @@ function dosomething_signup_user_signup_data_form_validate_school($form, &$form_
  *   The signup entity to save additional data to.
  */
 function dosomething_signup_user_skip_signup_data_form($form, &$form_state, $signup) {
+  $config = dosomething_signup_get_signup_data_form_info($signup->nid);
+  $skip_label = ($config['skip_text']) ? $config['skip_text'] : 'Skip';
+
   $form['#attributes']['class'] = array('form-actions');
   $form['sid'] = array(
     '#type' => 'hidden',
@@ -525,7 +543,7 @@ function dosomething_signup_user_skip_signup_data_form($form, &$form_state, $sig
   );
   $form['submit'] = array(
     '#type' => 'submit',
-    '#value' => t('Skip'),
+    '#value' => $skip_label,
     '#attributes' => array(
       'class' => array(
         'button',


### PR DESCRIPTION
#### What's this PR do?
- add 'competition signup' checkbox to the sign up data form that allows admins to specify this form is to sign up for a competition
- Makes the link text to the modal not required so that it doesn't show in the "Stuff you need" section
- Add fields to customize the submit and skip button text
- Adds a `competition` column to `dosomething_signup` and when a user submits the sign up data form that is a competition sign up, we update the sign up record to flag this column as true.
#### What are the relevant tickets?

Fixes #6169 - This PR should fulfill what is needed to start. But I did bring up something in that issue that we might need to think through a little further. This sorta hijacks the sign up data form to use for competitions. But, what happens when we both want to allow users to sign up for a competition but we also need them to fill out extra data as a part of the campaign (i.e teens for jeans, thumb wars)

Maybe we should make a separate issue for that?
### Background context

This is the same as pr #6182 with some additional changes
