### PR TITLE
checks to see if language is published before adding the altnernate link

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -5,10 +5,14 @@
  */
 function paraneue_dosomething_preprocess_node(&$vars) {
   $regional_url_data = paraneue_dosomething_get_regional_url_data($vars['node']);
+  $campaign = node_load($vars['node']->nid);
+  $languages = $campaign->translations->data;
 
   if ($regional_url_data) {
     foreach ($regional_url_data as $language => $url) {
-      drupal_add_html_head_link(['rel' => 'alternate', 'hreflang' => $language, 'href' => $url]);
+      if ($languages[$language]['status'] == 1) {
+        drupal_add_html_head_link(['rel' => 'alternate', 'hreflang' => $language, 'href' => $url]);
+      }
     }
   }
 


### PR DESCRIPTION
#### What's this PR do?

Checks if a translation is published before adding an alternate hreflang translation link. 
#### How should this be manually tested?

As an anonymous user:
1. Load the original (published) URL, e.g., https://www.dosomething.org/campaigns/not-stuck-traffick.
2. View source
3. There should be no cases one rel="alternate" markup in the source since only English and English, Global translations are published. e.g., <link rel="alternate" hreflang="es-mx" href="https://www.dosomething.org/mx/voluntario/sin-atarcarse-en-el-tráfico" />
#### What are the relevant tickets?

Fixes #6209
