### PR TITLE
User params

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -10,7 +10,7 @@
  */
 function dosomething_campaign_preprocess_node(&$vars) {
   if ($vars['type'] != 'campaign' || $vars['view_mode'] != 'full') return;
-  dosomething_signup_set_takeover();
+  // dosomething_signup_set_takeover();
   $node = $vars['node'];
   $vars['campaign'] = dosomething_campaign_load($node);
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -416,6 +416,8 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     array(
       'dosomethingCampaign' => array(
         'recommendedCampaigns' => $signup_takeover_recommended_campaigns,
+      ),
+      'dosomethingUser' => array(
         'userStatus' => $user_status,
       ),
     ),

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -10,7 +10,6 @@
  */
 function dosomething_campaign_preprocess_node(&$vars) {
   if ($vars['type'] != 'campaign' || $vars['view_mode'] != 'full') return;
-  // dosomething_signup_set_takeover();
   $node = $vars['node'];
   $vars['campaign'] = dosomething_campaign_load($node);
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -387,6 +387,7 @@ function dosomething_campaign_preprocess_media_vars(&$vars, &$wrapper) {
  */
 function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $campaign = $vars['campaign'];
+  $user = $vars['user'];
 
   // Get 3 recommended campaigns from recommendation engine.
   $signup_takeover_recommended_nids = dosomething_campaign_get_recommended_campaign_nids(NULL, NULL, 3);
@@ -401,11 +402,21 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     array_push($signup_takeover_recommended_campaigns, $campaign_array);
   }
 
-  // Send 3 campaigns to signup takeover, prompting user to signup for multiple campaigns.
+  // Check to see if this is a user's first signup for a campaign.
+  $existing_user = dosomething_signup_not_first_signup($user->uid);
+  if ($existing_user) {
+    $user_status = 'repeat-signup-existing';
+  }
+  else {
+    $user_status = 'repeat-signup-new';
+  }
+
+  // Send 3 campaigns to signup takeover, prompting user to signup for multiple campaigns. Also send param for existing or new user.
   drupal_add_js(
     array(
       'dosomethingCampaign' => array(
         'recommendedCampaigns' => $signup_takeover_recommended_campaigns,
+        'userStatus' => $user_status,
       ),
     ),
     array('type' => 'setting')

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -404,10 +404,10 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   // Check to see if this is a user's first signup for a campaign.
   $existing_user = dosomething_signup_not_first_signup($user->uid);
   if ($existing_user) {
-    $user_status = 'repeat-signup-existing';
+    $user_status = 'user-status-existing';
   }
   else {
-    $user_status = 'repeat-signup-new';
+    $user_status = 'user-status-new';
   }
 
   // Send 3 campaigns to signup takeover, prompting user to signup for multiple campaigns. Also send param for existing or new user.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -402,12 +402,12 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   }
 
   // Check to see if this is a user's first signup for a campaign.
-  $existing_user = dosomething_signup_not_first_signup($user->uid);
-  if ($existing_user) {
-    $user_status = 'user-status-existing';
+  $new_user = dosomething_signup_first_signup($user->uid);
+  if ($new_user) {
+    $user_status = 'user-status-new';
   }
   else {
-    $user_status = 'user-status-new';
+    $user_status = 'user-status-existing';
   }
 
   // Send 3 campaigns to signup takeover, prompting user to signup for multiple campaigns. Also send param for existing or new user.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -585,7 +585,8 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL) {
 
     // Set signup message, depending on type of user with specific params.
     if ($existing_user) {
-      // pass repeat-signup-existing in source param to dosomething_signup_set_takeover();
+      // pass repeat-signup-existing in source param to
+      dosomething_signup_set_signup_message();
     }
     else {
       // pass repeat-signup-new in source param to

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -596,6 +596,7 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL) {
 /**
  * Returns true if user this is a user's first signup.
  * @param int $user uid
+ * @return bool
  */
 function dosomething_signup_first_signup($uid) {
   // Check to see if the user has signed up for any campaigns, not including campaign they just signed up for.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -581,8 +581,36 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL) {
       return;
     }
 
-    // Set default signup message if we're still in this function.
-    dosomething_signup_set_takeover();
+    $existing_user = dosomething_signup_is_existing_user($account->uid, $sid);
+
+    // Set signup message, depending on type of user with specific params.
+    if ($existing_user) {
+      // pass repeat-signup-existing in source param to dosomething_signup_set_takeover();
+    }
+    else {
+      // pass repeat-signup-new in source param to
+      dosomething_signup_set_takeover();
+    }
+  }
+}
+
+/**
+ * Returns true if user is an existing user.
+ * @param object $user
+ *  The user object.
+ * @param int $sid
+ * The signup id the user just signed up for.
+ */
+function dosomething_signup_is_existing_user($uid, $sid) {
+  $signup = signup_load($sid);
+  $user = user_load($uid);
+
+  // Check to see if the user was created at the same time as the signup
+  if ($user->created != $signup->timestamp) {
+    return TRUE;
+  }
+  else {
+    return FALSE;
   }
 }
 
@@ -841,7 +869,7 @@ function dosomething_signup_set_presignup_message($title) {
 }
 
 /**
- * Returns total number of Signups based on supplied set of filters. 
+ * Returns total number of Signups based on supplied set of filters.
  *
  * @param array $filters
  * @return int

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -581,33 +581,31 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL) {
       return;
     }
 
-    $existing_user = dosomething_signup_not_first_signup($account->uid);
+    $new_user = dosomething_signup_first_signup($account->uid);
 
     // Set signup message, depending on type of user with specific params.
-    if ($existing_user) {
-      // pass repeat-signup-existing in source param to
-      dosomething_signup_set_signup_message();
+    if ($new_user) {
+      dosomething_signup_set_takeover();
     }
     else {
-      // pass repeat-signup-new in source param to
-      dosomething_signup_set_takeover();
+      dosomething_signup_set_signup_message();
     }
   }
 }
 
 /**
- * Returns true if user this is not a user's first signup.
+ * Returns true if user this is a user's first signup.
  * @param int $user uid
  */
-function dosomething_signup_not_first_signup($uid) {
+function dosomething_signup_first_signup($uid) {
   // Check to see if the user has signed up for any campaigns, not including campaign they just signed up for.
   $signups = count(dosomething_signup_get_signups_query(['user' => $uid]));
 
   if ($signups > 1) {
-    return TRUE;
+    return FALSE;
   }
   else {
-    return FALSE;
+    return TRUE;
   }
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -581,7 +581,7 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL) {
       return;
     }
 
-    $existing_user = dosomething_signup_is_existing_user($account->uid, $sid);
+    $existing_user = dosomething_signup_not_first_signup($account->uid);
 
     // Set signup message, depending on type of user with specific params.
     if ($existing_user) {
@@ -595,18 +595,14 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL) {
 }
 
 /**
- * Returns true if user is an existing user.
- * @param object $user
- *  The user object.
- * @param int $sid
- * The signup id the user just signed up for.
+ * Returns true if user this is not a user's first signup.
+ * @param int $user uid
  */
-function dosomething_signup_is_existing_user($uid, $sid) {
-  $signup = signup_load($sid);
-  $user = user_load($uid);
+function dosomething_signup_not_first_signup($uid) {
+  // Check to see if the user has signed up for any campaigns, not including campaign they just signed up for.
+  $signups = count(dosomething_signup_get_signups_query(['user' => $uid]));
 
-  // Check to see if the user was created at the same time as the signup
-  if ($user->created != $signup->timestamp) {
+  if ($signups > 1) {
     return TRUE;
   }
   else {


### PR DESCRIPTION
#### What's this PR do?
- Adds new function to determine if this is a user's first signup for a campaign. 
  - If it is a user's first signup, the signup takeover experience will be enabled. 
  - If a user has previously signed up for a campaign, they'll get the regular "You're sign up! Get started below." messaging. 
- Passes `userStatus` param front backend to JS to indicate if this is a user's first signup for a campaign. 
  - Two options for this param:
    - `user-status-existing`
    - `user-status-new`
#### How should this be reviewed?
- From an existing account, signup for a campaign.
  - You should get the "You're signed up!" messaging in an alert at the top of the page. 
  - Open up the dev tools console. Type in `Drupal.settings.dosomethingUser` and the `userStatus` should be `user-status-existing`
- From a new user account, sign up for a campaign. 
  - The signup takeover should be enabled. 
  - `Drupal-settings-dosomethingUser`'s `userStatus` should be `user-status-new`. 
#### Any background context you want to provide?

In the future, we can change the experience of the existing user (maybe they still get the signup takeover screen but they just skip to the multi-signup page instead of the onboarding experience). This is just a prototype and sets up params to pass user information from backend to JS. 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.

Fixes #6430 
