### PR TITLE
updating  field collection to beta version 11

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -80,9 +80,6 @@ projects[features][version] = "2.2"
 projects[features][subdir] = "contrib"
 
 ; Field Collection
-; Updated to dev to be compatible with latest field_collection patch.
-; Dev branch used: 2015-Mar-26
-; !! Users are cautioned that data loss has been reported – please test carefully !!
 projects[field_collection][version] = "1.0-beta11"
 projects[field_collection][subdir] = "contrib"
 ; See https://www.drupal.org/node/1344672?page=1#comment-10320327

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -83,7 +83,7 @@ projects[features][subdir] = "contrib"
 ; Updated to dev to be compatible with latest field_collection patch.
 ; Dev branch used: 2015-Mar-26
 ; !! Users are cautioned that data loss has been reported – please test carefully !!
-projects[field_collection][version] = "1.x-dev"
+projects[field_collection][version] = "1.0-beta11"
 projects[field_collection][subdir] = "contrib"
 ; See https://www.drupal.org/node/1344672?page=1#comment-10320327
 projects[field_collection][patch][] = "https://www.drupal.org/files/issues/field_collection-add_entity_translation_support-1344672-459.patch"


### PR DESCRIPTION
#### What's this PR do?

Lock field collection module to `1.0-beta11` version 
#### How should this be manually tested?

run `ds build` and check that everything looks :ok: and there's no data loss
### Any background context

The patch we are using to support entity translation and the dev branch of this module are not compatible
#### What are the relevant tickets?

Fixes #6332 
