### PR TITLE
catches errors and returns null for campaigns and reportbacks in orde…

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -97,13 +97,17 @@ class Signup extends Entity {
 
     $this->campaign_run = $data->run_nid;
 
+    // Only send to Reportback::get if there is a rbid. 
     if (isset($data->rbid) && is_numeric($data->rbid)) {
+      // Catch error if a reportback is not found.
+      // Reportback will not be returned if it hasn't yet been reviewed. 
       try {
         $this->reportback = Reportback::get($data->rbid);
       } catch (Exception $e) {
         $this->reportback = null;
       }
-    } else {
+    } 
+    else {
       $this->reportback = null;
     }
   }

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -97,16 +97,16 @@ class Signup extends Entity {
 
     $this->campaign_run = $data->run_nid;
 
-    // Only send to Reportback::get if there is a rbid. 
+    // Only send to Reportback::get if there is a rbid.
     if (isset($data->rbid) && is_numeric($data->rbid)) {
       // Catch error if a reportback is not found.
-      // Reportback will not be returned if it hasn't yet been reviewed. 
+      // Reportback will not be returned if it hasn't yet been reviewed.
       try {
         $this->reportback = Reportback::get($data->rbid);
       } catch (Exception $e) {
         $this->reportback = null;
       }
-    } 
+    }
     else {
       $this->reportback = null;
     }

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -88,7 +88,6 @@ class Signup extends Entity {
   private function build($data) {
     $this->id = $data->sid;
     $this->created_at = $data->timestamp;
-    
     try {
       $this->campaign = Campaign::get($data->nid);
     }

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -88,11 +88,22 @@ class Signup extends Entity {
   private function build($data) {
     $this->id = $data->sid;
     $this->created_at = $data->timestamp;
-    $this->campaign = Campaign::get($data->nid);
+    
+    try {
+      $this->campaign = Campaign::get($data->nid);
+    }
+    catch (Exception $error) {
+      $this->campaign = null;
+    }
+
     $this->campaign_run = $data->run_nid;
 
     if (isset($data->rbid) && is_numeric($data->rbid)) {
-      $this->reportback = Reportback::get($data->rbid);
+      try {
+        $this->reportback = Reportback::get($data->rbid);
+      } catch (Exception $e) {
+        $this->reportback = null;
+      }
     } else {
       $this->reportback = null;
     }

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -64,7 +64,6 @@ class SignupTransformer extends Transformer {
 
     $data = [];
 
-
     if (is_null($item->campaign)) {
       $data['campaign'] = null;
     } else {

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -64,11 +64,16 @@ class SignupTransformer extends Transformer {
 
     $data = [];
 
-    $campaign = (object) $item->campaign;
-    $current_run = $campaign->campaign_runs['current']['en']['id'];
-    $current = ($item->campaign_run == $current_run);
-    $data += $this->transformSignup($item, $current);
-    $data['campaign'] = $this->transformCampaign((object) $item->campaign);
+
+    if (is_null($item->campaign)) {
+      $data['campaign'] = null;
+    } else {
+      $campaign = (object) $item->campaign;
+      $current_run = $campaign->campaign_runs['current']['en']['id'];
+      $current = ($item->campaign_run == $current_run);
+      $data += $this->transformSignup($item, $current);
+      $data['campaign'] = $this->transformCampaign((object) $item->campaign);
+    }
 
     if (is_null($item->reportback)) {
       $data['reportback'] = null;

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -66,7 +66,7 @@ class SignupTransformer extends Transformer {
 
     if (is_null($item->campaign)) {
       $data['campaign'] = null;
-    } 
+    }
     else {
       $campaign = (object) $item->campaign;
       $current_run = $campaign->campaign_runs['current']['en']['id'];
@@ -77,7 +77,8 @@ class SignupTransformer extends Transformer {
 
     if (is_null($item->reportback)) {
       $data['reportback'] = null;
-    } else {
+    }
+    else {
       $data['reportback'] = $this->transformReportback((object) $item->reportback);
     }
 

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -66,7 +66,8 @@ class SignupTransformer extends Transformer {
 
     if (is_null($item->campaign)) {
       $data['campaign'] = null;
-    } else {
+    } 
+    else {
       $campaign = (object) $item->campaign;
       $current_run = $campaign->campaign_runs['current']['en']['id'];
       $current = ($item->campaign_run == $current_run);


### PR DESCRIPTION
What's this PR do?

Catches errors and returns null for campaigns and reportbacks in order to reach all /signup endpoints.

For some reason, users can sign up for some nodes that are not campaigns or sms_games which was breaking when we tried to build the campaign in Signup.php's get function.

We were hitting the No reportback found. error, again breaking the endpoint, in the situation where there was a reportback in the database but couldn't be returned if has not yet been reviewed.

How should this be manually tested?

Make sure all /signup endpoints work and don't log and errors in the Drupal log messages.

http://dev.dosomething.org:8888/api/v1/signups
http://dev.dosomething.org:8888/api/v1/signups/42
http://dev.dosomething.org:8888/api/v1/signups?user=98&campaigns=1227,1173

What are the relevant tickets?

Fixes #6193
