### PR TITLE
Patches international branch with security updates

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -5,4 +5,4 @@ core = 7.x
 
 ; Drupal Core
 projects[drupal][type] = core
-projects[drupal][version] = 7.41
+projects[drupal][version] = 7.43

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -5,4 +5,4 @@ core = 7.x
 
 ; Drupal Core
 projects[drupal][type] = core
-projects[drupal][version] = 7.38
+projects[drupal][version] = 7.39

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -5,4 +5,4 @@ core = 7.x
 
 ; Drupal Core
 projects[drupal][type] = core
-projects[drupal][version] = 7.39
+projects[drupal][version] = 7.41

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -64,7 +64,7 @@ projects[entityreference][version] = "1.1"
 projects[entityreference][subdir] = "contrib"
 
 ; Features
-projects[features][version] = "2.2"
+projects[features][version] = "2.9"
 projects[features][subdir] = "contrib"
 
 ; Field Collection

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -72,7 +72,7 @@ projects[field_collection][version] = "1.0-beta8"
 projects[field_collection][subdir] = "contrib"
 
 ; Field Group
-projects[field_group][version] = "1.4"
+projects[field_group][version] = "1.5"
 projects[field_group][subdir] = "contrib"
 
 ; File Entity

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -16,7 +16,7 @@ projects[admin_menu][version] = "3.0-rc5"
 projects[admin_menu][subdir] = "contrib"
 
 ; Apachesolr
-projects[apachesolr][version] = "1.6"
+projects[apachesolr][version] = "1.8"
 projects[apachesolr][subdir] = "contrib"
 
 ; Apachesolr Views

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -32,7 +32,7 @@ projects[cdn][version] = "2.6"
 projects[cdn][subdir] = "contrib"
 
 ; Ctools
-projects[ctools][version] = "1.7"
+projects[ctools][version] = "1.8"
 projects[ctools][subdir] = "contrib"
 
 ; Date


### PR DESCRIPTION
## Patches international branch with security updates
#### What's this PR do?
- Drupal core 7.38 to 7.43
- Apache Solr Search 7.x-1.6 to 7.x-1.8
- Chaos tool suite (ctools) 7.x-1.7 to 7.x-1.8
- Features 7.x-2.2 to 7.x-2.9
- Field Group 7.x-1.4 to 7.x-1.5
#### How should this be manually tested?

`ds build --intl --install`
#### Any background context you want to provide?

This is to be merged into `DoSomething:intl-sites`.
#### What are the relevant tickets?

Fixes #6331
