### PR TITLE
Set the source to phoenix if it's not set on the profile.

### DIFF
--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -82,5 +82,12 @@ function build_northstar_user($user) {
       $ns_user[$ns_key] = $field[$drupal_key]['value'];
     }
   }
+
+  // Set the "source" for this user to Phoenix if they weren't
+  // programmatically created through the API.
+  if(empty($ns_user['source'])) {
+    $ns_user['source'] = 'phoenix';
+  }
+
   return $ns_user;
 }


### PR DESCRIPTION
#### What's this PR do?

When performing a manual sync of Phoenix users into Northstar, set their `source` to be `phoenix` if it's not set on that profile (e.g. Niche users have `niche-import-service` set for this field).
#### How should this be manually tested?

Run `drush --script-path=../scripts/ php-script export-users-to-northstar.php` and you should see all of your local Drupal users saved into Northstar with their `source` field set to "phoenix" or "niche-import-service" or something like that.

Running this multiple times shouldn't create duplicates or explode or anything.
#### Any background context you want to provide?

See DoSomething/northstar#315 for some updates being made on that end.
#### What are the relevant tickets?

See #6260.

---

For review: @angaither 
