### PR TITLE
returns empty array if non admin tries to hit /reportbacks?flagged=tr…

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -131,6 +131,10 @@ class Reportback extends Entity {
       throw new Exception('No reportback data found.');
     }
 
+    if (!dosomething_reportback_accessible_results($results)) {
+      throw new Exception('Access denied.');
+    }
+
     foreach($results as $item) {
       // @TODO: remove need for passing variable for constructor check.
       $reportback = new static(['ignore' => true]);


### PR DESCRIPTION
#### What's this PR do?

Adds check to see if user has permission to access flagged reportbacks. If not, empty array will be returned to user trying to hit `/reportbacks?flagged=true` with a `200` status code. 
#### How should this be manually tested?

As a non admin user, try to hit  `/reportbacks?flagged=true`. Empty array and `200` status code should be returned. 
#### What are the relevant tickets?

Fixes #6319

…ue and a 200 status code
