### PR TITLE
create new path to get to profiles via northstar id

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -103,11 +103,7 @@ function dosomething_user_menu() {
     'file' => 'dosomething_user.admin.inc',
     'weight' => 500,
   );
-  return $items;
-}
-
-function dosomething_user_menu_alter(&$items) {
-  $items['user/%'] = array(
+  $items['northstar/%'] = array(
     'page callback' => 'dosomething_user_get_view',
     'page arguments' => array(1),
     'access callback' => 'user_view_access',
@@ -117,17 +113,11 @@ function dosomething_user_menu_alter(&$items) {
 }
 
 function dosomething_user_get_view($id) {
-  if (is_numeric($id)) {
-    $account = user_load($id);
-    return user_view($account);
+  $phoenix_user = dosomething_user_get_user_by_northstar_id($id);
+  if (!$phoenix_user) {
+    drupal_not_found();
   }
-  else {
-    $phoenix_user = dosomething_user_get_user_by_northstar_id($id);
-    if (!$phoenix_user) {
-      drupal_not_found();
-    }
-    drupal_goto('user/' . $phoenix_user->uid);
-  }
+  drupal_goto('user/' . $phoenix_user->uid);
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?

To get to user profiles via northstar id, I made a new path instead of user a `menu_alter` hook. Now you go to northstar/[id].
#### How should this be manually tested?

As admin and non-admin, make sure you can see your own profile and others you should have access to sans errors and redirect loops.
#### Any background context you want to provide?

Part 1 of this saga is a #6294 
#### What are the relevant tickets?

Fixes #6275

cc: @DFurnes 
