### PR TITLE
Signup takeover screen, repeat signup page, and functionality to dynamically add campaigns

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -388,6 +388,29 @@ function dosomething_campaign_preprocess_media_vars(&$vars, &$wrapper) {
 function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $campaign = $vars['campaign'];
 
+  // Get 3 recommended campaigns from recommendation engine.
+  $signup_takeover_recommended_nids = dosomething_campaign_get_recommended_campaign_nids(NULL, NULL, 3);
+  $signup_takeover_recommended_campaigns = [];
+
+  foreach ($signup_takeover_recommended_nids as $campaign) {
+    $campaign_array = [];
+    $campaign_object = node_load($campaign);
+    $campaign_array['title'] = $campaign_object->title;
+    $campaign_array['blurb'] = $campaign_object->field_call_to_action['en'][0]['value'];
+    $campaign_array['nid'] = $campaign;
+    array_push($signup_takeover_recommended_campaigns, $campaign_array);
+  }
+
+  // Send 3 campaigns to signup takeover, prompting user to signup for multiple campaigns.
+  drupal_add_js(
+    array(
+      'dosomethingCampaign' => array(
+        'recommendedCampaigns' => $signup_takeover_recommended_campaigns,
+      ),
+    ),
+    array('type' => 'setting')
+  );
+
   // Progress
   $vars['campaign_progress'] = dosomething_reportback_get_reportback_total_plus_override($vars['nid']);
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/signup/Signup.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/signup/Signup.js
@@ -18,23 +18,7 @@ const Signup = {
     const data = {
       'header': 'Thank you for signing up!',
       'caption': 'Want to do more good? Sign up for similar campaigns below!',
-      'campaigns': [
-        {
-          'title': 'Thumb Wars',
-          'blurb': 'some blurb',
-          'nid': '1173',
-        },
-        {
-          'title': 'Space Jam',
-          'blurb': 'Everybody get up! Its time to JAM now.',
-          'nid': '1631',
-        },
-        {
-          'title': 'Patient Playbooks',
-          'blurb': 'some blurb',
-          'nid': '1283',
-        },
-      ]
+      'campaigns': Drupal.settings.dosomethingCampaign.recommendedCampaigns,
     }
 
     // Add the takeover to the page.

--- a/lib/themes/dosomething/paraneue_dosomething/js/signup/Signup.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/signup/Signup.js
@@ -19,21 +19,21 @@ const Signup = {
       'header': 'Thank you for signing up!',
       'caption': 'Want to do more good? Sign up for similar campaigns below!',
       'campaigns': [
-        [
-          'Thumb Wars',
-          'some blurb',
-          '1173',
-        ],
-        [
-          'Space Jam',
-          'Everybody get up! Its time to JAM now.',
-          '1631',
-        ],
-        [
-          'Patient Playbooks',
-          'some blurb',
-          '1283',
-        ],
+        {
+          'title': 'Thumb Wars',
+          'blurb': 'some blurb',
+          'nid': '1173',
+        },
+        {
+          'title': 'Space Jam',
+          'blurb': 'Everybody get up! Its time to JAM now.',
+          'nid': '1631',
+        },
+        {
+          'title': 'Patient Playbooks',
+          'blurb': 'some blurb',
+          'nid': '1283',
+        },
       ]
     }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/signup/Signup.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/signup/Signup.js
@@ -37,22 +37,6 @@ const Signup = {
       ]
     }
 
-        // 'id': {
-        //   'title': 'Thumb Wars',
-        //   'blurb': 'some blurb',
-        //   'id': '1173'.
-        // },
-        // 'id': {
-        //   'title': 'Space Jam',
-        //   'blurb': 'Everybody get up! Its time to JAM now',
-        //   'id': '1631'.
-        // },
-        // 'id': {
-        //   'title': 'Patient Playbooks',
-        //   'blurb': 'some blurb',
-        //   'id': '1283'.
-        // }
-
     // Add the takeover to the page.
     this.takeoverContainer.html(markup(data));
 
@@ -91,7 +75,7 @@ const Signup = {
 
           const $buttonContainer = $('.spinner').closest('.takeover__campaign-item');
           console.log($buttonContainer);
-          $buttonContainer.html('<p>done</p>');
+          $buttonContainer.html('<p>Signed Up!</p>');
         }
       })
    });

--- a/lib/themes/dosomething/paraneue_dosomething/js/signup/Signup.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/signup/Signup.js
@@ -18,7 +18,40 @@ const Signup = {
     const data = {
       'header': 'Thank you for signing up!',
       'caption': 'Want to do more good? Sign up for similar campaigns below!',
+      'campaigns': [
+        [
+          'Thumb Wars',
+          'some blurb',
+          '1173',
+        ],
+        [
+          'Space Jam',
+          'Everybody get up! Its time to JAM now.',
+          '1631',
+        ],
+        [
+          'Patient Playbooks',
+          'some blurb',
+          '1283',
+        ],
+      ]
     }
+
+        // 'id': {
+        //   'title': 'Thumb Wars',
+        //   'blurb': 'some blurb',
+        //   'id': '1173'.
+        // },
+        // 'id': {
+        //   'title': 'Space Jam',
+        //   'blurb': 'Everybody get up! Its time to JAM now',
+        //   'id': '1631'.
+        // },
+        // 'id': {
+        //   'title': 'Patient Playbooks',
+        //   'blurb': 'some blurb',
+        //   'id': '1283'.
+        // }
 
     // Add the takeover to the page.
     this.takeoverContainer.html(markup(data));

--- a/lib/themes/dosomething/paraneue_dosomething/js/signup/templates/takeover.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/signup/templates/takeover.tpl.html
@@ -3,16 +3,16 @@
   <p><%= caption %></p>
 
   <div class="takeover__campaigns">
-    <ul class="form-actions -inline -padded takeover__campaign">
+    <% for (var i=0; i < campaigns.length; i++){ %>
+      <ul class="form-actions -inline -padded takeover__campaign">
         <li class="takeover__campaign-item">
-          <% for (var i=0; i < campaigns.length; i++){ %>
-            <h3><%= campaigns[i]['title'] %></h3>
-            <p><%= campaigns[i]['blurb'] %></p>
+              <h3><%= campaigns[i]['title'] %></h3>
+              <p><%= campaigns[i]['blurb'] %></p>
+          </li>
+        <li class="takeover__campaign-item">
+          <input type="submit" class="button signup-button" value="Signup" data-campaign-id=<%= campaigns[i]['nid'] %>>
         </li>
-      <li class="takeover__campaign-item">
-        <input type="submit" class="button signup-button" value="Signup" data-campaign-id=<%= campaigns[i]['nid'] %>>
-      </li>
-          <% } %>
-    </ul>
+      </ul>
+    <% } %>
   </div>
  </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/signup/templates/takeover.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/signup/templates/takeover.tpl.html
@@ -15,23 +15,5 @@
       </li>
           <% } %>
     </ul>
-    <!--  <ul class="form-actions -inline -padded takeover__campaign">
-        <li class="takeover__campaign-item">
-        <h3>Space Jam</h3>
-        <p>Everybody get up! It's time to JAM now.</p>
-        </li>
-      <li class="takeover__campaign-item">
-        <input type="submit" class="button signup-button" value="Signup" data-campaign-id="1631">
-      </li>
-    </ul>
-     <ul class="form-actions -inline -padded takeover__campaign">
-        <li class="takeover__campaign-item">
-        <h3>Patient Playbook</h3>
-        <p>Description klSJHDADSF ASJDLA KASJDF UWE a lkjsdfhasdkfjh wudahksjdhf suew gkjak utgt akslkguihwh vjaskdjhfau wgag skauwgakja sdf askjdhfluweg akjhsdlkuyfwl </p>
-        </li>
-      <li class="takeover__campaign-item">
-        <input type="submit" class="button signup-button" value="Signup" data-campaign-id="1283">
-      </li>
-    </ul> -->
   </div>
  </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/signup/templates/takeover.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/signup/templates/takeover.tpl.html
@@ -7,12 +7,11 @@
         <li class="takeover__campaign-item">
           <% var campaignsLength = campaigns.length; %>
           <% for (var i=0; i < campaignsLength; i++){ %>
-          <% console.log(campaigns[0][0]) %>
-            <h3><%= campaigns[i][0] %></h3>
-            <p><%= campaigns[i][1] %></p>
+            <h3><%= campaigns[i]['title'] %></h3>
+            <p><%= campaigns[i]['blurb'] %></p>
         </li>
       <li class="takeover__campaign-item">
-        <input type="submit" class="button signup-button" value="Signup" data-campaign-id=<%= campaigns[i][2] %>>
+        <input type="submit" class="button signup-button" value="Signup" data-campaign-id=<%= campaigns[i]['nid'] %>>
       </li>
           <% } %>
     </ul>

--- a/lib/themes/dosomething/paraneue_dosomething/js/signup/templates/takeover.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/signup/templates/takeover.tpl.html
@@ -3,16 +3,20 @@
   <p><%= caption %></p>
 
   <div class="takeover__campaigns">
-     <ul class="form-actions -inline -padded takeover__campaign">
+    <ul class="form-actions -inline -padded takeover__campaign">
         <li class="takeover__campaign-item">
-          <h3>Thumb wars</h3>
-          <p>Description klSJHDADSF ASJDLA KASJDF UWE a lkjsdfhasdkfjh wudahksjdhf suew gkjak utgt akslkguihwh vjaskdjhfau wgag skauwgakja sdf askjdhfluweg akjhsdlkuyfwl </p>
+          <% var campaignsLength = campaigns.length; %>
+          <% for (var i=0; i < campaignsLength; i++){ %>
+          <% console.log(campaigns[0][0]) %>
+            <h3><%= campaigns[i][0] %></h3>
+            <p><%= campaigns[i][1] %></p>
         </li>
       <li class="takeover__campaign-item">
-        <input type="submit" class="button signup-button" value="Signup" data-campaign-id="1173">
+        <input type="submit" class="button signup-button" value="Signup" data-campaign-id=<%= campaigns[i][2] %>>
       </li>
+          <% } %>
     </ul>
-     <ul class="form-actions -inline -padded takeover__campaign">
+    <!--  <ul class="form-actions -inline -padded takeover__campaign">
         <li class="takeover__campaign-item">
         <h3>Space Jam</h3>
         <p>Everybody get up! It's time to JAM now.</p>
@@ -29,6 +33,6 @@
       <li class="takeover__campaign-item">
         <input type="submit" class="button signup-button" value="Signup" data-campaign-id="1283">
       </li>
-    </ul>
+    </ul> -->
   </div>
  </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/signup/templates/takeover.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/signup/templates/takeover.tpl.html
@@ -5,8 +5,7 @@
   <div class="takeover__campaigns">
     <ul class="form-actions -inline -padded takeover__campaign">
         <li class="takeover__campaign-item">
-          <% var campaignsLength = campaigns.length; %>
-          <% for (var i=0; i < campaignsLength; i++){ %>
+          <% for (var i=0; i < campaigns.length; i++){ %>
             <h3><%= campaigns[i]['title'] %></h3>
             <p><%= campaigns[i]['blurb'] %></p>
         </li>


### PR DESCRIPTION
#### What's this PR do?

This PR includes work we did to close: 
- [Show takeover screen after sign up](https://github.com/DoSomething/phoenix/issues/6425)
- [Repeat sign up page](https://github.com/DoSomething/phoenix/issues/6427)
- [Pull in campaigns automatically](https://github.com/DoSomething/phoenix/issues/6428)
#### How should this be reviewed?
- Make sure that campaigns are dynamically pulled in.
- Test the sign up button to make sure it works.
- Double check the database to make sure the signup went through and was saved. 
#### Any background context you want to provide?

Formatting is still a little off for the sign up page - still working on this. 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
