### PR TITLE
Turn off extra modules locally

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -486,8 +486,8 @@ function pull_db {
       echo "Reverting features..."
       drush -y fra
 
-      echo "Disabling Optimizely module locally."
-      drush -y dis optimizely
+      echo "Disabling external modules locally."
+      drush -y dis optimizely dosomething_northstar dosomething_gladiator
 
       echo "Clearing cache..."
       drush cc all


### PR DESCRIPTION
#### What's this PR do?

After a pull from stage, this disables `dosomething_northstar` and `dosomething_gladiator`
#### How should this be reviewed?

👀 
#### Any background context you want to provide?

These rely on external api connections and shouldn't be enabled by default locally
Especially since by default everyone is pointing to the stage instance of those dbs and things could get wild. 
#### Relevant tickets

Fixes #6304
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
