### PR TITLE
Includes timing within the Signup.Campaign Run property

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -423,13 +423,17 @@ abstract class Transformer {
    *   - uri: (string) API URI for Signup data.
    * @return array
    */
-  protected function transformSignup($data, $current) {
+  protected function transformSignup($data, $current, $current_run_start, $current_run_end) {
     return [
       'id' => $data->id,
       'created_at' => $data->created_at,
       'campaign_run' => [
         'id' => $data->campaign_run,
         'current' => $current,
+        'timing' => [
+          'start' => $current_run_start,
+          'end' => $current_run_end,
+        ],
       ],
       'uri' => $data->uri,
     ];

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -86,6 +86,18 @@ class SignupTransformer extends Transformer {
       $current_run = $campaign->campaign_runs['current']['en']['id'];
       $current = ($item->campaign_run == $current_run);
       $data += $this->transformSignup($item, $current);
+      $campaign_run = node_load($current_run);
+      
+      if (isset($campaign_run->field_run_date['en'][0])) {
+        $current_run_start = $campaign_run->field_run_date['en'][0]['value'];
+        $current_run_end = $campaign_run->field_run_date['en'][0]['value2'];
+      } 
+      else {
+        $current_run_start = NULL;
+        $current_run_end = NULL;
+      }
+
+      $data += $this->transformSignup($item, $current, $current_run_start, $current_run_end);
       $data['campaign'] = $this->transformCampaign((object) $item->campaign);
     }
 

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -85,7 +85,6 @@ class SignupTransformer extends Transformer {
       $campaign = (object) $item->campaign;
       $current_run = $campaign->campaign_runs['current']['en']['id'];
       $current = ($item->campaign_run == $current_run);
-      $data += $this->transformSignup($item, $current);
       $campaign_run = node_load($current_run);
       
       if (isset($campaign_run->field_run_date['en'][0])) {

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -86,11 +86,11 @@ class SignupTransformer extends Transformer {
       $current_run = $campaign->campaign_runs['current']['en']['id'];
       $current = ($item->campaign_run == $current_run);
       $campaign_run = node_load($current_run);
-      
+
       if (isset($campaign_run->field_run_date['en'][0])) {
         $current_run_start = $campaign_run->field_run_date['en'][0]['value'];
         $current_run_end = $campaign_run->field_run_date['en'][0]['value2'];
-      } 
+      }
       else {
         $current_run_start = NULL;
         $current_run_end = NULL;


### PR DESCRIPTION
#### What's this PR do?

Includes timing within the Signup.Campaign Run property. 
#### How should this be manually tested?

Hit `/signups` and response should have `start` and `end` `timing` under `campaign_run`: 

![screen shot 2016-04-11 at 10 55 54 am](https://cloud.githubusercontent.com/assets/9019452/14431527/0e7dc606-ffd4-11e5-9f13-a9a818ce908a.png)
#### What are the relevant tickets?

Fixes #6166 
