### PR TITLE
view user profile by northstar id

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -46,6 +46,21 @@ function dosomething_user_init() {
       dosomething_user_non_staff_redirect();
     }
   }
+
+  // If viewing a user/[northstar id]
+  if(arg(0) == 'user') {
+    if(!is_numeric(arg(1))) {
+      $northstar_id = arg(2,request_path());
+      $query = db_select('field_data_field_northstar_id', 'f')
+              ->condition('f.field_northstar_id_value', $northstar_id)
+              ->fields('f', ['entity_id']);
+      $result = $query->execute()->fetchAll();
+      $phoenix_id = $result[0]->entity_id;
+      $user = user_load($phoenix_id);
+      $new_path = 'user/' . $phoenix_id;
+      drupal_goto($new_path);
+    }
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -108,27 +108,32 @@ function dosomething_user_menu() {
 }
 
 function dosomething_user_menu_alter(&$items) {
-    $items['user/%'] = array(
+  unset($items['user']);
+  unset($items['user/%user']);
+  $items['user/%'] = array(
     'page callback' => 'dosomething_user_get_view',
     'page arguments' => array(1),
-    'type' => MENU_CALLBACK,
     'access callback' => TRUE,
   );
+  unset($items['user/%user']);
 
   return $items;
 }
 
 function dosomething_user_get_view($id) {
-  if(is_numeric($id)) {
-    $user = user_load($id);
-    return user_view($user);
+  if (is_numeric($id)) {
+    $account = user_load($id);
+
+    return user_view($account);
   }
   else {
     $phoenix_user = dosomething_user_get_user_by_northstar_id($id);
-    if(!$phoenix_user) {
+    if (!$phoenix_user) {
       drupal_not_found();
     }
-    return user_view($phoenix_user);
+
+    // return user_view($phoenix_user);
+    drupal_goto('user/' . $phoenix_user->uid);
   }
 }
 
@@ -1016,7 +1021,7 @@ function dosomething_user_get_user_by_northstar_id($id) {
           ->condition('f.field_northstar_id_value', $id)
           ->fields('f', ['entity_id']);
   $result = $query->execute()->fetchField();
-  if($result) {
+  if ($result) {
     return user_load($result);
   }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -50,16 +50,10 @@ function dosomething_user_init() {
   // If viewing a user/[northstar id]
   if(arg(0) == 'user') {
     if(!is_numeric(arg(1))) {
-      $northstar_id = arg(2,request_path());
-      $query = db_select('field_data_field_northstar_id', 'f')
-              ->condition('f.field_northstar_id_value', $northstar_id)
-              ->fields('f', ['entity_id']);
-      $result = $query->execute()->fetchAll();
-      $phoenix_id = $result[0]->entity_id;
+      $phoenix_id = dosomething_user_get_user_by_northstar_id(arg(1));
       if(!$phoenix_id) {
         drupal_not_found();
       }
-      $user = user_load($phoenix_id);
       $new_path = 'user/' . $phoenix_id;
       drupal_goto($new_path);
     }
@@ -993,6 +987,28 @@ function dosomething_user_register_validate($form, &$form_state) {
 function dosomething_user_get_user_by_email($email) {
   $user = user_load_by_mail($email);
   return $user ? $user : FALSE;
+}
+
+/**
+ * Search for users users by their northstar id.
+ *
+ * @param string $nid
+ *   The northstar id for which you are searching.
+ *
+ * @return string/bool
+ *   The user's id in phoenix, or false if no user was found.
+ */
+function dosomething_user_get_user_by_northstar_id($nid) {
+  $query = db_select('field_data_field_northstar_id', 'f')
+          ->condition('f.field_northstar_id_value', $nid)
+          ->fields('f', ['entity_id']);
+  $result = $query->execute()->fetchAll();
+  $phoenix_id = $result[0]->entity_id;
+  if($phoenix_id) {
+    return $phoenix_id;
+  }
+
+  return FALSE;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -110,7 +110,8 @@ function dosomething_user_menu_alter(&$items) {
   $items['user/%'] = array(
     'page callback' => 'dosomething_user_get_view',
     'page arguments' => array(1),
-    'access callback' => TRUE,
+    'access callback' => 'user_access',
+    'access arguments' => array('access user profiles'),
   );
   return $items;
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -56,6 +56,9 @@ function dosomething_user_init() {
               ->fields('f', ['entity_id']);
       $result = $query->execute()->fetchAll();
       $phoenix_id = $result[0]->entity_id;
+      if(!$phoenix_id) {
+        drupal_not_found();
+      }
       $user = user_load($phoenix_id);
       $new_path = 'user/' . $phoenix_id;
       drupal_goto($new_path);

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -104,14 +104,15 @@ function dosomething_user_menu() {
     'weight' => 500,
   );
 
-    return $items;
+  return $items;
 }
 
 function dosomething_user_menu_alter(&$items) {
   $items['user/%'] = array(
     'page callback' => 'dosomething_user_get_view',
     'page arguments' => array(1),
-    'access callback' => TRUE,
+    'access callback' => 'user_access',
+    'access arguments' => array('administer modules'),
   );
 
   return $items;
@@ -127,7 +128,7 @@ function dosomething_user_get_view($id) {
     if (!$phoenix_user) {
       drupal_not_found();
     }
-    return user_view($phoenix_user);
+    drupal_goto('user/' . $phoenix_user->uid);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -110,8 +110,7 @@ function dosomething_user_menu_alter(&$items) {
   $items['user/%'] = array(
     'page callback' => 'dosomething_user_get_view',
     'page arguments' => array(1),
-    'access callback' => 'user_access',
-    'access arguments' => array('view any user profile'),
+    'access callback' => TRUE,
   );
   return $items;
 }
@@ -1013,9 +1012,9 @@ function dosomething_user_get_user_by_northstar_id($id) {
   $query = db_select('field_data_field_northstar_id', 'f')
           ->condition('f.field_northstar_id_value', $id)
           ->fields('f', ['entity_id']);
-  $result = $query->execute()->fetchField();
-  if ($result) {
-    return user_load($result);
+  $uid = $query->execute()->fetchField();
+  if ($uid) {
+    return user_load($uid);
   }
   return FALSE;
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -103,7 +103,6 @@ function dosomething_user_menu() {
     'file' => 'dosomething_user.admin.inc',
     'weight' => 500,
   );
-
   return $items;
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -111,7 +111,7 @@ function dosomething_user_menu_alter(&$items) {
     'page callback' => 'dosomething_user_get_view',
     'page arguments' => array(1),
     'access callback' => 'user_access',
-    'access arguments' => array('administer modules'),
+    'access arguments' => array('view any user profile'),
   );
   return $items;
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -48,16 +48,16 @@ function dosomething_user_init() {
   }
 
   // If viewing a user/[northstar id]
-  if(arg(0) == 'user') {
-    if(!is_numeric(arg(1))) {
-      $phoenix_id = dosomething_user_get_user_by_northstar_id(arg(1));
-      if(!$phoenix_id) {
-        drupal_not_found();
-      }
-      $new_path = 'user/' . $phoenix_id;
-      drupal_goto($new_path);
-    }
-  }
+  // if(arg(0) == 'user') {
+  //   if(!is_numeric(arg(1))) {
+  //     $phoenix_id = dosomething_user_get_user_by_northstar_id(arg(1));
+  //     if(!$phoenix_id) {
+  //       drupal_not_found();
+  //     }
+  //     $new_path = 'user/' . $phoenix_id;
+  //     drupal_goto($new_path);
+  //   }
+  // }
 }
 
 /**
@@ -73,6 +73,7 @@ function dosomething_user_ctools_plugin_directory($module, $plugin) {
  * Implements hook_menu().
  */
 function dosomething_user_menu() {
+  print_r('hook_menu');
   $items = array();
   $items['user/validate/address'] = array(
     'title' => 'address',
@@ -115,9 +116,32 @@ function dosomething_user_menu() {
     'file' => 'dosomething_user.admin.inc',
     'weight' => 500,
   );
-  return $items;
+  $items['katie/user/%'] = array(
+    'page callback' => 'dosomething_user_get_view',
+    'page arguments' => array(2),
+    'type' => MENU_CALLBACK,
+    'access callback' => TRUE,
+  );
+    return $items;
 }
 
+function dosomething_user_get_view($id) {
+  if(is_numeric($id)) {
+    // drupal_goto('user/' . $id);
+    $user = user_load($id);
+    // die($user);
+    return user_view($user);
+  }
+  else {
+    $phoenix_user = dosomething_user_get_user_by_northstar_id($id);
+    // user_view(user_load($phoenix_id));
+    // if(!$phoenix_id) {
+    //   drupal_not_found();
+    // }
+    // drupal_goto('user/' . $phoenix_id);
+    user_view($phoenix_user);
+  }
+}
 
 /**
  * Implements hook_permission().
@@ -998,14 +1022,13 @@ function dosomething_user_get_user_by_email($email) {
  * @return string/bool
  *   The user's id in phoenix, or false if no user was found.
  */
-function dosomething_user_get_user_by_northstar_id($nid) {
+function dosomething_user_get_user_by_northstar_id($id) {
   $query = db_select('field_data_field_northstar_id', 'f')
-          ->condition('f.field_northstar_id_value', $nid)
+          ->condition('f.field_northstar_id_value', $id)
           ->fields('f', ['entity_id']);
-  $result = $query->execute()->fetchAll();
-  $phoenix_id = $result[0]->entity_id;
-  if($phoenix_id) {
-    return $phoenix_id;
+  $result = $query->execute()->fetchField();
+  if($result) {
+    return user_load($result);
   }
 
   return FALSE;

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -123,7 +123,6 @@ function dosomething_user_menu_alter(&$items) {
 function dosomething_user_get_view($id) {
   if (is_numeric($id)) {
     $account = user_load($id);
-
     return user_view($account);
   }
   else {
@@ -131,8 +130,6 @@ function dosomething_user_get_view($id) {
     if (!$phoenix_user) {
       drupal_not_found();
     }
-
-    // return user_view($phoenix_user);
     drupal_goto('user/' . $phoenix_user->uid);
   }
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -108,14 +108,11 @@ function dosomething_user_menu() {
 }
 
 function dosomething_user_menu_alter(&$items) {
-  unset($items['user']);
-  unset($items['user/%user']);
   $items['user/%'] = array(
     'page callback' => 'dosomething_user_get_view',
     'page arguments' => array(1),
     'access callback' => TRUE,
   );
-  unset($items['user/%user']);
 
   return $items;
 }
@@ -130,7 +127,7 @@ function dosomething_user_get_view($id) {
     if (!$phoenix_user) {
       drupal_not_found();
     }
-    drupal_goto('user/' . $phoenix_user->uid);
+    return user_view($phoenix_user);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -113,7 +113,6 @@ function dosomething_user_menu_alter(&$items) {
     'access callback' => 'user_access',
     'access arguments' => array('administer modules'),
   );
-
   return $items;
 }
 
@@ -1018,7 +1017,6 @@ function dosomething_user_get_user_by_northstar_id($id) {
   if ($result) {
     return user_load($result);
   }
-
   return FALSE;
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -46,18 +46,6 @@ function dosomething_user_init() {
       dosomething_user_non_staff_redirect();
     }
   }
-
-  // If viewing a user/[northstar id]
-  // if(arg(0) == 'user') {
-  //   if(!is_numeric(arg(1))) {
-  //     $phoenix_id = dosomething_user_get_user_by_northstar_id(arg(1));
-  //     if(!$phoenix_id) {
-  //       drupal_not_found();
-  //     }
-  //     $new_path = 'user/' . $phoenix_id;
-  //     drupal_goto($new_path);
-  //   }
-  // }
 }
 
 /**
@@ -73,7 +61,6 @@ function dosomething_user_ctools_plugin_directory($module, $plugin) {
  * Implements hook_menu().
  */
 function dosomething_user_menu() {
-  print_r('hook_menu');
   $items = array();
   $items['user/validate/address'] = array(
     'title' => 'address',
@@ -116,30 +103,32 @@ function dosomething_user_menu() {
     'file' => 'dosomething_user.admin.inc',
     'weight' => 500,
   );
-  $items['katie/user/%'] = array(
+
+    return $items;
+}
+
+function dosomething_user_menu_alter(&$items) {
+    $items['user/%'] = array(
     'page callback' => 'dosomething_user_get_view',
-    'page arguments' => array(2),
+    'page arguments' => array(1),
     'type' => MENU_CALLBACK,
     'access callback' => TRUE,
   );
-    return $items;
+
+  return $items;
 }
 
 function dosomething_user_get_view($id) {
   if(is_numeric($id)) {
-    // drupal_goto('user/' . $id);
     $user = user_load($id);
-    // die($user);
     return user_view($user);
   }
   else {
     $phoenix_user = dosomething_user_get_user_by_northstar_id($id);
-    // user_view(user_load($phoenix_id));
-    // if(!$phoenix_id) {
-    //   drupal_not_found();
-    // }
-    // drupal_goto('user/' . $phoenix_id);
-    user_view($phoenix_user);
+    if(!$phoenix_user) {
+      drupal_not_found();
+    }
+    return user_view($phoenix_user);
   }
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
@@ -106,6 +106,10 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     if (isset($vars['theme_hook_suggestions'][1])) {
       // Check if page is user/%.
       $is_profile = ($vars['theme_hook_suggestions'][1] === 'page__user__%');
+      if(strlen(explode('__', $vars['theme_hook_suggestions'][1])[2]) == 24)
+      {
+        $is_profile = TRUE;
+      }
     }
     if ($is_profile) {
       // User profile page does not contain anymore suggestions than

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
@@ -106,10 +106,6 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     if (isset($vars['theme_hook_suggestions'][1])) {
       // Check if page is user/%.
       $is_profile = ($vars['theme_hook_suggestions'][1] === 'page__user__%');
-      if(strlen(explode('__', $vars['theme_hook_suggestions'][1])[2]) == 24)
-      {
-        $is_profile = TRUE;
-      }
     }
     if ($is_profile) {
       // User profile page does not contain anymore suggestions than


### PR DESCRIPTION
#### What's this PR do?

If you go to /user/[phoenix id or northstar id] it will take you to the correct user page.
#### How should this be manually tested?

Go to user/[phoenix id], user/[northstar id], and user/[anything else that exists] to make sure nothing is broken.
#### Any background context you want to provide?

I did this via redirect and I'm not sure if that's the best way to approach this or not. Also, this will break if we have any pages that are user/[other words]. I didn't find any paths like that, but I'm not positive.
#### What are the relevant tickets?

Fixes #6275 

cc: @DFurnes 
