### PR TITLE
Updates reportback review pages

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
@@ -21,4 +21,4 @@ features[user_permission][] = view any reportback
 features[user_permission][] = view own reportback
 features[views_view][] = reportback_files
 files[] = dosomething_reportback.test
-mtime = 1456236977
+mtime = 1456342149

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
@@ -21,4 +21,4 @@ features[user_permission][] = view any reportback
 features[user_permission][] = view own reportback
 features[views_view][] = reportback_files
 files[] = dosomething_reportback.test
-mtime = 1456349377
+mtime = 1456349880

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
@@ -21,4 +21,4 @@ features[user_permission][] = view any reportback
 features[user_permission][] = view own reportback
 features[views_view][] = reportback_files
 files[] = dosomething_reportback.test
-mtime = 1456342149
+mtime = 1456349377

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -486,24 +486,6 @@ function _dosomething_reportback_get_permalink_copy_vars($user) {
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
- *
- * Alters the reportback review form.
- */
-function dosomething_reportback_form_views_exposed_form_alter(&$form, &$form_state, $form_id) {
-  // Structure is excluded from this logic because its unclear what run it should be using, and will throw an error.
-  if ($form['#id'] === 'views-exposed-form-reportback-files-reviewed-reportbacks' && arg(1) != 'structure') {
-    // Make sure a default run is added to the filter
-    if (empty($_GET['run_nid'])) {
-      $run = dosomething_helpers_get_current_campaign_run_for_user(arg(1));
-      if (!empty($run)) {
-        $form_state['input']['run_nid'] = $run->nid;
-      }
-    }
-  }
-}
-
-/**
  * Implements hook_form_alter().
  *
  * Alters the signup form that is attached to permalink pages.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
@@ -351,6 +351,22 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['fields']['quantity']['field'] = 'quantity';
   $handler->display->display_options['fields']['quantity']['relationship'] = 'rbid';
   $handler->display->display_options['defaults']['arguments'] = FALSE;
+  /* Contextual filter: Reportback: Node nid */
+  $handler->display->display_options['arguments']['nid']['id'] = 'nid';
+  $handler->display->display_options['arguments']['nid']['table'] = 'dosomething_reportback';
+  $handler->display->display_options['arguments']['nid']['field'] = 'nid';
+  $handler->display->display_options['arguments']['nid']['relationship'] = 'rbid';
+  $handler->display->display_options['arguments']['nid']['default_action'] = 'empty';
+  $handler->display->display_options['arguments']['nid']['default_argument_type'] = 'fixed';
+  $handler->display->display_options['arguments']['nid']['summary']['number_of_records'] = '0';
+  $handler->display->display_options['arguments']['nid']['summary']['format'] = 'default_summary';
+  $handler->display->display_options['arguments']['nid']['summary_options']['items_per_page'] = '25';
+  $handler->display->display_options['arguments']['nid']['specify_validation'] = TRUE;
+  $handler->display->display_options['arguments']['nid']['validate']['type'] = 'node';
+  $handler->display->display_options['arguments']['nid']['validate_options']['types'] = array(
+    'campaign' => 'campaign',
+    'campaign_run' => 'campaign_run',
+  );
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
   /* Filter criterion: Reportback Item: Status */
@@ -544,6 +560,7 @@ function dosomething_reportback_views_default_views() {
     t('Promoted Reason'),
     t('Page'),
     t('Run NID'),
+    t('All'),
   );
   $export['reportback_files'] = $view;
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
@@ -521,6 +521,15 @@ function dosomething_reportback_views_default_views() {
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page_2');
   $handler->display->display_options['defaults']['arguments'] = FALSE;
+  /* Contextual filter: Content: Has taxonomy term ID */
+  $handler->display->display_options['arguments']['tid']['id'] = 'tid';
+  $handler->display->display_options['arguments']['tid']['table'] = 'taxonomy_index';
+  $handler->display->display_options['arguments']['tid']['field'] = 'tid';
+  $handler->display->display_options['arguments']['tid']['relationship'] = 'nid';
+  $handler->display->display_options['arguments']['tid']['default_argument_type'] = 'fixed';
+  $handler->display->display_options['arguments']['tid']['summary']['number_of_records'] = '0';
+  $handler->display->display_options['arguments']['tid']['summary']['format'] = 'default_summary';
+  $handler->display->display_options['arguments']['tid']['summary_options']['items_per_page'] = '25';
   $handler->display->display_options['path'] = 'taxonomy/term/%/rb/reviewed';
   $handler->display->display_options['menu']['type'] = 'tab';
   $handler->display->display_options['menu']['title'] = 'Reviewed';

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.views_default.inc
@@ -530,6 +530,12 @@ function dosomething_reportback_views_default_views() {
   $handler->display->display_options['arguments']['tid']['summary']['number_of_records'] = '0';
   $handler->display->display_options['arguments']['tid']['summary']['format'] = 'default_summary';
   $handler->display->display_options['arguments']['tid']['summary_options']['items_per_page'] = '25';
+  $handler->display->display_options['arguments']['tid']['specify_validation'] = TRUE;
+  $handler->display->display_options['arguments']['tid']['validate']['type'] = 'taxonomy_term';
+  $handler->display->display_options['arguments']['tid']['validate_options']['vocabularies'] = array(
+    'cause' => 'cause',
+    'issue' => 'issue',
+  );
   $handler->display->display_options['path'] = 'taxonomy/term/%/rb/reviewed';
   $handler->display->display_options['menu']['type'] = 'tab';
   $handler->display->display_options['menu']['title'] = 'Reviewed';


### PR DESCRIPTION
#### What's this PR do?
- Removes form alter that was implemented because a contextual filter was missing
- Adds the contextual filter which got accidentally deleted in both reportback pages
#### How should this be manually tested?

Does the reportback review page show all reportbacks for the campaign?
Does specifying a run only display the correct reportbacks?
Does the taxonomy reportback page show the correct reportbacks?
#### Any background context you want to provide?

Somehow these filters got accidentally removed in a previous PR and we were't sure what they were. The form alter here was how we patched it in the meantime, however is this is the proper solution.
#### What are the relevant tickets?

Fixes #6213 
