### PR TITLE
Northstar id field fixes

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -471,17 +471,17 @@ function dosomething_user_user_login(&$form_state, $account) {
   // Figure out whether user is logging in via email or mobile. Then, we'll
   // send a request to Northstar's `user/verify` endpoint to see if Northstar
   // is also able to successfully authenticate with the given credentials.
-  if ($account = dosomething_user_get_user_by_email($form_state['values']['name'])) {
+  if (dosomething_user_get_user_by_email($form_state['values']['name'])) {
     $northstar_user = dosomething_northstar_verify_user([
       'email' => $form_state['values']['name'],
       'password' => $form_state['values']['pass'],
     ]);
 
   }
-  elseif ($number = $form_state['values']['name']) {
-    if ($account = dosomething_user_get_user_by_mobile($number)) {
+  elseif ($form_state['values']['name']) {
+    if (dosomething_user_get_user_by_mobile($form_state['values']['name'])) {
       $northstar_user = dosomething_northstar_verify_user([
-        'mobile' => dosomething_user_clean_mobile_number($number),
+        'mobile' => dosomething_user_clean_mobile_number($form_state['values']['name']),
         'password' => $form_state['values']['pass'],
       ]);
     }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -268,6 +268,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
         unset($form['field_partner']);
         unset($form['field_school_id']);
         unset($form['field_user_registration_source']);
+        unset($form['field_northstar_id']);
         unset($form['picture']);
         unset($form['field_under_thirteen']);
         unset($form['field_job_title']);
@@ -278,6 +279,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
       else {
         // Registration Source should always be read-only.
         $form['field_user_registration_source']['#disabled'] = TRUE;
+        $form['field_northstar_id']['#disabled'] = TRUE;
         $form['field_under_thirteen']['#disabled'] = TRUE;
       }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -473,20 +473,17 @@ function dosomething_user_user_login(&$form_state, $account) {
   // Figure out whether user is logging in via email or mobile. Then, we'll
   // send a request to Northstar's `user/verify` endpoint to see if Northstar
   // is also able to successfully authenticate with the given credentials.
-  if (dosomething_user_get_user_by_email($form_state['values']['name'])) {
+  if (dosomething_user_get_user_by_email($form_state['input']['name'])) {
     $northstar_user = dosomething_northstar_verify_user([
-      'email' => $form_state['values']['name'],
-      'password' => $form_state['values']['pass'],
+      'email' => $form_state['input']['name'],
+      'password' => $form_state['input']['pass'],
     ]);
-
   }
-  elseif ($form_state['values']['name']) {
-    if (dosomething_user_get_user_by_mobile($form_state['values']['name'])) {
-      $northstar_user = dosomething_northstar_verify_user([
-        'mobile' => dosomething_user_clean_mobile_number($form_state['values']['name']),
-        'password' => $form_state['values']['pass'],
-      ]);
-    }
+  elseif (dosomething_user_get_user_by_mobile($form_state['input']['name'])) {
+    $northstar_user = dosomething_northstar_verify_user([
+      'mobile' => dosomething_user_clean_mobile_number($form_state['input']['name']),
+      'password' => $form_state['input']['pass'],
+    ]);
   }
 
   // If the user exists, store it on the user's Drupal profile.


### PR DESCRIPTION
#### What's this PR do?

Fixes some issues I noticed after merging #6196:
- Removes "Northstar ID" from user profile pages, and makes it read-only for admins.
- Fixes issue where everything would explode if you tried to log in with an account that had a username that wasn't it's email address or phone number (because it would overwrite `$account` to be false). So instead…
  - Don't overwrite `$account` since we already have it as an argument from the hook
  - Use `$form_state['input']` to get raw form input rather than the incorrect `$form_state['values']` I had been using before.
#### How should this be manually tested?

If you pulled down #6196, you'd probably get a big ol' error if you tried to log in with an account that had one of those programmatic numeric usernames. Now you won't.
#### What are the relevant tickets?

Fixes #6197.

---

For review: @angaither 
