### PR TITLE
Remove babel-eslint.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "@dosomething/eslint-config": "^1.1.1",
     "@dosomething/webpack-config": "^1.0.0",
-    "babel-eslint": "^5.0.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "eslint": "^2.4.0",


### PR DESCRIPTION
#### What's this PR do?

This fixes a build error that was occurring because the version of [babel-eslint](https://github.com/babel/babel-eslint) that we were using [was intended for ESLint 1.x](https://cloud.githubusercontent.com/assets/583202/14144992/1633e394-f660-11e5-9113-ccb96e26a6a9.png) . There was a new version released the other day that supports ESLint 2.x, but it so happens that ESLint actually supports ES2015 natively now!

So it seems like we can potentially remove this dependency and save ourselves some trouble.
#### How should this be manually tested?

Pull down this branch and run `npm install && npm start` in your theme directory. Nothing should fail.
#### Any background context you want to provide?

Here's the [failed Jenkins job](https://jenkins-thor.dosomething.org/job/Deploy-Thor/371/console) referenced above. We've had [other sporadic errors](https://github.com/DoSomething/voting-app/pull/456) relating to this plugin in the past, since it works by monkey-patching part of ESLint (rather than using a "standard" API) and so it's fairly brittle.
#### What are the relevant tickets?

:speak_no_evil: 
