### PR TITLE
Log exported users

### DIFF
--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -24,7 +24,7 @@ foreach ($users as $user) {
   // Create json object
   $user = user_load($user->uid);
   $ns_user = build_northstar_user($user);
-  
+
   // Don't "forward" the anonymous user.
   if($user->uid == 0) {
     continue;
@@ -37,14 +37,14 @@ foreach ($users as $user) {
     'method' => 'POST',
     'data' => json_encode($ns_user),
   ]);
-  
+
   // Log whether the request was successful or not
   dosomething_northstar_log_request('migrate', $user, json_encode($ns_user), $response);
 
   // Store the returned Northstar ID on the user's Drupal profile.
   $northstar_id = isset($response->data->id) ? $response->data->id : 'NONE';
   user_save($user, ['field_northstar_id' => [LANGUAGE_NONE => [0 => ['value' => $northstar_id]]]]);
-  
+
   // If the script fails, we can use this to start the script from a previous person.
   variable_set('dosomething_northstar_last_user_migrated', $user->uid);
 }

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -24,6 +24,11 @@ foreach ($users as $user) {
   // Create json object
   $user = user_load($user->uid);
   $ns_user = build_northstar_user($user);
+  
+  // Don't "forward" the anonymous user.
+  if($user->uid == 0) {
+    continue;
+  }
 
   // Use old drupal_http_request method.
   $client = _dosomething_northstar_build_http_client();

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -31,7 +31,7 @@ foreach ($users as $user) {
     'headers' => $client['headers'],
     'method' => 'POST',
     'data' => json_encode($ns_user),
-    ]);
+  ]);
 
   // If the script fails, we can use this to start the script from a previous person.
   variable_set('dosomething_northstar_last_user_migrated', $user->uid);

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -36,6 +36,10 @@ foreach ($users as $user) {
   // Log whether the request was successful or not
   dosomething_northstar_log_request('migrate', $user, json_encode($ns_user), $response);
 
+  // Store the returned Northstar ID on the user's Drupal profile.
+  $northstar_id = isset($response->data->id) ? $response->data->id : 'NONE';
+  user_save($user, ['field_northstar_id' => [LANGUAGE_NONE => [0 => ['value' => $northstar_id]]]]);
+  
   // If the script fails, we can use this to start the script from a previous person.
   variable_set('dosomething_northstar_last_user_migrated', $user->uid);
 }

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -32,6 +32,9 @@ foreach ($users as $user) {
     'method' => 'POST',
     'data' => json_encode($ns_user),
   ]);
+  
+  // Log whether the request was successful or not
+  dosomething_northstar_log_request('migrate', $user, json_encode($ns_user), $response);
 
   // If the script fails, we can use this to start the script from a previous person.
   variable_set('dosomething_northstar_last_user_migrated', $user->uid);


### PR DESCRIPTION
#### What's this PR do?

:memo: Adds migrated users to the [Northstar request log](https://github.com/DoSomething/phoenix/pull/6262), so we can track if we run into any errors.

:1234: Store the returned Northstar ID to the Drupal profiles of migrated users for future use.

:boom: Fixes a crash I ran into when re-testing this where it was trying to migrate the "anonymous" user and crashing in a big ball of flames.
#### How should this be manually tested?

Feel free to pull down this branch and test against your local environment.
#### Any background context you want to provide?

Noooooooope.
#### What are the relevant tickets?

References #6260.

---

For review: @angaither 
