### PR TITLE
changes join to leftJoin

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -41,7 +41,7 @@ function dosomething_signup_get_signups_query($params) {
  */
 function dosomething_signup_build_signups_query($params = []) {
   $query = db_select('dosomething_signup', 's');
-  $query->join('dosomething_reportback', 'rb', 's.nid = rb.nid AND s.run_nid = rb.run_nid');
+  $query->leftJoin('dosomething_reportback', 'rb', 's.nid = rb.nid AND s.run_nid = rb.run_nid');
   $query->fields('s', ['sid', 'uid', 'nid', 'run_nid', 'timestamp']);
   $query->fields('rb', ['rbid']);
   $query->where('s.uid = rb.uid');


### PR DESCRIPTION
#### What's this PR do?

Changes the `join` in the `dosomething_signup_build_signups_query` to a `leftJoin` to return all signups (not just signups a user has reported back for). 
