### PR TITLE
Fixes reportback review & content search

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
@@ -21,4 +21,4 @@ features[user_permission][] = view any reportback
 features[user_permission][] = view own reportback
 features[views_view][] = reportback_files
 files[] = dosomething_reportback.test
-mtime = 1455818121
+mtime = 1456236977

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
@@ -21,4 +21,4 @@ features[user_permission][] = view any reportback
 features[user_permission][] = view own reportback
 features[views_view][] = reportback_files
 files[] = dosomething_reportback.test
-mtime = 1455809638
+mtime = 1455818121

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -491,6 +491,7 @@ function _dosomething_reportback_get_permalink_copy_vars($user) {
  * Alters the reportback review form.
  */
 function dosomething_reportback_form_views_exposed_form_alter(&$form, &$form_state, $form_id) {
+  // Structure is excluded from this logic because its unclear what run it should be using, and will throw an error.
   if ($form['#id'] === 'views-exposed-form-reportback-files-reviewed-reportbacks' && arg(1) != 'structure') {
     // Make sure a default run is added to the filter
     if (empty($_GET['run_nid'])) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -491,11 +491,13 @@ function _dosomething_reportback_get_permalink_copy_vars($user) {
  * Alters the reportback review form.
  */
 function dosomething_reportback_form_views_exposed_form_alter(&$form, &$form_state, $form_id) {
-  // Make sure a default run is added to the filter
-  if (empty($_GET['run_nid'])) {
-    $run = dosomething_helpers_get_current_campaign_run_for_user(arg(1));
-    if (!empty($run)) {
-      $form_state['input']['run_nid'] = $run->nid;
+  if ($form['#id'] == 'views-exposed-form-reportback-files-reportback-review' && arg(1) != 'structure') {
+    // Make sure a default run is added to the filter
+    if (empty($_GET['run_nid'])) {
+      $run = dosomething_helpers_get_current_campaign_run_for_user(arg(1));
+      if (!empty($run)) {
+        $form_state['input']['run_nid'] = $run->nid;
+      }
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -491,7 +491,7 @@ function _dosomething_reportback_get_permalink_copy_vars($user) {
  * Alters the reportback review form.
  */
 function dosomething_reportback_form_views_exposed_form_alter(&$form, &$form_state, $form_id) {
-  if ($form['#id'] == 'views-exposed-form-reportback-files-reportback-review' && arg(1) != 'structure') {
+  if ($form['#id'] === 'views-exposed-form-reportback-files-reviewed-reportbacks' && arg(1) != 'structure') {
     // Make sure a default run is added to the filter
     if (empty($_GET['run_nid'])) {
       $run = dosomething_helpers_get_current_campaign_run_for_user(arg(1));

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
@@ -279,7 +279,7 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['menu']['context_only_inline'] = 0;
 
   /* Display: Page */
-  $handler = $view->new_display('page', 'Page', 'reportback_review');
+  $handler = $view->new_display('page', 'Page', 'reviewed_reportbacks');
   $handler->display->display_options['defaults']['relationships'] = FALSE;
   /* Relationship: Reportback Item: Reportback File rbid */
   $handler->display->display_options['relationships']['rbid']['id'] = 'rbid';

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
@@ -268,6 +268,7 @@ function dosomething_reportback_views_default_views() {
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');
+  $handler->display->display_options['defaults']['arguments'] = FALSE;
   $handler->display->display_options['path'] = 'admin/users/rb/reviewed';
   $handler->display->display_options['menu']['type'] = 'tab';
   $handler->display->display_options['menu']['title'] = 'Reviewed';
@@ -278,7 +279,7 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['menu']['context_only_inline'] = 0;
 
   /* Display: Page */
-  $handler = $view->new_display('page', 'Page', 'page_1');
+  $handler = $view->new_display('page', 'Page', 'reportback_review');
   $handler->display->display_options['defaults']['relationships'] = FALSE;
   /* Relationship: Reportback Item: Reportback File rbid */
   $handler->display->display_options['relationships']['rbid']['id'] = 'rbid';


### PR DESCRIPTION
#### What's this PR do?
- Renames the machine name of reportback review to something other than page 1
- Updates the form alter to be wrapped inside an IF block
#### How should this be manually tested?

Does going to the reportback structure page break?
Does going to a reportback review page properly fill in the run nid?
Does content/search work? 
#### Any background context you want to provide?

This code was running on every form that falls under vies_exposed_form 
#### What are the relevant tickets?

Fixes #6203 
