### PR TITLE
Rearrange RB Admin Interface for Incremental UX Enhancement

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -321,25 +321,23 @@ function theme_dosomething_reportback_files_form($variables) {
     $rows[] = array(
       'data' => array(
         // Add the columns defined in the form.
-        $rbf->rbid . ": " . $fid ,
         drupal_render($form['rb_files'][$fid]['date']),
-        drupal_render($view),
-        drupal_render($form['rb_files'][$fid]['quantity']),
         drupal_render($form['rb_files'][$fid]['node']),
-        drupal_render($form['rb_files'][$fid]['status']) . '<div class="flag-form"><hr />' . $flag_form . '</div>' .  drupal_render($form['rb_files'][$fid]['status']) . '<div class="promote-form"><hr />' . $promote_form . '</div>',
         drupal_render($form['rb_files'][$fid]['rotate']),
+        drupal_render($view),
+        '<h3>' . drupal_render($form['rb_files'][$fid]['quantity']) . '</h3>',
+        drupal_render($form['rb_files'][$fid]['status']) . '<div class="flag-form"><hr />' . $flag_form . '</div>' .  drupal_render($form['rb_files'][$fid]['status']) . '<div class="promote-form"><hr />' . $promote_form . '</div>',
 
       ),
     );
   }
   $header = array(
-    t('RBID: fid'),
     t('Submitted'),
+    t('Campaign'),
+    t('Rotate (CW)'),
     NULL,
     t('Quantity'),
-    t('Campaign'),
     t('Op'),
-    t('Rotate (CW)'),
   );
 
   $output = '';


### PR DESCRIPTION
#### What's this PR do?

Rearranges RB admin interface as follows: 
- submitted
- campaign name
- ROTATE radial buttons
- photo (placement of caption and answer to "why is this important to you" will stay where they are)
- impact quantity, bolded
- OP (approval) radial buttons
#### How should this be manually tested?

Visit http://dev.dosomething.org:8888/us/node/:nid/rb and view should look like the below: 
![screen shot 2016-04-12 at 12 54 20 pm](https://cloud.githubusercontent.com/assets/9019452/14468460/b85531ee-00ad-11e6-85e6-353339140637.png)
#### What are the relevant tickets?

Fixes #6327 
