### PR TITLE
Fixes SMS game active view

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -49,7 +49,6 @@ function dosomething_campaign_preprocess_node(&$vars) {
     }
     // Preprocess the vars for the campaign action page.
     dosomething_campaign_preprocess_action_page($vars, $wrapper);
-
     return;
   }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -44,8 +44,9 @@ function dosomething_campaign_preprocess_node(&$vars) {
   // @see dosomething_campaign_menu().
   $active_path = 'node/' . $node->nid . '/active';
   if ($current_path == $active_path) {
-    if(dosomething_campaign_get_campaign_type($node) == 'sms_game') {
+    if(dosomething_campaign_get_campaign_type($node) === 'sms_game') {
       dosomething_campaign_preprocess_sms_game($vars, $wrapper);
+      return;
     }
     // Preprocess the vars for the campaign action page.
     dosomething_campaign_preprocess_action_page($vars, $wrapper);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -44,8 +44,12 @@ function dosomething_campaign_preprocess_node(&$vars) {
   // @see dosomething_campaign_menu().
   $active_path = 'node/' . $node->nid . '/active';
   if ($current_path == $active_path) {
+    if(dosomething_campaign_get_campaign_type($node) == 'sms_game') {
+      dosomething_campaign_preprocess_sms_game($vars, $wrapper);
+    }
     // Preprocess the vars for the campaign action page.
     dosomething_campaign_preprocess_action_page($vars, $wrapper);
+
     return;
   }
 


### PR DESCRIPTION
#### What's this PR do?

Fixes SMS game active view to show up as an SMS game and not a regular campaign.
#### How should this be manually tested?

As an admin, go to a closed SMS campaign and go into the active view. It should show up like an SMS game and not a campaign. It should only be calling the `dosomething_campaign_preprocess_sms_game` if you are on the active path so I don't think it should be messing anything else up.
#### Any background context you want to provide?

I made the fix that @aaronschachter suggested in the issue and it seems to work.
#### What are the relevant tickets?

Fixes #4488 
