### PR TITLE
adds check to make sure that campaign run id is a number

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -707,10 +707,11 @@ function dosomething_helpers_unset_array_keys(array $array = [], array $keys = [
 
 /**
 * Checks to see if items are numeric. Unsets anything non-numeric and returns array of numbers.
+* @param string|array
 */
 function dosomething_helpers_unset_non_numeric_values($items) {
   if (is_string($items)) {
-      $items = explode(' ', $items);
+    $items = [$items];
   }
   
   foreach ($items as $key => $item) {

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -521,6 +521,8 @@ function dosomething_helpers_floor_decimal($value, $decimals = 1) {
   return floor($value * pow(10, $decimals)) / pow(10, $decimals);
 }
 
+
+
 /**
  * Adds custom GA event to page
  *
@@ -701,6 +703,25 @@ function dosomething_helpers_unset_array_keys(array $array = [], array $keys = [
   }
 
   return $array;
+}
+
+/**
+* Checks to see if items are numeric. Unsets anything non-numeric and returns array of numbers.
+*/
+function dosomething_helpers_unset_non_numeric_values($items) {
+  if (is_string($items)) {
+      $items = explode(' ', $items);
+  }
+
+  $numeric_items = [];
+  
+  foreach ($items as $item) {
+    if (is_numeric($item)) {
+      array_push($numeric_items, $item);
+    } 
+  }
+
+  return $numeric_items;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -712,16 +712,14 @@ function dosomething_helpers_unset_non_numeric_values($items) {
   if (is_string($items)) {
       $items = explode(' ', $items);
   }
-
-  $numeric_items = [];
   
-  foreach ($items as $item) {
-    if (is_numeric($item)) {
-      array_push($numeric_items, $item);
+  foreach ($items as $key => $item) {
+    if (! is_numeric($item)) {
+      unset($items[$key]);
     } 
   }
 
-  return $numeric_items;
+  return $items;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -706,10 +706,11 @@ function dosomething_helpers_unset_array_keys(array $array = [], array $keys = [
 }
 
 /**
-* Checks to see if items are numeric. Unsets anything non-numeric and returns array of numbers.
+* Checks to see if items are numeric. Unsets anything non-numeric and returns array of numbers (or empty array).
 * @param string|array
+* @return array
 */
-function dosomething_helpers_unset_non_numeric_values($items) {
+function dosomething_helpers_unset_non_numeric_array_values($items) {
   if (is_string($items)) {
     $items = [$items];
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
@@ -10,10 +10,10 @@
  *
  * @param array $params
  *   An associative array of conditions to filter by. Possible keys:
- *   - nid: (string) A campaign node nid to filter by.
- *   - rbid: (string) A reportback rbid to filter by.
+ *   - nid: (string or array) A campaign node nid to filter by.
+ *   - rbid: (string or array) A reportback rbid to filter by.
  *   - random: (boolean) If set, randomly sort the results.
- *   - runs: (string) Campaign run nid(s) to filter by. 
+ *   - runs: (string or array) Campaign run nid(s) to filter by. 
  * @return SelectQuery object
  */
 function dosomething_reportback_build_reportbacks_query($params = array()) {
@@ -66,12 +66,19 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
   }
 
   if (isset($params['runs'])) {
-    if (is_array($params['runs'])) {
-      $query->condition('rb.run_nid', $params['runs'], 'IN');
-    } 
-    else {
-      $query->condition('rb.run_nid', $params['runs'], '=');
+    if (is_string($params['runs'])) {
+      $params['runs'] = explode(' ', $params['runs']);
     }
+
+    $campaign_runs = [];
+    
+    foreach ($params['runs'] as $campaign_run) {
+      if (is_numeric($campaign_run)) {
+        array_push($campaign_runs, $campaign_run);
+      } 
+    }
+    
+    $query->condition('rb.run_nid', $campaign_runs, 'IN');
   }
 
   // Public API properties to expose:

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
@@ -66,19 +66,8 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
   }
 
   if (isset($params['runs'])) {
-    if (is_string($params['runs'])) {
-      $params['runs'] = explode(' ', $params['runs']);
-    }
-
-    $campaign_runs = [];
-    
-    foreach ($params['runs'] as $campaign_run) {
-      if (is_numeric($campaign_run)) {
-        array_push($campaign_runs, $campaign_run);
-      } 
-    }
-    
-    $query->condition('rb.run_nid', $campaign_runs, 'IN');
+    $params['runs'] = dosomething_helpers_unset_non_numeric_values($params['runs']);
+    $query->condition('rb.run_nid', $params['runs'], 'IN');
   }
 
   // Public API properties to expose:

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
@@ -10,10 +10,10 @@
  *
  * @param array $params
  *   An associative array of conditions to filter by. Possible keys:
- *   - nid: (string or array) A campaign node nid to filter by.
- *   - rbid: (string or array) A reportback rbid to filter by.
+ *   - nid: (string) A campaign node nid to filter by.
+ *   - rbid: (string) A reportback rbid to filter by.
  *   - random: (boolean) If set, randomly sort the results.
- *   - runs: (string or array) Campaign run nid(s) to filter by. 
+ *   - runs: (string) Campaign run nid(s) to filter by. 
  * @return SelectQuery object
  */
 function dosomething_reportback_build_reportbacks_query($params = array()) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
@@ -13,7 +13,7 @@
  *   - nid: (string) A campaign node nid to filter by.
  *   - rbid: (string) A reportback rbid to filter by.
  *   - random: (boolean) If set, randomly sort the results.
- *   - runs: (string) Campaign run nid(s) to filter by. 
+ *   - runs: (string|array) Campaign run nid(s) to filter by. 
  * @return SelectQuery object
  */
 function dosomething_reportback_build_reportbacks_query($params = array()) {
@@ -66,7 +66,7 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
   }
 
   if (isset($params['runs'])) {
-    $params['runs'] = dosomething_helpers_unset_non_numeric_values($params['runs']);
+    $params['runs'] = dosomething_helpers_unset_non_numeric_array_values($params['runs']);
     $query->condition('rb.run_nid', $params['runs'], 'IN');
   }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -47,17 +47,10 @@ function dosomething_signup_get_signups_query($params, $tally = FALSE) {
  *
  * @param array $params
  *   An associative array of conditions to filter by. Possible keys:
-<<<<<<< HEAD
  *   - uid: (string) User id(s) to filter by.
  *   - campaigns: (string) Campaign nid(s) to filter by.
- *   - competition: (boolean) Only return competition signups & order by reportback quantity.
- *   - runs: (string) Campaign run nid(s) to filter by.
-=======
- *   - uid: (string or array) User id(s) to filter by.
- *   - campaigns: (string or array) Campaign nid(s) to filter by.
  *   - competition: (boolean) Only return competition signups & order by reportback quantity. 
- *   - runs: (string or array) Campaign run nid(s) to filter by. 
->>>>>>> adds check to make sure that campaign run id is a number
+ *   - runs: (string) Campaign run nid(s) to filter by. 
  * @return SelectQuery object
  */
 function dosomething_signup_build_signups_query($params = []) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -50,7 +50,7 @@ function dosomething_signup_get_signups_query($params, $tally = FALSE) {
  *   - uid: (string) User id(s) to filter by.
  *   - campaigns: (string) Campaign nid(s) to filter by.
  *   - competition: (boolean) Only return competition signups & order by reportback quantity. 
- *   - runs: (string) Campaign run nid(s) to filter by. 
+ *   - runs: (string|array) Campaign run nid(s) to filter by. 
  * @return SelectQuery object
  */
 function dosomething_signup_build_signups_query($params = []) {
@@ -92,7 +92,7 @@ function dosomething_signup_build_signups_query($params = []) {
   }
 
   if (isset($params['runs'])) {
-    $params['runs'] = dosomething_helpers_unset_non_numeric_values($params['runs']);
+    $params['runs'] = dosomething_helpers_unset_non_numeric_array_values($params['runs']);
     $query->condition('s.run_nid', $params['runs'], 'IN');
   }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -47,10 +47,17 @@ function dosomething_signup_get_signups_query($params, $tally = FALSE) {
  *
  * @param array $params
  *   An associative array of conditions to filter by. Possible keys:
+<<<<<<< HEAD
  *   - uid: (string) User id(s) to filter by.
  *   - campaigns: (string) Campaign nid(s) to filter by.
  *   - competition: (boolean) Only return competition signups & order by reportback quantity.
  *   - runs: (string) Campaign run nid(s) to filter by.
+=======
+ *   - uid: (string or array) User id(s) to filter by.
+ *   - campaigns: (string or array) Campaign nid(s) to filter by.
+ *   - competition: (boolean) Only return competition signups & order by reportback quantity. 
+ *   - runs: (string or array) Campaign run nid(s) to filter by. 
+>>>>>>> adds check to make sure that campaign run id is a number
  * @return SelectQuery object
  */
 function dosomething_signup_build_signups_query($params = []) {
@@ -92,11 +99,19 @@ function dosomething_signup_build_signups_query($params = []) {
   }
 
   if (isset($params['runs'])) {
-    if (is_array($params['runs'])) {
-      $query->condition('s.run_nid', $params['runs'], 'IN');
-    } else {
-      $query->condition('s.run_nid', $params['runs'], '=');
+    if (is_string($params['runs'])) {
+      $params['runs'] = explode(' ', $params['runs']);
     }
+
+    $campaign_runs = [];
+    
+    foreach ($params['runs'] as $campaign_run) {
+      if (is_numeric($campaign_run)) {
+        array_push($campaign_runs, $campaign_run);
+      } 
+    }
+    
+    $query->condition('rb.run_nid', $campaign_runs, 'IN');
   }
 
   return $query;

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -92,19 +92,8 @@ function dosomething_signup_build_signups_query($params = []) {
   }
 
   if (isset($params['runs'])) {
-    if (is_string($params['runs'])) {
-      $params['runs'] = explode(' ', $params['runs']);
-    }
-
-    $campaign_runs = [];
-    
-    foreach ($params['runs'] as $campaign_run) {
-      if (is_numeric($campaign_run)) {
-        array_push($campaign_runs, $campaign_run);
-      } 
-    }
-    
-    $query->condition('s.run_nid', $campaign_runs, 'IN');
+    $params['runs'] = dosomething_helpers_unset_non_numeric_values($params['runs']);
+    $query->condition('s.run_nid', $params['runs'], 'IN');
   }
 
   return $query;

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -104,7 +104,7 @@ function dosomething_signup_build_signups_query($params = []) {
       } 
     }
     
-    $query->condition('rb.run_nid', $campaign_runs, 'IN');
+    $query->condition('s.run_nid', $campaign_runs, 'IN');
   }
 
   return $query;


### PR DESCRIPTION
#### What's this PR do?

Adds check to make sure that `$params['run']` is a number. 
#### How should this be manually tested?

Same as testing in #6359 , screen shots below: 

![screen shot 2016-04-12 at 2 08 11 pm](https://cloud.githubusercontent.com/assets/9019452/14470527/05f01f22-00b8-11e6-8630-aa6acc911227.png)
![screen shot 2016-04-12 at 2 08 45 pm](https://cloud.githubusercontent.com/assets/9019452/14470545/1c72a210-00b8-11e6-9a1a-67bb0bbcead9.png)
![screen shot 2016-04-12 at 2 09 42 pm](https://cloud.githubusercontent.com/assets/9019452/14470575/43a45a22-00b8-11e6-92ef-75a2cde1e300.png)
![screen shot 2016-04-12 at 2 10 19 pm](https://cloud.githubusercontent.com/assets/9019452/14470588/5018a010-00b8-11e6-862a-63b2e7b9c12e.png)
![screen shot 2016-04-12 at 2 10 36 pm](https://cloud.githubusercontent.com/assets/9019452/14470594/5c9658dc-00b8-11e6-8a71-2362da4b606a.png)
![screen shot 2016-04-12 at 2 11 12 pm](https://cloud.githubusercontent.com/assets/9019452/14470605/6f9807aa-00b8-11e6-8ae5-f9ea6eabc0a5.png)
![screen shot 2016-04-12 at 2 11 56 pm](https://cloud.githubusercontent.com/assets/9019452/14470628/8b6077ec-00b8-11e6-9ac1-79167923fc51.png)
#### Any background context you want to provide?

When testing on thor, `/signups?campaigns=362&runs=z` returned a signup with the `run_id` of `0`. No other params have ids of `0` in the production database so do not need this check (should we include anyway to be safe and not sorry?). 
#### What are the relevant tickets?

Fixes #6371 
