### PR TITLE
Fix bugs with Northstar auth verification.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -72,6 +72,17 @@ function dosomething_northstar_verify_user($credentials) {
 }
 
 /**
+ * Save the user's Northstar ID to their local profile.
+ *
+ * @param $user - Drupal user
+ * @param $northstar_response - Northstar user JSON response
+ */
+function dosomething_northstar_save_id_field($user, $northstar_response) {
+  $northstar_id = !empty($northstar_response->data->id) ? $northstar_response->data->id : 'NONE';
+  user_save($user, ['field_northstar_id' => [LANGUAGE_NONE => [0 => ['value' => $northstar_id]]]]);
+}
+
+/**
  * Send user registration events to northstar.
  */
 function dosomething_northstar_register_user($form_state) {
@@ -102,6 +113,9 @@ function dosomething_northstar_register_user($form_state) {
   elseif ($response->code !== '200') {
     watchdog('dosomething_northstar', 'User not migrated : ' . $response->code, NULL, WATCHDOG_ERROR);
   }
+
+  // Save the newly registered user's ID to their local profile field.
+  dosomething_northstar_save_id_field($user, json_decode($response->data));
 
   // Add to request log if enabled.
   dosomething_northstar_log_request('register_user', $user, $ns_user, $response);

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -89,24 +89,28 @@ function dosomething_northstar_register_user($form_state) {
   global $user;
   // Build a user that Northstar expects.
   $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
+  
   $client = _dosomething_northstar_build_http_client();
   $response = drupal_http_request($client['base_url'] . '/users', array(
     'headers' => $client['headers'],
     'method' => 'POST',
     'data' => json_encode($ns_user),
-    ));
-  if ($response->code === '200' && module_exists('stathat')) {
-    stathat_send_ez_count('drupal - Northstar - user migrated - count', 1);
-  }
-  elseif ($response->code !== '200') {
-    watchdog('dosomething_northstar', 'User not migrated : ' . $response->code, NULL, WATCHDOG_ERROR);
-  }
+  ));
 
   // Save the newly registered user's ID to their local profile field.
   dosomething_northstar_save_id_field($user, json_decode($response->data));
 
   // Add to request log if enabled.
   dosomething_northstar_log_request('register_user', $user, $ns_user, $response);
+  
+  if ($response->code !== '200') {
+    watchdog('dosomething_northstar', 'User not migrated : ' . $response->code, NULL, WATCHDOG_ERROR);
+    return;
+  }
+
+  if (module_exists('stathat')) {
+    stathat_send_ez_count('drupal - Northstar - user migrated - count', 1);
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -163,37 +163,8 @@ function dosomething_northstar_update_user($form_state) {
 }
 
 /**
- * If the log is enabled, log this request to the database.
  * Get user profile data from Northstar for the given Drupal ID.
  *
- * @param string $op - label for the operation being performed
- * @param object $user - the Drupal user
- * @param array $request_body - the body of the request
- * @param string $response - response JSON
- */
-function dosomething_northstar_log_request($op, $user, $request_body, $response) {
-  if (!variable_get('dosomething_northstar_log')) return;
-
-  // Don't log plaintext passwords.
-  if (isset($request_body['password'])) {
-    $request_body['password'] = '*****';
-  }
-
-  db_insert('dosomething_northstar_request_log')
-    ->fields([
-      'op' => $op,
-      'uid' => $user->uid,
-      'user_lang' => $user->language,
-      'user_country' => $user->field_address[LANGUAGE_NONE][0]['country'],
-      'fastly_country' => dosomething_settings_get_geo_country_code(),
-      'request_values' => json_encode($request_body),
-      'response_code' => $response->code,
-      'response_values' => $response->data,
-    ])
-    ->execute();
-}
-
-/**
  * @param int $drupal_id Drupal user id.
  * @return object
  */
@@ -280,6 +251,33 @@ function dosomething_northstar_build_ns_user($user, $form_state) {
   return $ns_user;
 }
 
+/**
+ * If the log is enabled, log this request to the database.
+ *
+ * @param string $op - label for the operation being performed
+ * @param object $user - the Drupal user
+ * @param array $request_body - the body of the request
+ * @param string $response - response JSON
+ */
+function dosomething_northstar_log_request($op, $user, $request_body, $response) {
+  if (!variable_get('dosomething_northstar_log')) return;
 
+  // Don't log plaintext passwords.
+  if (isset($request_body['password'])) {
+    $request_body['password'] = '*****';
+  }
 
+  db_insert('dosomething_northstar_request_log')
+    ->fields([
+      'op' => $op,
+      'uid' => $user->uid,
+      'user_lang' => $user->language,
+      'user_country' => $user->field_address[LANGUAGE_NONE][0]['country'],
+      'fastly_country' => dosomething_settings_get_geo_country_code(),
+      'request_values' => json_encode($request_body),
+      'response_code' => $response->code,
+      'response_values' => $response->data,
+    ])
+    ->execute();
 }
+

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -79,7 +79,10 @@ function dosomething_northstar_verify_user($credentials) {
  */
 function dosomething_northstar_save_id_field($user, $northstar_response) {
   $northstar_id = !empty($northstar_response->data->id) ? $northstar_response->data->id : 'NONE';
-  user_save($user, ['field_northstar_id' => [LANGUAGE_NONE => [0 => ['value' => $northstar_id]]]]);
+
+  $edit = [];
+  dosomething_user_set_fields($edit, ['northstar_id' => $northstar_id]);
+  user_save($user, $edit);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -89,18 +89,6 @@ function dosomething_northstar_register_user($form_state) {
   global $user;
   // Build a user that Northstar expects.
   $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
-  // Send that to NS.
-  // $northstar = new Northstar();
-  // try {
-  //   $response = $northstar->updateUser($ns_user);
-  //   if ($response->getStatusCode() === '200' && module_exists('stathat')) {
-  //     stathat_send_ez_count('drupal - Northstar - user migrated - count', 1);
-  //   }
-  // }
-  // catch (Exception $e) {
-
-  //   watchdog('dosomething_northstar', 'User not migrated : ' . $e, NULL, WATCHDOG_ERROR);
-  // }
   $client = _dosomething_northstar_build_http_client();
   $response = drupal_http_request($client['base_url'] . '/users', array(
     'headers' => $client['headers'],
@@ -293,43 +281,5 @@ function dosomething_northstar_build_ns_user($user, $form_state) {
 }
 
 
-class Northstar {
-
-  // protected $client;
-
-  // public function __construct() {
-
-  //   $base_url = NORTHSTAR_URL;
-  //   if (getenv('DS_ENVIRONMENT') === 'local') {
-  //     $base_url .=  ":" . NORTHSTAR_PORT;
-  //   }
-  //   $version = NORTHSTAR_VERSION;
-
-  //   if (libraries_load('guzzle') == TRUE) {
-  //     $client = new GuzzleHttp\Client(array(
-  //       'base_url' => array($base_url . '/{version}/', array('version' => $version)),
-  //       'defaults' => array(
-  //         'headers' => array(
-  //           'X-DS-Application-Id' => NORTHSTAR_APP_ID,
-  //           'X-DS-REST-API-Key' => NORTHSTAR_APP_KEY,
-  //           'Content-Type' => 'application/json',
-  //           'Accept' => 'application/json'
-  //           ),
-  //         ),
-  //     ));
-  //     $this->client = $client;
-
-  //   }
-  // }
-
-  // public function updateUser($user) {
-  //   // return $this->client->getUrl();
-  //   $response = $this->client->post('users', array(
-  //     'body' => json_encode($user),
-  //     ));
-
-  //   // watchdog('dosomething_northstar', 'full url' . $response->getUrl(), NULL, WATCHDOG_ERROR);
-  //   return $response;
-  // }
 
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -172,8 +172,8 @@ function dosomething_northstar_update_user($form_state) {
  * @param int $drupal_id Drupal user id.
  * @return object
  */
-function dosomething_northstar_get_northstar_user($id) {
-  $northstar_user_info = cache_get('northstar_user_info_' . $id, 'cache_dosomething_northstar');
+function dosomething_northstar_get_northstar_user($drupal_id) {
+  $northstar_user_info = cache_get('northstar_user_info_' . $drupal_id, 'cache_dosomething_northstar');
 
   if ($northstar_user_info) {
     $northstar_user_info = $northstar_user_info->data;
@@ -181,7 +181,7 @@ function dosomething_northstar_get_northstar_user($id) {
   else {
     $client = _dosomething_northstar_build_http_client();
 
-    $northstar_user_info = drupal_http_request($client['base_url'] . '/users/drupal_id/' . $id, array(
+    $northstar_user_info = drupal_http_request($client['base_url'] . '/users/drupal_id/' . $drupal_id, array(
       'headers' => $client['headers'],
       'method' => 'GET',
       ));
@@ -189,10 +189,10 @@ function dosomething_northstar_get_northstar_user($id) {
       $northstar_user_info = $northstar_user_info->data;
 
       if (!empty($northstar_user_info->error)) {
-        $error = sprintf("Error fetching Northstar user data, uid=%d: '%s'", $id, $northstar_user_info->error);
+        $error = sprintf("Error fetching Northstar user data, uid=%d: '%s'", $drupal_id, $northstar_user_info->error);
         watchdog_exception('northstar', new Exception($error));
       } else {
-        cache_set('northstar_user_info_' . $id, $northstar_user_info, 'cache_dosomething_northstar', REQUEST_TIME + 60*60*24);
+        cache_set('northstar_user_info_' . $drupal_id, $northstar_user_info, 'cache_dosomething_northstar', REQUEST_TIME + 60*60*24);
       }
   }
 

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -108,8 +108,8 @@ function dosomething_northstar_register_user($form_state) {
 }
 
 /**
- * Build the drupal_http_request object for nothstar calls.
- * This will be depricated once guzzle is fixed...
+ * Build the drupal_http_request object for Northstar calls.
+ * @returns array
  */
 function _dosomething_northstar_build_http_client() {
   $base_url = NORTHSTAR_URL;
@@ -131,7 +131,10 @@ function _dosomething_northstar_build_http_client() {
 }
 
 /**
- * Send user profile updates to northstar.
+ * Update a user's existing Northstar profile based on
+ * their Drupal ID.
+ * 
+ * @return void
  */
 function dosomething_northstar_update_user($form_state) {
   $user = $form_state['user'];
@@ -159,6 +162,7 @@ function dosomething_northstar_update_user($form_state) {
 
 /**
  * If the log is enabled, log this request to the database.
+ * Get user profile data from Northstar for the given Drupal ID.
  *
  * @param string $op - label for the operation being performed
  * @param object $user - the Drupal user
@@ -188,9 +192,7 @@ function dosomething_northstar_log_request($op, $user, $request_body, $response)
 }
 
 /**
- * Get user data from northstar.
- *
- * @param  int  $id Drupal user id.
+ * @param int $drupal_id Drupal user id.
  * @return object
  */
 function dosomething_northstar_get_northstar_user($id) {
@@ -221,11 +223,10 @@ function dosomething_northstar_get_northstar_user($id) {
 }
 
 /**
- * Build a user json object, that's accepted by Northstar.
+ * Build a user JSON object in the format that Northstar expects.
  *
- * @param obj $user
- *  Drupal user object
- *
+ * @param $user - Drupal user object
+ * @return array
  */
 function dosomething_northstar_build_ns_user($user, $form_state) {
   // Optional fields

--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -96,8 +96,7 @@ class Signup extends Entity {
       $northstar_response = json_decode($northstar_response);
 
       if (!empty($northstar_response->data) && !isset($northstar_response->error)) {
-        $northstar_user = $northstar_response->data;
-        user_save($drupal_user, ['field_northstar_id' => [LANGUAGE_NONE => [0 => ['value' => $northstar_user->id]]]]);
+        dosomething_northstar_save_id_field($drupal_user, $northstar_response);
       }
     }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -558,38 +558,6 @@ function dosomething_user_user_pass_submit($form, &$form_state) {
 }
 
 /**
- * Trigger events after a user successfully logs in.
- *
- * Implements hook_user_login.
- */
-function dosomething_user_user_login(&$form_state, $account) {
-  if (!module_exists('dosomething_northstar')) return;
-
-  $northstar_user = null;
-
-  // Figure out whether user is logging in via email or mobile. Then, we'll
-  // send a request to Northstar's `user/verify` endpoint to see if Northstar
-  // is also able to successfully authenticate with the given credentials.
-  if (dosomething_user_get_user_by_email($form_state['input']['name'])) {
-    $northstar_user = dosomething_northstar_verify_user([
-      'email' => $form_state['input']['name'],
-      'password' => $form_state['input']['pass'],
-    ]);
-  }
-  elseif (dosomething_user_get_user_by_mobile($form_state['input']['name'])) {
-    $northstar_user = dosomething_northstar_verify_user([
-      'mobile' => dosomething_user_clean_mobile_number($form_state['input']['name']),
-      'password' => $form_state['input']['pass'],
-    ]);
-  }
-
-  // If the user exists, store it on the user's Drupal profile.
-  $northstar_id = isset($northstar_user->data->id) ? $northstar_user->data->id : 'NONE';
-  user_save($account, ['field_northstar_id' => [LANGUAGE_NONE => [0 => ['value' => $northstar_id]]]]);
-}
-
-/**
- *
  * Custom form submission handler to update an existing user.
  * Triggered when making changes on the user profile form.
  * 
@@ -618,6 +586,10 @@ function dosomething_user_new_user($form, &$form_state)
 
   // Sign the user up for transactional messaging
   _dosomething_user_send_to_message_broker();
+
+  if (module_exists('dosomething_northstar')) {
+    dosomething_northstar_register_user($form_state);
+  };
 }
 
 /**
@@ -789,6 +761,31 @@ function dosomething_user_is_old_person($user = NULL) {
 function dosomething_user_login_submit($form, &$form_state) {
   // Trigger an analytics event on login
   dosomething_helpers_add_analytics_event('Authentication', 'Login');
+
+  // Attempt to verify the given credentials with Northstar.
+  _dosomething_user_verify_northstar_login($form_state);
+}
+
+/**
+ * Verify the given login against Northstar's records! This is a "dry run"
+ * for eventually having authentication solely happen in Northstar.
+ *
+ * @param $form_state
+ */
+function _dosomething_user_verify_northstar_login($form_state) {
+  global $user;
+
+  // Short-circuit if Northstar is not enabled.
+  if (!module_exists('dosomething_northstar')) return;
+
+  $northstar_user = dosomething_northstar_verify_user([
+    'username' => $form_state['input']['name'],
+    'password' => $form_state['input']['pass'],
+  ]);
+
+  // If the user exists in Northstar, store their ID on their Drupal profile.
+  // @TODO: Remove this once we properly back-fill this field!
+  dosomething_northstar_save_id_field($user, $northstar_user);
 }
 
 /**
@@ -817,11 +814,6 @@ function dosomething_user_authentication_submit($form, &$form_state) {
         dosomething_signup_user_signup($nid, $user, $source);
       }
     }
-  }
-
-  // Send updated user profiles into Northstar.
-  if (module_exists('dosomething_northstar')) {
-    dosomething_northstar_register_user($form_state);
   }
 
   // After all log-ins, except reportback pages redirect to page user was just on.

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -268,6 +268,8 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
         _dosomething_user_add_signup_data($form);
       }
       else {
+        // If this is not the registration form, then register submit handler
+        // to update that existing Northstar user by their Drupal ID.
         $form['#submit'][] = 'dosomething_user_update_user';
       }
 
@@ -424,13 +426,13 @@ function dosomething_user_validate_address_field($form, &$form_state) {
   }
 }
 
-/** 
+/**
  * Validates address for dosomething_user_info_form
  *
  * @param array $form
- * A drupal form. 
+ * A drupal form.
  * @param array $form_state
- * A drupal form_state array. 
+ * A drupal form_state array.
  */
 function dosomething_user_validate_info_form_address ($form, &$form_state) {
   $first_name = $form_state['input']['first_name'];
@@ -439,7 +441,7 @@ function dosomething_user_validate_info_form_address ($form, &$form_state) {
    'country' => 'US',
    'thoroughfare' => $form_state['input']['street'],
    'premise' => $form_state['input']['sub_street'],
-   'locality' => $form_state['input']['city'], 
+   'locality' => $form_state['input']['city'],
    'administrative_area' => $form_state['input']['state'],
    'postal_code' => $form_state['input']['zipcode'],
   ];
@@ -466,7 +468,7 @@ function dosomething_user_validate_info_form_address ($form, &$form_state) {
 }
 
 /**
- * Validates that password is 6 or more characters long.  
+ * Validates that password is 6 or more characters long.
  *
  * @param array $form
  *  A drupal form.
@@ -588,9 +590,15 @@ function dosomething_user_user_login(&$form_state, $account) {
 
 /**
  *
+ * Custom form submission handler to update an existing user.
+ * Triggered when making changes on the user profile form.
+ * 
+ * @param $form
+ * @param $form_state
  */
 function dosomething_user_update_user($form, &$form_state) {
   if (!module_exists('dosomething_northstar')) { return; }
+  
   // Forward user updates into Northstar.
   dosomething_northstar_update_user($form_state);
 }
@@ -775,7 +783,8 @@ function dosomething_user_is_old_person($user = NULL) {
 }
 
 /**
- * Custom login submission handler.
+ * Custom login submission handler. This does _not_ trigger on log-ins
+ * that happen post-registration.
  */
 function dosomething_user_login_submit($form, &$form_state) {
   // Trigger an analytics event on login
@@ -815,7 +824,7 @@ function dosomething_user_authentication_submit($form, &$form_state) {
     dosomething_northstar_register_user($form_state);
   }
 
-  // After all logins, except reportback pages redirect to page user was just on.
+  // After all log-ins, except reportback pages redirect to page user was just on.
   if (isset($source) && stripos($source, 'reportback') > 0) {
     $form_state['redirect'] = drupal_get_path_alias($_SERVER['HTTP_REFERER']);
   }
@@ -1402,7 +1411,7 @@ function dosomething_user_info_form($form, &$form_state, $account) {
     '#type' => 'textfield',
     '#default_value' => $birthday,
     '#description' => t("Format: M/D/YYYY"),
-    '#field_suffix' => 'User age: ' . $age, 
+    '#field_suffix' => 'User age: ' . $age,
   );
   $form['picture'] = array(
     '#type' => 'fieldset',


### PR DESCRIPTION
#### What's this PR do?

This pull request includes cleanup and fixes to the Northstar auth verification & sync code:

🐛 The "verify" check was previously being run on newly registered users (_before_ their profiles were synced to Northstar), resulting in "failed" validation and a bunch of users with `NONE` saved to their Northstar ID field. This PR moves this call to occur in a submit handler on the login form, rather than a Drupal hook. Also now just sends "username" and lets Northstar infer which type. (4a655c7)

📄 Updates docblocks to try to make it clearer when different hooks and submit handlers are run, since it was ambiguous from looking at the method names without plopping `dpm` hooks everywhere. (ab3ec96)

👉 Adds a helper method to save the "Northstar ID" profile field, since the syntax is kinda wonky and it's nice to not have the same code duplicated all over. (71c70e8)

🍃 Removes some commented out code from the Northstar Guzzle implementation, since it was making that file harder to skim. Once we revisit #5932, hopefully we can start using the Northstar PHP library here instead! (3f86eb6)

🍂 General tidying up. (c502379, a7df8ff, 939b0bb)
#### How should this be manually tested?

It's probably easiest to just test this on staging TBH. But there should be significantly fewer cases where users have `NONE` for their Northstar ID field, since it's now properly set on registration.
#### Any background context you want to provide?

👻 
#### What are the relevant tickets?

References #6260.

---

For review: @angaither @weerd 
