### PR TITLE
Update user endpoint to accept country code and language.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -180,19 +180,8 @@ function _member_resource_create($account) {
 
   dosomething_user_set_fields($edit, $fields);
 
-  // Set user's language if provided, or infer from country code
-  if(! empty($account['language'])) {
-    $languages = array_keys(variable_get('dosomething_global_language_map', ''));
-
-    // Only allow whitelisted languages.
-    if(! in_array($account['language'], $languages)) {
-      return services_error(t('The language @language is not supported.', ['@language' => $account['language']]), 422);
-    }
-
-    $edit['language'] = $account['language'];
-  } else {
-    $edit['language'] = dosomething_global_convert_country_to_language($fields['country']);
-  }
+  // Infer the user's language from their country code field.
+  $edit['language'] = dosomething_global_convert_country_to_language($fields['country']);
 
   try {
     $account = user_save('', $edit);

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -130,7 +130,7 @@ function _member_resource_access($op) {
 /**
  * Callback for User create.
  *
- * @param obj $account
+ * @param $account
  *   Array passed to the endpoint. Possible keys:
  *   - email (string). Required.
  *   - password (string).
@@ -172,7 +172,7 @@ function _member_resource_create($account) {
   $fields = array(
     'birthdate' => $account['birthdate'],
     'first_name' => $account['first_name'],
-    'country' => dosomething_settings_get_affiliate_country_code(),
+    'country' => !empty($account['country']) ? $account['country'] : 'US',
     'last_name' => !empty($account['last_name']) ? $account['last_name'] : NULL,
     'mobile' => !empty($account['mobile']) ? dosomething_user_clean_mobile_number($account['mobile']) : NULL,
     'user_registration_source' => !empty($account['user_registration_source']) ? $account['user_registration_source'] : NULL,

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -150,14 +150,14 @@ function _member_resource_create($account) {
   $email = $account['email'];
   // Check if account exists for email.
   if ($user = user_load_by_mail($email)) {
-    return services_error(t('Email @email is registered to User uid @uid.', array('@email' => $email, '@uid' => $user->uid)), 403);
+    return services_error(t('Email @email is registered to User uid @uid.', ['@email' => $email, '@uid' => $user->uid]), 403);
   }
   // Check if account exists for phone.
   $mobile = $account['mobile'];
   if ($mobile && $user = dosomething_user_get_user_by_mobile($mobile)) {
-    return services_error(t('Mobile @mobile is registered to User uid @uid.', array('@mobile' => $mobile, '@uid' => $user->uid)), 403);
+    return services_error(t('Mobile @mobile is registered to User uid @uid.', ['@mobile' => $mobile, '@uid' => $user->uid]), 403);
   }
-  
+
   // Initialize array to pass to user_save().
   $edit = array();
   $edit['mail'] = $email;
@@ -179,6 +179,20 @@ function _member_resource_create($account) {
   );
 
   dosomething_user_set_fields($edit, $fields);
+
+  // Set user's language if provided, or infer from country code
+  if(! empty($account['language'])) {
+    $languages = array_keys(variable_get('dosomething_global_language_map', ''));
+
+    // Only allow whitelisted languages.
+    if(! in_array($account['language'], $languages)) {
+      return services_error(t('The language @language is not supported.', ['@language' => $account['language']]), 422);
+    }
+
+    $edit['language'] = $account['language'];
+  } else {
+    $edit['language'] = dosomething_global_convert_country_to_language($fields['country']);
+  }
 
   try {
     $account = user_save('', $edit);


### PR DESCRIPTION
#### What's this PR do?

This updates the API endpoint to _not_ try to use the Fastly header to set a user's country code. Since these requests are (almost?) exclusively coming from our own internal services, this will always just set the user's country to the location of the server (US).

The endpoint now accepts a `country` value, which will be saved to the user's address field. If nothing is provided for that field, it defaults to `US`.
#### How should this be reviewed?

Hit that endpoint. Does it now save a country code and language? It should.
#### Any background context you want to provide?

Should it default to US? Or should we try to save `null` to that user's country? Also, should we consider allowing this endpoint to accept a full address?
#### Relevant tickets

Fixes #6442.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
