### PR TITLE
Signups API - Join bug on Reportbacks and Drupal Logs

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -355,7 +355,7 @@ abstract class Transformer {
       $output['flagged'] = $data->flagged;
 
       try {
-        $items = ReportbackItem::get($data->reportback_items, FALSE);
+        $items = ReportbackItem::get($data->reportback_items);
         $items = services_resource_build_index_list($items, 'reportback-items', 'id');
       }
       catch (Exception $error) {

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -355,7 +355,7 @@ abstract class Transformer {
       $output['flagged'] = $data->flagged;
 
       try {
-        $items = ReportbackItem::get($data->reportback_items);
+        $items = ReportbackItem::get($data->reportback_items, FALSE);
         $items = services_resource_build_index_list($items, 'reportback-items', 'id');
       }
       catch (Exception $error) {

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -163,7 +163,7 @@ class Reportback extends Entity {
       $northstar_response = dosomething_northstar_get_northstar_user($data->uid);
       $northstar_response = json_decode($northstar_response);
 
-      if ($northstar_response && !isset($northstar_response->error)) {
+      if (!empty($northstar_response->data) && !isset($northstar_response->error)) {
         $northstar_user = $northstar_response->data;
       }
     }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -112,7 +112,7 @@ class ReportbackItem extends Entity {
       $northstar_response = dosomething_northstar_get_northstar_user($data->uid);
       $northstar_response = json_decode($northstar_response);
 
-      if ($northstar_response && !isset($northstar_response->error)) {
+      if (!empty($northstar_response->data) && !isset($northstar_response->error)) {
         $northstar_user = $northstar_response->data;
       }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -53,7 +53,7 @@ function dosomething_signup_get_signups_query($params, $tally = FALSE) {
  */
 function dosomething_signup_build_signups_query($params = []) {
   $query = db_select('dosomething_signup', 's');
-  $query->leftJoin('dosomething_reportback', 'rb', 's.uid = rb.uid and s.nid = rb.nid'); 
+  $query->leftJoin('dosomething_reportback', 'rb', 's.uid = rb.uid and s.nid = rb.nid and s.run_nid = rb.run_nid'); 
   $query->fields('s', ['sid', 'uid', 'nid', 'run_nid', 'timestamp']);
   $query->fields('rb', ['rbid']);
 


### PR DESCRIPTION
#### What's this PR do?

Changed the query to make sure that campaign runs also equal each other, not just campaign nodes. 
Added more explicit check to make sure `!empty($northstar_response->data)` to get rid of db logs. 
#### How should this be manually tested?

Make sure that each signup has a unique Reportback ID.  (can use https://www.dosomething.org/api/v1/signups?user=1176550&campaigns=362 in prod)
#### What are the relevant tickets?

Fixes #6266
