### PR TITLE
Log all the stars

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.admin.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.admin.inc
@@ -49,5 +49,16 @@ function dosomething_northstar_config_form($form, &$form_state) {
     '#default_value' => variable_get('dosomething_northstar_app_key', 'abc4324'),
   );
 
+  $form['log'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Logging'),
+  ];
+  $form['log']['dosomething_northstar_log'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Log requests and responses.'),
+    '#default_value' => variable_get('dosomething_northstar_log', FALSE),
+    '#description' => t("Logs Northstar activity. This should be disabled on production."),
+  ];
+
   return system_settings_form($form);
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.install
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.install
@@ -38,6 +38,12 @@ function dosomething_northstar_schema() {
         'length' => 255,
         'default' => '',
       ],
+      'fastly_country' => [
+        'description' => 'The Fastly country code',
+        'type' => 'varchar',
+        'length' => 255,
+        'default' => '',
+      ],
       'request_values' => [
         'description' => 'The JSON request made to Northstar',
         'type' => 'varchar',

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.install
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.install
@@ -10,6 +10,53 @@
  */
 function dosomething_northstar_schema() {
   $schema['cache_dosomething_northstar'] = drupal_get_schema_unprocessed('system', 'cache');
+
+  $schema['dosomething_northstar_request_log'] = [
+    'description' => 'Log of requests made to Northstar for debugging.',
+    'fields' => [
+      'uid' => [
+        'description' => 'The user\'s Drupal UID',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ],
+      'op' => [
+        'description' => 'The operation being performed',
+        'type' => 'varchar',
+        'length' => 255,
+        'default' => '',
+      ],
+      'user_lang' => [
+        'description' => 'The user\'s language',
+        'type' => 'varchar',
+        'length' => 255,
+        'default' => '',
+      ],
+      'user_country' => [
+        'description' => 'The user\'s country code',
+        'type' => 'varchar',
+        'length' => 255,
+        'default' => '',
+      ],
+      'request_values' => [
+        'description' => 'The JSON request made to Northstar',
+        'type' => 'varchar',
+        'length' => 5000,
+        'default' => '',
+      ],
+      'response_code' => [
+        'description' => 'The HTTP response code from Northstar',
+        'type' => 'int',
+        'default' => 0,
+      ],
+      'response_values' => [
+        'description' => 'The JSON response from Northstar',
+        'type' => 'varchar',
+        'length' => 5000,
+      ],
+    ],
+  ];
+
   return $schema;
 }
 
@@ -23,4 +70,14 @@ function dosomething_northstar_update_7001() {
     $schema['cache_dosomething_northstar'] = drupal_get_schema_unprocessed('system', 'cache');
     db_create_table('cache_dosomething_northstar', $schema['cache_dosomething_northstar']);
   }
+}
+
+/**
+ * Create a new table "dosomething_northstar_request_log" for logging details of any
+ * Northstar request errors that occur.
+ */
+function dosomething_northstar_update_7002() {
+  $table_name = 'dosomething_northstar_request_log';
+  $schema = dosomething_northstar_schema();
+  db_create_table($table_name, $schema[$table_name]);
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -147,6 +147,25 @@ function dosomething_northstar_update_user($form_state) {
     watchdog('dosomething_northstar', 'User not updated : ' . $response->code, NULL, WATCHDOG_ERROR);
   }
 
+  // Add to request log
+  if(variable_get('dosomething_northstar_log')) {
+    // Don't log plaintext password.
+    if (isset($ns_user['password'])) {
+      $ns_user['password'] = '*****';
+    }
+
+    db_insert('dosomething_northstar_request_log')
+      ->fields([
+        'op' => 'update_user',
+        'uid' => $user->uid,
+        'user_lang' => $user->language,
+        'user_country' => $user->field_address[LANGUAGE_NONE][0]['country'],
+        'request_values' => json_encode($ns_user),
+        'response_code' => $response->code,
+        'response_values' => $response->data,
+      ])
+      ->execute();
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -64,7 +64,9 @@ function dosomething_northstar_verify_user($credentials) {
   // Add to request log
   if(variable_get('dosomething_northstar_log')) {
     // Don't log plaintext password.
-    $credentials['password'] = '*****';
+    if (isset($credentials['password'])) {
+      $credentials['password'] = '*****';
+    }
 
     db_insert('dosomething_northstar_request_log')
       ->fields([

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -179,6 +179,7 @@ function dosomething_northstar_log_request($op, $user, $request_body, $response)
       'uid' => $user->uid,
       'user_lang' => $user->language,
       'user_country' => $user->field_address[LANGUAGE_NONE][0]['country'],
+      'fastly_country' => dosomething_settings_get_geo_country_code(),
       'request_values' => json_encode($request_body),
       'response_code' => $response->code,
       'response_values' => $response->data,

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -52,6 +52,7 @@ function dosomething_northstar_libraries_info() {
  * @return mixed|null
  */
 function dosomething_northstar_verify_user($credentials) {
+  global $user;
   $client = _dosomething_northstar_build_http_client();
 
   $response = drupal_http_request($client['base_url'] . '/auth/verify', [
@@ -59,6 +60,24 @@ function dosomething_northstar_verify_user($credentials) {
     'method' => 'POST',
     'data' => json_encode($credentials),
   ]);
+
+  // Add to request log
+  if(variable_get('dosomething_northstar_log')) {
+    // Don't log plaintext password.
+    $credentials['password'] = '*****';
+
+    db_insert('dosomething_northstar_request_log')
+      ->fields([
+        'op' => 'verify user',
+        'uid' => $user->uid,
+        'user_lang' => $user->language,
+        'user_country' => $user->field_address[LANGUAGE_NONE][0]['country'],
+        'request_values' => json_encode($credentials),
+        'response_code' => $response->code,
+        'response_values' => $response->data,
+      ])
+      ->execute();
+  }
 
   if($response->code !== '200') {
     return null;

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -132,7 +132,6 @@ function dosomething_northstar_update_user($form_state) {
   $id = $user->uid;
   $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
 
-  $northstar = new Northstar();
   $client = _dosomething_northstar_build_http_client();
 
   $response = drupal_http_request($client['base_url'] . '/users/drupal_id/' . $id, array(

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -61,25 +61,8 @@ function dosomething_northstar_verify_user($credentials) {
     'data' => json_encode($credentials),
   ]);
 
-  // Add to request log
-  if(variable_get('dosomething_northstar_log')) {
-    // Don't log plaintext password.
-    if (isset($credentials['password'])) {
-      $credentials['password'] = '*****';
-    }
-
-    db_insert('dosomething_northstar_request_log')
-      ->fields([
-        'op' => 'verify user',
-        'uid' => $user->uid,
-        'user_lang' => $user->language,
-        'user_country' => $user->field_address[LANGUAGE_NONE][0]['country'],
-        'request_values' => json_encode($credentials),
-        'response_code' => $response->code,
-        'response_values' => $response->data,
-      ])
-      ->execute();
-  }
+  // Add to request log if enabled.
+  dosomething_northstar_log_request('verify_user', $user, $credentials, $response);
 
   if($response->code !== '200') {
     return null;
@@ -120,6 +103,8 @@ function dosomething_northstar_register_user($form_state) {
     watchdog('dosomething_northstar', 'User not migrated : ' . $response->code, NULL, WATCHDOG_ERROR);
   }
 
+  // Add to request log if enabled.
+  dosomething_northstar_log_request('register_user', $user, $ns_user, $response);
 }
 
 /**
@@ -168,25 +153,37 @@ function dosomething_northstar_update_user($form_state) {
     watchdog('dosomething_northstar', 'User not updated : ' . $response->code, NULL, WATCHDOG_ERROR);
   }
 
-  // Add to request log
-  if(variable_get('dosomething_northstar_log')) {
-    // Don't log plaintext password.
-    if (isset($ns_user['password'])) {
-      $ns_user['password'] = '*****';
-    }
+  // Add to request log if enabled.
+  dosomething_northstar_log_request('update_user', $user, $ns_user, $response);
+}
 
-    db_insert('dosomething_northstar_request_log')
-      ->fields([
-        'op' => 'update_user',
-        'uid' => $user->uid,
-        'user_lang' => $user->language,
-        'user_country' => $user->field_address[LANGUAGE_NONE][0]['country'],
-        'request_values' => json_encode($ns_user),
-        'response_code' => $response->code,
-        'response_values' => $response->data,
-      ])
-      ->execute();
+/**
+ * If the log is enabled, log this request to the database.
+ *
+ * @param string $op - label for the operation being performed
+ * @param object $user - the Drupal user
+ * @param array $request_body - the body of the request
+ * @param string $response - response JSON
+ */
+function dosomething_northstar_log_request($op, $user, $request_body, $response) {
+  if (!variable_get('dosomething_northstar_log')) return;
+
+  // Don't log plaintext passwords.
+  if (isset($request_body['password'])) {
+    $request_body['password'] = '*****';
   }
+
+  db_insert('dosomething_northstar_request_log')
+    ->fields([
+      'op' => $op,
+      'uid' => $user->uid,
+      'user_lang' => $user->language,
+      'user_country' => $user->field_address[LANGUAGE_NONE][0]['country'],
+      'request_values' => json_encode($request_body),
+      'response_code' => $response->code,
+      'response_values' => $response->data,
+    ])
+    ->execute();
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?

Hello Drupal, my old friend. This PR adds request logging for Northstar update/verify requests, in the hopes that we can figure out why so many users can't be mock authenticated. :mag: 
#### How should this be manually tested?

If you want to pull this branch down to your local and run the ol' `drush updb -y`, any attempts to login or update your profile should log the corresponding Northstar requests to the `dosomething_northstar_request_log` table. Like so:

![screen shot 2016-03-11 at 10 50 11 am](https://cloud.githubusercontent.com/assets/583202/13707315/13748f5c-e777-11e5-97da-ded033e8c723.png)
#### Any background context you want to provide?

Nah. See the relevant ticket below.
#### What are the relevant tickets?

References #6260.

---

For review: @angaither 
