### PR TITLE
Replaced continue with a return.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1209,10 +1209,10 @@ function dosomething_reportback_mark_reportback_as_excluded($fid) {
   $reportback = reportback_load($fid->rbid);
 
   if (empty($reportback)) {
-    continue;
+    return;
   }
 
-  // Get all reportback item files associated with reportback. 
+  // Get all reportback item files associated with reportback.
   $items = $reportback->getFids();
   $items = entity_load('reportback_item', $items);
 


### PR DESCRIPTION
#### What's this PR do?

changes the `continue` inside of `dosomething_reportback_mark_reportback_as_excluded` to a  `return`
#### How should this be reviewed?

👀 
#### Any background context you want to provide?

causing php upgrade to fail
#### Relevant tickets

Fixes #6416
