### PR TITLE
Fix warnings on pulling staging database.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -69,15 +69,13 @@ function paraneue_dosomething_add_info_bar(&$vars) {
   if (module_exists('dosomething_global')) {
     $country_code = dosomething_global_get_current_prefix();
 
-    if ($country_code) {
-      $country_contact_emails = array(
-        'br' => 'ajuda@dosomething.org',
-        'mx' => 'ayuda@dosomething.org',
-        );
-    }
+    $country_contact_emails = [
+      'br' => 'ajuda@dosomething.org',
+      'mx' => 'ayuda@dosomething.org',
+    ];
 
     // For the countries in $country_contact_emails, use a contact email address instead of zendesk form.
-    if (array_key_exists($country_code, $country_contact_emails)) {
+    if ($country_code && array_key_exists($country_code, $country_contact_emails)) {
       $info_bar_vars['contact_us_email'] = '<a href="mailto:' . $country_contact_emails[$country_code] .'">'. $country_contact_emails[$country_code] . '</a>';
       // All other countries get the zendesk form.
     }


### PR DESCRIPTION
#### What's this PR do?

This only attempts to check the `$country_contact_emails` array when there actually is a country code to check for, silencing warnings during the DB pull command.
#### How should this be reviewed?

If you run `ds pull stage --db` then you shouldn't see errors.
#### Any background context you want to provide?

🌊 
#### Relevant tickets

Fixes #6312.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
