### PR TITLE
Moves 404 error codes to Transformer level

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -51,7 +51,6 @@ class Campaign {
     $results = node_load_multiple($ids);
 
     if (!$results) {
-      http_response_code(404);
       throw new Exception('No campaign data found.');
     }
 

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -40,6 +40,7 @@ class CampaignTransformer extends Transformer {
     }
     catch (Exception $error) {
       // @TODO: Potentially log error to watchdog.
+      http_response_code('404');
       return [
         'data' => [],
       ];
@@ -77,6 +78,7 @@ class CampaignTransformer extends Transformer {
       $campaign = array_pop($campaign);
     }
     catch (Exception $error) {
+      http_response_code('404');
       return [
         'error' => [
           'message' => $error->getMessage(),

--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -40,7 +40,6 @@ class CampaignTransformer extends Transformer {
     }
     catch (Exception $error) {
       // @TODO: Potentially log error to watchdog.
-      http_response_code('404');
       return [
         'data' => [],
       ];

--- a/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
@@ -23,7 +23,6 @@ class KudosTransformer extends Transformer {
       $kudos = services_resource_build_index_list($kudos, 'kudos', 'id');
     }
     catch (Exception $error) {
-      http_response_code('404');
       return [
         'error' => [
           'message' => $error->getMessage(),

--- a/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
@@ -23,6 +23,7 @@ class KudosTransformer extends Transformer {
       $kudos = services_resource_build_index_list($kudos, 'kudos', 'id');
     }
     catch (Exception $error) {
+      http_response_code('404');
       return [
         'error' => [
           'message' => $error->getMessage(),
@@ -52,6 +53,7 @@ class KudosTransformer extends Transformer {
       $kudos = services_resource_build_index_list($kudos, 'kudos', 'id');
     }
     catch (Exception $error) {
+      http_response_code('404');
       return [
         'error' => [
           'message' => $error->getMessage(),

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -99,7 +99,7 @@ class ReportbackItem extends Entity {
       'uri' => dosomething_image_get_themed_image_url_by_fid($data->fid, '480x480'),
       'type' => 'image',
     ];
-    // $this->kudos = dosomething_helpers_format_data($data->kids);
+    $this->kudos = dosomething_helpers_format_data($data->kids);
     $this->reportback = [
       'id' => $data->rbid,
       'created_at' => $data->created,

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -99,7 +99,7 @@ class ReportbackItem extends Entity {
       'uri' => dosomething_image_get_themed_image_url_by_fid($data->fid, '480x480'),
       'type' => 'image',
     ];
-    $this->kudos = dosomething_helpers_format_data($data->kids);
+    // $this->kudos = dosomething_helpers_format_data($data->kids);
     $this->reportback = [
       'id' => $data->rbid,
       'created_at' => $data->created,

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -18,6 +18,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
     }
     catch (Exception $error) {
       // @TODO: Potentially log error to watchdog.
+      http_response_code('404');
       return [
         'data' => [],
       ];
@@ -44,6 +45,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
       $reportbackItem = services_resource_build_index_list($reportbackItem, 'reportback-items', 'id');
     }
     catch (Exception $error) {
+      http_response_code('404');
       return [
         'error' => [
           'message' => $error->getMessage(),

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -18,7 +18,6 @@ class ReportbackItemTransformer extends ReportbackTransformer {
     }
     catch (Exception $error) {
       // @TODO: Potentially log error to watchdog.
-      http_response_code('404');
       return [
         'data' => [],
       ];

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -28,7 +28,6 @@ class ReportbackTransformer extends Transformer {
     }
     catch (Exception $error) {
       // @TODO: Potentially log error to watchdog.
-      http_response_code('404');
       return [
         'data' => [],
       ];

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -28,6 +28,7 @@ class ReportbackTransformer extends Transformer {
     }
     catch (Exception $error) {
       // @TODO: Potentially log error to watchdog.
+      http_response_code('404');
       return [
         'data' => [],
       ];
@@ -54,6 +55,7 @@ class ReportbackTransformer extends Transformer {
       $reportback = array_pop($reportback);
     }
     catch (Exception $error) {
+      http_response_code('404');
       return [
         'error' => [
           'message' => $error->getMessage(),

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -26,7 +26,6 @@ class SignupTransformer extends Transformer {
       $total = $this->getTotalCount($filters);
     }
     catch (Exception $error) {
-      http_response_code('404');
       return [
         'data' => [],
       ];

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -26,6 +26,7 @@ class SignupTransformer extends Transformer {
       $total = $this->getTotalCount($filters);
     }
     catch (Exception $error) {
+      http_response_code('404');
       return [
         'data' => [],
       ];
@@ -52,6 +53,7 @@ class SignupTransformer extends Transformer {
       $signup = array_pop($signup);
     }
     catch (Exception $error) {
+      http_response_code('404');
       return [
         'error' => [
           'message' => $error->getMessage(),


### PR DESCRIPTION
#### What's this PR do?

Sets 404 error codes at the transformer level.
#### How should this be manually tested?

Hit the below endpoints to make sure everything returns a 404 status code. 
`/signups/z`
`/kudos/z`
`/reportbacks/z`
`/reportback-items/z`
`/campaigns/z`

Also ensure that hitting `/signups` returns a 200 status code.
#### Any background context you want to provide?

Refs https://github.com/DoSomething/northstar/issues/313
Found the above bug returning a signup object but throwing a 404 status code because there was a signup but couldn't find a kudos associated with the reportback. This informed us to move status codes to transformer level. 
#### What are the relevant tickets?

Fixes #6261 and fixes 404 error code in #6274 - 403 error code fix to come in separate PR.
