### PR TITLE
Fix heading in action guide modals.

### DIFF
--- a/lib/modules/dosomething/dosomething_action_guide/node--action_guide.tpl.php
+++ b/lib/modules/dosomething/dosomething_action_guide/node--action_guide.tpl.php
@@ -1,6 +1,8 @@
 <article id="node-<?php print $node->nid; ?>" class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
 
-  <h2 class="heading -banner"><?php print $title; ?></h2>
+  <div class="modal__block">
+    <h2><?php print $title; ?></h2>
+  </div>
 
   <div class="modal__block">
     <?php if (isset($subtitle)): ?>


### PR DESCRIPTION
#### What's this PR do?

Fixes action guide modal to use consistent markup with how other modals are formatted.
#### How should this be reviewed?

Look at an action guide. The heading should now look _just right_.
#### Any background context you want to provide?

👡🍶  
#### Relevant tickets

Fixes #6400.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.

---

For review: @DoSomething/front-end 
