### PR TITLE
Fix issue where database update hooks were stuck on 7002.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.install
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.install
@@ -84,6 +84,8 @@ function dosomething_northstar_update_7001() {
  */
 function dosomething_northstar_update_7002() {
   $table_name = 'dosomething_northstar_request_log';
-  $schema = dosomething_northstar_schema();
-  db_create_table($table_name, $schema[$table_name]);
+  if (!db_table_exists($table_name)) {
+    $schema = dosomething_northstar_schema();
+    db_create_table($table_name, $schema[$table_name]);
+  }
 }


### PR DESCRIPTION
#### What's this PR do?

Only runs `dosomething_northstar_update_7002` if the table doesn't already exist, because Drupal was very insistently trying to recreate it otherwise!
#### How should this be manually tested?

If you're having trouble running this migration, y'know try to run it with _this_ code.
#### What are the relevant tickets?

Fixes #6272.

---

For review: @angaither 
