### PR TITLE
Let those kudos do their thing.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -73,7 +73,7 @@ function _kudos_resource_definition() {
             'optional' => FALSE,
             'type' => 'string',
             'source' => [
-              'param' => 'reportback_item_id',
+              'data' => 'reportback_item_id',
             ],
           ],
           [
@@ -82,7 +82,7 @@ function _kudos_resource_definition() {
             'optional' => FALSE,
             'type' => 'string',
             'source' => [
-              'param' => 'user_id',
+              'data' => 'user_id',
             ],
           ],
           [
@@ -91,7 +91,7 @@ function _kudos_resource_definition() {
             'optional' => FALSE,
             'type' => 'array',
             'source' => [
-              'param' => 'term_ids',
+              'data' => 'term_ids',
             ],
           ],
         ],

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -14,7 +14,6 @@ function makeKudoRequest($el, id)
     url: id ? `/api/v1/kudos/${id}` : '/api/v1/kudos',
     dataType: 'json',
     headers: {
-      'Accepts': 'application/json',
       'Content-Type': 'application/json',
       'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content'),
     },


### PR DESCRIPTION
#### What's this PR do?

It was looking for a URL parameter, rather than the ol' JSON data. This PR fixes that. 🐛 
#### How should this be reviewed?

Look at those changes. 👀 
#### Any background context you want to provide?

We were also sending an `Accepts` header which like _isn't_ a thing. jQuery seems to automatically sends the correct `Accept` header so no need to try to override that here.
#### Relevant tickets

References a bug in #6424.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
