### PR TITLE
add kudos into user profile

### DIFF
--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -252,3 +252,12 @@ function dosomething_kudos_get_kudos_by_file($fid) {
 
   return $result;
 }
+
+/**
+ * Get the name of a kudo by the term id
+ * @param  string $tid
+ * @return string
+ */
+function dosomething_kudos_get_name_by_tid($tid) {
+  return taxonomy_term_load($tid)->name;
+}

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -217,7 +217,7 @@ function dosomething_kudos_get_total_for_file_by_term_name($fid, $term) {
 }
 
 /**
- * Get the ids of Kudos on a file by a user and pair with corresponding term
+ * Get the ids of Kudos on a file that were kudoed by the current user and pair with corresponding term
  * @param  string $fid
  * @return array
  */
@@ -232,4 +232,23 @@ function dosomething_kudos_get_kudos_for_user_by_file($fid) {
       ->fetchAllAssoc('tid');
 
   return $kudos;
+}
+
+/**
+ * Get the kudos on a file as an array of term -> total
+ * @param  string $fid
+ * @return array
+ */
+function dosomething_kudos_get_kudos_by_file($fid) {
+  $kudos = db_select('dosomething_kudos', 'k')
+        ->fields('k', ['tid'])
+        ->condition('fid', $fid, '=')
+        ->groupBy('tid');
+
+  $kudos->addExpression('COUNT(k.kid)', 'kudo_count');
+  $kudos = $kudos->execute();
+
+  $result = $kudos->fetchAllAssoc('tid');
+
+  return $result;
 }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc
@@ -39,6 +39,23 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
         $impact = l($impact, 'reportback/' . $rbid);
       }
       $img = dosomething_image_get_themed_image_by_fid($reportback->fids[0], '300x300');
+
+      // Get all those kudos
+      $kudos_term_ids = dosomething_kudos_get_kudos_by_file($reportback->fids[0]);
+      if ($kudos_term_ids) {
+        $impact .= '<br/>';
+        foreach ($kudos_term_ids as $term_id) {
+
+          // Get the term name from the id and make it plural if necessary
+          $name = taxonomy_term_load($term_id->tid)->name;
+          if ($term_id->kudo_count > 1)
+            $name .= 's';
+
+          // Add the kudos into the description
+          $impact .= $term_id->kudo_count . ' ' . $name . '<br/>';
+        }
+      }
+
       // Media gallery template expects a full URL.
       $url = dosomething_global_url('node/' . $reportback->nid);
       $content = array(

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc
@@ -47,7 +47,7 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
         foreach ($kudos_term_ids as $term_id) {
 
           // Get the term name from the id and make it plural if necessary
-          $name = taxonomy_term_load($term_id->tid)->name;
+          $name = dosomething_kudos_get_name_by_tid($term_id->tid);
           if ($term_id->kudo_count > 1)
             $name .= 's';
 


### PR DESCRIPTION
#### What's this PR do?
- Added a new function into the kudos module to be able to grab number of kudos per term on a reportback file
- When the user profile is being processed, we now add up kudos per reportback and display that too
#### How should this be reviewed?

Put some kudos on a reportback and check out the profile of the user who submitted the reportback. Get ready for this:
![image](https://cloud.githubusercontent.com/assets/4240292/15400508/c2e7fb7c-1db9-11e6-8310-24ca4f3e0580.png)
#### Relevant tickets

Fixes #6457 
