### PR TITLE
Address validation

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -258,7 +258,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
 
       // Add extra validation on the edit page, for addresses.
       $current_page = $_SERVER['REQUEST_URI'];
-      if (preg_match('/user\/([0-9]+)\/edit/', $current_page) && $validate_address) {
+      if (preg_match('/us/user\/([0-9]+)\/edit/', $current_page) && $validate_address) {
         $form['#validate'][] = 'dosomething_user_validate_address_field';
       }
 
@@ -1292,6 +1292,9 @@ function dosomething_user_info_form($form, &$form_state, $account) {
       '#value' => t('Submit'),
     ),
   );
+
+  $form['#validate'][] = 'dosomething_user_validate_address_field';
+  
   return $form;
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -258,7 +258,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
 
       // Add extra validation on the edit page, for addresses.
       $current_page = $_SERVER['REQUEST_URI'];
-      if (preg_match('/us/user\/([0-9]+)\/edit/', $current_page) && $validate_address) {
+      if (preg_match('/us\/user\/([0-9]+)\/edit/', $current_page) && $validate_address) {
         $form['#validate'][] = 'dosomething_user_validate_address_field';
       }
 
@@ -1294,7 +1294,7 @@ function dosomething_user_info_form($form, &$form_state, $account) {
   );
 
   $form['#validate'][] = 'dosomething_user_validate_address_field';
-  
+
   return $form;
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -258,7 +258,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
 
       // Add extra validation on the edit page, for addresses.
       $current_page = $_SERVER['REQUEST_URI'];
-      if (preg_match('/us\/user\/([0-9]+)\/edit/', $current_page) && $validate_address) {
+      if ((preg_match('/us\/user\/([0-9]+)\/edit/', $current_page) || preg_match('/user\/([0-9]+)\/edit/', $current_page)) && $validate_address) {
         $form['#validate'][] = 'dosomething_user_validate_address_field';
       }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -258,7 +258,7 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
 
       // Add extra validation on the edit page, for addresses.
       $current_page = $_SERVER['REQUEST_URI'];
-      if ((preg_match('/us\/user\/([0-9]+)\/edit/', $current_page) || preg_match('/user\/([0-9]+)\/edit/', $current_page)) && $validate_address) {
+      if (preg_match('/user\/([0-9]+)\/edit/', $current_page) && $validate_address) {
         $form['#validate'][] = 'dosomething_user_validate_address_field';
       }
 


### PR DESCRIPTION
#### What's this PR do?

Adds a validation check in the user info edit form and updates URL in admin update form to include US country code. 
#### How should this be manually tested?

On your admin account, try to edit your address and put "hi" as the zip code. An error message should pop up and not let you save. 

On a non-admin account, sign up for a campaign that asks for member's address upon signup. Again, try and add "hi" as the zip code to see if it allows you to save. 
#### What are the relevant tickets?

Fixes #6214
