### PR TITLE
Forward to gladiator

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -65,6 +65,19 @@ function dosomething_signup_menu() {
 }
 
 /**
+ * Implements hook_libraries_info().
+ */
+function dosomething_signup_libraries_info() {
+  $libraries['guzzle'] = array(
+    'name' => 'guzzle',
+    'path' => 'vendor',
+    'files' => ['php' => ['autoload.php']],
+    'version' => 5.0,
+  );
+  return $libraries;
+}
+
+/**
  * Implements hook_entity_info().
  */
 function dosomething_signup_entity_info() {
@@ -1025,4 +1038,22 @@ function dosomething_signup_get_target_nid_for_source($source_string) {
     }
   }
   return NULL;
+}
+
+function _dosomething_signup_build_http_client() {
+  $base_url = 'http://jsonplaceholder.typicode.com';
+
+  if (libraries_load('guzzle') == TRUE) {
+    $client = new GuzzleHttp\Client(array(
+      'base_uri' => 'http://jsonplaceholder.typicode.com',
+      'defaults' => array(
+        'headers' => array(
+          'Content-Type' => 'application/json',
+          'Accept' => 'application/json'
+          ),
+        ),
+    ));
+    $res = $client->request('GET', '/posts/1');
+    echo $res->getBody();
+  }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -1040,6 +1040,12 @@ function dosomething_signup_get_target_nid_for_source($source_string) {
   return NULL;
 }
 
+/**
+ * Build the Guzzle HTTP Client to make requests to Gladiator.
+ *
+ * https://github.com/DoSomething/gladiator
+ * @TODO - use correct URL
+ */
 function _dosomething_signup_build_http_client() {
   $base_url = 'http://jsonplaceholder.typicode.com';
 
@@ -1053,7 +1059,9 @@ function _dosomething_signup_build_http_client() {
           ),
         ),
     ));
-    $res = $client->request('GET', '/posts/1');
-    echo $res->getBody();
+
+    return $client;
   }
+
+  return;
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -507,6 +507,10 @@ function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
   }
   // Update signup record.
   dosomething_signup_update_signup_data($values, $config);
+  // If this is a competition sign up, send it to gladiator.
+  if ($config['competition_signup']) {
+    dosomething_signup_send_user_to_gladiator($user, $values);
+  }
   // Display the signup_data_form's confirm_msg field.
   drupal_set_message($config['confirm_msg']);
 }
@@ -611,4 +615,31 @@ function dosomething_signup_filter_form_submitted_copy($string, $timestamp) {
   // Custom format: January 1st.
   $submitted = format_date($timestamp, 'custom', 'F jS');
   return str_replace(DOSOMETHING_SIGNUP_DATA_FORM_TIMESTAMP_TOKEN, $submitted, $string);
+}
+
+/**
+ * Sends a user to Gladiator (https://github.com/DoSomething/gladiator)
+ *
+ * @param object $user
+ *   The user that signup up for the competition.
+ * @param array $values
+ *   Values from the signup data form.
+ */
+function dosomething_signup_send_user_to_gladiator($user, $values) {
+  $client = _dosomething_signup_build_http_client();
+
+  // @TODO - once the real endpoint is set up, only send what we need to Gladiator.
+  $user = json_encode($user);
+  $values = json_encode($values);
+
+  try {
+    $response = $client->request('POST', 'posts', [
+      'json' => [
+        'user' => $user,
+        'values' => $values,
+        'userId' => 1],
+    ]);
+  } catch (GuzzleHttp\Exception\RequestException $e) {
+    watchdog('dosomething_signup', $e, array(), WATCHDOG_ERROR);
+  }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -626,6 +626,9 @@ function dosomething_signup_filter_form_submitted_copy($string, $timestamp) {
  *   Values from the signup data form.
  */
 function dosomething_signup_send_user_to_gladiator($user, $values) {
+  // Make sure the client is set up.
+  if (!_dosomething_signup_build_http_client()) { return; }
+
   $client = _dosomething_signup_build_http_client();
 
   // @TODO - once the real endpoint is set up, only send what we need to Gladiator.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -626,10 +626,9 @@ function dosomething_signup_filter_form_submitted_copy($string, $timestamp) {
  *   Values from the signup data form.
  */
 function dosomething_signup_send_user_to_gladiator($user, $values) {
-  // Make sure the client is set up.
-  if (!_dosomething_signup_build_http_client()) { return; }
-
   $client = _dosomething_signup_build_http_client();
+
+  if (!$client) { return; }
 
   // @TODO - once the real endpoint is set up, only send what we need to Gladiator.
   $user = json_encode($user);


### PR DESCRIPTION
#### What's this PR do?

This PR starts the work of sending users to [gladiator](https://github.com/DoSomething/gladiator) when they sign up for a competition using the sign up data form. 

I didn't have the endpoint that we are actually going to be using in gladiator, so this uses a fake endpoint, but flushes out the basic logic that we will be using to do this work. 
#### How should this be manually tested?

This is isn't fully functional yet, but if you pull down this branch and then run

`drush eval 'dosomething_signup_send_user_to_gladiator('user', 'values')'` you shouldn't see any errors pop back. Also, you should be able to submit a sign up data form, that is configured to be a competition sign up, without any issues.
#### Any background context you want to provide?

There was a previous issue with Guzzle working in Phoenix ( #4616 ) But I believe that was an issue because the guzzle client was being configured incorrectly. See that issue for deets.
#### What are the relevant tickets?

Addresses #6170 

cc @weerd 
