### PR TITLE
Fix Forge 6.7 visual bugs.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -23,6 +23,7 @@ $asset-path: "";
 
 // Local patterns
 @import "patterns/author-callout";
+@import "patterns/container";
 @import "patterns/photo";
 @import "patterns/gallery";
 @import "patterns/promotion";

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/container.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/container.scss
@@ -1,0 +1,6 @@
+.container > .wrapper {
+  // Whaaa? This fixes issues with container__block's margin
+  // escaping outside of the container by creating a new block
+  // formatting context.
+  float: left;
+}

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--sms-game.tpl.php
@@ -124,11 +124,12 @@
               <div><?php print $starter['safe_value']; ?></div>
             <?php endif; ?>
           </div>
-
-          <?php if (isset($signup_form)) : ?>
-            <?php print render($signup_form); ?>
-          <?php endif; ?>
         </div>
+        <?php if (isset($signup_form)) : ?>
+          <div class="container__row">
+            <?php print render($signup_form); ?>
+          </div>
+        <?php endif; ?>
         <div class="container__row">
           <div class="container__block -narrow">
             <?php if (isset($official_rules)): ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -40,7 +40,7 @@
   <?php endif; ?>
 
   <?php // KNOW IT ////////////////////////////////////////////////////// ?>
-  <section id="know" class="container">
+  <section id="know" class="container -padded">
     <div class="wrapper">
       <div class="container__row">
         <div class="container__block">


### PR DESCRIPTION
#### What's this PR do?

Fix overflow issue in Step 4 of the campaign template.

So this is happening because we switched container spacing to use margins rather than padding. On mobile, the [container block's margin is collapsing and being lost outside the container](https://cloud.githubusercontent.com/assets/583202/14434806/d104209a-ffe2-11e5-8c25-8ab73f73b875.png)... but on desktop, this doesn't happen because the `float: left;` on the `.container > .wrapper` creates a new block formatting context.

I think a good fix would be to add a universal `float: left` to all `.container > .wrapper`s, regardless of breakpoint. It's a bit weird, but has less potential side effects than adding an `overflow: hidden` I think...
#### How should this be manually tested?

Idk, look at things do they look nice? :eyes: 
#### Any background context you want to provide?

Gah. [CSS](https://cloud.githubusercontent.com/assets/583202/14435101/31591b2a-ffe4-11e5-8630-1bc3ce72a9d4.gif), am I right?

I'll update this in a Forge patch release too but wanted to get a PR up to unblock today's deploy!
#### What are the relevant tickets?

Fixes #6363. Fixes #6364.

---

For review: @DoSomething/front-end 
