### PR TITLE
Standardize api markdown properties

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -213,6 +213,7 @@ abstract class Transformer {
         $output['time_commitment'] = $data->time_commitment;
 
         foreach ($data->cover_image as $key => $image) {
+
           if (!is_null($image)) {
             $output['cover_image'][$key] = $this->transformMedia($image, 'square');
           } else {
@@ -227,7 +228,15 @@ abstract class Transformer {
         $output['facts']['solution'] = $data->facts['solution'] ? $data->facts['solution']['fact'] : NULL;
         $output['facts']['sources'] = $data->facts['sources'] ? $data->facts['sources'] : NULL;
 
-        $output['solutions'] = $data->solutions;
+        foreach ($data->solutions as $key => $value) {
+          if (!is_array($value)) {
+            $output['solutions'][$key]['raw'] = $value;
+            $output['solutions'][$key]['formatted'] = NULL;
+          } 
+          else {
+            $output['solutions'][$key] = $value; 
+          }
+        }
 
         $output['pre_step'] = $data->pre_step;
 

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -213,7 +213,6 @@ abstract class Transformer {
         $output['time_commitment'] = $data->time_commitment;
 
         foreach ($data->cover_image as $key => $image) {
-
           if (!is_null($image)) {
             $output['cover_image'][$key] = $this->transformMedia($image, 'square');
           } else {

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -232,9 +232,9 @@ abstract class Transformer {
           if (!is_array($value)) {
             $output['solutions'][$key]['raw'] = $value;
             $output['solutions'][$key]['formatted'] = NULL;
-          } 
+          }
           else {
-            $output['solutions'][$key] = $value; 
+            $output['solutions'][$key] = $value;
           }
         }
 

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -228,7 +228,6 @@ abstract class Transformer {
         $output['facts']['solution'] = $data->facts['solution'] ? $data->facts['solution']['fact'] : NULL;
         $output['facts']['sources'] = $data->facts['sources'] ? $data->facts['sources'] : NULL;
 
-        // For Babysitters Club specifically, raw supported_copy brings in the source since that was included in the string. This will be hard to weed out sources.
         foreach ($data->solutions as $key => $value) {
           if (!is_array($value)) {
             $output['solutions'][$key]['raw'] = $value;

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -228,6 +228,7 @@ abstract class Transformer {
         $output['facts']['solution'] = $data->facts['solution'] ? $data->facts['solution']['fact'] : NULL;
         $output['facts']['sources'] = $data->facts['sources'] ? $data->facts['sources'] : NULL;
 
+        // For Babysitters Club specifically, raw supported_copy brings in the source since that was included in the string. This will be hard to weed out sources.
         foreach ($data->solutions as $key => $value) {
           if (!is_array($value)) {
             $output['solutions'][$key]['raw'] = $value;

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -97,7 +97,6 @@ class CampaignTransformer extends Transformer {
    */
   protected function transform($item) {
     $data = [];
-    
     $data += $this->transformCampaign($item);
 
     return $data;

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -97,7 +97,7 @@ class CampaignTransformer extends Transformer {
    */
   protected function transform($item) {
     $data = [];
-
+    
     $data += $this->transformCampaign($item);
 
     return $data;


### PR DESCRIPTION
#### What's this PR do?

Standardizes `['solutions']['copy']` and `['solutions']['support_copy']` to return objects regardless if the format is Markdown or Plain Text. 
#### How should this be manually tested?

Hit endpoint `/api/v1/campaigns/362` and make sure solutions is returns as follows: 

```
solutions: {
  copy: {
    raw: "Instead of trashing old clothes, give them a second life by recycling them. You’ll save water, energy, and landfill space.",
    formatted: "<p>Instead of trashing old clothes, give them a second life by recycling them. You’ll save water, energy, and landfill space.</p> "
  },
  support_copy: {
    raw: "Run a drive at your school to collect recycled clothes and drop them off at your local H&M.",
    formatted: "<p>Run a drive at your school to collect recycled clothes and drop them off at your local H&amp;M.</p> "
  }
},
```
#### What are the relevant tickets?

Fixes #6250 

cc @DFurnes @weerd 
