### PR TITLE
changes code to 404 if no campaigns are found

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -51,6 +51,7 @@ class Campaign {
     $results = node_load_multiple($ids);
 
     if (!$results) {
+      http_response_code(404);
       throw new Exception('No campaign data found.');
     }
 


### PR DESCRIPTION
#### What's this PR do?

Changes status code to a 404 if a campaign does not exists from the `campaigns/:id` endpoint. 
#### How should this be manually tested?

In postman or paw, hit `/campaigns/abc` and the response code should be a 404 along with the error message. 
#### What are the relevant tickets?

Fixes #6261 
