### PR TITLE
Added some logging to the run script.

### DIFF
--- a/scripts/move-signups-reportbacks-from-runs.php
+++ b/scripts/move-signups-reportbacks-from-runs.php
@@ -33,7 +33,7 @@ if (db_table_exists($table)) {
       ->fields(['nid' => $result->field_campaigns_target_id, 'run_nid' => $result->nid])
       ->condition($id, $result->id)
       ->execute();
-      echo "updated : " . $result->id . "\n";
+      echo 'updated : ' . $result->id . "\n";
     }
     catch(Exception $e) {
       echo 'bad things: ' . $e;

--- a/scripts/move-signups-reportbacks-from-runs.php
+++ b/scripts/move-signups-reportbacks-from-runs.php
@@ -11,20 +11,29 @@ $arg = drush_get_arguments();
 $table = 'dosomething_' . $arg[2];
 
 if (db_table_exists($table)) {
+  if ($table == 'dosomething_signup') {
+    $id = 'sid';
+  }
+  else {
+    $id = 'rbid';
+  }
   $query = db_select($table, 't');
   $query->join('field_data_field_campaigns', 'c', 't.nid = c.entity_id');
   $query->join('node', 'n', 't.nid = n.nid');
-  $results = $query->fields('t', ['nid'])
+  $query->fields('t', ['nid'])
   ->fields('c', ['field_campaigns_target_id'])
-  ->condition('n.type', 'campaign_run')
+  ->fields('t', [$id])
+  ->addField('t', $id, 'id');
+  $results = $query->condition('n.type', 'campaign_run')
   ->execute();
 
   foreach($results as $result) {
     try{
       db_update($table)
-      ->fields(['nid' => $result->field_campaigns_target_id])
-      ->condition('nid', $result->nid)
+      ->fields(['nid' => $result->field_campaigns_target_id, 'run_nid' => $result->nid])
+      ->condition($id, $result->id)
       ->execute();
+      echo "updated : " . $result->id . "\n";
     }
     catch(Exception $e) {
       echo 'bad things: ' . $e;


### PR DESCRIPTION
#### What's this PR do?

I was running the fix for #5995 on thor and noticed some errors, this addresses that! 
#### How should this be manually tested?

run `drush --script-path=../scripts/ php-script move-signups-reportbacks-from-runs.php signup|reportback`
and watch content that was archived become unarchived
#### Any background context you want to provide?

I pushed this code a while ago, but needed a mental break from runs. 
It's a good thing too, because the code I wrote in #6155 was wrong, this fixes that up! 
#### What are the relevant tickets?

Fixes #5995 refs #6155

fixed up the query to include rbid, or sid
set the run_nid as well as the nid :facepalm:
