### PR TITLE
adds campaign closed state link to campaign run view

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
@@ -7,6 +7,10 @@
   <p><?php print l($campaign_title, 'node/' . $field_campaigns[0]['target_id']); ?></p>
 </h4>
 
+<h4>Campaign Closed State:
+  <p><?php print l($campaign_title . ': Closed State', 'node/' . $field_campaigns[0]['target_id'] . '/closed'); ?></p>
+</h4>
+
 <?php 
   print render($content['field_winners']);
   print render($content['field_gallery_collection']);


### PR DESCRIPTION
#### What's this PR do?

Adds link to campaign closed state page in campaign run template. 
#### How should this be manually tested?
- From campaign edit page (e.g. http://dev.dosomething.org:8888/us/node/1173/edit), click on current run link.
- This will take you to edit page of campaign run (e.g. http://dev.dosomething.org:8888/us/node/1816/edit/en). Scroll down and click "Save."
- This will take you to campaign run edit page (e.g. http://dev.dosomething.org:8888/us/node/1816). Here you will see a link to the campaign's closed page under the the campaign link.
#### What are the relevant tickets?

Refs [comment](https://github.com/DoSomething/phoenix/issues/6326#issuecomment-205859764) in #6326 
