### PR TITLE
Signups API modifications TAKE 2!

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -45,7 +45,7 @@ function _signup_resource_definition() {
           ],
           [
             'name' => 'users',
-            'description' => 'The id of the specified user to get signups for.',
+            'description' => 'The ids of the specified users to get signups for.',
             'optional' => TRUE,
             'type' => 'string',
             'source' => ['param' => 'users'],

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -44,6 +44,14 @@ function _signup_resource_definition() {
             'default value' => NULL,
           ],
           [
+            'name' => 'users',
+            'description' => 'The id of the specified user to get signups for.',
+            'optional' => TRUE,
+            'type' => 'string',
+            'source' => ['param' => 'users'],
+            'default value' => NULL,
+          ],
+          [
             'name' => 'campaigns',
             'description' => 'The ids of the specified campaigns to get signups for.',
             'optional' => TRUE,
@@ -99,7 +107,12 @@ function _signup_resource_access() {
  * @param boolean $competition
  * @return array
  */
-function _signup_resource_index($user, $campaigns, $count, $page, $competition) {
+function _signup_resource_index($user, $users, $campaigns, $count, $page, $competition) {
+
+  if (isset($users)) {
+    $user = $users;
+  }
+
   $parameters = [
     'user' => $user,
     'campaigns' => $campaigns,

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -54,8 +54,10 @@ function dosomething_signup_get_signups_query($params, $tally = FALSE) {
 function dosomething_signup_build_signups_query($params = []) {
   $query = db_select('dosomething_signup', 's');
   $query->leftJoin('dosomething_reportback', 'rb', 's.uid = rb.uid and s.nid = rb.nid and s.run_nid = rb.run_nid');
+  $query->leftJoin('field_data_field_northstar_id', 'ns', 'ns.entity_id = s.uid');
   $query->fields('s', ['sid', 'uid', 'nid', 'run_nid', 'timestamp']);
   $query->fields('rb', ['rbid']);
+  $query->fields('ns', ['field_northstar_id_value']);
 
   if (isset($params['sid'])) {
     if (is_array($params['sid'])) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -66,7 +66,11 @@ function dosomething_signup_build_signups_query($params = []) {
   }
 
   if (isset($params['user'])) {
-    $query->condition('s.uid', $params['user'], '=');
+    if (is_array($params['user'])) {
+      $query->condition('s.uid', $params['user'], 'IN');
+    } else {
+      $query->condition('s.uid', $params['user'], '=');
+    }
   }
 
   if (isset($params['competition'])) {

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -91,7 +91,7 @@ class Signup extends Entity {
 
     $user = user_load($data->uid);
     $this->user = [
-      'id' => $data->field_northstar_id_value,
+      'id' => dosomething_helpers_isset($data, 'field_northstar_id_value'),
       'first_name' => dosomething_helpers_extract_field_data($user->field_first_name),
       'last_initial' => dosomething_helpers_extract_field_data($user->field_last_name),
       'photo' => $user->picture,

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -88,6 +88,12 @@ class Signup extends Entity {
   private function build($data) {
     $this->id = $data->sid;
     $this->created_at = $data->timestamp;
+
+    $user = user_load($data->uid);
+    $this->user = [
+      'id' => $data->field_northstar_id_value,
+    ];
+
     try {
       $this->campaign = Campaign::get($data->nid);
     }

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -90,8 +90,9 @@ class Signup extends Entity {
     $this->created_at = $data->timestamp;
 
     $user = user_load($data->uid);
+
     $this->user = [
-      'id' => dosomething_helpers_isset($data, 'field_northstar_id_value'),
+      'id' => $data->field_northstar_id_value === "NONE" ? NULL : $data->field_northstar_id_value,
       'first_name' => dosomething_helpers_extract_field_data($user->field_first_name),
       'last_initial' => dosomething_helpers_extract_field_data($user->field_last_name),
       'photo' => $user->picture,

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -92,6 +92,10 @@ class Signup extends Entity {
     $user = user_load($data->uid);
     $this->user = [
       'id' => $data->field_northstar_id_value,
+      'first_name' => dosomething_helpers_extract_field_data($user->field_first_name),
+      'last_initial' => dosomething_helpers_extract_field_data($user->field_last_name),
+      'photo' => $user->picture,
+      'country' => dosomething_helpers_extract_field_data($user->field_address),
     ];
 
     try {

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -92,7 +92,7 @@ class Signup extends Entity {
     $user = user_load($data->uid);
 
     $this->user = [
-      'id' => $data->field_northstar_id_value === "NONE" ? NULL : $data->field_northstar_id_value,
+      'id' => $data->field_northstar_id_value === 'NONE' ? NULL : $data->field_northstar_id_value,
       'first_name' => dosomething_helpers_extract_field_data($user->field_first_name),
       'last_initial' => dosomething_helpers_extract_field_data($user->field_last_name),
       'photo' => $user->picture,

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -96,6 +96,13 @@ class SignupTransformer extends Transformer {
       $data['reportback'] = $this->transformReportback((object) $item->reportback);
     }
 
+    if (is_null($item->user)) {
+      $data['user'] = null;
+    }
+    else {
+      $data['user'] = $this->transformUser((object) $item->user);
+    }
+
     return $data;
   }
 


### PR DESCRIPTION
#### What's this PR do?
- Allows you to request multiple signups by ID
- Adds a plural 'users' param because Diego likes plural things.
#### How should this be manually tested?

Ive been using this locally
`http://dev.dosomething.org:8888/api/v1/signups?competition=true&users=1705752,1700226&campaigns=1485`
#### Any background context you want to provide?

:cake: 
#### What are the relevant tickets?

Fixes #6316 
