### PR TITLE
Actually delete the fields.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
@@ -145,3 +145,12 @@ function dosomething_campaign_update_7012() {
     db_create_table('cache_dosomething_campaign', $schema['cache_dosomething_campaign']);
   }
 }
+
+/**
+ * Remove mobile app fields, apparently features can't handle it.
+ * Refs #6239
+ */
+function dosomething_campaign_update_7013() {
+  field_delete_field('field_mobile_app_date');
+  field_delete_field('field_on_mobile_app');
+}


### PR DESCRIPTION
#### What's this PR do?

delete the mobile app fields
#### How should this be manually tested?

after a deploy, check that the fields are now gone from the campaign template type
#### Any background context you want to provide?

I tried reverting features locally, and it worked, but since I had manually removed the fields I didn't notice that a features revert without those fields wouldn't actually remove the fields. 
this fixes that
#### What are the relevant tickets?

Fixes #6236 
