### PR TITLE
allow editors to view, edit, and upload files

### DIFF
--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.features.user_permission.inc
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.features.user_permission.inc
@@ -16,6 +16,7 @@ function dosomething_settings_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'creative team' => 'creative team',
+      'editor' => 'editor',
     ),
     'module' => 'file_entity',
   );
@@ -26,6 +27,7 @@ function dosomething_settings_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'creative team' => 'creative team',
+      'editor' => 'editor',
     ),
     'module' => 'file_entity',
   );
@@ -36,6 +38,7 @@ function dosomething_settings_user_default_permissions() {
     'roles' => array(
       'administrator' => 'administrator',
       'creative team' => 'creative team',
+      'editor' => 'editor',
     ),
     'module' => 'file_entity',
   );

--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.info
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.info
@@ -23,4 +23,4 @@ features[variable][] = pathauto_file_pattern
 features[variable][] = pathauto_node_pattern
 features[variable][] = seckit_clickjacking
 features[variable][] = seckit_xss
-mtime = 1447688428
+mtime = 1450208149


### PR DESCRIPTION
#### What's this PR do?

Editors can now:
- Administer files
- Add and upload new files
- View own private files
- View own files
- View files
- Image: Edit any files
- Video: Edit any files
- Audio: Edit any files
- Document: Edit any files
#### How should this be manually tested?

Login as an editor. Go to /admin/content/file and you should be able to view, add, and edit files.
#### Any background context you want to provide?

There are a bunch more choices for things we can allow editors to do and those can be seen at admin/people/permissions/4 (make sure you're logged in as an admin). 
#### What are the relevant tickets?

Fixes #6141

cc: @namimody @mikefantini 
