### PR TITLE
Remove code that updates a signup run if no signup on the current run…

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -357,33 +357,8 @@ function dosomething_signup_exists($nid, $run_nid = NULL, $uid = NULL, $presignu
   }
   $sid = $result->fetchField();
 
-  // If not see if they are signed up for the campaign without the run.
-  // This section is added to test for duplicate signup problems.
-  // Refs #6095.
-  if (!is_numeric($sid) && !$presignup) {
-     $result = db_select('dosomething_signup', 's')
-      ->condition('uid', $uid)
-      ->condition('nid', $nid)
-      ->fields('s', array('sid'))
-      ->execute();
-      $running_free = TRUE;
-
-    $sid = $result->fetchField();
-  }
-
   // If a sid was found, return it.
   if (is_numeric($sid)) {
-
-    // If this was a node without a run, add that in.
-    // This section is also added to fix creating duplicate signups.
-    // Refs #6095.
-    if (isset($running_free)) {
-      $query = db_update('dosomething_signup')
-               ->fields(['run_nid' => $run_nid])
-               ->condition('sid', $sid)
-               ->execute();
-    }
-
     return $sid;
   }
 


### PR DESCRIPTION
#### What's this PR do?

removes code introduced in #6098 
#### How should this be manually tested?

lord. don't get me started.
it's difficult. see background context.
you basically just need to test that signing up still works.
#### Any background context you want to provide?

This was added in to support #6095 when signup run ids were null or 0
But our main man, sharron, found a crazy bug that this causes.
Essentially if you signup for a campaign, but don't reportback
We close the campaign
Open the campaign with a new run
Go to view the campaign with from the doing section on your profile
The signup you had for the previous run, will get updated to the current run.
#### What are the relevant tickets?

Fixes #6269
