### PR TITLE
Adds parent campaign link to campaign run template 

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -6,6 +6,7 @@
 
 include_once 'dosomething_campaign_run.features.inc';
 include_once 'dosomething_campaign_run.cron.inc';
+include_once 'dosomething_campaign_run.theme.inc';
 
 /**
  * Adds loaded closed campaign_run node to the given parent campaign's $vars.

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.theme.inc
@@ -25,6 +25,6 @@ function dosomething_campaign_run_preprocess_node(&$vars) {
  */
 function dosomething_campaign_run_preprocess_page(&$vars, &$wrapper) {  
 
-  // Use the pitch page template to the theme. 
+  // Use the campaign run template to the theme. 
   $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'];
 }

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.theme.inc
@@ -14,17 +14,3 @@ function dosomething_campaign_run_preprocess_node(&$vars) {
   
   $vars['campaign_title'] = node_load($vars['field_campaigns'][0]['target_id'])->title;
 }
-
-/**
- * Preprocesses variables for campaign run page.
- *
- * @param array $vars
- *  Node variables, passed from the preprocess_node.
- * @param object $wrapper
- *  The corresponding entity wrapper for the node in $vars. 
- */
-function dosomething_campaign_run_preprocess_page(&$vars, &$wrapper) {  
-
-  // Use the campaign run template to the theme. 
-  $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'];
-}

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.theme.inc
@@ -12,7 +12,12 @@ function dosomething_campaign_run_preprocess_node(&$vars) {
   
   $campaign_nid = dosomething_campaign_run_get_parent_nid($vars['node']->nid);
   $vars['campaign_nid'] = $campaign_nid;
+  
   $vars['campaign_title'] = node_load($campaign_nid)->title;
+  
+  $run_date = strtotime($vars['field_run_date']['0']['value']);
+  $vars['run_date'] = date('l, F  d, Y', $run_date);
+
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.theme.inc
@@ -9,15 +9,11 @@
  */
 function dosomething_campaign_run_preprocess_node(&$vars) {
   if ($vars['type'] != 'campaign_run' || $vars['view_mode'] != 'full') return;
-  
+
   $campaign_nid = dosomething_campaign_run_get_parent_nid($vars['node']->nid);
   $vars['campaign_nid'] = $campaign_nid;
   
   $vars['campaign_title'] = node_load($campaign_nid)->title;
-  
-  $run_date = strtotime($vars['field_run_date']['0']['value']);
-  $vars['run_date'] = date('l, F  d, Y', $run_date);
-
 }
 
 /**
@@ -29,6 +25,7 @@ function dosomething_campaign_run_preprocess_node(&$vars) {
  *  The corresponding entity wrapper for the node in $vars. 
  */
 function dosomething_campaign_run_preprocess_page(&$vars, &$wrapper) {  
+
   // Use the pitch page template to the theme. 
   $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'];
 }

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.theme.inc
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @file 
+ * Preprocess funtions for the dosomething_campaign_run module.
+ */
+
+/**
+ * Implements hook_preprocess_node().
+ */
+function dosomething_campaign_run_preprocess_node(&$vars) {
+  if ($vars['type'] != 'campaign_run' || $vars['view_mode'] != 'full') return;
+  
+  $campaign_nid = dosomething_campaign_run_get_parent_nid($vars['node']->nid);
+  $vars['campaign_nid'] = $campaign_nid;
+  $vars['campaign_title'] = node_load($campaign_nid)->title;
+}
+
+/**
+ * Preprocesses variables for campaign run page.
+ *
+ * @param array $vars
+ *  Node variables, passed from the preprocess_node.
+ * @param object $wrapper
+ *  The corresponding entity wrapper for the node in $vars. 
+ */
+function dosomething_campaign_run_preprocess_page(&$vars, &$wrapper) {  
+  // Use the pitch page template to the theme. 
+  $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'];
+}

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.theme.inc
@@ -9,8 +9,6 @@
  */
 function dosomething_campaign_run_preprocess_node(&$vars) {
   if ($vars['type'] != 'campaign_run' || $vars['view_mode'] != 'full') return;
-
-  $vars['campaign_nid'] = $vars['field_campaigns'][0]['target_id'];
   
   $vars['campaign_title'] = node_load($vars['field_campaigns'][0]['target_id'])->title;
 }

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.theme.inc
@@ -10,10 +10,9 @@
 function dosomething_campaign_run_preprocess_node(&$vars) {
   if ($vars['type'] != 'campaign_run' || $vars['view_mode'] != 'full') return;
 
-  $campaign_nid = dosomething_campaign_run_get_parent_nid($vars['node']->nid);
-  $vars['campaign_nid'] = $campaign_nid;
+  $vars['campaign_nid'] = $vars['field_campaigns'][0]['target_id'];
   
-  $vars['campaign_title'] = node_load($campaign_nid)->title;
+  $vars['campaign_title'] = node_load($vars['field_campaigns'][0]['target_id'])->title;
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/templates/README.md
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/README.md
@@ -19,6 +19,10 @@ Campaign
 
 * `submit-campaign-idea.tpl.php` - Block content callback for the "DS Submit Campaign Idea" block, defined in DoSomething Campaign.  Displays a form which has been configured in Google Docs, to submit the data to the doc. The form redirect is defined from within the Google Doc.
 
+Campaign Run
+------------
+* `node--campaign_run.tpl.php` - Node view of campaign run upon editing and saving.
+
 Reportback
 ----------
 * `reportback.tpl.php` - Staff only view of a reportback entity. e.g. /reportback/[id]

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
@@ -1,0 +1,7 @@
+<?php 
+/**
+ * Returns the HTML for the Campaign Run page.
+ */
+?>
+
+<p>Campaign: <?php print l($campaign_title, 'node/' . $campaign_nid); ?></p>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
@@ -4,7 +4,7 @@
  */
 ?>
 <h4>Campaign: 
-  <p><?php print l($campaign_title, 'node/' . $campaign_nid); ?></p>
+  <p><?php print l($campaign_title, 'node/' . $field_campaigns[0]['target_id']); ?></p>
 </h4>
 
 <?php 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
@@ -3,21 +3,14 @@
  * Returns the HTML for the Campaign Run page.
  */
 ?>
-
 <h4>Campaign: 
   <p><?php print l($campaign_title, 'node/' . $campaign_nid); ?></p>
 </h4>
 
-<h4>Winners:</h4>
-  <p><?php print l('Add', '/field-collection/field-winners/add/node/' . $nid . '/?destination=node/' . $nid); ?></p>
-
-<h4>Klout Gallery:</h4>
-  <p><?php print l('Add', '/field-collection/field-gallery-collection/add/node/' . $nid . '/?destination=node/' . $nid); ?></p>
-
-<h4>Run Date: 
-  <p><?php print t($run_date); ?></p>
-</h4
-
-
+<?php 
+  print render($content['field_winners']); 
+  print render($content['field_gallery_collection']);
+  print render($content['field_run_date']);
+?>
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
@@ -4,4 +4,12 @@
  */
 ?>
 
-<p>Campaign: <?php print l($campaign_title, 'node/' . $campaign_nid); ?></p>
+<h4>Campaign: 
+  <p><?php print l($campaign_title, 'node/' . $campaign_nid); ?></p>
+</h4>
+
+<h4>Winners:</h4>
+<h4>Klout Gallery:</h4>
+<h4>Run Date: 
+  <p><?php print t($run_date); ?></p>
+</h4>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
@@ -9,7 +9,15 @@
 </h4>
 
 <h4>Winners:</h4>
+  <p><?php print l('Add', '/field-collection/field-winners/add/node/' . $nid . '/?destination=node/' . $nid); ?></p>
+
 <h4>Klout Gallery:</h4>
+  <p><?php print l('Add', '/field-collection/field-gallery-collection/add/node/' . $nid . '/?destination=node/' . $nid); ?></p>
+
 <h4>Run Date: 
   <p><?php print t($run_date); ?></p>
-</h4>
+</h4
+
+
+
+

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
@@ -8,7 +8,7 @@
 </h4>
 
 <?php 
-  print render($content['field_winners']); 
+  print render($content['field_winners']);
   print render($content['field_gallery_collection']);
   print render($content['field_run_date']);
 ?>


### PR DESCRIPTION
#### What's this PR do?

Makes the parent campaign title a clickable link to return to campaign page. 
#### How should this be manually tested?
- From campaign edit page (e.g. http://dev.dosomething.org:8888/us/node/1173/edit), click on current run link. 
- This will take you to edit page of campaign run (e.g. http://dev.dosomething.org:8888/us/node/1816/edit/en). Scroll down and click "Save." 
- This will take you to campaign run edit page (e.g. http://dev.dosomething.org:8888/us/node/1816). Here you will see new template with clickable campaign title to parent campaign page. 
#### What are the relevant tickets?

Fixes #6326 

cc'ing @sbsmith86 to see the code and for all the help on this!
