### PR TITLE
Reportback 403

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
@@ -107,8 +107,8 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
  * @return object
  *   An executed database query object to iterate through.
  */
-function dosomething_reportback_get_reportbacks_query($params, $load_all = FALSE) {
-  $params = dosomething_reportback_filter_flagged_reportbacks($params, $load_all);
+function dosomething_reportback_get_reportbacks_query($params, $include_flagged = FALSE) {
+  $params = dosomething_reportback_filter_flagged_reportbacks($params, $include_flagged);
 
   $query = dosomething_reportback_build_reportbacks_query($params);
   $offset = dosomething_helpers_isset($params, 'offset', 0);
@@ -130,7 +130,7 @@ function dosomething_reportback_get_reportbacks_query($params, $load_all = FALSE
  * @param  array  $params
  * @return mixed
  */
-function dosomething_reportback_filter_flagged_reportbacks($params, $load_all) {
+function dosomething_reportback_filter_flagged_reportbacks($params, $include_flagged) {
   if (user_access('view any reportback')) {
     if (isset($params['flagged'])) {
       unset($params['flagged']);
@@ -139,7 +139,7 @@ function dosomething_reportback_filter_flagged_reportbacks($params, $load_all) {
     return $params;
   }
 
-  if ($load_all) {
+  if ($include_flagged) {
     $params['flagged'] = TRUE;
   } 
   else {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
@@ -131,7 +131,7 @@ function dosomething_reportback_accessible_results ($results) {
   }
   else {
     foreach ($results as $key => $reportback) {
-      if ($reportback->flagged == 1) {
+      if ($reportback->flagged === 1) {
         unset($results[$key]);
       }
     }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
@@ -107,8 +107,8 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
  * @return object
  *   An executed database query object to iterate through.
  */
-function dosomething_reportback_get_reportbacks_query($params, $include_flagged = FALSE) {
-  $params = dosomething_reportback_filter_flagged_reportbacks($params, $include_flagged);
+function dosomething_reportback_get_reportbacks_query($params) {
+  // $params = dosomething_reportback_filter_flagged_reportbacks($params, $include_flagged);
 
   $query = dosomething_reportback_build_reportbacks_query($params);
   $offset = dosomething_helpers_isset($params, 'offset', 0);
@@ -123,30 +123,26 @@ function dosomething_reportback_get_reportbacks_query($params, $include_flagged 
   return $result;
 }
 
-
 /**
- * Filter out requested flagged Reportbacks based on user permissions.
- *
- * @param  array  $params
- * @return mixed
+ * Determine if user has access to flagged Reportbacks based on user permission. 
+ * @param array $results
  */
-function dosomething_reportback_filter_flagged_reportbacks($params, $include_flagged) {
+function dosomething_reportback_accessible_results ($results) {
   if (user_access('view any reportback')) {
-    if (isset($params['flagged'])) {
-      unset($params['flagged']);
+    return $results;
+  }
+  else {
+    foreach ($results as $key => $reportback) {
+      if ($reportback->flagged == 1) {
+        unset($results[$key]);
+      }
     }
 
-    return $params;
+    if (!$results) {
+      return FALSE;
+    }
+    else {
+      return $results;
+    }
   }
-
-  if ($include_flagged) {
-    $params['flagged'] = TRUE;
-  } 
-  else {
-    // Only show reviewed and/or un-flagged Reportbacks.
-    $params['flagged'] = FALSE;
-  }
-
-  return $params;
 }
-

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
@@ -108,8 +108,6 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
  *   An executed database query object to iterate through.
  */
 function dosomething_reportback_get_reportbacks_query($params) {
-  // $params = dosomething_reportback_filter_flagged_reportbacks($params, $include_flagged);
-
   $query = dosomething_reportback_build_reportbacks_query($params);
   $offset = dosomething_helpers_isset($params, 'offset', 0);
   $count = dosomething_helpers_isset($params, 'count', 25);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
@@ -107,8 +107,8 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
  * @return object
  *   An executed database query object to iterate through.
  */
-function dosomething_reportback_get_reportbacks_query($params) {
-  $params = dosomething_reportback_filter_flagged_reportbacks($params);
+function dosomething_reportback_get_reportbacks_query($params, $load_all = FALSE) {
+  $params = dosomething_reportback_filter_flagged_reportbacks($params, $load_all);
 
   $query = dosomething_reportback_build_reportbacks_query($params);
   $offset = dosomething_helpers_isset($params, 'offset', 0);
@@ -130,7 +130,7 @@ function dosomething_reportback_get_reportbacks_query($params) {
  * @param  array  $params
  * @return mixed
  */
-function dosomething_reportback_filter_flagged_reportbacks($params) {
+function dosomething_reportback_filter_flagged_reportbacks($params, $load_all) {
   if (user_access('view any reportback')) {
     if (isset($params['flagged'])) {
       unset($params['flagged']);
@@ -139,8 +139,13 @@ function dosomething_reportback_filter_flagged_reportbacks($params) {
     return $params;
   }
 
-  // Only show reviewed and/or un-flagged Reportbacks.
-  $params['flagged'] = FALSE;
+  if ($load_all) {
+    $params['flagged'] = TRUE;
+  } 
+  else {
+    // Only show reviewed and/or un-flagged Reportbacks.
+    $params['flagged'] = FALSE;
+  }
 
   return $params;
 }

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -92,6 +92,7 @@ class Reportback extends Entity {
 
     $results = dosomething_reportback_get_reportbacks_query(['rbid' => $ids]);
 
+
     if (!user_access('administer modules') && !$results) {
       $results = dosomething_reportback_get_reportbacks_query(['rbid' => $ids], TRUE);
       
@@ -100,7 +101,8 @@ class Reportback extends Entity {
         throw new Exception('Access denied.');
       }
     }
-    else if (!$results) {
+   
+   if (!$results) {
       throw new Exception('No reportback data found.');
     }
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -101,7 +101,7 @@ class Reportback extends Entity {
       }
     }
    
-   if (!$results) {
+    if (!$results) {
       throw new Exception('No reportback data found.');
     }
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -92,16 +92,12 @@ class Reportback extends Entity {
 
     $results = dosomething_reportback_get_reportbacks_query(['rbid' => $ids]);
 
-    if (!user_access('administer modules') && !$results) {
-      $results = dosomething_reportback_get_reportbacks_query(['rbid' => $ids], TRUE);
-
-      if ($results) {
-        throw new Exception('Access denied.');
-      }
-    }
-
     if (!$results) {
       throw new Exception('No reportback data found.');
+    }
+
+    if (!dosomething_reportback_accessible_results($results)) {
+      throw new Exception('Access denied.');
     }
 
     foreach($results as $item) {

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -97,7 +97,6 @@ class Reportback extends Entity {
       $results = dosomething_reportback_get_reportbacks_query(['rbid' => $ids], TRUE);
       
       if ($results) {
-        http_response_code(403);
         throw new Exception('Access denied.');
       }
     }

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -94,12 +94,12 @@ class Reportback extends Entity {
 
     if (!user_access('administer modules') && !$results) {
       $results = dosomething_reportback_get_reportbacks_query(['rbid' => $ids], TRUE);
-      
+
       if ($results) {
         throw new Exception('Access denied.');
       }
     }
-   
+
     if (!$results) {
       throw new Exception('No reportback data found.');
     }

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -92,7 +92,15 @@ class Reportback extends Entity {
 
     $results = dosomething_reportback_get_reportbacks_query(['rbid' => $ids]);
 
-    if (!$results) {
+    if (!user_access('administer modules') && !$results) {
+      $results = dosomething_reportback_get_reportbacks_query(['rbid' => $ids], TRUE);
+      
+      if ($results) {
+        http_response_code(403);
+        throw new Exception('Access denied.');
+      }
+    }
+    else if (!$results) {
       throw new Exception('No reportback data found.');
     }
 
@@ -121,9 +129,18 @@ class Reportback extends Entity {
   public static function find(array $filters = []) {
     $reportbacks = [];
 
+    // What if there are results that are returned but not all results are returned since flagged will not be included. Is this mis-leading? 
     $results = dosomething_reportback_get_reportbacks_query($filters);
 
-    if (!$results) {
+    if (!user_access('administer modules') && !$results) {
+      $results = dosomething_reportback_get_reportbacks_query($filters, TRUE);
+      
+      if ($results) {
+        http_response_code(403);
+        throw new Exception('Access denied.');
+      }
+    }
+    else if (!$results) {
       throw new Exception('No reportback data found.');
     }
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -129,17 +129,9 @@ class Reportback extends Entity {
   public static function find(array $filters = []) {
     $reportbacks = [];
 
-    // What if there are results that are returned but not all results are returned since flagged will not be included. Is this mis-leading? 
     $results = dosomething_reportback_get_reportbacks_query($filters);
 
-    if (!user_access('administer modules') && !$results) {
-      $results = dosomething_reportback_get_reportbacks_query($filters, TRUE);
-      
-      if ($results) {
-        throw new Exception('Access denied.');
-      }
-    }
-    else if (!$results) {
+    if (!$results) {
       throw new Exception('No reportback data found.');
     }
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -92,7 +92,6 @@ class Reportback extends Entity {
 
     $results = dosomething_reportback_get_reportbacks_query(['rbid' => $ids]);
 
-
     if (!user_access('administer modules') && !$results) {
       $results = dosomething_reportback_get_reportbacks_query(['rbid' => $ids], TRUE);
       

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -137,7 +137,6 @@ class Reportback extends Entity {
       $results = dosomething_reportback_get_reportbacks_query($filters, TRUE);
       
       if ($results) {
-        http_response_code(403);
         throw new Exception('Access denied.');
       }
     }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -44,8 +44,9 @@ class ReportbackItem extends Entity {
     if (!$results) {
       throw new Exception('No reportback items data found.');
     }
-
+    
     foreach($results as $item) {
+
       $reportbackItem = new static;
       $reportbackItem->build($item, TRUE);
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -44,7 +44,7 @@ class ReportbackItem extends Entity {
     if (!$results) {
       throw new Exception('No reportback items data found.');
     }
-    
+
     foreach($results as $item) {
       $reportbackItem = new static;
       $reportbackItem->build($item, TRUE);

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -46,7 +46,6 @@ class ReportbackItem extends Entity {
     }
     
     foreach($results as $item) {
-
       $reportbackItem = new static;
       $reportbackItem->build($item, TRUE);
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -159,7 +159,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
 
     foreach ($data as $index => $item) {
       if (!in_array($item->status, $this->accessibleStatuses) && $one_rb_item) {
-        throw new Exception('Access denied.');  
+        throw new Exception('Access denied.');
       }
       elseif (!in_array($item->status, $this->accessibleStatuses)) {
         unset($data[$index]);

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -40,17 +40,8 @@ class ReportbackItemTransformer extends ReportbackTransformer {
   public function show($id) {
     try {
       $reportbackItem = ReportbackItem::get($id);
-
-      if (!user_access('administer modules')) {
-        $reportbackItem = $this->removeUnauthorizedResults($reportbackItem);
-      }
-
-      if ($reportbackItem) {
-        $reportbackItem = services_resource_build_index_list($reportbackItem, 'reportback-items', 'id');
-      } else {
-        throw new Exception('Access denied.');
-      }
-
+      $reportbackItem = $this->removeUnauthorizedResults($reportbackItem);
+      $reportbackItem = services_resource_build_index_list($reportbackItem, 'reportback-items', 'id');
     }
     catch (Exception $error) {
       if ($error->getMessage() === 'Access denied.') {
@@ -158,6 +149,10 @@ class ReportbackItemTransformer extends ReportbackTransformer {
    * @throws Exception
    */
   private function removeUnauthorizedResults($data) {
+    if (!$data) {
+      throw new Exception('No reportback items data found.');
+    }
+
     if (user_access('view any reportback')) {
       return $data;
     }
@@ -168,11 +163,8 @@ class ReportbackItemTransformer extends ReportbackTransformer {
       }
     }
 
-    if (!$data) {
-      return FALSE;
-    }
-    else {
-      return $data;
+    if(!$data) {
+      throw new Exception('Access denied.');
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -45,7 +45,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
         $reportbackItem = $this->removeUnauthorizedResults($reportbackItem, TRUE);
       }
 
-      // $reportbackItem = services_resource_build_index_list($reportbackItem, 'reportback-items', 'id');
+      $reportbackItem = services_resource_build_index_list($reportbackItem, 'reportback-items', 'id');
     }
     catch (Exception $error) {
       if ($error->getMessage() === 'Access denied.') {

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -42,10 +42,15 @@ class ReportbackItemTransformer extends ReportbackTransformer {
       $reportbackItem = ReportbackItem::get($id);
 
       if (!user_access('administer modules')) {
-        $reportbackItem = $this->removeUnauthorizedResults($reportbackItem, TRUE);
+        $reportbackItem = $this->removeUnauthorizedResults($reportbackItem);
       }
 
-      $reportbackItem = services_resource_build_index_list($reportbackItem, 'reportback-items', 'id');
+      if ($reportbackItem) {
+        $reportbackItem = services_resource_build_index_list($reportbackItem, 'reportback-items', 'id');
+      } else {
+        throw new Exception('Access denied.');
+      }
+
     }
     catch (Exception $error) {
       if ($error->getMessage() === 'Access denied.') {
@@ -152,25 +157,22 @@ class ReportbackItemTransformer extends ReportbackTransformer {
    * @return mixed
    * @throws Exception
    */
-  private function removeUnauthorizedResults($data, $one_rb_item = FALSE) {
+  private function removeUnauthorizedResults($data) {
     if (user_access('view any reportback')) {
       return $data;
     }
 
     foreach ($data as $index => $item) {
-      if (!in_array($item->status, $this->accessibleStatuses) && $one_rb_item) {
-        throw new Exception('Access denied.');
-      }
-      elseif (!in_array($item->status, $this->accessibleStatuses)) {
+      if (!in_array($item->status, $this->accessibleStatuses)) {
         unset($data[$index]);
       }
     }
 
     if (!$data) {
-      throw new Exception('No reportback items data found.');
+      return FALSE;
     }
-
-    return $data;
+    else {
+      return $data;
+    }
   }
-
 }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -40,7 +40,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
   public function show($id) {
     try {
       $reportbackItem = ReportbackItem::get($id);
-  
+
       if (!user_access('administer modules')) {
         $reportbackItem = $this->removeUnauthorizedResults($reportbackItem, TRUE);
       }
@@ -50,11 +50,11 @@ class ReportbackItemTransformer extends ReportbackTransformer {
     catch (Exception $error) {
       if ($error->getMessage() === 'Access denied.') {
         http_response_code('403');
-      } 
+      }
       else {
         http_response_code('404');
       }
-      
+
       return [
         'error' => [
           'message' => $error->getMessage(),
@@ -159,9 +159,9 @@ class ReportbackItemTransformer extends ReportbackTransformer {
 
     foreach ($data as $index => $item) {
       if (!in_array($item->status, $this->accessibleStatuses) && $one_rb_item) {
-        throw new Exception('Access denied.');      
+        throw new Exception('Access denied.');  
       }
-      else if (!in_array($item->status, $this->accessibleStatuses)) {
+      elseif (!in_array($item->status, $this->accessibleStatuses)) {
         unset($data[$index]);
       }
     }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -82,9 +82,6 @@ class ReportbackTransformer extends Transformer {
   protected function transform($item) {
     $data = [];
 
-    print_r($item);
-    die();
-
     $data += $this->transformReportback($item);
 
     $data['campaign'] = $this->transformCampaign((object) $item->campaign);

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -27,8 +27,6 @@ class ReportbackTransformer extends Transformer {
       $total = $this->getTotalCount($filters);
     }
     catch (Exception $error) {
-      print_r($error->getMessage());
-      die();
       // @TODO: Potentially log error to watchdog.
       return [
         'data' => [],

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -27,6 +27,8 @@ class ReportbackTransformer extends Transformer {
       $total = $this->getTotalCount($filters);
     }
     catch (Exception $error) {
+      print_r($error->getMessage());
+      die();
       // @TODO: Potentially log error to watchdog.
       return [
         'data' => [],

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -54,7 +54,12 @@ class ReportbackTransformer extends Transformer {
       $reportback = array_pop($reportback);
     }
     catch (Exception $error) {
-      http_response_code('404');
+      if (http_response_code('403')) {
+        http_response_code('403');
+      } 
+      else {
+        http_response_code('404');
+      }
       return [
         'error' => [
           'message' => $error->getMessage(),

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -56,11 +56,10 @@ class ReportbackTransformer extends Transformer {
     catch (Exception $error) {
       if ($error->getMessage() === 'Access denied.') {
         http_response_code('403');
-      } 
+      }
       else {
         http_response_code('404');
       }
-
       return [
         'error' => [
           'message' => $error->getMessage(),

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -82,6 +82,9 @@ class ReportbackTransformer extends Transformer {
   protected function transform($item) {
     $data = [];
 
+    print_r($item);
+    die();
+
     $data += $this->transformReportback($item);
 
     $data['campaign'] = $this->transformCampaign((object) $item->campaign);

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -54,12 +54,13 @@ class ReportbackTransformer extends Transformer {
       $reportback = array_pop($reportback);
     }
     catch (Exception $error) {
-      if (http_response_code('403')) {
+      if ($error->getMessage() === 'Access denied.') {
         http_response_code('403');
       } 
       else {
         http_response_code('404');
       }
+
       return [
         'error' => [
           'message' => $error->getMessage(),


### PR DESCRIPTION
#### What's this PR do?

If a user is not an admin, a flagged reportback or reportback item will not be returned. Instead, they will see error message `Access denied.` and response will return a `403` status code.
#### How should this be manually tested?

Find a flagged `rbid` and `fid`. 

From admin account, `/reportbacks/:rbid` should return `202` status code and reportback object. 

From an anon user account, same URL should return `403` status code and error message that reads `Access denied.`
#### What are the relevant tickets?

Fixes #6274 
