### PR TITLE
keeps old root-level pagination and retrieved count but adds meta pag…

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/CampaignTransformer.php
@@ -48,6 +48,9 @@ class CampaignTransformer extends Transformer {
     return [
       'pagination' => $this->paginate($total, $filters, 'campaigns'),
       'retrieved_count' => count($campaigns),
+      'meta' => [
+        'pagination' => $this->paginate($total, $filters, 'campaigns'),
+      ],
       'data' => $this->transformCollection($campaigns),
     ];
   }


### PR DESCRIPTION
#### What's this PR do?

Adds `meta.pagination` property to the `/campaigns` response while keeping the old root-level `pagination` and `retrieved_count` included for Android compatibility. 
#### How should this be manually tested?

visit `/campaigns` and response should look like: 

```
{
  pagination: {
    total: 85,
    per_page: 25,
    current_page: 1,
    total_pages: 4,
    links: {
      prev_uri: null,
      next_uri: "http://dev.dosomething.org:8888/api/v1/campaigns?type=campaign&count=25&page=2"
    }
  },
  retrieved_count: 25,
  meta: {
    pagination: {
      total: 85,
      per_page: 25,
      current_page: 1,
      total_pages: 4,
      links: {
        prev_uri: null,
        next_uri: "http://dev.dosomething.org:8888/api/v1/campaigns?type=campaign&count=25&page=2"
      }
    }
  },
  data: [
  {
```
#### Any background context you want to provide?

We'll want to update this in the future to eventually get rid of the root-level `pagination` and `retrieved count` fields. 
#### What are the relevant tickets?

Fixes #6314 

…ination wrapper below as well
