### PR TITLE
Update to include affiliates info in Campaign class build.

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,0 +1,3 @@
+# Phoenix API
+
+This is the **Phoenix API** for working with the [DoSomething.org](https://dosomething.org) platform.

--- a/documentation/endpoints/campaigns.md
+++ b/documentation/endpoints/campaigns.md
@@ -1,0 +1,242 @@
+# Campaigns Endpoint
+
+- [Retrieve A Campaign](#retrieve-a-campaign)
+
+## Retrieve A Campaign
+
+Get data for a specified campaign.
+
+```
+GET /api/v1/campaign/:id
+```
+
+**Headers**
+
+```javascript
+Accept: application/json
+Content-Type: application/json
+```
+
+**Example Request**
+
+```sh
+curl -X GET \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  https://www.dosomething.org/api/v1/campaigns/362
+```
+
+**Example Response**
+
+```javascript
+// 200 Okay
+
+{
+  "data": {
+    "id": "362",
+    "title": "Comeback Clothes",
+    "campaign_runs": {
+      "current": {
+        "en": {
+          "id": "1227"
+        }
+      },
+      "past": [
+        
+      ]
+    },
+    "language": {
+      "language_code": "en",
+      "prefix": "us"
+    },
+    "translations": {
+      "original": "en",
+      "en": {
+        "language_code": "en",
+        "prefix": "us"
+      },
+      "en-global": {
+        "language_code": "en-global",
+        "prefix": null
+      }
+    },
+    "tagline": "Recycle old or worn-out clothes to help all the planets.",
+    "status": "active",
+    "type": "campaign",
+    "created_at": "1393518858",
+    "updated_at": "1461690475",
+    "time_commitment": 5,
+    "cover_image": {
+      "default": {
+        "uri": "http://dev.dosomething.org:8888/sites/default/files/styles/300x300/public/ComebackClothes_hero_square.jpg?itok=tWoJlXKl",
+        "sizes": {
+          "landscape": {
+            "uri": "http://dev.dosomething.org:8888/sites/default/files/styles/1440x810/public/ComebackClothes_hero_landscape.jpg?itok=urtK3cfp"
+          },
+          "square": {
+            "uri": "http://dev.dosomething.org:8888/sites/default/files/styles/300x300/public/ComebackClothes_hero_square.jpg?itok=tWoJlXKl"
+          }
+        },
+        "type": "image",
+        "dark_background": false
+      },
+      "alternate": null
+    },
+    "staff_pick": true,
+    "competition": false,
+    "facts": {
+      "problem": "11.1 million tons of fabric that could be recycled ends up in landfills every year. That's the equivalent of over 70 billion t-shirts.",
+      "solution": null,
+      "sources": [
+        {
+          "formatted": "<p>\"Textiles.\" United States Environmental Protection Agency. Accessed February 24, 2014. http://www.epa.gov/osw/conserve/materials/textiles.htm</p>\n"
+        }
+      ]
+    },
+    "solutions": {
+      "copy": {
+        "raw": "Instead of trashing old clothes, give them a second life by recycling them. You’ll save water, energy, and landfill space.",
+        "formatted": "<p>Instead of trashing old clothes, give them a second life by recycling them. You’ll save water, energy, and landfill space.</p>\n"
+      },
+      "support_copy": {
+        "raw": "Run a drive at your school to collect recycled clothes and drop them off at your local H&M.",
+        "formatted": "<p>Run a drive at your school to collect recycled clothes and drop them off at your local H&amp;M.</p>\n"
+      }
+    },
+    "pre_step": {
+      "header": "Run Your Drive!",
+      "copy": {
+        "raw": "If you’re lucky, you’ll see more mustard-, blood-, and mystery-liquid-stained stuff than ever before! Gross! Hooray!",
+        "formatted": "<p>If you’re lucky, you’ll see more mustard-, blood-, and mystery-liquid-stained stuff than ever before! Gross! Hooray!</p>\n"
+      }
+    },
+    "latest_news": {
+      "latest_news": null
+    },
+    "causes": {
+      "primary": {
+        "id": "4",
+        "name": "environment"
+      },
+      "secondary": [
+        {
+          "id": "4",
+          "name": "environment"
+        }
+      ]
+    },
+    "action_types": {
+      "primary": {
+        "id": "7",
+        "name": "donate something"
+      },
+      "secondary": [
+        {
+          "id": "7",
+          "name": "donate something"
+        },
+        {
+          "id": "11",
+          "name": "host an event"
+        },
+        {
+          "id": "8",
+          "name": "improve a space"
+        }
+      ]
+    },
+    "issue": {
+      "id": "347",
+      "name": "recycling"
+    },
+    "tags": [
+      {
+        "id": "48",
+        "name": "trash"
+      },
+      {
+        "id": "348",
+        "name": "recycling"
+      },
+      {
+        "id": "349",
+        "name": "clothes"
+      },
+      {
+        "id": "350",
+        "name": "h&m"
+      },
+      {
+        "id": "102",
+        "name": "drive"
+      },
+      {
+        "id": "49",
+        "name": "earth"
+      },
+      {
+        "id": "351",
+        "name": "planet"
+      },
+      {
+        "id": "97",
+        "name": "environment"
+      },
+      {
+        "id": "352",
+        "name": "eco"
+      },
+      {
+        "id": "366",
+        "name": "collection"
+      },
+      {
+        "id": "668",
+        "name": "music"
+      }
+    ],
+    "timing": {
+      "high_season": {
+        "start": "2015-07-18T00:00:00+0000",
+        "end": "2015-07-25T00:00:00+0000"
+      },
+      "low_season": null
+    },
+    "services": {
+      "mobile_commons": {
+        "opt_in_path_id": "165501",
+        "friends_opt_in_path_id": null
+      },
+      "mailchimp": {
+        "grouping_id": null,
+        "group_name": null
+      }
+    },
+    "affiliates": {
+      "partners": [
+        {
+          "name": "H&M",
+          "sponsor": true,
+          "copy": {
+            "raw": "H&M was the first fast fashion company, and now they’re leading the movement toward a more sustainable fashion future. We <3 them and they <3 the earth. At H&M, sustainability is a word of action – something they do rather than something they simply say. It is an ongoing process that requires determination, passion and teamwork.\r\n\r\nH&M wants to make more sustainable choices in fashion affordable and desirable to as many people as possible.\r\n\r\nWe believe that partnering with a sustainably minded company can create real and long-term changes. With our 2.5 million members and H&M's millions of customers, we can extend this impact even further – from improving the livelihood of a cotton farmer to how people everywhere dispose of their worn-out clothing.\r\n\r\nLearn more about <a href=”http://about.hm.com/en/About/Sustainability/HMConscious/Aboutconscious.html>H&M’s sustainability initiatives here.</a>",
+            "formatted": "<p>H&amp;M was the first fast fashion company, and now they’re leading the movement toward a more sustainable fashion future. We &lt;3 them and they &lt;3 the earth. At H&amp;M, sustainability is a word of action – something they do rather than something they simply say. It is an ongoing process that requires determination, passion and teamwork.</p>\n\n<p>H&amp;M wants to make more sustainable choices in fashion affordable and desirable to as many people as possible.</p>\n\n<p>We believe that partnering with a sustainably minded company can create real and long-term changes. With our 2.5 million members and H&amp;M's millions of customers, we can extend this impact even further – from improving the livelihood of a cotton farmer to how people everywhere dispose of their worn-out clothing.</p>\n\n<p>Learn more about <a href=\"//about.hm.com/en/About/Sustainability/HMConscious/Aboutconscious.html\">H&amp;M’s sustainability initiatives here.</a></p>\n"
+          },
+          "uri": "http://www.hm.com/",
+          "media": {
+            "uri": "http://dev.dosomething.org:8888/sites/default/files/styles/wmax-423px/public/partners/hm-logo.png?itok=hf89RS8a",
+            "type": "image"
+          }
+        }
+      ]
+    },
+    "reportback_info": {
+      "copy": "Submit your photo before June 20 to qualify for the scholarship.",
+      "confirmation_message": "Going green is always in style! Thanks for helping the Earth.",
+      "noun": "Items",
+      "verb": "Recycled"
+    },
+    "uri": "http://dev.dosomething.org:8888/api/v1/campaigns/362"
+  }
+}
+```
+

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -253,6 +253,8 @@ abstract class Transformer {
         $output['timing']['low_season'] = $data->timing['low_season'];
 
         $output['services'] = $data->services;
+
+        $output['affiliates'] = $data->affiliates;
       }
 
       $output['reportback_info'] = $data->reportback_info;

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -30,6 +30,7 @@ class Campaign {
   public $tags;
   public $timing;
   public $reportback_info;
+  public $affiliates;
   public $services;
 
   /**
@@ -184,6 +185,8 @@ class Campaign {
         $timing = $this->getTiming();
         $this->timing = $timing;
 
+        $this->affiliates = $this->getAffiliates();
+
         $this->services = $this->getServices();
       }
 
@@ -220,6 +223,14 @@ class Campaign {
     }
 
     return $data;
+  }
+
+  protected function getAffiliates()
+  {
+    // @TODO: Only grabs partners for now. Update with further affiliates as needed.
+    return [
+      'partners' => $this->getPartners(),
+    ];
   }
 
   /**
@@ -442,6 +453,49 @@ class Campaign {
       'opt_in_path_id' => dosomething_helpers_isset($this->variables, 'mobilecommons_opt_in_path'),
       'friends_opt_in_path_id' => dosomething_helpers_isset($this->variables, 'mobilecommons_friends_opt_in_path'),
     ];
+  }
+
+  protected function getPartners() {
+    $data = [];
+
+    // @TODO: only accounts for single partner at the moment.
+    // Update extract function to grab array of partners instead of just first id.
+    $partner_data_collection_ids = dosomething_helpers_extract_field_data($this->node->field_partners);
+
+    if (! $partner_data_collection_ids) {
+      return $data;
+    }
+
+    if (! is_array($partner_data_collection_ids)) {
+      $partner_data_collection_ids = [$partner_data_collection_ids];
+    }
+
+    foreach ($partner_data_collection_ids as $id) {
+      $partner = [];
+
+      $data_collection = field_collection_item_load($id);
+      $data_taxonomy = taxonomy_term_load(dosomething_helpers_extract_field_data($data_collection->field_partner));
+
+      $partner['name'] = $data_taxonomy->name;
+      $partner['sponsor'] = (bool) dosomething_helpers_extract_field_data($data_collection->field_is_sponsor);
+      $partner['copy'] = dosomething_helpers_extract_field_data($data_collection->field_partner_copy);
+      $partner['uri'] = dosomething_helpers_extract_field_data($data_collection->field_partner_url);
+
+      $logo = dosomething_helpers_extract_field_data($data_taxonomy->field_partner_logo);
+
+      if ($logo) {
+        $partner['media'] = [
+          'uri' => image_style_url('wmax-423px', $logo['uri']),
+          'type' => $logo['type'],
+        ];
+      } else {
+        $partner['media'] = NULL;
+      }
+
+      $data[] = $partner;
+    }
+
+    return $data;
   }
 
   /**

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -460,6 +460,7 @@ class Campaign {
 
     // @TODO: only accounts for single partner at the moment.
     // Update extract function to grab array of partners instead of just first id.
+    // @see https://github.com/DoSomething/phoenix/issues/6396
     $partner_data_collection_ids = dosomething_helpers_extract_field_data($this->node->field_partners);
 
     if (! $partner_data_collection_ids) {

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -180,7 +180,7 @@ function dosomething_helpers_extract_field_data($field, $language = LANGUAGE_NON
 
     $data = $field[$language];
 
-    $values = array();
+    $values = [];
 
     foreach ($data as $item => $content) {
       $keys = array_keys($content);
@@ -189,9 +189,17 @@ function dosomething_helpers_extract_field_data($field, $language = LANGUAGE_NON
         // Date values, so need to extract using custom method.
         $values[] = dosomething_helpers_extract_field_dates($content);
       }
-      else if (in_array('country', $keys)) {
+      elseif (in_array('country', $keys)) {
         //TODO: Build function to get all address data, not just country.
         $values[] = $content['country'];
+      }
+      elseif (in_array('type', $keys)) {
+        if ($content['type'] === 'image') {
+          $values[] = dosomething_helpers_extract_field_image($content);
+        } else {
+          // Default to first item; typically an id value.
+          $values[] = $content[$keys[0]];
+        }
       }
       elseif ($keys[0] === 'value') {
         // Text value, so need to extract using custom method.
@@ -228,6 +236,19 @@ function dosomething_helpers_extract_field_dates($data) {
   return $values;
 }
 
+function dosomething_helpers_extract_field_image($data) {
+  $values = [];
+
+  $values['id'] = isset($data['fid']) ? $data['fid'] : NULL;
+  $values['type'] = isset($data['type']) ? $data['type'] : NULL;
+  $values['uri'] = isset($data['uri']) ? $data['uri'] : NULL;
+  $values['file_name'] = isset($data['filename']) ? $data['filename'] : NULL;
+  $values['file_mime'] = isset($data['filemime']) ? $data['filemime'] : NULL;
+  $values['file_size'] = isset($data['filesize']) ? $data['filesize'] : NULL;
+  $values['timestamp'] = isset($data['timestamp']) ? $data['timestamp'] : NULL;
+
+  return $values;
+}
 
 /**
  * Utility function to extract field text content; both the raw


### PR DESCRIPTION
#### What's this PR do?

This PR include a Campaign's affiliates information (such as partners in this particular case) to the `Campaign` class build function when a new `Campaign` is instantiated and also exposes this data to the API.

Example output:
![image](https://cloud.githubusercontent.com/assets/105849/14827518/cbaf7bba-0bb0-11e6-8e60-6776cedd6547.png)
#### How should this be manually tested?

Load a few campaigns both with and without partners (and partners that are also sponsors) via the API and see if the affiliate property on the response object is appropriately filled out.
#### Any background context you want to provide?

If a partner does not have a logo "media" available, instead of making the `uri` and `type` be `NULL` I decided to make the entire `media` object `NULL`. Just seemed to make more sense to me that when planning on outputting the path to the logo, better to check the `media` object if that's something valid first. But we can nerd 🤓 battle over this if others feel strongly with a different opinion!

Also, since this is on the `Campaign` class object, the partner information is now nicely formatted and available for use in future Campaign template updates via the web interface as well, wink wink 😉 
#### What are the relevant tickets?

Fixes #6393

---

@aaronschachter @angaither @chloealee 

cc: @mikefantini 
