### PR TITLE
Fixes logic error in ds build install.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -216,27 +216,9 @@ function build_helper {
   # Clear caches and Run updates
   cd "$WEB_PATH/sites/$SITE"
 
-  if [[ $2 == "--install" ]]
-  then
-    echo "Installing"
-    install
-  fi
-
-  if [[ $3 == "--dev" ]]
-  then
-    echo "Dev"
-    dev
-  fi
-
   echo 'Replacing settings.php file...'
   sudo rm -f $WEB_PATH/sites/$SITE/settings.php && chmod u+w $WEB_PATH/sites/$SITE
   ln -s $CONFIG_PATH/settings.php $WEB_PATH/sites/$SITE/settings.php
-
-  # See https://www.drupal.org/PSA-2015-001
-  echo 'Removing install.php...'
-  if [[ -f $WEB_PATH/install.php ]]; then
-    rm $WEB_PATH/install.php
-  fi
 
   if [[ $SITE != "default" ]]
   then
@@ -252,9 +234,27 @@ function build_helper {
       cp $CONFIG_PATH/default.settings.local.php $CONFIG_PATH/settings.local.php
     fi
 
-  echo 'Linking local settings file...'
-  ln -s $CONFIG_PATH/settings.local.php $WEB_PATH/sites/$SITE/settings.local.php
+    echo 'Linking local settings file...'
+    ln -s $CONFIG_PATH/settings.local.php $WEB_PATH/sites/$SITE/settings.local.php
 
+  fi
+
+  if [[ $2 == "--install" ]]
+  then
+    echo "Installing"
+    install
+  fi
+
+  if [[ $3 == "--dev" ]]
+  then
+    echo "Dev"
+    dev
+  fi
+
+  # See https://www.drupal.org/PSA-2015-001
+  echo 'Removing install.php...'
+  if [[ -f $WEB_PATH/install.php ]]; then
+    rm $WEB_PATH/install.php
   fi
 
   # Before running drush it's required to flush Redis cache to avoid

--- a/config/default.settings.local.php
+++ b/config/default.settings.local.php
@@ -14,3 +14,4 @@
 
 // Use local Solr instance.
 putenv('DS_FINDER_URL=http://127.0.0.1:8983');
+$conf['apachesolr_environments']['solr']['url'] = 'http://127.0.0.1:8983/solr/collection1';


### PR DESCRIPTION
#### What's this PR do?
- Fixes logic error in ds build install
- Implicitly sets up local solr environment
- As a result solr build errors are fixed: `WD Apache Solr: HTTP Status: 404; Message: Not Found: Not Found; Response: [error] Error 404 Not Found`, see #5921.
#### How should this be manually tested?

Rebuild site as usual.
#### Any background context you want to provide?

There was a logic problem in `ds build --install` script. It copied global and local settings file AFTER profile installation. Without settings were installed incorrectly and configuration through features was incomplete. Also, the only reason why Drupal even knew how to access the database without settings file was that connection details were set in [`ds.aliases.drushrc.php`](https://github.com/DoSomething/tower/blob/master/roles/dosomething.phoenix/templates/drush/ds.aliases.drushrc.php.j2#L3).
#### What are the relevant tickets?

Ref #6341
A part of #5921
