### PR TITLE
Runs bug

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -451,12 +451,12 @@ abstract class Transformer {
    */
   protected function transformUser($data) {
     return [
-      'id' => $data->id,
-      'drupal_id' => $data->drupal_id,
-      'first_name' => $data->first_name,
-      'last_initial' => $data->last_initial,
-      'photo' => $data->photo,
-      'country' => $data->country,
+      'id' => dosomething_helpers_isset($data, 'id'),
+      'drupal_id' => dosomething_helpers_isset($data, 'drupal_id'),
+      'first_name' => dosomething_helpers_isset($data, 'first_name'),
+      'last_initial' => dosomething_helpers_isset($data, 'last_initial'),
+      'photo' => dosomething_helpers_isset($data, 'photo'),
+      'country' => dosomething_helpers_isset($data, 'country'),
     ];
   }
 

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -452,6 +452,7 @@ abstract class Transformer {
   protected function transformUser($data) {
     return [
       'id' => $data->id,
+      'drupal_id' => $data->drupal_id,
       'first_name' => $data->first_name,
       'last_initial' => $data->last_initial,
       'photo' => $data->photo,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
@@ -68,7 +68,8 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
   if (isset($params['runs'])) {
     if (is_array($params['runs'])) {
       $query->condition('rb.run_nid', $params['runs'], 'IN');
-    } else {
+    } 
+    else {
       $query->condition('rb.run_nid', $params['runs'], '=');
     }
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.query.inc
@@ -74,7 +74,7 @@ function dosomething_reportback_build_reportbacks_query($params = array()) {
   }
 
   // Public API properties to expose:
-  $rb_fields = array('rbid', 'created', 'updated', 'quantity', 'uid', 'flagged');
+  $rb_fields = array('rbid', 'created', 'updated', 'quantity', 'uid', 'flagged', 'run_nid');
 
   // Staff-only properties to add:
   if (user_access('view any reportback')) {

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -109,7 +109,7 @@ class ReportbackTransformer extends Transformer {
       'flagged' => dosomething_helpers_convert_string_to_boolean($parameters['flagged']),
       'runs' => dosomething_helpers_format_data($parameters['runs']),
     ];
-    
+
     $filters['offset'] = $this->setOffset($filters['page'], $filters['count']);
 
     // Unset False boolean values that affect the query builder.

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -21,6 +21,7 @@ class ReportbackTransformer extends Transformer {
    */
   public function index($parameters) {
     $filters = $this->setFilters($parameters);
+
     try {
       $reportbacks = Reportback::find($filters);
       $reportbacks = services_resource_build_index_list($reportbacks, 'reportbacks', 'id');
@@ -108,6 +109,8 @@ class ReportbackTransformer extends Transformer {
       'flagged' => dosomething_helpers_convert_string_to_boolean($parameters['flagged']),
       'runs' => dosomething_helpers_format_data($parameters['runs']),
     ];
+    
+    $filters['offset'] = $this->setOffset($filters['page'], $filters['count']);
 
     // Unset False boolean values that affect the query builder.
     if (!$filters['random']) {

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -89,19 +89,8 @@ class Signup extends Entity {
     $this->id = $data->sid;
     $this->created_at = $data->timestamp;
 
-    $drupal_user = user_load($data->uid);
-
-    if (!isset($data->field_northstar_id_value) || $data->field_northstar_id_value === 'NONE') {
-      $northstar_response = dosomething_northstar_get_northstar_user($data->uid);
-      $northstar_response = json_decode($northstar_response);
-
-      if (!empty($northstar_response->data) && !isset($northstar_response->error)) {
-        dosomething_northstar_save_id_field($drupal_user, $northstar_response);
-      }
-    }
-
     $this->user = [
-      'id' => isset($northstar_user) ? $northstar_user->id : $data->field_northstar_id_value,
+      'drupal_id' => $data->uid,
     ];
 
     try {

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -100,17 +100,8 @@ class Signup extends Entity {
       }
     }
 
-    $last_initial = substr(dosomething_helpers_extract_field_data($drupal_user->field_last_name), 0, 1);
-    if ($last_initial === FALSE) {
-      $last_initial = NULL;
-    }
-
     $this->user = [
       'id' => isset($northstar_user) ? $northstar_user->id : $data->field_northstar_id_value,
-      'first_name' => dosomething_helpers_extract_field_data($drupal_user->field_first_name),
-      'last_initial' => $last_initial,
-      'photo' => isset($drupal_user->picture) ? $drupal_user->picture : NULL,
-      'country' => dosomething_helpers_extract_field_data($drupal_user->field_address),
     ];
 
     try {

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -109,7 +109,7 @@ class Signup extends Entity {
       'id' => isset($northstar_user) ? $northstar_user->id : $data->field_northstar_id_value,
       'first_name' => dosomething_helpers_extract_field_data($drupal_user->field_first_name),
       'last_initial' => $last_initial,
-      'photo' => dosomething_helpers_extract_field_data($drupal_user->photo),
+      'photo' => isset($drupal_user->picture) ? $drupal_user->picture : NULL,
       'country' => dosomething_helpers_extract_field_data($drupal_user->field_address),
     ];
 

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -90,12 +90,7 @@ class Signup extends Entity {
     $this->created_at = $data->timestamp;
 
     $this->user = [
-      'id' => NULL,
       'drupal_id' => $data->uid,
-      'first_name' => NULL,
-      'last_initial' => NULL,
-      'photo' => NULL,
-      'country' => NULL,
     ];
 
     try {

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -90,7 +90,12 @@ class Signup extends Entity {
     $this->created_at = $data->timestamp;
 
     $this->user = [
+      'id' => NULL,
       'drupal_id' => $data->uid,
+      'first_name' => NULL,
+      'last_initial' => NULL,
+      'photo' => NULL,
+      'country' => NULL,
     ];
 
     try {
@@ -109,11 +114,11 @@ class Signup extends Entity {
       try {
         $this->reportback = Reportback::get($data->rbid);
       } catch (Exception $e) {
-        $this->reportback = null;
+        $this->reportback = NULL;
       }
     }
     else {
-      $this->reportback = null;
+      $this->reportback = NULL;
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -133,6 +133,8 @@ class SignupTransformer extends Transformer {
       'runs' => dosomething_helpers_format_data($parameters['runs']),
     ];
 
+    $filters['offset'] = $this->setOffset($filters['page'], $filters['count']);
+
     return $filters;
   }
 }


### PR DESCRIPTION
#### What's this PR do?

Added missing `setOffset` to `ReportbackTransformer.php` and `SignupTransformer.php` to fix pagination issues. 

Updates `build` function in Signup.php to only return `drupal_id` - the rest of the user information gets filled in by [Northstar proxy](https://github.com/DoSomething/northstar/pull/343). 
#### How should this be manually tested?

Make sure that `prev_uri` and `next_uri` links return different data on each page for `/signups` and `/reportbacks`.
#### What are the relevant tickets?

Fixes #6373 
Refs #6372 - fixes pagination error for this issue.
