### PR TITLE
Adds backlog cron

### DIFF
--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.cron.inc
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.cron.inc
@@ -4,6 +4,11 @@
  * Implements hook_cron()
  */
  function dosomething_gladiator_cron() {
+   dosomething_gladiator_update_campaigns();
+   dosomething_gladiator_retry_failed_users();
+ }
+
+ function dosomething_gladiator_update_campaigns() {
    $client = _dosomething_gladiator_build_http_client();
 
    $options = [
@@ -30,5 +35,25 @@
        ])
        ->condition('nid', $nid)
        ->execute();
+   }
+ }
+
+ function dosomething_gladiator_retry_failed_users() {
+   $task_log = db_select('dosomething_gladiator_failed_task_log', 't')
+    ->fields('t')
+    ->execute()
+    ->fetchAll();
+
+   foreach ($task_log as $task) {
+      $user = user_load($task->uid);
+      $values = [
+        'nid' => $task->nid,
+        'run_nid' => $task->run_nid,
+      ];
+      db_delete('dosomething_gladiator_failed_task_log')
+        ->condition('uid', $task->uid)
+        ->condition('run_nid', $task->run_nid)
+        ->execute();
+      dosomething_gladiator_send_user_to_gladiator($user, $values);
    }
  }

--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.cron.inc
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.cron.inc
@@ -39,21 +39,18 @@
  }
 
  function dosomething_gladiator_retry_failed_users() {
-   $task_log = db_select('dosomething_gladiator_failed_task_log', 't')
-    ->fields('t')
-    ->execute()
-    ->fetchAll();
+    $task_log = db_select('dosomething_gladiator_failed_task_log', 't')
+      ->fields('t')
+      ->execute()
+      ->fetchAll();
+    db_truncate('dosomething_gladiator_failed_task_log')->execute();
 
-   foreach ($task_log as $task) {
+    foreach ($task_log as $task) {
       $user = user_load($task->uid);
       $values = [
         'nid' => $task->nid,
         'run_nid' => $task->run_nid,
       ];
-      db_delete('dosomething_gladiator_failed_task_log')
-        ->condition('uid', $task->uid)
-        ->condition('run_nid', $task->run_nid)
-        ->execute();
       dosomething_gladiator_send_user_to_gladiator($user, $values);
    }
  }


### PR DESCRIPTION
#### What's this PR do?
- Adds cron to go through backlog table and resubmit people to the gladiators
- Moves this & previous gladiator cron work into functions so its separated out
#### How should this be manually tested?

start phoenix, than gladiator (if theyre already running vagrant halt that shiz or its gonna error out with ports)
setup some campaign to have a signup data form and submit to competitions
make a bad url in the gladiator module so it cant submit people
use chrome incognito on that campaign and signup for competition
check you've been placed in the table for people that failed joining competition
go into gladiator and make sure there is a contest that matches the nid/run_nid and is open for business
run cron on drupal
10 minutes later
check the user is no longer in the table
check the user is in the proper contest waiting room in gladiator
#### Any background context you want to provide?

no
#### What are the relevant tickets?

Fixes #6287 
