### PR TITLE
Non admin users can see their own profiles

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -110,8 +110,8 @@ function dosomething_user_menu_alter(&$items) {
   $items['user/%'] = array(
     'page callback' => 'dosomething_user_get_view',
     'page arguments' => array(1),
-    'access callback' => 'user_access',
-    'access arguments' => array('access user profiles'),
+    'access callback' => 'user_view_access',
+    'access arguments' => array(1),
   );
   return $items;
 }


### PR DESCRIPTION
#### What's this PR do?

Now using `user_view_access` for access callback. This is a special access function just for views that will allow users to see their own profiles, but no others. It also allows admins/other users that can see all profiles to do that too
#### How should this be manually tested?

Login as an admin and make sure you can see user profiles. Throw a northstar id in there just to make sure. As a normal user, make sure you can see your own profile and NOT other profiles.
#### Any background context you want to provide?

This was caused by #6294 
#### What are the relevant tickets?

Fixes #6310
