### PR TITLE
Adds northstar id to signups api response

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -427,7 +427,6 @@ abstract class Transformer {
     return [
       'id' => $data->id,
       'created_at' => $data->created_at,
-      'northstar_id' => $data->northstar_id,
       'campaign_run' => [
         'id' => $data->campaign_run,
         'current' => $current,

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -427,6 +427,7 @@ abstract class Transformer {
     return [
       'id' => $data->id,
       'created_at' => $data->created_at,
+      'northstar_id' => $data->northstar_id,
       'campaign_run' => [
         'id' => $data->campaign_run,
         'current' => $current,

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -445,7 +445,8 @@ abstract class Transformer {
    */
   protected function transformUser($data) {
     return [
-      'id' => $data->id,
+      'id' => $data->drupal_id,
+      'northstar_id' => $data->northstar_id,
       'first_name' => $data->first_name,
       'last_initial' => $data->last_initial,
       'photo' => $data->photo,

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -170,11 +170,11 @@ class Reportback extends Entity {
 
     $this->user = [
       'drupal_id' => $data->uid,
-      'id' => dosomething_helpers_isset($northstar_user, 'id'),
-      'first_name' => dosomething_helpers_isset($northstar_user, 'first_name'),
-      'last_initial' => dosomething_helpers_isset($northstar_user, 'last_initial'),
-      'photo' => dosomething_helpers_isset($northstar_user, 'photo'),
-      'country' => dosomething_helpers_isset($northstar_user, 'country'),
+      'northstar_id' => dosomething_helpers_isset($northstar_user->id, 'id'),
+      'first_name' => dosomething_helpers_isset($northstar_user->first_name, 'first_name'),
+      'last_initial' => dosomething_helpers_isset($northstar_user->last_initial, 'last_initial'),
+      'photo' => dosomething_helpers_isset($northstar_user->photo, 'photo'),
+      'country' => dosomething_helpers_isset($northstar_user->country, 'country'),
     ];
   }
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -120,11 +120,11 @@ class ReportbackItem extends Entity {
 
     $this->user = [
       'drupal_id' => $data->uid,
-      'id' => dosomething_helpers_isset($northstar_user, 'id'),
-      'first_name' => dosomething_helpers_isset($northstar_user, 'first_name'),
-      'last_initial' => dosomething_helpers_isset($northstar_user, 'last_initial'),
-      'photo' => dosomething_helpers_isset($northstar_user, 'photo'),
-      'country' => dosomething_helpers_isset($northstar_user, 'country'),
+      'northstar_id' => dosomething_helpers_isset($northstar_user->id, 'id'),
+      'first_name' => dosomething_helpers_isset($northstar_user->first_name, 'first_name'),
+      'last_initial' => dosomething_helpers_isset($northstar_user->last_initial, 'last_initial'),
+      'photo' => dosomething_helpers_isset($northstar_user->photo, 'photo'),
+      'country' => dosomething_helpers_isset($northstar_user->country, 'country'),
     ];
   }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -54,8 +54,10 @@ function dosomething_signup_get_signups_query($params, $tally = FALSE) {
 function dosomething_signup_build_signups_query($params = []) {
   $query = db_select('dosomething_signup', 's');
   $query->leftJoin('dosomething_reportback', 'rb', 's.uid = rb.uid and s.nid = rb.nid and s.run_nid = rb.run_nid');
+  $query->leftJoin('field_data_field_northstar_id', 'ns', 'ns.entity_id = s.uid');
   $query->fields('s', ['sid', 'uid', 'nid', 'run_nid', 'timestamp']);
   $query->fields('rb', ['rbid']);
+  $query->fields('ns', ['field_northstar_id_value']);
 
   if (isset($params['sid'])) {
     if (is_array($params['sid'])) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -71,6 +71,8 @@ function dosomething_signup_build_signups_query($params = []) {
 
   if (isset($params['competition'])) {
     $query->condition('s.competition', 1, '=');
+    $query->leftJoin('field_data_field_northstar_id', 'ns', 'ns.entity_id = s.uid');
+    $query->fields('ns', ['field_northstar_id_value']);
     $query->orderBy('rb.quantity', 'DESC');
   }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -54,8 +54,10 @@ function dosomething_signup_get_signups_query($params, $tally = FALSE) {
 function dosomething_signup_build_signups_query($params = []) {
   $query = db_select('dosomething_signup', 's');
   $query->leftJoin('dosomething_reportback', 'rb', 's.uid = rb.uid and s.nid = rb.nid and s.run_nid = rb.run_nid');
+  $query->leftJoin('field_data_field_northstar_id', 'ns', 'ns.entity_id = s.uid');
   $query->fields('s', ['sid', 'uid', 'nid', 'run_nid', 'timestamp']);
   $query->fields('rb', ['rbid']);
+  $query->fields('ns', ['field_northstar_id_value']);
 
   if (isset($params['sid'])) {
     if (is_array($params['sid'])) {
@@ -71,8 +73,6 @@ function dosomething_signup_build_signups_query($params = []) {
 
   if (isset($params['competition'])) {
     $query->condition('s.competition', 1, '=');
-    $query->leftJoin('field_data_field_northstar_id', 'ns', 'ns.entity_id = s.uid');
-    $query->fields('ns', ['field_northstar_id_value']);
     $query->orderBy('rb.quantity', 'DESC');
   }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -54,10 +54,8 @@ function dosomething_signup_get_signups_query($params, $tally = FALSE) {
 function dosomething_signup_build_signups_query($params = []) {
   $query = db_select('dosomething_signup', 's');
   $query->leftJoin('dosomething_reportback', 'rb', 's.uid = rb.uid and s.nid = rb.nid and s.run_nid = rb.run_nid');
-  $query->leftJoin('field_data_field_northstar_id', 'ns', 'ns.entity_id = s.uid');
   $query->fields('s', ['sid', 'uid', 'nid', 'run_nid', 'timestamp']);
   $query->fields('rb', ['rbid']);
-  $query->fields('ns', ['field_northstar_id_value']);
 
   if (isset($params['sid'])) {
     if (is_array($params['sid'])) {

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -92,7 +92,7 @@ class Signup extends Entity {
     $user = user_load($data->uid);
     $this->user = [
       'drupal_id' => $data->uid,
-      'id' => dosomething_helpers_isset($user->uuid, 'id'),
+      'northstar_id' => dosomething_helpers_isset($user->uuid, 'id'),
       'first_name' => dosomething_helpers_isset($user->field_first_name[LANGUAGE_NONE][0]['value'], 'first_name'),
       'last_initial' => dosomething_helpers_isset($user->field_last_name[LANGUAGE_NONE][0]['value'], 'last_initial'),
       'photo' => dosomething_helpers_isset($user->photo, 'photo'),

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -88,7 +88,21 @@ class Signup extends Entity {
   private function build($data) {
     $this->id = $data->sid;
     $this->created_at = $data->timestamp;
-    $this->northstar_id = $data->field_northstar_id_value;
+
+    $northstar_response = dosomething_northstar_get_northstar_user($data->uid);
+    $northstar_response = json_decode($northstar_response);
+    if (!empty($northstar_response->data) && !isset($northstar_response->error)) {
+      $northstar_user = $northstar_response->data;
+
+      $this->user = [
+        'drupal_id' => $data->uid,
+        'id' => dosomething_helpers_isset($northstar_user, 'id'),
+        'first_name' => dosomething_helpers_isset($northstar_user, 'first_name'),
+        'last_initial' => dosomething_helpers_isset($northstar_user, 'last_initial'),
+        'photo' => dosomething_helpers_isset($northstar_user, 'photo'),
+        'country' => dosomething_helpers_isset($northstar_user, 'country'),
+      ];
+    }
 
     try {
       $this->campaign = Campaign::get($data->nid);

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -95,8 +95,8 @@ class Signup extends Entity {
       'drupal_id' => $data->uid,
       'northstar_id' => dosomething_helpers_isset($data->field_northstar_id_value, 'id'),
       'first_name' => dosomething_helpers_isset(dosomething_helpers_extract_field_data($user->field_first_name), 'first_name'),
-      'last_initial' => dosomething_helpers_isset($user->field_last_name[LANGUAGE_NONE][0]['value'], 'last_initial'),
-      'photo' => dosomething_helpers_isset($user->photo, 'photo'),
+      'last_initial' => dosomething_helpers_isset(dosomething_helpers_extract_field_data($user->field_last_name), 'last_initial'),
+      'photo' => dosomething_helpers_isset(dosomething_helpers_extract_field_data($user->photo), 'photo'),
       'country' => dosomething_helpers_isset($user->field_address[LANGUAGE_NONE][0]['country'], 'country'),
     ];
 

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -93,8 +93,8 @@ class Signup extends Entity {
 
     $this->user = [
       'drupal_id' => $data->uid,
-      'northstar_id' => dosomething_helpers_isset($user->field_northstar_id_value, 'id'),
-      'first_name' => dosomething_helpers_isset($user->field_first_name[LANGUAGE_NONE][0]['value'], 'first_name'),
+      'northstar_id' => dosomething_helpers_isset($data->field_northstar_id_value, 'id'),
+      'first_name' => dosomething_helpers_isset(dosomething_helpers_extract_field_data($user->field_first_name), 'first_name'),
       'last_initial' => dosomething_helpers_isset($user->field_last_name[LANGUAGE_NONE][0]['value'], 'last_initial'),
       'photo' => dosomething_helpers_isset($user->photo, 'photo'),
       'country' => dosomething_helpers_isset($user->field_address[LANGUAGE_NONE][0]['country'], 'country'),

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -88,6 +88,8 @@ class Signup extends Entity {
   private function build($data) {
     $this->id = $data->sid;
     $this->created_at = $data->timestamp;
+    $this->northstar_id = $data->field_northstar_id_value;
+
     try {
       $this->campaign = Campaign::get($data->nid);
     }

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -90,9 +90,10 @@ class Signup extends Entity {
     $this->created_at = $data->timestamp;
 
     $user = user_load($data->uid);
+
     $this->user = [
       'drupal_id' => $data->uid,
-      'northstar_id' => dosomething_helpers_isset($user->uuid, 'id'),
+      'northstar_id' => dosomething_helpers_isset($user->field_northstar_id_value, 'id'),
       'first_name' => dosomething_helpers_isset($user->field_first_name[LANGUAGE_NONE][0]['value'], 'first_name'),
       'last_initial' => dosomething_helpers_isset($user->field_last_name[LANGUAGE_NONE][0]['value'], 'last_initial'),
       'photo' => dosomething_helpers_isset($user->photo, 'photo'),

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -89,20 +89,15 @@ class Signup extends Entity {
     $this->id = $data->sid;
     $this->created_at = $data->timestamp;
 
-    $northstar_response = dosomething_northstar_get_northstar_user($data->uid);
-    $northstar_response = json_decode($northstar_response);
-    if (!empty($northstar_response->data) && !isset($northstar_response->error)) {
-      $northstar_user = $northstar_response->data;
-
-      $this->user = [
-        'drupal_id' => $data->uid,
-        'id' => dosomething_helpers_isset($northstar_user, 'id'),
-        'first_name' => dosomething_helpers_isset($northstar_user, 'first_name'),
-        'last_initial' => dosomething_helpers_isset($northstar_user, 'last_initial'),
-        'photo' => dosomething_helpers_isset($northstar_user, 'photo'),
-        'country' => dosomething_helpers_isset($northstar_user, 'country'),
-      ];
-    }
+    $user = user_load($data->uid);
+    $this->user = [
+      'drupal_id' => $data->uid,
+      'id' => dosomething_helpers_isset($user->uuid, 'id'),
+      'first_name' => dosomething_helpers_isset($user->field_first_name[LANGUAGE_NONE][0]['value'], 'first_name'),
+      'last_initial' => dosomething_helpers_isset($user->field_last_name[LANGUAGE_NONE][0]['value'], 'last_initial'),
+      'photo' => dosomething_helpers_isset($user->photo, 'photo'),
+      'country' => dosomething_helpers_isset($user->field_address[LANGUAGE_NONE][0]['country'], 'country'),
+    ];
 
     try {
       $this->campaign = Campaign::get($data->nid);

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -96,6 +96,8 @@ class SignupTransformer extends Transformer {
       $data['reportback'] = $this->transformReportback((object) $item->reportback);
     }
 
+    $data['user'] = $this->transformUser((object) $item->user);
+
     return $data;
   }
 

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -96,7 +96,12 @@ class SignupTransformer extends Transformer {
       $data['reportback'] = $this->transformReportback((object) $item->reportback);
     }
 
-    $data['user'] = $this->transformUser((object) $item->user);
+    if (is_null($item->user)) {
+      $data['user'] = null;
+    }
+    else {
+      $data['user'] = $this->transformUser((object) $item->user);
+    }
 
     return $data;
   }


### PR DESCRIPTION
#### What's this PR do?

adds northstar user id to the signups response so gladiator can use it to do magical things

competitions=true means only return signups that are for a competition, and order them by reportback quantity.
#### How should this be manually tested?

`http://dev.dosomething.org:8888/api/v1/signups?competition=true`
#### Any background context you want to provide?

:cake: 
#### What are the relevant tickets?

Fixes #nope
