### PR TITLE
Fixes #6472: Updates MB module version

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -272,7 +272,7 @@ projects[external_auth][subdir] = "contrib"
 projects[message_broker_producer][type] = "module"
 projects[message_broker_producer][download][type] = "git"
 projects[message_broker_producer][download][url] = "https://github.com/DoSomething/message_broker_producer.git"
-projects[message_broker_producer][download][tag] = "0.2.5"
+projects[message_broker_producer][download][tag] = "0.2.6"
 projects[message_broker_producer][subdir] = "contrib"
 
 ; DEVELOPMENT


### PR DESCRIPTION
#### What's this PR do?

Updates Message Broker module version from `0.2.5` to `0.2.6`, which was released in Sept 2015.
#### How should this be reviewed?

Test MB integration on Thor for email delivery on core experiences (registration, signup, reportback).
#### Any background context you want to provide?

The specific fix in `0.2.6` is for a requirements test, but there are other, non-trivial changes in this module release that means we should check thoroughly before we release to prod.
#### Relevant tickets

Fixes #6472 

cc @DeeZone @sergii-tkachenko 
