### PR TITLE
Oh behave, API.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -174,7 +174,7 @@ function _member_resource_create($account) {
     'first_name' => $account['first_name'],
     'country' => dosomething_settings_get_affiliate_country_code(),
     'last_name' => !empty($account['last_name']) ? $account['last_name'] : NULL,
-    'mobile' => !empty($account['mobile']) ? $account['mobile'] : NULL,
+    'mobile' => !empty($account['mobile']) ? dosomething_user_clean_mobile_number($account['mobile']) : NULL,
     'user_registration_source' => !empty($account['user_registration_source']) ? $account['user_registration_source'] : NULL,
   );
 

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -152,6 +152,12 @@ function _member_resource_create($account) {
   if ($user = user_load_by_mail($email)) {
     return services_error(t('Email @email is registered to User uid @uid.', array('@email' => $email, '@uid' => $user->uid)), 403);
   }
+  // Check if account exists for phone.
+  $mobile = $account['mobile'];
+  if ($mobile && $user = dosomething_user_get_user_by_mobile($mobile)) {
+    return services_error(t('Mobile @mobile is registered to User uid @uid.', array('@mobile' => $mobile, '@uid' => $user->uid)), 403);
+  }
+  
   // Initialize array to pass to user_save().
   $edit = array();
   $edit['mail'] = $email;


### PR DESCRIPTION
#### What's this PR do?

This fixes some bugs with the `POST api/v1/users` endpoint:
1. We previously didn't have any validation to prevent creating duplicate mobile users via the API.
2. We also didn't previously "clean" mobile numbers to strip out non-numeric characters like we do from the web registration form.
#### How should this be reviewed?

Try hitting those endpoints. You should no longer be able to do the aforementioned bad things.
#### Any background context you want to provide?

It'd be great if we could share the same business/validation logic anywhere we create a user. I'm not sure if there's any idiomatic way of doing that in Drupal, or if it's worth taking the risk of refactoring things too much though.
#### Relevant tickets

Fixes #6450.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
