### PR TITLE
revert "Revert "Campaign run param""

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
@@ -99,6 +99,14 @@ function _reportback_resource_definition() {
             'source' => ['param' => 'flagged'],
             'default value' => FALSE,
           ],
+          [
+            'name' => 'runs',
+            'description' => 'The ids of the specified campaign runs to get reportbacks for.',
+            'optional' => TRUE,
+            'type' => 'string',
+            'source' => ['param' => 'runs'],
+            'default value' => NULL,
+          ],
         ],
         'access callback' => '_reportback_resource_access',
         'access arguments' => ['index'],
@@ -144,7 +152,7 @@ function _reportback_resource_access($op) {
  * @param  bool    $flagged
  * @return array
  */
-function _reportback_resource_index($ids, $campaigns, $status, $count, $random, $page, $load_user, $flagged) {
+function _reportback_resource_index($ids, $campaigns, $status, $count, $random, $page, $load_user, $flagged, $runs) {
   $parameters =  [
     'ids' => $ids,
     'campaigns' => $campaigns,
@@ -154,6 +162,7 @@ function _reportback_resource_index($ids, $campaigns, $status, $count, $random, 
     'page' => $page,
     'load_user' => $load_user,
     'flagged' => $flagged,
+    'runs' => $runs,
   ];
 
   return (new ReportbackTransformer)->index($parameters);

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -83,6 +83,14 @@ function _signup_resource_definition() {
             'source' => ['param' => 'competition'],
             'default value' => FALSE,
           ],
+          [
+            'name' => 'runs',
+            'description' => 'The ids of the specified campaign runs to get signups for.',
+            'optional' => TRUE,
+            'type' => 'string',
+            'source' => ['param' => 'runs'],
+            'default value' => NULL,
+          ],
         ],
         'access callback' => '_signup_resource_access',
         'access arguments' => ['index'],
@@ -105,9 +113,10 @@ function _signup_resource_access() {
  * @param int $count
  * @param int $page
  * @param boolean $competition
+ * @param string $runs
  * @return array
  */
-function _signup_resource_index($user, $users, $campaigns, $count, $page, $competition) {
+function _signup_resource_index($user, $users, $campaigns, $count, $page, $competition, $runs) {
 
   if (isset($users)) {
     $user = $users;
@@ -119,6 +128,7 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
     'count' => $count,
     'page' => $page,
     'competition' => $competition,
+    'runs' => $runs,
   ];
 
   return (new SignupTransformer)->index($parameters);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
@@ -13,6 +13,7 @@
  *   - nid: (string) A campaign node nid to filter by.
  *   - rbid: (string) A reportback rbid to filter by.
  *   - random: (boolean) If set, randomly sort the results.
+ *   - runs: (string) Campaign run nid(s) to filter by. 
  * @return SelectQuery object
  */
 function dosomething_reportback_build_reportbacks_query($params = array()) {
@@ -61,6 +62,14 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
     }
     else {
       $query->condition('rb.flagged', 0);
+    }
+  }
+
+  if (isset($params['runs'])) {
+    if (is_array($params['runs'])) {
+      $query->condition('rb.run_nid', $params['runs'], 'IN');
+    } else {
+      $query->condition('rb.run_nid', $params['runs'], '=');
     }
   }
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -106,6 +106,7 @@ class ReportbackTransformer extends Transformer {
       'random' => dosomething_helpers_convert_string_to_boolean($parameters['random']),
       'load_user' => dosomething_helpers_convert_string_to_boolean($parameters['load_user']),
       'flagged' => dosomething_helpers_convert_string_to_boolean($parameters['flagged']),
+      'runs' => dosomething_helpers_format_data($parameters['runs']),
     ];
 
     // Unset False boolean values that affect the query builder.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -49,7 +49,8 @@ function dosomething_signup_get_signups_query($params, $tally = FALSE) {
  *   An associative array of conditions to filter by. Possible keys:
  *   - uid: (string) User id(s) to filter by.
  *   - campaigns: (string) Campaign nid(s) to filter by.
- *   - competition: (boolean) Only return competition signups & order by reportback quantity.
+ *   - competition: (boolean) Only return competition signups & order by reportback quantity. 
+ *   - runs: (string) Campaign run nid(s) to filter by. 
  * @return SelectQuery object
  */
 function dosomething_signup_build_signups_query($params = []) {
@@ -87,6 +88,14 @@ function dosomething_signup_build_signups_query($params = []) {
       $query->condition('s.nid', $params['campaigns'], 'IN');
     } else {
       $query->condition('s.nid', $params['campaigns'], '=');
+    }
+  }
+
+  if (isset($params['runs'])) {
+    if (is_array($params['runs'])) {
+      $query->condition('s.run_nid', $params['runs'], 'IN');
+    } else {
+      $query->condition('s.run_nid', $params['runs'], '=');
     }
   }
 

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -130,6 +130,7 @@ class SignupTransformer extends Transformer {
       'count' => (int) $parameters['count'] ?: 25,
       'page' => (int) $parameters['page'],
       'competition' => $parameters['competition'] ?: NULL,
+      'runs' => dosomething_helpers_format_data($parameters['runs']),
     ];
 
     return $filters;


### PR DESCRIPTION
#### What's this PR do?

Re-adds code from #6359 
#### How should this be manually tested?

http://dev.dosomething.org:8888/api/v1/reportbacks?campaigns=1631&runs=1874 should return an empty data array (there are no reportbacks for this campaign run.

http://dev.dosomething.org:8888/api/v1/reportbacks?campaigns=1631&runs=1903 should return reportback with rbid = 3543

http://dev.dosomething.org:8888/api/v1/signups?campaigns=1631&runs=1903 should return only signups with campaign run id = 1903 (this will show in the returned results.

see more tests from #6359 
#### Any background context you want to provide?

When I merged in #6359, I had some problems testing on thor - `/signups?campaigns=362&runs=z` gave a signup object with the `run_nid` of `0`. 

`/reportbacks` broke on thor when using the `campaigns` and/or the `runs` param (returned empty data objects when I expected many reportback objects to be returned) but when I cleared the cache, everything worked as expected.
#### What are the relevant tickets?

Fixes #6328 

cc @deadlybutter 

This reverts commit c158b9e2df898bc11f4e797976247c1db123da7f.
