### PR TITLE
Adds competition param to signup index

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -69,11 +69,11 @@ function _signup_resource_definition() {
           ],
           [
             'name' => 'competition',
-            'description' => 'Only competition signups, defaults to 0.',
+            'description' => 'Only competition signups, defaults to false.',
             'optional' => TRUE,
-            'type' => 'int',
+            'type' => 'boolean',
             'source' => ['param' => 'competition'],
-            'default value' => 0,
+            'default value' => FALSE,
           ],
         ],
         'access callback' => '_signup_resource_access',
@@ -96,7 +96,7 @@ function _signup_resource_access() {
  * @param string $campaigns
  * @param int $count
  * @param int $page
- * @param int $competition
+ * @param boolean $competition
  * @return array
  */
 function _signup_resource_index($user, $campaigns, $count, $page, $competition) {

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -67,6 +67,14 @@ function _signup_resource_definition() {
             'source' => ['param' => 'page'],
             'default value' => 1,
           ],
+          [
+            'name' => 'competition',
+            'description' => 'Only competition signups, defaults to 0.',
+            'optional' => TRUE,
+            'type' => 'int',
+            'source' => ['param' => 'competition'],
+            'default value' => 0,
+          ],
         ],
         'access callback' => '_signup_resource_access',
         'access arguments' => ['index'],
@@ -88,14 +96,16 @@ function _signup_resource_access() {
  * @param string $campaigns
  * @param int $count
  * @param int $page
+ * @param int $competition
  * @return array
  */
-function _signup_resource_index($user, $campaigns, $count, $page) {
+function _signup_resource_index($user, $campaigns, $count, $page, $competition) {
   $parameters = [
     'user' => $user,
     'campaigns' => $campaigns,
     'count' => $count,
     'page' => $page,
+    'competition' => $competition,
   ];
 
   return (new SignupTransformer)->index($parameters);

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -38,7 +38,7 @@ function dosomething_signup_get_signups_query($params, $tally = FALSE) {
     return $result->rowCount();
   }
   else {
-    return $result->fetchAll(); 
+    return $result->fetchAll();
   }
 }
 
@@ -53,7 +53,7 @@ function dosomething_signup_get_signups_query($params, $tally = FALSE) {
  */
 function dosomething_signup_build_signups_query($params = []) {
   $query = db_select('dosomething_signup', 's');
-  $query->leftJoin('dosomething_reportback', 'rb', 's.uid = rb.uid and s.nid = rb.nid and s.run_nid = rb.run_nid'); 
+  $query->leftJoin('dosomething_reportback', 'rb', 's.uid = rb.uid and s.nid = rb.nid and s.run_nid = rb.run_nid');
   $query->fields('s', ['sid', 'uid', 'nid', 'run_nid', 'timestamp']);
   $query->fields('rb', ['rbid']);
 
@@ -67,6 +67,11 @@ function dosomething_signup_build_signups_query($params = []) {
 
   if (isset($params['user'])) {
     $query->condition('s.uid', $params['user'], '=');
+  }
+
+  if (isset($params['competition'])) {
+    $query->condition('s.competition', 1, '=');
+    $query->orderBy('rb.quantity', 'DESC');
   }
 
   if (isset($params['campaigns'])) {

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -111,7 +111,7 @@ class SignupTransformer extends Transformer {
       'campaigns' => dosomething_helpers_format_data($parameters['campaigns']),
       'count' => (int) $parameters['count'] ?: 25,
       'page' => (int) $parameters['page'],
-      'competition' => (int) $parameters['competition'] ?: NULL,
+      'competition' => $parameters['competition'] ?: NULL,
     ];
 
     return $filters;

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -111,6 +111,7 @@ class SignupTransformer extends Transformer {
       'campaigns' => dosomething_helpers_format_data($parameters['campaigns']),
       'count' => (int) $parameters['count'] ?: 25,
       'page' => (int) $parameters['page'],
+      'competition' => (int) $parameters['competition'] ?: NULL,
     ];
 
     return $filters;


### PR DESCRIPTION
#### What's this PR do?

Adds competition parameter to the signup index endpoint, this does two things.
1- Only include signups that are marked as competition signups.
2- Order the signups by quantity.
#### How should this be manually tested?

Checkout `http://dev.dosomething.org:8888/api/v1/signups?competition=1`
#### Any background context you want to provide?

nope
#### What are the relevant tickets?

Fixes #6316 
