### PR TITLE
Forces a default run nid to be inserted into the filter

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -492,6 +492,17 @@ function _dosomething_reportback_get_permalink_copy_vars($user) {
  * Alters the signup form that is attached to permalink pages.
  */
 function dosomething_reportback_form_alter(&$form, &$form_state, $form_id) {
+
+  // Make sure a default run is added to the filter
+  if ($form['#id'] == 'views-exposed-form-reportback-files-page-1') {
+    if (empty($_GET['run_nid'])) {
+      $run = dosomething_helpers_get_current_campaign_run_for_user(arg(1));
+      if (isset($run)) {
+        $form_state['input']['run_nid'] = $run->nid;
+      }
+    }
+  }
+
   // A signup/login/register form, on a reportback page.
   $forms = array('dosomething_signup_form', 'user_register_form', 'user_login', 'user_login_block');
   if (in_array($form_id, $forms) && drupal_match_path($path = current_path(), 'reportback/*')) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -494,7 +494,7 @@ function dosomething_reportback_form_views_exposed_form_alter(&$form, &$form_sta
   // Make sure a default run is added to the filter
   if (empty($_GET['run_nid'])) {
     $run = dosomething_helpers_get_current_campaign_run_for_user(arg(1));
-    if (isset($run)) {
+    if (!empty($run)) {
       $form_state['input']['run_nid'] = $run->nid;
     }
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -485,15 +485,19 @@ function _dosomething_reportback_get_permalink_copy_vars($user) {
   );
 }
 
-
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Alters the reportback review form.
+ */
 function dosomething_reportback_form_views_exposed_form_alter(&$form, &$form_state, $form_id) {
   // Make sure a default run is added to the filter
-    if (empty($_GET['run_nid'])) {
-      $run = dosomething_helpers_get_current_campaign_run_for_user(arg(1));
-      if (isset($run)) {
-        $form_state['input']['run_nid'] = $run->nid;
-      }
+  if (empty($_GET['run_nid'])) {
+    $run = dosomething_helpers_get_current_campaign_run_for_user(arg(1));
+    if (isset($run)) {
+      $form_state['input']['run_nid'] = $run->nid;
     }
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -486,23 +486,22 @@ function _dosomething_reportback_get_permalink_copy_vars($user) {
 }
 
 
-/**
- * Implements hook_form_alter().
- *
- * Alters the signup form that is attached to permalink pages.
- */
-function dosomething_reportback_form_alter(&$form, &$form_state, $form_id) {
-
+function dosomething_reportback_form_views_exposed_form_alter(&$form, &$form_state, $form_id) {
   // Make sure a default run is added to the filter
-  if ($form['#id'] == 'views-exposed-form-reportback-files-page-1') {
     if (empty($_GET['run_nid'])) {
       $run = dosomething_helpers_get_current_campaign_run_for_user(arg(1));
       if (isset($run)) {
         $form_state['input']['run_nid'] = $run->nid;
       }
     }
-  }
+}
 
+/**
+ * Implements hook_form_alter().
+ *
+ * Alters the signup form that is attached to permalink pages.
+ */
+function dosomething_reportback_form_alter(&$form, &$form_state, $form_id) {
   // A signup/login/register form, on a reportback page.
   $forms = array('dosomething_signup_form', 'user_register_form', 'user_login', 'user_login_block');
   if (in_array($form_id, $forms) && drupal_match_path($path = current_path(), 'reportback/*')) {


### PR DESCRIPTION
#### What's this PR do?

Makes sure that the run nid on reportback view tab has a default value corresponding to the campaigns current default.
#### How should this be manually tested?

Go to a reportback review tab, is the correct thing filled out and does it show the correct reportbacks?
#### Any background context you want to provide?

I realized i didn't notice this the first time because on my machine the first ~10 reportbacks we're correct, but after that they were not. Whereas on Thor/Prod shit is just completely wrong and out of order.
#### What are the relevant tickets?

Fixes #6192 
