### PR TITLE
adds 404 error code when error is thrown in campaign.php, signup.php,…

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -90,6 +90,7 @@ class Campaign {
     $results = dosomething_campaign_get_campaigns_query($filters);
 
     if (!$results) {
+      http_response_code(404);
       throw new Exception('No campaign data found.');
     }
 

--- a/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
@@ -45,6 +45,7 @@ class Kudos extends Entity {
     $results = entity_load('kudos', $ids);
 
     if (!$results) {
+      http_response_code(404);
       throw new Exception('No kudos data found.');
     }
 
@@ -72,6 +73,7 @@ class Kudos extends Entity {
     $results = entity_load('kudos', $results);
 
     if (!$results) {
+      http_response_code(404);
       throw new Exception('No kudos data found.');
     }
 

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -42,6 +42,7 @@ class Signup extends Entity {
     $results = dosomething_signup_get_signups_query(['sid' => $ids]);
 
     if (!$results) {
+      http_response_code('404');
       throw new Exception('No signup data found.');
     }
 
@@ -67,6 +68,7 @@ class Signup extends Entity {
     $results = dosomething_signup_get_signups_query($filters);
 
     if (!$results) {
+      http_response_code('404');
       throw new Exception('No signup data found.');
     }
 


### PR DESCRIPTION
#### What's this PR do?

Adds `404` response code when no campaign, signup, or kudos data is found. 
#### How should this be manually tested?

Hit any of the below endpoints to make sure the status code if a `404 Not Found`
#### What are the relevant tickets?

Fixes #6261 

… and kudos.php
