### PR TITLE
Added a script to remove activity on non-campaign nodes.

### DIFF
--- a/scripts/remove-non-campaign-activity.php
+++ b/scripts/remove-non-campaign-activity.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * Script to remove activity on non-campaign nodes.
+ *
+ * To run you need to pass which table you would like to update. signup|reportback
+ * drush --script-path=../scripts/ php-script remove-non-campaign-activity.php signup|reportback
+ *
+ */
+
+$arg = drush_get_arguments();
+$table = 'dosomething_' . $arg[2];
+
+if (db_table_exists($table)) {
+  if ($table == 'dosomething_signup') {
+    $id = 'sid';
+  }
+  else {
+    $id = 'rbid';
+  }
+  $types = ['campaign_group', 'home', 'fact', 'fact_page', 'image'];
+  $query = db_select($table, 't');
+  $query->join('node', 'n', 't.nid = n.nid');
+  $query->fields('t', ['nid'])
+  ->fields('t', [$id])
+  ->addField('t', $id, 'id');
+  $results = $query->condition('n.type', $types, 'IN')
+  ->execute();
+
+  foreach($results as $result) {
+    try {
+      db_delete($table)
+      ->condition($id, $result->id)
+      ->execute();
+      $count++;
+      echo 'removed : ' . $result->id . "\n";
+    }
+    catch(Exception $e) {
+      echo 'bad things: ' . $e;
+    }
+  }
+  echo 'done ';
+}
+else {
+  echo 'Are you outta your mind? ' . $arg[2] . ' is not a valid table' .  "\n";
+}


### PR DESCRIPTION
#### What's this PR do?

removes all activity (signups/reportbacks) on any of these node types
-  `campaign_group`  
- `home`
- `fact` 
- `fact_page`
-  `image`
#### How should this be manually tested?

run `drush --script-path=../scripts/ php-script remove-non-campaign-activity.php signup|reportback`
#### Any background context you want to provide?

no
#### What are the relevant tickets?

Refs #6232
