### PR TITLE
Expose competition in campaign api

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -219,6 +219,7 @@ abstract class Transformer {
         }
 
         $output['staff_pick'] = $data->staff_pick;
+        $output['competition'] = $data->competition;
 
         $output['facts']['problem'] = $data->facts['problem'] ? $data->facts['problem']['fact'] : NULL;
         $output['facts']['solution'] = $data->facts['solution'] ? $data->facts['solution']['fact'] : NULL;

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -220,13 +220,6 @@ abstract class Transformer {
         }
 
         $output['staff_pick'] = $data->staff_pick;
-
-        if ($data->competition == '1') {
-          $data->competition = TRUE;
-        }
-        elseif ($data->competition == '0') {
-          $data->competition = FALSE;
-        }
         $output['competition'] = $data->competition;
 
         $output['facts']['problem'] = $data->facts['problem'] ? $data->facts['problem']['fact'] : NULL;

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -174,6 +174,7 @@ abstract class Transformer {
    *   - status: (string)
    *   - cover_image: (array)
    *   - staff_pick: (bool)
+   *   - competition: (bool)
    *   - facts: (array)
    *   - solutions: (array)
    *   - causes: (array)
@@ -219,6 +220,14 @@ abstract class Transformer {
         }
 
         $output['staff_pick'] = $data->staff_pick;
+
+        if ($data->competition == '1') {
+          $data->competition = TRUE;
+        }
+        elseif ($data->competition == '0') {
+          $data->competition = FALSE;
+        }
+        
         $output['competition'] = $data->competition;
 
         $output['facts']['problem'] = $data->facts['problem'] ? $data->facts['problem']['fact'] : NULL;

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -227,7 +227,6 @@ abstract class Transformer {
         elseif ($data->competition == '0') {
           $data->competition = FALSE;
         }
-        
         $output['competition'] = $data->competition;
 
         $output['facts']['problem'] = $data->facts['problem'] ? $data->facts['problem']['fact'] : NULL;

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -12,6 +12,7 @@ include_once 'includes/Campaign.php';
 include_once 'includes/CampaignController.php';
 include_once 'includes/CampaignTransformer.php';
 include_once 'dosomething_campaign.theme.inc';
+include_once 'dosomething_campaign.query.inc';
 
 define('DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER', t('Snap a Pic'));
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.query.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.query.inc
@@ -4,7 +4,7 @@
 *
 * @return bool
 */
-protected function getCompetition($id) {
+public function getCompetition($id) {
 	$query = db_select('node', 'n');
 	$query->leftJoin('dosomething_signup_data_form', 'sdf', 'n.nid = sdf.nid');
 	$query->fields('sdf', ['competition_signup']);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.query.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.query.inc
@@ -10,7 +10,7 @@
 *
 * @return bool
 */
-public function dosomething_campaign_is_competition($id) {
+function dosomething_campaign_is_competition($id) {
 	$query = db_select('node', 'n');
 	$query->leftJoin('dosomething_signup_data_form', 'sdf', 'n.nid = sdf.nid');
 	$query->fields('sdf', ['competition_signup']);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.query.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.query.inc
@@ -4,7 +4,7 @@
 *
 * @return bool
 */
-public function getCompetition($id) {
+public function dosomething_campaign_is_compeition($id) {
 	$query = db_select('node', 'n');
 	$query->leftJoin('dosomething_signup_data_form', 'sdf', 'n.nid = sdf.nid');
 	$query->fields('sdf', ['competition_signup']);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.query.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.query.inc
@@ -1,10 +1,16 @@
 <?php
 /**
+ * @file
+ * Database query code for Campaign data.
+ */
+
+
+/**
 * Get status whether this campaign has a competition or not.
 *
 * @return bool
 */
-public function dosomething_campaign_is_compeition($id) {
+public function dosomething_campaign_is_competition($id) {
 	$query = db_select('node', 'n');
 	$query->leftJoin('dosomething_signup_data_form', 'sdf', 'n.nid = sdf.nid');
 	$query->fields('sdf', ['competition_signup']);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.query.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.query.inc
@@ -1,0 +1,24 @@
+<?php
+/**
+* Get status whether this campaign has a competition or not.
+*
+* @return bool
+*/
+protected function getCompetition($id) {
+	$query = db_select('node', 'n');
+	$query->leftJoin('dosomething_signup_data_form', 'sdf', 'n.nid = sdf.nid');
+	$query->fields('sdf', ['competition_signup']);
+	$query->condition('n.nid', $id);
+
+	$result = $query->execute()->fetchAll();
+	$result = $result[0]->competition_signup;
+
+	if ($result == '1') {
+	  $result = TRUE;
+	}
+	elseif ($result == '0') {
+	  $result = FALSE;
+	}
+
+	return $result;
+}

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.query.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.query.inc
@@ -13,12 +13,5 @@ protected function getCompetition($id) {
 	$result = $query->execute()->fetchAll();
 	$result = $result[0]->competition_signup;
 
-	if ($result == '1') {
-	  $result = TRUE;
-	}
-	elseif ($result == '0') {
-	  $result = FALSE;
-	}
-
 	return $result;
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.query.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.query.inc
@@ -11,13 +11,13 @@
 * @return bool
 */
 function dosomething_campaign_is_competition($id) {
-	$query = db_select('node', 'n');
-	$query->leftJoin('dosomething_signup_data_form', 'sdf', 'n.nid = sdf.nid');
-	$query->fields('sdf', ['competition_signup']);
-	$query->condition('n.nid', $id);
+  $query = db_select('node', 'n');
+  $query->leftJoin('dosomething_signup_data_form', 'sdf', 'n.nid = sdf.nid');
+  $query->fields('sdf', ['competition_signup']);
+  $query->condition('n.nid', $id);
 
-	$result = $query->execute()->fetchAll();
-	$result = $result[0]->competition_signup;
+  $result = $query->execute()->fetchAll();
+  $result = $result[0]->competition_signup;
 
-	return $result;
+  return $result;
 }

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -161,9 +161,7 @@ class Campaign {
         $this->scholarship = $this->getScholarship();
         $this->staff_pick = $this->getStaffPickStatus();
 
-        $is_competition = dosomething_campaign_is_competition($this->id);
-        $is_competition = dosomething_helpers_convert_string_to_boolean($is_competition);
-        $this->competition = $is_competition;
+        $this->competition =  dosomething_helpers_convert_string_to_boolean(dosomething_campaign_is_competition($this->id));
 
         $fact_data = $this->getFactData();
         $this->facts = [

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -160,7 +160,11 @@ class Campaign {
 
         $this->scholarship = $this->getScholarship();
         $this->staff_pick = $this->getStaffPickStatus();
-        $this->competition = dosomething_campaign_is_competition($this->id);
+
+        $is_competition = dosomething_campaign_is_competition($this->id);
+        $is_competition = dosomething_helpers_convert_string_to_boolean($is_competition);
+        $this->competition = $is_competition;
+
         $fact_data = $this->getFactData();
         $this->facts = [
           'problem' => $fact_data['fact_problem'],

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -358,7 +358,7 @@ class Campaign {
     if ($result == '1') {
       $result = TRUE;
     }
-    else if ($result == '0') {
+    elseif ($result == '0') {
       $result = FALSE;
     }
 

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -354,7 +354,14 @@ class Campaign {
 
     $result = $query->execute()->fetchAll();
     $result = $result[0]->competition_signup;
-    
+
+    if ($result == '1') {
+      $result = TRUE;
+    }
+    else if ($result == '0') {
+      $result = FALSE;
+    }
+
     return $result;
   }
 

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -342,30 +342,6 @@ class Campaign {
   }
 
   /**
-  * Get status whether this campaign has a competition or not.
-  *
-  * @return bool
-  */
-  protected function getCompetition($id) {
-    $query = db_select('node', 'n');
-    $query->leftJoin('dosomething_signup_data_form', 'sdf', 'n.nid = sdf.nid');
-    $query->fields('sdf', ['competition_signup']);
-    $query->condition('n.nid', $id);
-
-    $result = $query->execute()->fetchAll();
-    $result = $result[0]->competition_signup;
-
-    if ($result == '1') {
-      $result = TRUE;
-    }
-    elseif ($result == '0') {
-      $result = FALSE;
-    }
-
-    return $result;
-  }
-
-  /**
    * Get Facts data for campaign if available; collects both fact problem
    * and fact solution as well as the sources for both.
    *

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -160,8 +160,7 @@ class Campaign {
 
         $this->scholarship = $this->getScholarship();
         $this->staff_pick = $this->getStaffPickStatus();
-        $this->competition = $this->getCompetition($this->id);
-
+        $this->competition = dosomething_campaign_is_competition($this->id);
         $fact_data = $this->getFactData();
         $this->facts = [
           'problem' => $fact_data['fact_problem'],

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -160,6 +160,7 @@ class Campaign {
 
         $this->scholarship = $this->getScholarship();
         $this->staff_pick = $this->getStaffPickStatus();
+        $this->competition = $this->getCompetition($this->id);
 
         $fact_data = $this->getFactData();
         $this->facts = [
@@ -338,6 +339,23 @@ class Campaign {
     else {
       return NULL;
     }
+  }
+
+  /**
+  * Get status whether this campaign has a competition or not.
+  *
+  * @return bool
+  */
+  protected function getCompetition($id) {
+    $query = db_select('node', 'n');
+    $query->leftJoin('dosomething_signup_data_form', 'sdf', 'n.nid = sdf.nid');
+    $query->fields('sdf', ['competition_signup']);
+    $query->condition('n.nid', $id);
+
+    $result = $query->execute()->fetchAll();
+    $result = $result[0]->competition_signup;
+    
+    return $result;
   }
 
   /**


### PR DESCRIPTION
#### What's this PR do?

Exposes competition in campaign object with boolean value or null if not set. 
#### How should this be manually tested?

Hit any `/campaigns` endpoint and campaigns object should return a line `competitions` under `staff_pick`. 

```
{
  data: {
    id: "1736",
  title: "Test Title",
  campaign_runs: {
    current: {
      en: {
        id: "1902"
      }
    },
    past: [ ]
  },
  language: {
    language_code: "en",
    prefix: "us"
  },
  translations: {
    original: "en",
    en: {
      language_code: "en",
      prefix: "us"
    }
  },
  tagline: "Test CTA",
  status: "active",
  type: "campaign",
  created_at: "1445282953",
  updated_at: "1456252247",
  time_commitment: 0,
  cover_image: {
    default: null,
    alternate: null
  },
  staff_pick: false,
  competition: true,
...
```
#### What are the relevant tickets?

Fixes #6205 
