### PR TITLE
exposes campaign tagline, type, and status in /signups

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -193,6 +193,9 @@ abstract class Transformer {
       'campaign_runs' => $data->campaign_runs,
       'language' => $data->language,
       'translations' => $data->translations,
+      'tagline' => $data->tagline,
+      'status' => $data->status,
+      'type' => $data->type,
     ];
 
     // If an instance of Campaign class, then there is much
@@ -201,17 +204,11 @@ abstract class Transformer {
 
       // Show all properties for "full" display.
       if ($data->display === 'full') {
-        $output['tagline'] = $data->tagline;
-
         $output['created_at'] = $data->created_at;
 
         $output['updated_at'] = $data->updated_at;
 
-        $output['status'] = $data->status ? $data->status : 'active';
-
         $output['time_commitment'] = $data->time_commitment;
-
-        $output['type'] = $data->type;
 
         foreach ($data->cover_image as $key => $image) {
           if (!is_null($image)) {

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -145,13 +145,13 @@ class Campaign {
       $this->campaign_runs = $this->getCampaignRuns($this->id);
       $this->language = $this->getLanguage();
       $this->translations = $this->getTranslations();
+      $this->tagline = $this->getTagline();
+      $this->status = $this->getStatus();
+      $this->type = $this->getType();
 
       if ($display === 'full') {
-        $this->tagline = $this->getTagline();
         $this->created_at = $data->created;
         $this->updated_at = $data->changed;
-        $this->status = $this->getStatus();
-        $this->type = $this->getType();
         $this->time_commitment = $this->getTimeCommitment();
 
         $this->cover_image = [


### PR DESCRIPTION
#### What's this PR do?

Adds campaign tagline, campaign status, and campaign type to campaign object returned in /signups (in campaign object teaser). 
#### How should this be manually tested?

Hit `/signups` endpoint and make sure all new information gets returned in campaign object.
#### What are the relevant tickets?

Fixes #6185 

cc: @aaronschachter @jonuy 
