### PR TITLE
Return pass reset link + login.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -305,6 +305,6 @@ function _member_resource_get_activity_result($uid, $nid) {
  */
 function _member_resource_reset($uid) {
   $account = user_load($uid);
-  $reset_url = user_pass_reset_url($account);
+  $reset_url = user_pass_reset_url($account) . '/login';
   return $reset_url;
 }


### PR DESCRIPTION
#### What's this PR do?

changes the `password_reset_url` to return a login in link instead of the `are you sure you want to login` page
#### How should this be reviewed?

👀 
#### Any background context you want to provide?

@aaronschachter not sure if you're using this anywhere in the mobile app! 
#### Relevant tickets

Fixes #6470 

you get this
![image](https://cloud.githubusercontent.com/assets/645205/15481940/198bacdc-20fb-11e6-81a1-ea23b1fd0a27.png)

instead of
![image](https://cloud.githubusercontent.com/assets/645205/15481956/2ef0a564-20fb-11e6-9f0e-81b66e65d2c3.png)
