### PR TITLE
Only load campaign nodes in Campaign.php.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -48,7 +48,8 @@ class Campaign {
       $single_campaign = TRUE;
       $ids = [$ids];
     }
-    $results = node_load_multiple($ids);
+    // Only load campaign types in this class.
+    $results = node_load_multiple($ids, ['type' => 'campaign']);
 
     if (!$results) {
       throw new Exception('No campaign data found.');


### PR DESCRIPTION
#### What's this PR do?

Only loads node in the campaign class of `type = campaign`
#### How should this be manually tested?

pull down
`drush cc all`
check campaign pages & api endpoints, only get campaigns, not facts, not home pages, not NUTTIN
#### Any background context you want to provide?

duh.
![](https://media.giphy.com/media/rF3HGm9eW0kaA/giphy.gif)
#### What are the relevant tickets?

Fixes #6357
