### PR TITLE
Gives editors ability to delete any reportback

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.features.user_permission.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.features.user_permission.inc
@@ -15,6 +15,7 @@ function dosomething_reportback_user_default_permissions() {
     'name' => 'delete any reportback',
     'roles' => array(
       'administrator' => 'administrator',
+      'editor' => 'editor',
     ),
     'module' => 'dosomething_reportback',
   );

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.info
@@ -21,4 +21,4 @@ features[user_permission][] = view any reportback
 features[user_permission][] = view own reportback
 features[views_view][] = reportback_files
 files[] = dosomething_reportback.test
-mtime = 1456349880
+mtime = 1457017096


### PR DESCRIPTION
#### What's this PR do?

Gives editors permission to edit any reportback
#### How should this be manually tested?

Do editors now see the primary tabs on top of a reportback perma link page thing?
#### Any background context you want to provide?

The `dosomething_reportback_access` function was being called twice by the menu local tasks, and was failing because editors only had the edit any reportback.
#### What are the relevant tickets?

Fixes #5045 
