### PR TITLE
Professional campaigns only please

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -464,11 +464,8 @@ function dosomething_campaign_build_campaigns_query($params = array()) {
   $query = db_select('node', 'n');
   $query->join('field_data_field_campaign_type', 't', 't.entity_id = n.nid');
 
-  // @TODO: this is a temporary fix to address the need to allow unpublished mobile_app campaigns to be retrieved, only for the mobile app.
-  if (!$params['mobile_app']) {
-    $query->condition('n.status', 1);
-  }
 
+  $query->condition('n.status', 1);
   $query->condition('t.field_campaign_type_value', $params['type']);
   $query->condition('n.type', $params['type']);
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -885,11 +885,6 @@ function dosomething_campaign_is_closed($node) {
 function dosomething_campaign_is_active($node) {
   // Campaign must be active and not closed.
   if (!dosomething_campaign_is_closed($node)) {
-    // Campaign is on mobile app and may/may not be published.
-    $on_mobile_app = dosomething_helpers_extract_field_data($node->field_on_mobile_app);
-    if ($on_mobile_app) {
-      return TRUE;
-    }
 
     // Campaign is published.
     if ($node->status == 1) {


### PR DESCRIPTION
#### What's this PR do?

remove unpublished campaigns from the api index. 
#### How should this be manually tested?

do unpublished campaigns show up in the index?
#### Any background context you want to provide?

This fix was added in with #5175 to support the original
idea in the mobile app, where we had campaigns show up on
the app, but not on the web.
As we are no longer going that route, let's only return
published campaigns.
#### What are the relevant tickets?

Fixes #6233
#### doesn't fix

> it kinda feels like always setting the campaign.status to closed for an unpublished campaign node will do the trick there 
> because even if we hide the campaign from API, that signup is still returned from `signups?user=:id`
