### PR TITLE
More Northstar sync fixes

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -87,25 +87,24 @@ function dosomething_northstar_save_id_field($user, $northstar_response) {
 
 /**
  * Send user registration events to northstar.
+ *
+ * @param $user - Drupal user object
+ * @param $payload - Array of data to be sent to Northstar
  */
-function dosomething_northstar_register_user($form_state) {
-  global $user;
-  // Build a user that Northstar expects.
-  $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
-  
+function dosomething_northstar_register_user($user, $payload) {
   $client = _dosomething_northstar_build_http_client();
   $response = drupal_http_request($client['base_url'] . '/users', array(
     'headers' => $client['headers'],
     'method' => 'POST',
-    'data' => json_encode($ns_user),
+    'data' => json_encode($payload),
   ));
 
   // Save the newly registered user's ID to their local profile field.
   dosomething_northstar_save_id_field($user, json_decode($response->data));
 
   // Add to request log if enabled.
-  dosomething_northstar_log_request('register_user', $user, $ns_user, $response);
-  
+  dosomething_northstar_log_request('register_user', $user, $payload, $response);
+
   if ($response->code !== '200') {
     watchdog('dosomething_northstar', 'User not migrated : ' . $response->code, NULL, WATCHDOG_ERROR);
     return;
@@ -142,24 +141,22 @@ function _dosomething_northstar_build_http_client() {
 /**
  * Update a user's existing Northstar profile based on
  * their Drupal ID.
- * 
- * @return void
+ *
+ * @param $user - Drupal user object
+ * @param $payload - Array of data to be sent to Northstar
  */
-function dosomething_northstar_update_user($form_state) {
-  $user = $form_state['user'];
-  $id = $user->uid;
-  $ns_user = dosomething_northstar_build_ns_user($user, $form_state);
-
+function dosomething_northstar_update_user($user, $payload) {
   $client = _dosomething_northstar_build_http_client();
 
+  $id = $user->uid;
   $response = drupal_http_request($client['base_url'] . '/users/drupal_id/' . $id, array(
     'headers' => $client['headers'],
     'method' => 'PUT',
-    'data' => json_encode($ns_user),
+    'data' => json_encode($payload),
   ));
 
   // Add to request log if enabled.
-  dosomething_northstar_log_request('update_user', $user, $ns_user, $response);
+  dosomething_northstar_log_request('update_user', $user, $payload, $response);
   
   if ($response->code === '200' && module_exists('stathat')) {
     stathat_send_ez_count('drupal - Northstar - user updated - count', 1);

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -215,6 +215,7 @@ function dosomething_northstar_build_ns_user($user, $form_state) {
     'mobile' => 'field_mobile',
     'birthdate' => 'field_birthdate',
     'first_name' => 'field_first_name',
+    'last_name' => 'field_last_name',
   ];
 
   // Address fields

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -156,17 +156,17 @@ function dosomething_northstar_update_user($form_state) {
     'headers' => $client['headers'],
     'method' => 'PUT',
     'data' => json_encode($ns_user),
-    ));
+  ));
 
+  // Add to request log if enabled.
+  dosomething_northstar_log_request('update_user', $user, $ns_user, $response);
+  
   if ($response->code === '200' && module_exists('stathat')) {
     stathat_send_ez_count('drupal - Northstar - user updated - count', 1);
   }
   elseif ($response->code !== '200') {
     watchdog('dosomething_northstar', 'User not updated : ' . $response->code, NULL, WATCHDOG_ERROR);
   }
-
-  // Add to request log if enabled.
-  dosomething_northstar_log_request('update_user', $user, $ns_user, $response);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -161,6 +161,10 @@ function dosomething_northstar_update_user($user, $payload) {
   if ($response->code === '200' && module_exists('stathat')) {
     stathat_send_ez_count('drupal - Northstar - user updated - count', 1);
   }
+  elseif ($response->code === '404') {
+    // If the given Drupal ID 404s, try to register them.
+    dosomething_northstar_register_user($user, $payload);
+  }
   elseif ($response->code !== '200') {
     watchdog('dosomething_northstar', 'User not updated : ' . $response->code, NULL, WATCHDOG_ERROR);
   }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -254,6 +254,12 @@ function dosomething_northstar_build_ns_user($user, $form_state) {
     $ns_user['password'] = $form_state['values']['pass'];
   }
 
+  // Set the "source" for this user to Phoenix if they weren't
+  // programmatically created through the API.
+  if(empty($ns_user['source'])) {
+    $ns_user['source'] = 'phoenix';
+  }
+
   // Return fully built northstar user object.
   return $ns_user;
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -270,7 +270,7 @@ function dosomething_northstar_build_ns_user($user, $form_state) {
  * @param string $op - label for the operation being performed
  * @param object $user - the Drupal user
  * @param array $request_body - the body of the request
- * @param string $response - response JSON
+ * @param $response - response JSON
  */
 function dosomething_northstar_log_request($op, $user, $request_body, $response) {
   if (!variable_get('dosomething_northstar_log')) return;

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -568,7 +568,9 @@ function dosomething_user_update_user($form, &$form_state) {
   if (!module_exists('dosomething_northstar')) { return; }
   
   // Forward user updates into Northstar.
-  dosomething_northstar_update_user($form_state);
+  $user = $form_state['user'];
+  $northstar_user = dosomething_northstar_build_ns_user($user, $form_state);
+  dosomething_northstar_update_user($user, $northstar_user);
 }
 
 /**
@@ -579,6 +581,8 @@ function dosomething_user_update_user($form, &$form_state) {
  */
 function dosomething_user_new_user($form, &$form_state)
 {
+  global $user;
+  
   // Trigger an analytics event on registration
   // @NOTE: The 'Authentication - Login' event will *also* be triggered here,
   // since registered users are subsequently logged in to their new accounts.
@@ -588,7 +592,10 @@ function dosomething_user_new_user($form, &$form_state)
   _dosomething_user_send_to_message_broker();
 
   if (module_exists('dosomething_northstar')) {
-    dosomething_northstar_register_user($form_state);
+    $northstar_user = dosomething_northstar_build_ns_user($user, $form_state);
+    
+    // Send the prepared user to Northstar.
+    dosomething_northstar_register_user($user, $northstar_user);
   };
 }
 
@@ -659,8 +666,12 @@ function _dosomething_user_send_to_message_broker() {
 
 function dosomething_user_new_user_attributes($form, &$form_state) {
   dosomething_user_set_global_attributes();
+  
   if (module_exists('dosomething_northstar')){
-    dosomething_northstar_update_user($form_state);
+    $user = $form_state['user'];
+    $northstar_user = dosomething_northstar_build_ns_user($user, $form_state);
+    
+    dosomething_northstar_update_user($user, $northstar_user);
   }
 }
 

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -52,7 +52,7 @@ foreach ($users as $user) {
 }
 
 /**
- *
+ * Build a Northstar request from the $user global variable.
  */
 function build_northstar_user($user) {
   // Optional fields

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -41,7 +41,7 @@ foreach ($users as $user) {
   ]);
 
   // Output progress to stdout & log request details for later review.
-  dosomething_northstar_log_request('migrate', $user, json_encode($ns_user), $response);
+  dosomething_northstar_log_request('migrate', $user, $ns_user, $response);
   echo 'Migrated user ' . $user->uid . ' to Northstar [' . $response->code . ']' . PHP_EOL;
 
   // Store the returned Northstar ID on the user's Drupal profile.

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -95,6 +95,13 @@ function build_northstar_user($user) {
     }
   }
 
+  // If user has a "1234565555@mobile" placeholder username, don't send
+  // that to Northstar (since it will cause a validation error and Northstar
+  // doesn't require every account to have an email like Drupal does).
+  if(preg_match('/^[0-9]+@mobile$/', $ns_user['email'])) {
+    unset($ns_user['email']);
+  }
+
   // Set the "source" for this user to Phoenix if they weren't
   // programmatically created through the API.
   if(empty($ns_user['source'])) {

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -43,8 +43,7 @@ foreach ($users as $user) {
   echo 'Migrated user ' . $user->uid . ' to Northstar [' . $response->code . ']' . PHP_EOL;
 
   // Store the returned Northstar ID on the user's Drupal profile.
-  $northstar_id = isset($response->data->id) ? $response->data->id : 'NONE';
-  user_save($user, ['field_northstar_id' => [LANGUAGE_NONE => [0 => ['value' => $northstar_id]]]]);
+  dosomething_northstar_save_id_field($user, json_decode($response->data));
 
   // If the script fails, we can use this to start the script from a previous person.
   variable_set('dosomething_northstar_last_user_migrated', $user->uid);

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -38,8 +38,9 @@ foreach ($users as $user) {
     'data' => json_encode($ns_user),
   ]);
 
-  // Log whether the request was successful or not
+  // Output progress to stdout & log request details for later review.
   dosomething_northstar_log_request('migrate', $user, json_encode($ns_user), $response);
+  echo 'Migrated user ' . $user->uid . ' to Northstar [' . $response->code . ']' . PHP_EOL;
 
   // Store the returned Northstar ID on the user's Drupal profile.
   $northstar_id = isset($response->data->id) ? $response->data->id : 'NONE';

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -12,12 +12,14 @@ $last_saved = variable_get('dosomething_northstar_last_user_migrated', NULL);
 if ($last_saved) {
   $users = db_query("SELECT u.uid
             FROM users u
-            WHERE uid > $last_saved");
+            WHERE uid > $last_saved
+            ORDER BY u.uid");
 }
 else {
   // Get all the users!
   $users = db_query('SELECT u.uid
-                   FROM users u');
+                   FROM users u
+                   ORDER BY u.uid');
 }
 
 foreach ($users as $user) {


### PR DESCRIPTION
#### What's this PR do?

This PR fixes a number of smaller issues with Northstar migration and syncing. The highlights:
- Fixes issue where `1234445555@mobile` "placeholder" emails were being sent with mobile users and causing validation errors on Phoenix. These are now ignored when forming the payload. (cc3640b)
- When forwarding new registrations, set `phoenix` as the signup source. This was previously only happening for batch migrated users. (0096db3)
- I also did a little refactoring to extract the `build_ns_user` call _out_ of the methods which make the HTTP requests to Northstar (c946d7b). This allows us to easily chain another request to register a user if the "update" request failed without having to try to re-build the whole user object. (9492787)
- Outputs progress to the console when migrating now! (d100755)

I'd recommend reviewing commit-by-commit since otherwise some of the changes get jumbled.
#### How should this be manually tested?

I've tested by manually checking that users are created/updated against my local Northstar, and by adding `dpm` calls to trace which hooks/methods get called.
#### Any background context you want to provide?

I'm not 100% sure that triggering a "register" whenever an "update" call fails will work... I feel like there might be some sort of conflict that's preventing those users from being registered in the first place. _But_ it'll help surface that issue if so, and if not it's a nice way to "stop the bleeding" while continuing to investigate to figure out the underlying issue. 🔍 
#### What are the relevant tickets?

References #6406 and #6260.

---

For review: @angaither
