### PR TITLE
API formatting updates

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -331,13 +331,10 @@ abstract class Transformer {
    * @return array
    */
   protected function transformReportback($data) {
-    $iso_created_at = date('c', $data->created_at);
-    $iso_updated_at = date('c', $data->updated_at);
-
     $output = [
       'id' => $data->id,
-      'created_at' => $iso_created_at,
-      'updated_at' => $iso_updated_at,
+      'created_at' => date('c', $data->created_at),
+      'updated_at' => date('c', $data->updated_at),
       'quantity' => $data->quantity,
     ];
 

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -115,7 +115,7 @@ abstract class Transformer {
    */
   protected function paginate($total, $filters, $endpoint) {
     $data = [];
-    
+
     $data['total'] = $total;
     $data['per_page'] = $filters['count'];
     $data['current_page'] = (isset($filters['page']) && $filters['page'] > 0) ? (int) $filters['page'] : 1;

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -115,13 +115,15 @@ abstract class Transformer {
    */
   protected function paginate($total, $filters, $endpoint) {
     $data = [];
-
+    
     $data['total'] = $total;
     $data['per_page'] = $filters['count'];
     $data['current_page'] = (isset($filters['page']) && $filters['page'] > 0) ? (int) $filters['page'] : 1;
     $data['total_pages'] = ceil($data['total'] / $data['per_page']);
-    $data['prev_uri'] = $this->getPrevPageUri($data, $filters, $endpoint);
-    $data['next_uri'] = $this->getNextPageUri($data, $filters, $endpoint);
+    $data['links'] = [
+      'prev_uri' => $this->getPrevPageUri($data, $filters, $endpoint),
+      'next_uri' => $this->getNextPageUri($data, $filters, $endpoint),
+    ];
 
     return $data;
   }

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -329,10 +329,13 @@ abstract class Transformer {
    * @return array
    */
   protected function transformReportback($data) {
+    $iso_created_at = date('c', $data->created_at);
+    $iso_updated_at = date('c', $data->updated_at);
+
     $output = [
       'id' => $data->id,
-      'created_at' => $data->created_at,
-      'updated_at' => $data->updated_at,
+      'created_at' => $iso_created_at,
+      'updated_at' => $iso_updated_at,
       'quantity' => $data->quantity,
     ];
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -25,7 +25,6 @@ class ReportbackItemTransformer extends ReportbackTransformer {
 
     return [
       'pagination' => $this->paginate($total, $filters, 'reportback-items'),
-      'retrieved_count' => count($reportbackItems),
       'data' => $this->transformCollection($reportbackItems),
     ];
   }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -24,7 +24,9 @@ class ReportbackItemTransformer extends ReportbackTransformer {
     }
 
     return [
-      'pagination' => $this->paginate($total, $filters, 'reportback-items'),
+      'meta' => [
+        'pagination' => $this->paginate($total, $filters, 'reportback-items'),
+      ],
       'data' => $this->transformCollection($reportbackItems),
     ];
   }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -21,7 +21,6 @@ class ReportbackTransformer extends Transformer {
    */
   public function index($parameters) {
     $filters = $this->setFilters($parameters);
-    
     try {
       $reportbacks = Reportback::find($filters);
       $reportbacks = services_resource_build_index_list($reportbacks, 'reportbacks', 'id');

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -21,9 +21,11 @@ class ReportbackTransformer extends Transformer {
    */
   public function index($parameters) {
     $filters = $this->setFilters($parameters);
+    
     try {
       $reportbacks = Reportback::find($filters);
       $reportbacks = services_resource_build_index_list($reportbacks, 'reportbacks', 'id');
+      $total = $this->getTotalCount($filters);
     }
     catch (Exception $error) {
       // @TODO: Potentially log error to watchdog.
@@ -33,6 +35,9 @@ class ReportbackTransformer extends Transformer {
     }
 
     return [
+      'meta' => [
+        'pagination' => $this->paginate($total, $filters, 'reportbacks'),
+      ],
       'data' => $this->transformCollection($reportbacks),
     ];
   }
@@ -92,6 +97,7 @@ class ReportbackTransformer extends Transformer {
       'nid' => dosomething_helpers_format_data($parameters['campaigns']),
       'status' => dosomething_helpers_format_data($parameters['status']),
       'count' => (int) $parameters['count'] ?: 25,
+      'page' => (int) $parameters['page'],
       'random' => dosomething_helpers_convert_string_to_boolean($parameters['random']),
       'load_user' => dosomething_helpers_convert_string_to_boolean($parameters['load_user']),
       'flagged' => dosomething_helpers_convert_string_to_boolean($parameters['flagged']),


### PR DESCRIPTION
#### What's this PR do?
- Updates dates to be returned as ISO-8601 string rather than UNIX timestamps
- Moves pagination into a meta object, and formats links object for next/prev URL
- Removes `retrieved_count` property from response
- Adds pagination to `/reportbacks` endpoint
#### How should this be manually tested?

Check `/reportbacks` and `/reportback-items` to make sure all of the above is changed. 
#### What are the relevant tickets?

Refs #6048. Fixes bullet points 1-3. 
