### PR TITLE
Fix path for Forge fallback image.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/patterns.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/patterns.inc
@@ -31,7 +31,7 @@ function paraneue_dosomething_get_gallery_item($content, $type = 'figure', $use_
 
     if (empty($content['image'])) {
       $content['image'] = theme('image', array(
-        'path' => FORGE_ASSET_PATH . '/dist/assets/images/apple-touch-icon-precomposed.png'
+        'path' => FORGE_ASSET_PATH . '/assets/images/apple-touch-icon-precomposed.png'
       ));
     }
   }


### PR DESCRIPTION
#### What's this PR do?

This updates the path for the "touch image" used as a fallback for search results with no image thumbnail, since the `assets` folder is no longer copy-pasted into `dist` since the latest Forge update (as we now use Webpack to process and fingerprint assets in that folder).
#### How should this be reviewed?

Check out that search page. It should not be broke.
#### Any background context you want to provide?

🚛 
#### Relevant tickets

Fixes #6403.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.

---

For review: @DoSomething/front-end 
