### PR TITLE
Fix mobile fields

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1710,6 +1710,18 @@ function dosomething_user_views_pre_render(&$view) {
  * Implements hook_user_update().
  */
 function dosomething_user_user_update(&$edit, $account, $category) {
+  if (!empty($edit['roles'])) {
+    _dosomething_user_audit_roles($edit, $account);
+  }
+}
+
+/**
+ * Audit changes to user roles and send an alert to DevOps.
+ *
+ * @param $edit
+ * @param $account
+ */
+function _dosomething_user_audit_roles(&$edit, $account) {
   $added_rids = array_diff_key($edit['roles'], $edit['original']->roles);
   if ($added_rids) {
     $added_roles = array();

--- a/scripts/fix-mobile-fields.php
+++ b/scripts/fix-mobile-fields.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Script to fix users with `xxxx@mobile` emails, but nothing set in their mobile field.
+ *
+ * to run:
+ * drush --script-path=../scripts/ php-script fix-mobile-fields.php
+ */
+
+$records = db_query('SELECT u.uid FROM users u
+  LEFT JOIN field_data_field_mobile m ON u.uid = m.entity_id
+  WHERE mail LIKE \'%@mobile\'
+  AND (m.field_mobile_value IS NULL OR m.field_mobile_value = \'\')');
+
+foreach ($records as $record) {
+  $user = user_load($record->uid);
+
+  $mobile = dosomething_user_clean_mobile_number(str_replace('@mobile', '', $user->mail));
+
+  // If we couldn't clean the mobile number, print an error and skip this record.
+  if(! $mobile) {
+    print 'Could not fix mobile field for ' . $user->uid . ' (' . $user->mail . ')' . PHP_EOL;
+    continue;
+  }
+
+  $edit = [];
+  dosomething_user_set_fields($edit, [
+    'mobile' => $mobile
+  ]);
+
+  // Make sure we're not making a duplicate of an existing mobile field.
+  if($existing = dosomething_user_get_user_by_mobile($mobile)) {
+    print 'Could not overwrite existing mobile field for ' . $existing->uid . ' with ' . $user->uid . ' (' . $user->mail . ')' . PHP_EOL;
+    continue;
+  }
+
+  user_save($user, $edit);
+
+  print 'Fixed mobile field for ' . $user->uid . ' (' . $user->mail . ' --> ' . $mobile . ')' . PHP_EOL;
+}

--- a/scripts/remove-duplicate-emails.php
+++ b/scripts/remove-duplicate-emails.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Script to remove users with
+ * Script to remove users with duplicate email accounts.
  *
  * to run:
  * drush --script-path=../scripts/ php-script remove-duplicate-emails.php


### PR DESCRIPTION
#### What's this PR do?

This pull request adds a script which attempts to fix users who have a `xxxxx@mobile` email address but nothing set for their mobile field. A quick spot-check shows these users do exist in Mobile Commons, so it'd be good to fix our data for them on our end.

This pull request also includes a small fix for #6477.
#### How should this be reviewed?

Read through that script and consider how it might work/not work when run against the results of that query on the production database. Are there things I'm missing?
#### Any background context you want to provide?

☎️ 
#### Relevant tickets

Fixes #6408 and #6477.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
