### PR TITLE
Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,5 @@ npm-debug.log
 Gemfile.lock
 .fuse_hidden*
 lib/themes/dosomething/paraneue_dosomething/dist/
-lib/themes/dosomething/paraneue_dosomething/bower_components/
-lib/themes/dosomething/paraneue_dosomething/vendor/
 tmp/
-.sass-cache
+vendor/

--- a/bin/ds
+++ b/bin/ds
@@ -406,24 +406,14 @@ function deploy {
 function composer {
   if hash composer 2>/dev/null;
   then
-    cd $WEB_PATH/profiles/dosomething/libraries/zendesk
-    echo -e "\e[4mInstalling composer dependencies for Zendesk...\e[0m"
+    echo -e "\e[4mInstalling Composer dependencies...\e[0m"
     eval "/usr/local/bin/composer install"
 
     cd $WEB_PATH/profiles/dosomething/libraries/messagebroker-phplib
-    echo -e "\e[4mInstalling composer dependencies for Message Broker PHPLIB...\e[0m"
-    eval "/usr/local/bin/composer install"
-
-    cd $WEB_PATH/profiles/dosomething/libraries/stripe-php
-    echo -e "\e[4mInstalling composer dependencies for Stripe PHP Library...\e[0m"
-    eval "/usr/local/bin/composer install"
-
-    cd $WEB_PATH/profiles/dosomething/libraries/guzzle
-    echo -e "\e[4mInstalling composer dependencies for Guzzle PHP Library...\e[0m"
+    echo -e "\e[4mInstalling Composer dependencies for Message Broker PHPLIB...\e[0m"
     eval "/usr/local/bin/composer install"
 
     cd $BASE_PATH
-
   fi
 }
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+  "name": "dosomething/phoenix",
+  "description": "The DoSomething.org platform.",
+  "license": "MIT",
+  "type": "project",
+  "autoload": {
+    "psr-4": {
+      "Phoenix\\": "lib/app/"
+    }
+  },
+  "config": {
+    "preferred-install": "dist"
+  },
+  "require": {
+    "stripe/stripe-php": "^1.18.0",
+    "zendesk/zendesk_api_client_php": "^1.2.0"
+  }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,100 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "eea86c837efda216671b620e473afb0d",
+    "packages": [
+        {
+            "name": "stripe/stripe-php",
+            "version": "v1.18.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stripe/stripe-php.git",
+                "reference": "022c3f21ec1e4141b46738bd5e7ab730d04f78cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/022c3f21ec1e4141b46738bd5e7ab730d04f78cc",
+                "reference": "022c3f21ec1e4141b46738bd5e7ab730d04f78cc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "simpletest/simpletest": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/Stripe/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stripe and contributors",
+                    "homepage": "https://github.com/stripe/stripe-php/contributors"
+                }
+            ],
+            "description": "Stripe PHP Library",
+            "homepage": "https://stripe.com/",
+            "keywords": [
+                "api",
+                "payment processing",
+                "stripe"
+            ],
+            "time": "2015-01-22 05:01:46"
+        },
+        {
+            "name": "zendesk/zendesk_api_client_php",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendesk/zendesk_api_client_php.git",
+                "reference": "32e7e950753d89c8d815e0914f36b0bb4adabd29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendesk/zendesk_api_client_php/zipball/32e7e950753d89c8d815e0914f36b0bb4adabd29",
+                "reference": "32e7e950753d89c8d815e0914f36b0bb4adabd29",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.5.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Zendesk\\API\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache License Version 2.0"
+            ],
+            "description": "PHP Client for Zendesk REST API. See http://developer.zendesk.com/api-docs",
+            "homepage": "https://github.com/zendesk/zendesk_api_client_php",
+            "time": "2015-05-31 00:16:34"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/config/settings.php
+++ b/config/settings.php
@@ -1,6 +1,11 @@
 <?php
 
 /**
+ * Require Composer's class loader.
+ */
+require_once __DIR__ . '/../lib/autoload.php';
+
+/**
  * Lets do something about globals
  */
 define('DS_PROFILE_PATH', 'profiles/dosomething');

--- a/lib/autoload.php
+++ b/lib/autoload.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Require Composer's class loader so we don't have to worry
+ * about manually loading any PSR-4 or vendor classes.
+ *
+ * This file is referenced from `settings.php` during Drupal's
+ * standard bootstrapping process so autoloaded classes are
+ * automatically made available.
+ *
+ * For further reading:
+ * https://getcomposer.org/doc/01-basic-usage.md#autoloading
+ */
+require __DIR__ . '/../vendor/autoload.php';

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -31,20 +31,6 @@ function dosomething_northstar_menu() {
 }
 
 /**
- * Implements hook_libraries_info().
- */
-function dosomething_northstar_libraries_info() {
-  $libraries['guzzle'] = array(
-    'name' => 'guzzle',
-    'path' => 'vendor',
-    'files' => ['php' => ['autoload.php']],
-    'version' => 5.0,
-  );
-  return $libraries;
-}
-
-
-/**
  * Verify the given credentials against Northstar, returning the authorized
  * user account if one exists.
  *

--- a/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
+++ b/lib/modules/dosomething/dosomething_payment/dosomething_payment.module
@@ -21,23 +21,6 @@ function dosomething_payment_menu() {
 }
 
 /**
- * Implements hook_libraries_info().
- */
-function dosomething_payment_libraries_info() {
-  $libraries['stripe-php'] = array(
-    'name' => 'Stripe',
-    'path' => 'lib',
-    'files' => array(
-      'php' => array(
-        'Stripe.php',
-      ),
-    ),
-    'version' => 1,
-  );
-  return $libraries;
-}
-
-/**
  * Implements hook_block_info().
  */
 function dosomething_payment_block_info() {
@@ -272,9 +255,8 @@ function dosomething_payment_form_submit($form, &$form_state) {
  *   TRUE if success, FALSE if not.
  */
 function dosomething_payment_stripe_get_client() {
-  $library = libraries_load('stripe-php');
-  if (empty($library['loaded'])) {
-    $error = t("Stripe library not found.");
+  if (! class_exists(Stripe::class)) {
+    $error = t("Stripe class not found.");
     watchdog('dosomething_payment', $error, NULL, WATCHDOG_ERROR);
     return FALSE;
   }

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -35,35 +35,19 @@ function dosomething_zendesk_permission() {
 }
 
 /**
- * Implements hook_libraries_info().
- */
-function dosomething_zendesk_libraries_info() {
-  $libraries['zendesk'] = array(
-    'name' => 'Zendesk',
-    'path' => 'vendor',
-    'files' => array(
-      'php' => array(
-        'autoload.php'
-      ),
-    ),
-    'version' => 1
-  );
-  return $libraries;
-}
-
-/**
  * Returns a Zendesk Client object with auth vars.
  */
 function dosomething_zendesk_get_client() {
-  $library = libraries_load('zendesk');
-  if (empty($library['loaded'])) {
+  if (! class_exists(\Zendesk\API\Client::class)) {
     return FALSE;
   }
+  
   $subdomain = variable_get('dosomething_zendesk_subdomain');
   $username = variable_get('dosomething_zendesk_username');
   $token = variable_get('dosomething_zendesk_token');
   $client = new Zendesk\API\Client($subdomain, $username);
   $client->setAuth('token', $token);
+  
   return $client;
 }
 
@@ -72,6 +56,7 @@ function dosomething_zendesk_get_client() {
  *
  * @param object $entity
  *   Optional. A loaded entity which this zendesk form is being rendered on.
+ * @return array 
  */
 function dosomething_zendesk_form($form, &$form_state, $entity = NULL)  {
   // Initialize zendesk group_id as NULL.

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -288,14 +288,6 @@ projects[stage_file_proxy][subdir] = "contrib"
 
 ; LIBRARIES
 
-; DSAPI PHP Library
-;libraries[dsapi][download][type] = "git"
-;libraries[dsapi][download][url] = "git@github.com:DoSomething/dsapi-php.git"
-
-; Guzzle
-libraries[guzzle][download][type] = "git"
-libraries[guzzle][download][url] = "https://github.com/guzzle/guzzle.git"
-
 ; Message Broker PHP Library
 libraries[messagebroker-phplib][download][type] = "git"
 libraries[messagebroker-phplib][download][url] = "https://github.com/DoSomething/messagebroker-phplib.git"
@@ -315,17 +307,6 @@ libraries[predis][download][url] = "https://github.com/nrk/predis.git"
 libraries[predis][download][revision] = "4123fcd85d61354c6c9900db76c9597dbd129bf6"
 
 ; Stathat
+; @TODO: We should use our Stathat-PHP library here! :)
 libraries[stathat][download][type] = "get"
 libraries[stathat][download][url] = "https://www.stathat.com/downloads/stathat.php"
-
-; Stripe PHP
-libraries[stripe-php][download][type] = "git"
-libraries[stripe-php][download][url] = "https://github.com/stripe/stripe-php"
-; Pin to v.1.18.0 release, which supports Client::setApiKey methods we Use
-libraries[stripe-php][download][tag] = "v1.18.0"
-
-; Zendesk PHP
-libraries[zendesk][download][type] = "git"
-libraries[zendesk][download][url] = "https://github.com/zendesk/zendesk_api_client_php"
-; Use last working commit. See https://github.com/DoSomething/phoenix/issues/2064
-libraries[zendesk][download][revision] = "6aa9662fb1ed45b6bcc93ef9e1e4ab14685e80ac"


### PR DESCRIPTION
### What's this PR do?

This pull request revisits the Composer experiments that we tried out in #5932, sans crazy merge conflicts. This lets us more easily include Composer packages (yay!) and also means that Composer can resolve version ranges and check dependency conflicts like it's supposed to!

This moves (most) Composer dependencies into the gitignored `vendor/` directory and installs them in a single step during the `bin/ds` install process. Drupal then uses Composer's `autoload.php` to load all those classes in one fell swoop.
#### How should this be reviewed?

Pull down the branch and run `ds build --install`. It should install dependencies & work as expected.
#### Any background context you want to provide?

We should probably add this to the docs somewhere, but (if merged) this means that dependencies can be installed by simply adding them to `composer.php` (y'know like you'd do in any other modern PHP project) rather than updating a Drupal makefile.

Drupal modules, of course, still work the same as they always have.
#### Relevant tickets

🎼 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
