### PR TITLE
get the user address form to show up

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -454,7 +454,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
 
   // @todo Hacky solution to deal with form elements when no elements added and eliminate empty container added.
   // @see https://github.com/DoSomething/phoenix/pull/5809
-  if (count($form['elements']) <= 10) {
+  if (count($form['elements']) <= 2) {
     unset($form['elements']);
   }
 


### PR DESCRIPTION
#### What's this PR do?

There was an if statement that was unsetting all the form elements if there were fewer than 10 of them. However, we only want that to unset if only the default elements are there, and there are 2 of those.
#### How should this be manually tested?
1. Go to a campaign and go to custom settings.
2. Scroll down to "Signup Data Form"
3. Check "Collect additional signup data"
4. Expand "Configuration"
5. Expand "Form Elements"
6. Check "Collect User address"
7. Fill in the necessary fields
8. Login as a non-admin, sign up for the campaign and click the link under "Stuff you need" and the form should appear
#### Any background context you want to provide?

When I was submitting my address, it was saying it was invalid. I'm not sure if it just doesn't work on local or if that has to do with the UPS api.
#### What are the relevant tickets?

Fixes #6158

cc: @mikefantini, @DFurnes (also shoutout to him for help with drupal spelunking)
