### PR TITLE
Make caption the same smaller size that it used to be.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_photo.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_photo.scss
@@ -31,6 +31,10 @@
       margin-top: ($base-spacing / 2);
       word-wrap: break-word;
 
+      .photo__caption {
+        font-size: $font-smaller;
+      }
+
       .footnote {
         font-size: $font-small;
       }


### PR DESCRIPTION
#### What's this PR do?

References #6447. I forgot to commit this line because I am bad at Git. This resets the font-size for the reportback photo caption back to the original tiny size that it used to be.
#### How should this be reviewed?

Check out that fab CSS.
#### Any background context you want to provide?

👀 🎨 
#### Relevant tickets

Fixes no such thing.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
