### PR TITLE
Adds stathat logging to permalink signup

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -243,6 +243,10 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
     return FALSE;
   }
 
+  if (strpos($source, 'reportback') === 0) {
+    stathat_send_ez_count('drupal - Signup - permalink signup', 1);
+  }
+
   $values = array(
     'nid' => $nid,
     'uid' => $uid,

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -243,8 +243,10 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
     return FALSE;
   }
 
-  if (strpos($source, 'reportback') === 0) {
-    stathat_send_ez_count('drupal - Signup - permalink signup', 1);
+  if (module_exists('stathat')) {
+    if (strpos($source, 'reportback') === 0) {
+      stathat_send_ez_count('drupal - Signup - permalink signup', 1);
+    }
   }
 
   $values = array(

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -244,6 +244,7 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
   }
 
   if (module_exists('stathat')) {
+    // The source is often a string longer than just "reportback", this logic accounts for that.
     if (strpos($source, 'reportback') === 0) {
       stathat_send_ez_count('drupal - Signup - permalink signup', 1);
     }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -243,13 +243,6 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
     return FALSE;
   }
 
-  if (module_exists('stathat')) {
-    // The source is often a string longer than just "reportback", this logic accounts for that.
-    if (strpos($source, 'reportback') === 0) {
-      stathat_send_ez_count('drupal - Signup - permalink signup', 1);
-    }
-  }
-
   $values = array(
     'nid' => $nid,
     'uid' => $uid,
@@ -264,6 +257,14 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
     // The SignupEntityController save method handles any NULL values.
     $entity->save();
     if (isset($entity->sid)) {
+
+      if (module_exists('stathat')) {
+        // The source is often a string longer than just "reportback", but always starts with it if the page is a permalink
+        if (strpos($source, 'reportback') === 0) {
+          stathat_send_ez_count('drupal - Signup - permalink signup', 1);
+        }
+      }
+
       return $entity->sid;
     }
     return FALSE;


### PR DESCRIPTION
#### What's this PR do?

Adds stat hat logging to permalink signups
#### How should this be manually tested?

If you do a normal signup, does this log?
If you do a permalink signup, does this log?
#### Any background context you want to provide?

I couldn't see a better way than using the $source parameter / URL to figure out if this was the perma link so just went with that. 
#### What are the relevant tickets?

Fixes #6075 
