### PR TITLE
Update to include attachment id in Campaign object response.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -314,6 +314,7 @@ class Campaign {
     foreach ($items as $item) {
       $attachment = [];
 
+      $attachment['id'] = $item['id'];
       $attachment['title'] = $item['title'];
       $attachment['description'] = $item['description'];
       $attachment['uri'] = file_create_url($item['uri']);


### PR DESCRIPTION
#### What's this PR do?

This PR adds the ID to the attachment object in the Campaign response.

![image](https://cloud.githubusercontent.com/assets/105849/15480557/394161c2-20f4-11e6-8469-3cf64970d083.png)
#### How should this be reviewed?

For campaigns that have attachments, can you see the ID for the attachment in the Campaign API response? Great!
#### Relevant tickets

Fixes #6479
#### Checklist
- [ ] Documentation added for new features/changed endpoints.

---

@aaronschachter @angaither 
