### PR TITLE
adds field for campaign run id

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -37,6 +37,15 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
       '#required' => TRUE,
       '#default_value' => $entity->nid,
     );
+    $form['camapgin_run_nid'] = array(
+      '#type' => 'entity_autocomplete',
+      '#title' => t('Campaign Run ID'),
+      '#description' => t("The campaign run node this reportback was submitted for."),
+      '#entity_type' => 'node',
+      '#bundles' => array('campaign_run'),
+      '#required' => TRUE,
+      '#default_value' => $entity->nid,
+    );
     if (!empty($entity->uid)) {
       $account = user_load($entity->uid);
       $username = $account->name;


### PR DESCRIPTION
#### What's this PR do?

Adds a new field for Campaign Run ID in the reportback form. 
#### How should this be manually tested?
- Visit `/admin/users/rb/add`
- Put `362` into the `Node` field.
- Try to add `d` into the `Campaign Run ID` field - this should throw an error - `The specified entity d does not match requirements.`
- Put `1227` into the `Campaign Run ID` field - it should not only save but also update the field to read `Comeback Clothes 2014 [id:1227]` after saving. 
#### What are the relevant tickets?

Fixes #6338 
