### PR TITLE
Refactor save ID method to load user object via UID.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -74,15 +74,16 @@ function dosomething_northstar_verify_user($credentials) {
 /**
  * Save the user's Northstar ID to their local profile.
  *
- * @param $user - Drupal user
+ * @param $uid - Drupal user ID
  * @param $northstar_response - Northstar user JSON response
  */
-function dosomething_northstar_save_id_field($user, $northstar_response) {
+function dosomething_northstar_save_id_field($uid, $northstar_response) {
   $northstar_id = !empty($northstar_response->data->id) ? $northstar_response->data->id : 'NONE';
+  $user = user_load($uid);
 
   $edit = [];
   dosomething_user_set_fields($edit, ['northstar_id' => $northstar_id]);
-  user_save((object) ['uid' => $user->uid], $edit);
+  user_save($user, $edit);
 }
 
 /**
@@ -100,7 +101,7 @@ function dosomething_northstar_register_user($user, $payload) {
   ));
 
   // Save the newly registered user's ID to their local profile field.
-  dosomething_northstar_save_id_field($user, json_decode($response->data));
+  dosomething_northstar_save_id_field($user->uid, json_decode($response->data));
 
   // Add to request log if enabled.
   dosomething_northstar_log_request('register_user', $user, $payload, $response);

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -796,7 +796,7 @@ function _dosomething_user_verify_northstar_login($form_state) {
 
   // If the user exists in Northstar, store their ID on their Drupal profile.
   // @TODO: Remove this once we properly back-fill this field!
-  dosomething_northstar_save_id_field($user, $northstar_user);
+  dosomething_northstar_save_id_field($user->uid, $northstar_user);
 }
 
 /**

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -45,7 +45,7 @@ foreach ($users as $user) {
   echo 'Migrated user ' . $user->uid . ' to Northstar [' . $response->code . ']' . PHP_EOL;
 
   // Store the returned Northstar ID on the user's Drupal profile.
-  dosomething_northstar_save_id_field($user, json_decode($response->data));
+  dosomething_northstar_save_id_field($user->uid, json_decode($response->data));
 
   // If the script fails, we can use this to start the script from a previous person.
   variable_set('dosomething_northstar_last_user_migrated', $user->uid);


### PR DESCRIPTION
#### What's this PR do?

Refactors the `dosomething_northstar_save_id_field` method to ask for a UID rather than user object, and then load that unmodified user account in order to save the updated Northstar ID to it.
#### How should this be reviewed?

This should still work the same way, but will no longer cause [warnings on undefined fields](https://cloud.githubusercontent.com/assets/583202/15331858/433a4814-1c31-11e6-9e6c-a1415951a90a.png).
#### Any background context you want to provide?

References #6452.
#### Relevant tickets

🍃
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
