### PR TITLE
adds ->fetchAll(); after db_query to return the expected array of user objects

### DIFF
--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -13,11 +13,13 @@ if ($last_saved) {
   $users = db_query("SELECT u.uid
             FROM users u
             WHERE uid > $last_saved");
+  $users = $users->fetchAll();
 }
 else {
   // Get all the users!
   $users = db_query('SELECT u.uid
                    FROM users u');
+  $users = $users->fetchAll();
 }
 
 foreach ($users as $user) {


### PR DESCRIPTION
#### What's this PR do?

Added `$users = $users->fetchAll();` after `db_query` to return an array of user objects. 

Without this, when I did `print_r` for `$users`, it returned a `DatabaseStatementBase Object`. With this update, it will return an array of the user objects.
#### How should this be manually tested?

Check by adding `print_r($users);` and `die();` after these two new lines and run the script. Make sure an array of uses is returned. 

To run script: cd in vagrant box and within `/var/www/dev.dosomething.org/html` run `drush --script-path=../scripts/ php-script export-users-to-northstar.php`
