### PR TITLE
Vagrant 2.0.0.beta1 release: PHP7.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,14 +20,9 @@ Vagrant.configure("2") do |config|
   config.ssh.forward_agent = true
 
   # Mount shared folders
-  if ENV['DS_VAGRANT_MOUNT_NFS']
-    # NFS
-    config.vm.network :private_network, ip: "10.11.12.13"
-    config.vm.synced_folder ".", "/var/www/dev.dosomething.org", type: "nfs"
-  else
-    # SSHFS -- reverse mount from within Vagrant box
-    config.sshfs.paths = { "/var/www/dev.dosomething.org" => "../dosomething-mount" }
-  end
+  # NFS
+  config.vm.network :private_network, ip: "10.11.12.13"
+  config.vm.synced_folder ".", "/var/www/dev.dosomething.org", type: "nfs"
 
   # Allow `npm link` for Neue
   if File.exists?("/usr/local/lib/node_modules/@dosomething/forge")

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,11 @@ Vagrant.configure("2") do |config|
 
   ## Choose your base box
   config.vm.box = "dosomething/phoenix"
-  config.vm.box_version = "1.0.8"
+  if ENV['DS_VAGRANT_BETA']
+    config.vm.box_version = "2.0.0.beta1"
+  else
+    config.vm.box_version = "1.0.8"
+  end
 
   config.vm.provider "virtualbox" do |v|
     v.customize ["modifyvm", :id, "--memory", 3072]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,6 +46,10 @@ Vagrant.configure("2") do |config|
   # Solr.
   config.vm.network :forwarded_port, guest: 8983, host: 8983
 
-  config.vm.provision :shell, :inline => 'more /vagrant/scripts/install_complete.txt'
+  # Welcome message.
+  config.vm.provision :shell do |h|
+    h.inline = 'cat /var/www/dev.dosomething.org/scripts/install_complete.txt'
+  end
+
 end
 

--- a/scripts/install_complete.txt
+++ b/scripts/install_complete.txt
@@ -3,4 +3,4 @@ That's it!
 If this is the first time you ran "vagrant up", be sure to read the documentation
 on the dosomething wiki to finish building your local environment:
 
-https://github.com/DoSomething/phoenix/wiki/Building-your-local-environment
+https://github.com/DoSomething/phoenix/wiki/Building-your-local-environment-(NFS)


### PR DESCRIPTION
#### What's this PR do?
- Provides an option to run Vagrant 2.0.0.beta1 box, including PHP7!
- Deprecates SSHFS host-to-guest vagrant synced folders
- Fixes welcome message path
- Hardcodes box's private network ip to `10.11.12.13`
- Change the link to new default building env wiki page
#### How should this be manually tested?
- Add `export DS_VAGRANT_BETA=1` to your shell profile, for example `.bashrc` or `.profile`
- Reload shell
- Destroy old box: `vagrant destroy`
- Build [as usual](https://github.com/DoSomething/phoenix/wiki/Building-your-local-environment-%28NFS%29)
#### Any background context you want to provide?

Old `config.sshfs` syntax got removed from the module after the main maintainer was changed.
See https://github.com/dustymabe/vagrant-sshfs
