### PR TITLE
Updated gladiator response value type to a medium text.

### DIFF
--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.install
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.install
@@ -94,7 +94,7 @@ function dosomething_gladiator_update_7002(&$sandbox) {
 }
 
 /**
- * Update response values to be a long text field, as the response is LONG.
+ * Update response values to be a medium text field, as the response is medium-long.
  */
 function dosomething_gladiator_update_7003(&$sandbox) {
   $field = 'response_values';

--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.install
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.install
@@ -49,14 +49,16 @@ function dosomething_gladiator_schema() {
         'default' => 0,
       ),
       'response_code' => array(
-        'description' => 'The HTTP response code from Northstar',
+        'description' => 'The HTTP response code from Gladiator',
         'type' => 'int',
         'default' => 0,
       ),
       'response_values' => array(
-        'description' => 'The JSON response from Northstar',
-        'type' => 'varchar',
-        'length' => 5000,
+        'description' => 'The JSON response from Gladiator',
+        'type' => 'text',
+        'length' => '500000',
+        'not null' => FALSE,
+        'default' => NULL,
       ),
     ),
     'primary key' => array('id'),
@@ -89,4 +91,21 @@ function dosomething_gladiator_update_7002(&$sandbox) {
       db_add_field($table, $field, $schema[$table]['fields'][$field]);
     }
   }
+}
+
+/**
+ * Update response values to be a long text field, as the response is LONG.
+ */
+function dosomething_gladiator_update_7003(&$sandbox) {
+  $field = 'response_values';
+  $table = 'dosomething_gladiator_failed_task_log';
+  // Update the field to a large text.
+  db_change_field($table, $field, $field, array(
+    'description' => 'The JSON response from Gladiator',
+    'type' => 'text',
+    'length' => '500000',
+    'not null' => FALSE,
+    'default' => NULL,
+    )
+  );
 }


### PR DESCRIPTION
#### What's this PR do?

Updated `response values` from a varchar to a medium text
#### How should this be manually tested?

run `drush updb -y`
#### Any background context you want to provide?

Users weren't getting added to the `failed_log` table because the response was too large for a `varchar` col, doi
#### What are the relevant tickets?

Refs #6283
