### PR TITLE
Comp comp comp it up

### DIFF
--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.admin.inc
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.admin.inc
@@ -1,0 +1,25 @@
+<?php
+/**
+ * System settings form for northstar config.
+ */
+function dosomething_gladiator_config_form($form, &$form_state) {
+  $form = array();
+
+  $form['gladiator'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Gladiator Settings'),
+  );
+  $form['gladiator']['dosomething_gladiator_url'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Gladiator URL'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_gladiator_url', 'http://gladiator.app:8000'),
+  );
+  $form['gladiator']['dosomething_gladiator_version'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Gladiator API version number'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_gladiator_version', 'v1'),
+  );
+  return system_settings_form($form);
+}

--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.admin.inc
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.admin.inc
@@ -13,7 +13,7 @@ function dosomething_gladiator_config_form($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Gladiator URL'),
     '#required' => TRUE,
-    '#default_value' => variable_get('dosomething_gladiator_url', 'http://gladiator.app:8000'),
+    '#default_value' => variable_get('dosomething_gladiator_url', 'http://gladiator.app:8000/api'),
   );
   $form['gladiator']['dosomething_gladiator_version'] = array(
     '#type' => 'textfield',

--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.info
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.info
@@ -1,0 +1,6 @@
+name = DoSomething Gladiator
+description = Provides connection to our gladiatior competition platform.
+core = 7.x
+package = DoSomething
+version = 7.x-0.3
+project = dosomething_gladiator

--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @file
+ * Code for the dosomething_gladiatior.module.
+ */
+
+include_once('dosomething_gladiator.admin.inc');
+
+function dosomething_gladiator_menu() {
+  $items = [];
+  $items['admin/config/services/gladiator'] = array(
+    'title' => 'Gladiator',
+    'description' => 'Manage Gladiator connection settings.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_gladiator_config_form'),
+    'access arguments' => array('administer modules'),
+    'file' => 'dosomething_gladiator.admin.inc',
+  );
+  return $items;
+}
+/**
+ * Build the Guzzle HTTP Client to make requests to Gladiator.
+ *
+ * https://github.com/DoSomething/gladiator
+ * @TODO - use correct URL
+ */
+function _dosomething_signup_build_http_client() {
+  $base_url = 'http://jsonplaceholder.typicode.com';
+
+  if (libraries_load('guzzle') == TRUE) {
+    $client = new GuzzleHttp\Client(array(
+      'base_uri' => 'http://jsonplaceholder.typicode.com',
+      'defaults' => array(
+        'headers' => array(
+          'Content-Type' => 'application/json',
+          'Accept' => 'application/json'
+          ),
+        ),
+    ));
+
+    return $client;
+  }
+
+  return;
+}
+
+/**
+ * Sends a user to Gladiator (https://github.com/DoSomething/gladiator)
+ *
+ * @param object $user
+ *   The user that signup up for the competition.
+ * @param array $values
+ *   Values from the signup data form.
+ */
+function dosomething_signup_send_user_to_gladiator($user, $values) {
+  $client = _dosomething_signup_build_http_client();
+
+  if (!$client) { return; }
+
+  // @TODO - once the real endpoint is set up, only send what we need to Gladiator.
+  $user = json_encode($user);
+  $values = json_encode($values);
+
+  try {
+    $response = $client->request('POST', 'posts', [
+      'json' => [
+        'user' => $user,
+        'values' => $values,
+        'userId' => 1],
+    ]);
+  } catch (GuzzleHttp\Exception\RequestException $e) {
+    watchdog('dosomething_signup', $e, array(), WATCHDOG_ERROR);
+  }
+}
+

--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
@@ -25,7 +25,6 @@ function dosomething_gladiator_menu() {
  * Build the Guzzle HTTP Client to make requests to Gladiator.
  *
  * https://github.com/DoSomething/gladiator
- * @TODO - use correct URL
  */
 function _dosomething_signup_build_http_client() {
 

--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
@@ -26,7 +26,7 @@ function dosomething_gladiator_menu() {
  *
  * https://github.com/DoSomething/gladiator
  */
-function _dosomething_signup_build_http_client() {
+function _dosomething_gladiator_build_http_client() {
 
   if (libraries_load('guzzle') == TRUE) {
     $client = new GuzzleHttp\Client(array(
@@ -53,8 +53,8 @@ function _dosomething_signup_build_http_client() {
  * @param array $values
  *   Values from the signup data form.
  */
-function dosomething_signup_send_user_to_gladiator($user, $values) {
-  $client = _dosomething_signup_build_http_client();
+function dosomething_gladiator_send_user_to_gladiator($user, $values) {
+  $client = _dosomething_gladiator_build_http_client();
 
   if (!$client) { return; }
 

--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
@@ -6,6 +6,9 @@
 
 include_once('dosomething_gladiator.admin.inc');
 
+define('GLADIATOR_URL', variable_get('dosomething_gladiator_url', 'http://gladiator.app:8000/api'));
+define('GLADIATOR_VERSION', variable_get('dosomething_gladiator_version', 'v1'));
+
 function dosomething_gladiator_menu() {
   $items = [];
   $items['admin/config/services/gladiator'] = array(
@@ -25,11 +28,10 @@ function dosomething_gladiator_menu() {
  * @TODO - use correct URL
  */
 function _dosomething_signup_build_http_client() {
-  $base_url = 'http://jsonplaceholder.typicode.com';
 
   if (libraries_load('guzzle') == TRUE) {
     $client = new GuzzleHttp\Client(array(
-      'base_uri' => 'http://jsonplaceholder.typicode.com',
+      'base_uri' => GLADIATOR_URL . '/' . GLADIATOR_VERSION . '/',
       'defaults' => array(
         'headers' => array(
           'Content-Type' => 'application/json',
@@ -57,19 +59,17 @@ function dosomething_signup_send_user_to_gladiator($user, $values) {
 
   if (!$client) { return; }
 
-  // @TODO - once the real endpoint is set up, only send what we need to Gladiator.
-  $user = json_encode($user);
-  $values = json_encode($values);
-
   try {
-    $response = $client->request('POST', 'posts', [
-      'json' => [
-        'user' => $user,
-        'values' => $values,
-        'userId' => 1],
-    ]);
+    $response = $client->request('POST', 'users', [
+      'body' => json_encode([
+        'key' => $user->mail,
+        'type' => 'email',
+        'campaign_id' => $values['nid'],
+        'campaign_run_id' => $values['run_nid'],
+        ]),
+      ]);
   } catch (GuzzleHttp\Exception\RequestException $e) {
-    watchdog('dosomething_signup', $e, array(), WATCHDOG_ERROR);
+    watchdog('dosomething_gladiator', $e, array(), WATCHDOG_ERROR);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -1075,29 +1075,3 @@ function dosomething_signup_get_target_nid_for_source($source_string) {
   }
   return NULL;
 }
-
-/**
- * Build the Guzzle HTTP Client to make requests to Gladiator.
- *
- * https://github.com/DoSomething/gladiator
- * @TODO - use correct URL
- */
-function _dosomething_signup_build_http_client() {
-  $base_url = 'http://jsonplaceholder.typicode.com';
-
-  if (libraries_load('guzzle') == TRUE) {
-    $client = new GuzzleHttp\Client(array(
-      'base_uri' => 'http://jsonplaceholder.typicode.com',
-      'defaults' => array(
-        'headers' => array(
-          'Content-Type' => 'application/json',
-          'Accept' => 'application/json'
-          ),
-        ),
-    ));
-
-    return $client;
-  }
-
-  return;
-}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -294,7 +294,6 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
 function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) {
   // Load signup data form config to determine what form elements we need.
   $config = dosomething_signup_get_signup_data_form_info($signup->nid);
-
   $form['sid'] = array(
     '#type' => 'hidden',
     '#value' => $signup->sid,
@@ -514,7 +513,7 @@ function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
   dosomething_signup_update_signup_data($values, $config);
   // If this is a competition sign up, send it to gladiator.
   if ($config['competition_signup'] && module_exists('dosomething_gladiator')) {
-    dosomething_signup_send_user_to_gladiator($user, $values);
+    dosomething_gladiator_send_user_to_gladiator($user, $values);
   }
   // Display the signup_data_form's confirm_msg field.
   drupal_set_message($config['confirm_msg']);

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -305,6 +305,11 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     '#value' => $signup->nid,
     '#access' => FALSE,
   );
+  $form['run_nid'] = array(
+    '#type' => 'hidden',
+    '#value' => $signup->run_nid,
+    '#access' => FALSE,
+  );
   $form['header'] = array(
     '#prefix' => '<h2 class="heading -banner">',
     '#markup' => $config['form_header'],

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -508,7 +508,7 @@ function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
   // Update signup record.
   dosomething_signup_update_signup_data($values, $config);
   // If this is a competition sign up, send it to gladiator.
-  if ($config['competition_signup']) {
+  if ($config['competition_signup'] && module_exists('dosomething_gladiator')) {
     dosomething_signup_send_user_to_gladiator($user, $values);
   }
   // Display the signup_data_form's confirm_msg field.
@@ -615,33 +615,4 @@ function dosomething_signup_filter_form_submitted_copy($string, $timestamp) {
   // Custom format: January 1st.
   $submitted = format_date($timestamp, 'custom', 'F jS');
   return str_replace(DOSOMETHING_SIGNUP_DATA_FORM_TIMESTAMP_TOKEN, $submitted, $string);
-}
-
-/**
- * Sends a user to Gladiator (https://github.com/DoSomething/gladiator)
- *
- * @param object $user
- *   The user that signup up for the competition.
- * @param array $values
- *   Values from the signup data form.
- */
-function dosomething_signup_send_user_to_gladiator($user, $values) {
-  $client = _dosomething_signup_build_http_client();
-
-  if (!$client) { return; }
-
-  // @TODO - once the real endpoint is set up, only send what we need to Gladiator.
-  $user = json_encode($user);
-  $values = json_encode($values);
-
-  try {
-    $response = $client->request('POST', 'posts', [
-      'json' => [
-        'user' => $user,
-        'values' => $values,
-        'userId' => 1],
-    ]);
-  } catch (GuzzleHttp\Exception\RequestException $e) {
-    watchdog('dosomething_signup', $e, array(), WATCHDOG_ERROR);
-  }
 }

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -90,6 +90,7 @@ dependencies[] = dosomething_campaign_group
 dependencies[] = dosomething_campaign_run
 dependencies[] = dosomething_fact
 dependencies[] = dosomething_fact_page
+dependencies[] = dosomething_gladiator
 dependencies[] = dosomething_global
 dependencies[] = dosomething_image
 dependencies[] = dosomething_kudos

--- a/lib/profiles/dosomething/dosomething.make
+++ b/lib/profiles/dosomething/dosomething.make
@@ -49,6 +49,12 @@ projects[dosomething_campaign_run][download][type] = local
 projects[dosomething_campaign_run][download][source] = './lib/modules/dosomething/dosomething_campaign_run'
 projects[dosomething_campaign_run][subdir] = "dosomething"
 
+; Dosomething Gladiator
+projects[dosomething_gladiator][type] = "module"
+projects[dosomething_gladiator][download][type] = local
+projects[dosomething_gladiator][download][source] = './lib/modules/dosomething/dosomething_gladiator'
+projects[dosomething_gladiator][subdir] = "dosomething"
+
 ; Dosomething Global
 projects[dosomething_global][type] = "module"
 projects[dosomething_global][download][type] = local


### PR DESCRIPTION
#### What's this PR do?
- Creates `dosomething_gladiator.module`
- config page to set custom urls per environment
- sends post request to gladiator app after user says "YEAH" to a competition
- Add `run_nid` to signup_data_form values array
#### How should this be manually tested?

Pull down, enable `dosomething_gladiator.module`
Set the url to either your local, or qa environment
Signup for a campaign with a competition enabled & see the user created in the platform
#### Any background context you want to provide?

To get this to work on local Phoenix and Gladiator environments you need to add this line to `etc/hosts` inside of phoenix's vagrant
`10.0.2.2 gladiator.app`

We also might want to add some safety if anything along this route fails. But that also requires a better response from [the gladiator endpoint](https://github.com/DoSomething/gladiator/blob/master/documentation/endpoints/users.md)
#### What are the relevant tickets?

Fixes #6201 

cc @deadlybutter @weerd 
