### PR TITLE
Update to include campaign attachments in API response.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -203,7 +203,6 @@ abstract class Transformer {
     // If an instance of Campaign class, then there is much
     // more information that can be obtained.
     if ($data instanceof Campaign) {
-
       // Show all properties for "full" display.
       if ($data->display === 'full') {
         $output['created_at'] = $data->created_at;
@@ -244,6 +243,8 @@ abstract class Transformer {
         $output['causes'] = $data->causes;
 
         $output['action_types'] = $data->action_types;
+
+        $output['attachments'] = $data->attachments;
 
         $output['issue'] = $data->issue;
 

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -257,6 +257,10 @@ class Campaign {
 
     $items = dosomething_helpers_extract_field_data($this->node->field_downloads);
 
+    if (!$items) {
+      return $data;
+    }
+
     if (dosomething_helpers_array_is_associative($items)) {
       $items = [$items];
     }

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -257,13 +257,9 @@ class Campaign {
 
     $items = dosomething_helpers_extract_field_data($this->node->field_downloads);
 
-//    print_r($items);
-
     if (dosomething_helpers_array_is_associative($items)) {
       $items = [$items];
     }
-
-//    print_r($items);
 
     foreach ($items as $item) {
       $attachment = [];

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -5,17 +5,24 @@ class Campaign {
   protected $node;
   protected $variables;
 
+  /**
+   * Properties always exposed.
+   */
   public $id;
   public $title;
   public $display;
   public $tagline;
   public $campaign_runs;
-  public $created_at;
-  public $updated_at;
   public $status;
   public $type;
   public $language;
   public $translations;
+
+  /**
+   * Properties exposed in full Campaign view.
+   */
+  public $created_at;
+  public $updated_at;
   public $time_commitment;
   public $cover_image;
   public $scholarship;
@@ -26,6 +33,7 @@ class Campaign {
   public $latest_news;
   public $causes;
   public $action_types;
+  public $attachments;
   public $issue;
   public $tags;
   public $timing;
@@ -179,6 +187,8 @@ class Campaign {
 
         $this->action_types = $this->getActionTypes();
 
+        $this->attachments = $this->getAttachments();
+
         $this->issue = $this->getIssue();
         $this->tags = $this->getTags();
 
@@ -225,12 +235,40 @@ class Campaign {
     return $data;
   }
 
-  protected function getAffiliates()
-  {
+  /**
+   * Get all affiliates (partners, etc) for the campaign.
+   * 
+   * @return array
+   */
+  protected function getAffiliates() {
     // @TODO: Only grabs partners for now. Update with further affiliates as needed.
     return [
       'partners' => $this->getPartners(),
     ];
+  }
+
+  /**
+   * Get all downloadable attachments for the campaign.
+   *
+   * @return array
+   */
+  protected function getAttachments() {
+    $data = [];
+
+    $items = dosomething_helpers_extract_field_data($this->node->field_downloads);
+
+    foreach ($items as $item) {
+      $attachment = [];
+
+      $attachment['title'] = !empty($item['title']) ? $item['title'] : NULL;
+      $attachment['description'] = !empty($item['description']) ? $item['description'] : NULL;
+      $attachment['uri'] = file_create_url($item['uri']);
+      $attachment['type'] = $item['type'];
+
+      $data[] = $attachment;
+    }
+
+    return $data;
   }
 
   /**

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -6,7 +6,7 @@ class Campaign {
   protected $variables;
 
   /**
-   * Properties always exposed.
+   * Properties exposed in teaser Campaign view.
    */
   public $id;
   public $title;
@@ -237,7 +237,7 @@ class Campaign {
 
   /**
    * Get all affiliates (partners, etc) for the campaign.
-   * 
+   *
    * @return array
    */
   protected function getAffiliates() {
@@ -257,11 +257,19 @@ class Campaign {
 
     $items = dosomething_helpers_extract_field_data($this->node->field_downloads);
 
+//    print_r($items);
+
+    if (dosomething_helpers_array_is_associative($items)) {
+      $items = [$items];
+    }
+
+//    print_r($items);
+
     foreach ($items as $item) {
       $attachment = [];
 
-      $attachment['title'] = !empty($item['title']) ? $item['title'] : NULL;
-      $attachment['description'] = !empty($item['description']) ? $item['description'] : NULL;
+      $attachment['title'] = $item['title'];
+      $attachment['description'] = $item['description'];
       $attachment['uri'] = file_create_url($item['uri']);
       $attachment['type'] = $item['type'];
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -11,6 +11,15 @@ include_once('dosomething_helpers.strongarm.inc');
 include_once('dosomething_helpers.variable.inc');
 include_once('dosomething_helpers.share.inc');
 
+/**
+ * Utility function to determine if an array is associative.
+ *
+ * @param array $data
+ * @return bool
+ */
+function dosomething_helpers_array_is_associative(array $data) {
+  return count(array_filter(array_keys($data), 'is_string')) > 0;
+}
 
 /**
  * Utility function to check if a variable is set, and return it
@@ -227,8 +236,8 @@ function dosomething_helpers_extract_field_file_attachment($data) {
   $values['file_name'] = isset($data['filename']) ? $data['filename'] : NULL;
   $values['file_mime'] = isset($data['filemime']) ? $data['filemime'] : NULL;
   $values['file_size'] = isset($data['filesize']) ? $data['filesize'] : NULL;
-  $values['title'] = isset($data['title']) ? $data['title'] : NULL;
-  $values['description'] = isset($data['description']) ? $data['description'] : NULL;
+  $values['title'] = isset($data['title']) && !empty($data['title']) ? $data['title'] : NULL;
+  $values['description'] = isset($data['description']) && !empty($data['description']) ? $data['description'] : NULL;
   $values['timestamp'] = isset($data['timestamp']) ? $data['timestamp'] : NULL;
 
   return $values;

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -148,7 +148,6 @@ function dosomething_helpers_delete_test_nodes() {
   }
 }
 
-
 /**
  * Utility function to extract content data from fields, while accounting
  * for language selection.
@@ -159,66 +158,48 @@ function dosomething_helpers_delete_test_nodes() {
  * @return mixed|null
  */
 function dosomething_helpers_extract_field_data($field, $language = LANGUAGE_NONE) {
-  if (isset($field) && !empty($field)) {
+  if (!isset($field) || empty($field)) {
+    return NULL;
+  }
 
-    // ---
-    // Temporary fix for translatable fields.
-    // If no specific language requested, attempt to return English value first.
-    //
-    // In future the API will be extended with functionally that controls
-    // output language with a URL parameter.
-    if ($language === LANGUAGE_NONE) {
-      if (!empty($field['en'])) {
-        $language = 'en';
-      }
+  $data = dosomething_helpers_get_field_data_by_language($field, $language);
+
+  $values = [];
+
+  foreach ($data as $item => $content) {
+    $keys = array_keys($content);
+
+    if (in_array('date_type', $keys)) {
+      // Date values, so need to extract using custom method.
+      $values[] = dosomething_helpers_extract_field_dates($content);
     }
-    // ---
-
-    if (!array_key_exists($language, $field)) {
-      return NULL;
+    elseif (in_array('country', $keys)) {
+      //TODO: Build function to get all address data, not just country.
+      $values[] = $content['country'];
     }
-
-    $data = $field[$language];
-
-    $values = [];
-
-    foreach ($data as $item => $content) {
-      $keys = array_keys($content);
-
-      if (in_array('date_type', $keys)) {
-        // Date values, so need to extract using custom method.
-        $values[] = dosomething_helpers_extract_field_dates($content);
-      }
-      elseif (in_array('country', $keys)) {
-        //TODO: Build function to get all address data, not just country.
-        $values[] = $content['country'];
-      }
-      elseif (in_array('type', $keys)) {
-        if ($content['type'] === 'image') {
-          $values[] = dosomething_helpers_extract_field_image($content);
-        } else {
-          // Default to first item; typically an id value.
-          $values[] = $content[$keys[0]];
-        }
-      }
-      elseif ($keys[0] === 'value') {
-        // Text value, so need to extract using custom method.
-        $values[] = dosomething_helpers_extract_field_text($content);
-      }
-      else {
-        // ID value.
+    elseif (in_array('type', $keys)) {
+      if ($content['type'] === 'image' || $content['type'] === 'document') {
+        $values[] = dosomething_helpers_extract_field_file_attachment($content);
+      } else {
+        // Default to first item; typically an id value.
         $values[] = $content[$keys[0]];
       }
     }
-
-    if (count($values) > 1) {
-      return $values;
+    elseif ($keys[0] === 'value') {
+      // Text value, so need to extract using custom method.
+      $values[] = dosomething_helpers_extract_field_text($content);
     }
-
-    return $values[0];
+    else {
+      // ID value.
+      $values[] = $content[$keys[0]];
+    }
   }
 
-  return NULL;
+  if (count($values) > 1) {
+    return $values;
+  }
+
+  return $values[0];
 }
 
 
@@ -236,7 +217,8 @@ function dosomething_helpers_extract_field_dates($data) {
   return $values;
 }
 
-function dosomething_helpers_extract_field_image($data) {
+
+function dosomething_helpers_extract_field_file_attachment($data) {
   $values = [];
 
   $values['id'] = isset($data['fid']) ? $data['fid'] : NULL;
@@ -245,6 +227,8 @@ function dosomething_helpers_extract_field_image($data) {
   $values['file_name'] = isset($data['filename']) ? $data['filename'] : NULL;
   $values['file_mime'] = isset($data['filemime']) ? $data['filemime'] : NULL;
   $values['file_size'] = isset($data['filesize']) ? $data['filesize'] : NULL;
+  $values['title'] = isset($data['title']) ? $data['title'] : NULL;
+  $values['description'] = isset($data['description']) ? $data['description'] : NULL;
   $values['timestamp'] = isset($data['timestamp']) ? $data['timestamp'] : NULL;
 
   return $values;
@@ -307,6 +291,38 @@ function dosomething_helpers_format_data($data) {
   return $data;
 }
 
+/**
+ * Utility function to extract data translated in the specified language from an
+ * array of available translations.
+ *
+ * @param $field
+ * @param string $language Language selection, defaults to Drupal constant for "undefined".
+ * @return array|null
+ */
+function dosomething_helpers_get_field_data_by_language($field, $language = LANGUAGE_NONE) {
+  if (!$field) {
+    return NULL;
+  }
+
+  // ---
+  // Temporary fix for translatable fields.
+  // If no specific language requested, attempt to return English value first.
+  //
+  // In future the API will be extended with functionally that controls
+  // output language with a URL parameter.
+  if ($language === LANGUAGE_NONE) {
+    if (!empty($field['en'])) {
+      $language = 'en';
+    }
+  }
+  // ---
+
+  if (!array_key_exists($language, $field)) {
+    return NULL;
+  }
+
+  return $field[$language];
+}
 
 /**
  * Wrapper function for Drupal's ip_address function.
@@ -714,11 +730,11 @@ function dosomething_helpers_unset_non_numeric_array_values($items) {
   if (is_string($items)) {
     $items = [$items];
   }
-  
+
   foreach ($items as $key => $item) {
     if (! is_numeric($item)) {
       unset($items[$key]);
-    } 
+    }
   }
 
   return $items;


### PR DESCRIPTION
#### What's this PR do?

This PR exposes file download attachments included in a Campaign so the data is available via the API.

This also adds a new simple [helper function](https://github.com/DoSomething/phoenix/pull/6434/files#diff-db98b09850e08759ec1a1280686dcb60R260) which will return a `boolean` whether the supplied array is associative or not.

Preview of the API response output:

![image](https://cloud.githubusercontent.com/assets/105849/15251869/6c0ed68c-18f9-11e6-850c-2308d4a765fe.png)
#### How should this be reviewed?

Pull down this branch, and load a few Campaigns via the `/campaigns` endpoint and see if it includes the new `attachments` property.
#### Relevant tickets

Fixes #6413 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.

---

@aaronschachter @angaither 

cc: @lkpttn @mikefantini 
