### PR TITLE
Campaign api expose action guides

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -244,6 +244,8 @@ abstract class Transformer {
 
         $output['action_types'] = $data->action_types;
 
+        $output['action_guides'] = $data->action_guides;
+
         $output['attachments'] = $data->attachments;
 
         $output['issue'] = $data->issue;

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -188,7 +188,7 @@ class Campaign {
 
         $this->action_types = $this->getActionTypes();
 
-        $this->action_types = $this->getActionGuides();
+        $this->action_guides = $this->getActionGuides();
 
         $this->attachments = $this->getAttachments();
 
@@ -207,9 +207,14 @@ class Campaign {
     }
   }
 
+  /**
+   * Get Action Guides for campaign if available.
+   *
+   * @return array
+   */
   protected function getActionGuides() {
     $data = [];
-    
+
     $action_guide_ids = dosomething_helpers_extract_field_data($this->node->field_action_guide);
 
     if (! $action_guide_ids) {
@@ -241,6 +246,8 @@ class Campaign {
 
       $data[] = $action_guide;
     }
+
+    return $data;
   }
 
   /**

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -33,6 +33,7 @@ class Campaign {
   public $latest_news;
   public $causes;
   public $action_types;
+  public $action_guides;
   public $attachments;
   public $issue;
   public $tags;
@@ -187,6 +188,8 @@ class Campaign {
 
         $this->action_types = $this->getActionTypes();
 
+        $this->action_types = $this->getActionGuides();
+
         $this->attachments = $this->getAttachments();
 
         $this->issue = $this->getIssue();
@@ -201,6 +204,42 @@ class Campaign {
       }
 
       $this->reportback_info = $this->getReportbackInfo();
+    }
+  }
+
+  protected function getActionGuides() {
+    $data = [];
+    
+    $action_guide_ids = dosomething_helpers_extract_field_data($this->node->field_action_guide);
+
+    if (! $action_guide_ids) {
+      return $data;
+    }
+
+    if (! is_array($action_guide_ids)) {
+      $action_guide_ids = [$action_guide_ids];
+    }
+
+    $items = node_load_multiple($action_guide_ids);
+
+    foreach ($items as $item) {
+      $action_guide = [];
+
+      $action_guide['id'] = $item->nid;
+      $action_guide['title'] = $item->title;
+      $action_guide['subtitle'] = dosomething_helpers_extract_field_data($item->field_subtitle);
+      $action_guide['description'] = dosomething_helpers_extract_field_data($item->field_description);
+
+      $action_guide['intro']['title'] = dosomething_helpers_extract_field_data($item->field_intro_title);
+      $action_guide['intro']['copy'] = dosomething_helpers_extract_field_data($item->field_intro);
+
+      $action_guide['additional_text']['title'] = dosomething_helpers_extract_field_data($item->field_additional_text_title);
+      $action_guide['additional_text']['copy'] = dosomething_helpers_extract_field_data($item->field_additional_text);
+
+      $action_guide['created_at'] = $item->created;
+      $action_guide['updated_at'] = $item->changed;
+
+      $data[] = $action_guide;
     }
   }
 


### PR DESCRIPTION
#### What's this PR do?

This PR exposes the action guides in a campaign (if available) to the `/campaigns` endpoint. The new `action_guides` property is an array of available action guides on a campaign. If there are _no_ action guides on a campaign, then it is simple an empty array.

![image](https://cloud.githubusercontent.com/assets/105849/15299592/12a76876-1b73-11e6-8ed0-1c0426ff9403.png)
#### How should this be reviewed?

Make sure the code looks ok! Please review the highlighted API response above for a single action guide and let me know if the data hierarchy seems reasonable.
#### Any background context you want to provide?

I'm exposing the `id` of the action guide. Not sure if this is useful or not, and we don't really expose the ids of other things that are returned via the API in the campaign object. It doesn't hurt, but let me know if it's something to remove or not.
#### Relevant tickets

Fixes #6412
#### Checklist
- [ ] Documentation added for new features/changed endpoints.

---

@aaronschachter @angaither 

cc: @lkpttn @mikefantini 
