### PR TITLE
Fixes northstar id not displaying on some requests

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -189,6 +189,9 @@ function dosomething_helpers_extract_field_data($field, $language = LANGUAGE_NON
         // Date values, so need to extract using custom method.
         $values[] = dosomething_helpers_extract_field_dates($content);
       }
+      else if (in_array('country', $keys)) {
+        $values[] = $content['country'];
+      }
       elseif ($keys[0] === 'value') {
         // Text value, so need to extract using custom method.
         $values[] = dosomething_helpers_extract_field_text($content);

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -190,6 +190,7 @@ function dosomething_helpers_extract_field_data($field, $language = LANGUAGE_NON
         $values[] = dosomething_helpers_extract_field_dates($content);
       }
       else if (in_array('country', $keys)) {
+        //TODO: Build function to get all address data, not just country.
         $values[] = $content['country'];
       }
       elseif ($keys[0] === 'value') {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -49,17 +49,15 @@ function dosomething_signup_get_signups_query($params, $tally = FALSE) {
  *   An associative array of conditions to filter by. Possible keys:
  *   - uid: (string) User id(s) to filter by.
  *   - campaigns: (string) Campaign nid(s) to filter by.
- *   - competition: (boolean) Only return competition signups & order by reportback quantity. 
- *   - runs: (string) Campaign run nid(s) to filter by. 
+ *   - competition: (boolean) Only return competition signups & order by reportback quantity.
+ *   - runs: (string) Campaign run nid(s) to filter by.
  * @return SelectQuery object
  */
 function dosomething_signup_build_signups_query($params = []) {
   $query = db_select('dosomething_signup', 's');
   $query->leftJoin('dosomething_reportback', 'rb', 's.uid = rb.uid and s.nid = rb.nid and s.run_nid = rb.run_nid');
-  $query->leftJoin('field_data_field_northstar_id', 'ns', 'ns.entity_id = s.uid');
   $query->fields('s', ['sid', 'uid', 'nid', 'run_nid', 'timestamp']);
   $query->fields('rb', ['rbid']);
-  $query->fields('ns', ['field_northstar_id_value']);
   $query->orderBy('sid', 'DESC');
 
   if (isset($params['sid'])) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.query.inc
@@ -56,8 +56,10 @@ function dosomething_signup_get_signups_query($params, $tally = FALSE) {
 function dosomething_signup_build_signups_query($params = []) {
   $query = db_select('dosomething_signup', 's');
   $query->leftJoin('dosomething_reportback', 'rb', 's.uid = rb.uid and s.nid = rb.nid and s.run_nid = rb.run_nid');
+  $query->leftJoin('field_data_field_northstar_id', 'ns', 'ns.entity_id = s.uid');
   $query->fields('s', ['sid', 'uid', 'nid', 'run_nid', 'timestamp']);
   $query->fields('rb', ['rbid']);
+  $query->fields('ns', ['field_northstar_id_value']);
   $query->orderBy('sid', 'DESC');
 
   if (isset($params['sid'])) {

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -91,7 +91,7 @@ class Signup extends Entity {
 
     $drupal_user = user_load($data->uid);
 
-    if (!isset($data->field_northstar_id_value)) {
+    if (!isset($data->field_northstar_id_value) || $data->field_northstar_id_value === "NONE") {
       $northstar_response = dosomething_northstar_get_northstar_user($data->uid);
       $northstar_response = json_decode($northstar_response);
 

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -97,13 +97,19 @@ class Signup extends Entity {
 
       if (!empty($northstar_response->data) && !isset($northstar_response->error)) {
         $northstar_user = $northstar_response->data;
+        user_save($drupal_user, ['field_northstar_id' => [LANGUAGE_NONE => [0 => ['value' => $northstar_user->id]]]]);
       }
+    }
+
+    $last_initial = substr(dosomething_helpers_extract_field_data($drupal_user->field_last_name), 0, 1);
+    if ($last_initial === FALSE) {
+      $last_initial = NULL;
     }
 
     $this->user = [
       'id' => isset($northstar_user) ? $northstar_user->id : $data->field_northstar_id_value,
       'first_name' => dosomething_helpers_extract_field_data($drupal_user->field_first_name),
-      'last_initial' => dosomething_helpers_extract_field_data($drupal_user->field_last_name),
+      'last_initial' => $last_initial,
       'photo' => dosomething_helpers_extract_field_data($drupal_user->photo),
       'country' => dosomething_helpers_extract_field_data($drupal_user->field_address),
     ];

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -89,14 +89,21 @@ class Signup extends Entity {
     $this->id = $data->sid;
     $this->created_at = $data->timestamp;
 
-    $user = user_load($data->uid);
+    $drupal_user = user_load($data->uid);
+
+    $northstar_response = dosomething_northstar_get_northstar_user($data->uid);
+    $northstar_response = json_decode($northstar_response);
+
+    if (!empty($northstar_response->data) && !isset($northstar_response->error)) {
+      $northstar_user = $northstar_response->data;
+    }
 
     $this->user = [
-      'id' => $data->field_northstar_id_value === 'NONE' ? NULL : $data->field_northstar_id_value,
-      'first_name' => dosomething_helpers_extract_field_data($user->field_first_name),
-      'last_initial' => dosomething_helpers_extract_field_data($user->field_last_name),
-      'photo' => $user->picture,
-      'country' => dosomething_helpers_extract_field_data($user->field_address),
+      'id' => isset($northstar_user) ? $northstar_user->id : NULL,
+      'first_name' => dosomething_helpers_extract_field_data($drupal_user->field_first_name),
+      'last_initial' => dosomething_helpers_extract_field_data($drupal_user->field_last_name),
+      'photo' => dosomething_helpers_extract_field_data($drupal_user->photo),
+      'country' => dosomething_helpers_extract_field_data($drupal_user->field_address),
     ];
 
     try {

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -91,19 +91,21 @@ class Signup extends Entity {
 
     $drupal_user = user_load($data->uid);
 
-    $northstar_response = dosomething_northstar_get_northstar_user($data->uid);
-    $northstar_response = json_decode($northstar_response);
+    if (!isset($data->field_northstar_id_value)) {
+      $northstar_response = dosomething_northstar_get_northstar_user($data->uid);
+      $northstar_response = json_decode($northstar_response);
 
-    if (!empty($northstar_response->data) && !isset($northstar_response->error)) {
-      $northstar_user = $northstar_response->data;
+      if (!empty($northstar_response->data) && !isset($northstar_response->error)) {
+        $northstar_user = $northstar_response->data;
+      }
     }
 
     $this->user = [
-      'id' => isset($northstar_user) ? $northstar_user->id : NULL,
-      'first_name' => dosomething_helpers_isset($northstar_user, 'first_name'),
-      'last_initial' => dosomething_helpers_isset($northstar_user, 'last_initial'),
-      'photo' => dosomething_helpers_isset($northstar_user, 'photo'),
-      'country' => dosomething_helpers_isset($northstar_user, 'country'),
+      'id' => isset($northstar_user) ? $northstar_user->id : $data->field_northstar_id_value,
+      'first_name' => dosomething_helpers_extract_field_data($drupal_user->field_first_name),
+      'last_initial' => dosomething_helpers_extract_field_data($drupal_user->field_last_name),
+      'photo' => dosomething_helpers_extract_field_data($drupal_user->photo),
+      'country' => dosomething_helpers_extract_field_data($drupal_user->field_address),
     ];
 
     try {

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -100,10 +100,10 @@ class Signup extends Entity {
 
     $this->user = [
       'id' => isset($northstar_user) ? $northstar_user->id : NULL,
-      'first_name' => dosomething_helpers_extract_field_data($drupal_user->field_first_name),
-      'last_initial' => dosomething_helpers_extract_field_data($drupal_user->field_last_name),
-      'photo' => dosomething_helpers_extract_field_data($drupal_user->photo),
-      'country' => dosomething_helpers_extract_field_data($drupal_user->field_address),
+      'first_name' => dosomething_helpers_isset($northstar_user, 'first_name'),
+      'last_initial' => dosomething_helpers_isset($northstar_user, 'last_initial'),
+      'photo' => dosomething_helpers_isset($northstar_user, 'photo'),
+      'country' => dosomething_helpers_isset($northstar_user, 'country'),
     ];
 
     try {

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -91,7 +91,7 @@ class Signup extends Entity {
 
     $drupal_user = user_load($data->uid);
 
-    if (!isset($data->field_northstar_id_value) || $data->field_northstar_id_value === "NONE") {
+    if (!isset($data->field_northstar_id_value) || $data->field_northstar_id_value === 'NONE') {
       $northstar_response = dosomething_northstar_get_northstar_user($data->uid);
       $northstar_response = json_decode($northstar_response);
 


### PR DESCRIPTION
#### What's this PR do?

Instead of using the northstar id table (which @DFurnes says is not properly working, and Ive confirmed) we decided make a call to northstar to get the ID, like the reportbacks endpoint.
#### How should this be manually tested?

Ive been using http://dev.dosomething.org:8888/api/v1/signups?users=1700226 (My user id)
#### Any background context you want to provide?

Some people being exported in gladiator did not have any reportback activity, even though theye have reportedback. I believe this is because the ID is null in the response for them (and when you visit the profile NORTHSTAR_ID isnt set). because the ID is null we cant associate data with members in gladiator. 
#### What are the relevant tickets?

Fixes # 🍰 
