### PR TITLE
Bulk exclude

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -919,7 +919,7 @@ function dosomething_reportback_update_7034() {
   $fids_to_be_marked_as_excluded = db_query("SELECT rb.rbid, rb.nid, rb.run_nid, rb.quantity, rbf.status, rbf.fid
                                             FROM dosomething_reportback rb
                                             JOIN dosomething_reportback_file rbf on rb.rbid = rbf.rbid
-                                            WHERE rb.nid = '1173' AND  rb.run_nid = '5439' OR rb.run_nid = '2341' AND rb.quantity < 200 AND rbf.status = 'pending';");
+                                            WHERE rb.nid = '362' AND  rb.run_nid = '5439' OR rb.run_nid = '2341' AND rb.quantity < 200 AND rbf.status = 'pending';");
 
   foreach ($fids_to_be_marked_as_excluded as $fid) {
     db_update('dosomething_reportback_file')

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -916,10 +916,10 @@ function dosomething_reportback_update_7033() {
  * Updates any fid with a pending status to be marked as excluded if the quantity in the reportback is less than 200.  
  */   
 function dosomething_reportback_update_7034() {
-  $fids_to_be_marked_as_excluded = db_query("SELECT rb.nid, rb.run_nid, rb.quantity, rbf.status, rbf.fid
+  $fids_to_be_marked_as_excluded = db_query("SELECT rb.rbid, rb.nid, rb.run_nid, rb.quantity, rbf.status, rbf.fid
                                             FROM dosomething_reportback rb
                                             JOIN dosomething_reportback_file rbf on rb.rbid = rbf.rbid
-                                            WHERE rb.nid = '362' AND rb.run_nid = '5439' OR rb.run_nid = '2341' AND rb.quantity < 200 AND rbf.status = 'pending';");
+                                            WHERE rb.nid = '1173' AND  rb.run_nid = '5439' OR rb.run_nid = '2341' AND rb.quantity < 200 AND rbf.status = 'pending';");
 
   foreach ($fids_to_be_marked_as_excluded as $fid) {
     db_update('dosomething_reportback_file')
@@ -930,13 +930,19 @@ function dosomething_reportback_update_7034() {
       ->condition('fid', $fid->fid)
       ->execute();
 
-    $reportback_item = entity_load_single('reportback_item', $fid->fid);
     $reportback = reportback_load($fid->rbid);
+    
+    if (empty($reportback)) {
+      continue;
+    }
+
     $items = $reportback->getFids();
+    $items = entity_load('reportback_item', $items);
 
     foreach ($items as $item) {
+      $flagged_fids = [];
+      
       if ($item->status === 'flagged') {
-        $flagged_fids = [];
         array_push($flagged_fids, $item);
       }
     }
@@ -945,6 +951,5 @@ function dosomething_reportback_update_7034() {
       $reportback->flagged = 0;
       entity_save('reportback', $reportback);
     }
-    
   }
 }


### PR DESCRIPTION
#### What's this PR do?

Script to bulk exclude any fids for node 362 (campaign runs 5439 or 2341) that are pending and whose reportback has a quantity of less than 200. This is a fix for #6353 . 
#### How should this be manually tested?

When ssh'd in your vagrant environment, run `drush updb -y` in `dosomething@dev:/var/www/dev.dosomething.org/html$`

Check `http://dev.dosomething.org:8888/us/node/362/rb/` and only `fids` with a quantity over 200 should still be pending and appear in the inbox. 
#### Any background context you want to provide?

Is an update to #6353 .

To test on my local, I added a reportback with 2 reportback items. I ran the script and saw that both reportback items statuses were changed to `excluded` and the parent reportback `flagged` status changed to `0`. 

Then, I added two more reportback items and changed one `status` to `flagged` and the parent reportback `flagged` status to `1`. I ran the script and the second reportback item's status updated to `excluded` and the reportback `flagged` status remained as `1`. 
#### What are the relevant tickets?

Fixes #6344 
