### PR TITLE
Reset some style changes that leaked out of the Gallery prototype.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -2,36 +2,6 @@
   position: relative;
 }
 
-.container--campaign-gallery {
-  background: $yellow;
-
-  .gallery--reportback > li {
-    width: 100% !important;
-    margin-bottom: $base-spacing;
-
-    @include media($medium) {
-      width: 50% !important;
-      margin-bottom: 0;
-    }
-  }
-
-  .gallery--extended > li {
-    width: 100% !important;
-
-    @include media($medium) {
-      width: 50% !important;
-    }
-  }
-
-  .photo .__copy {
-    height: auto;
-
-    @include media($medium) {
-      height: 60px;
-    }
-  }
-}
-
 // Page Specific Components
 .campaign--action .container--prove,
 .campaign--sms .container--do {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_button.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_button.scss
@@ -1,3 +1,4 @@
+// @TODO: Should this become a real modifier?
 .button.-mini {
   font-size: 13px !important;
   padding-top: 6px !important;
@@ -12,7 +13,7 @@
   }
 }
 
-
+// @TODO: Make this into a real pattern.
 .counter {
   display: inline-block;
   color: $med-gray;
@@ -21,14 +22,5 @@
 
   &.is-active {
     color: $purple;
-  }
-}
-
-
-.social-icon.-secondary:after {
-  color: $light-gray;
-
-  &:hover {
-    color: $med-gray;
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_photo.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_photo.scss
@@ -31,11 +31,6 @@
       margin-top: ($base-spacing / 2);
       word-wrap: break-word;
 
-      .photo__caption {
-        font-family: $font-handwritten;
-        font-size: $font-regular;
-      }
-
       .footnote {
         font-size: $font-small;
       }
@@ -53,23 +48,4 @@
   .photo--actions {
     width: 100%;
   }
-
-  .photo--shares {
-    float: right;
-    position: relative;
-    top: -24px;
-
-    @include media($mobile) {
-      display: none;
-    }
-
-    li + li {
-      padding-left: 12px;
-    }
-
-    a:after {
-      font-size: 18px;
-    }
-  }
-
 }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -1,9 +1,9 @@
 <figure class="photo -stacked -framed" data-reportback-item-id="<?php print $content->id; ?>">
-<!--  --><?php //if (isset($content->admin_link)): ?>
-<!--    <div class="admin-edit">-->
-<!--      <a class="button -secondary" href="--><?php //print $content->admin_link; ?><!--">--><?php //print t('Edit Status'); ?><!--</a>-->
-<!--    </div>-->
-<!--  --><?php //endif; ?>
+  <?php if (isset($content->admin_link)): ?>
+    <div class="admin-edit">
+      <a class="button -secondary" href="<?php print $content->admin_link; ?>"><?php print t('Edit Status'); ?></a>
+    </div>
+  <?php endif; ?>
   <img src="<?php print $content->media['uri']; ?>" alt="<?php print filter_xss($content->caption); ?>" />
   <figcaption class="__copy">
     <p class="photo__caption"><?php print filter_xss($content->caption); ?></p>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/user/user-profile.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/user/user-profile.tpl.php
@@ -40,7 +40,7 @@
   </section>
 
   <?php if (!empty($reportbacks)): ?>
-    <section class="container">
+    <section class="container -padded">
       <h2 class="heading -banner"><span><?php print t('You Did'); ?></span></h2>
       <div class="wrapper">
         <?php print $reportback_gallery; ?>


### PR DESCRIPTION
#### What's this PR do?

Removes some style changes that were accidentally merged in #6424, notably removing some styles that changed the campaign gallery to use our handwritten font on user photo captions.
#### How should this be reviewed?

Does it look the way it used to look? 🎨 🔍 
#### Any background context you want to provide?

💥 
#### Relevant tickets

References a conversation in the `#deploys` room.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.

---

For review: @DoSomething/front-end @angaither 
