### PR TITLE
Updates to remove unnecessary button from finder on mobile view.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/FormView.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/FormView.js
@@ -27,9 +27,6 @@ define(function(require) {
     // The div where the form goes
     $div: null,
 
-    // <button> that mobile users click to initiate the search
-    $searchButton: null,
-
     // The field groups that contain the checkmarks
     $fields: {},
 
@@ -70,9 +67,6 @@ define(function(require) {
       FormView.$fields.time = $div.find("input[name='time']");
       FormView.$fields["action-type"] = $div.find("input[name='action-type']");
 
-      // Hook up to the DOM
-      FormView.$searchButton = $div.find(".campaign-search");
-
       // Loop through each field selector
       // @TODO This is tightly coupled.
       forEach(FormView.$fields, function(fieldGroup) {
@@ -111,14 +105,6 @@ define(function(require) {
           queryCallback();
         });
       });
-
-      // Search button appears on mobile in lieu of live filtering
-      FormView.$searchButton.click(function () {
-        queryCallback();
-        $("html,body").animate({
-          scrollTop: ResultsView.$div.offset().scrollTop
-        }, 1000);
-      });
     },
 
     /**
@@ -133,7 +119,6 @@ define(function(require) {
       // Yup.
     },
 
-
     /**
      * Shows an error message for network issues
      **/
@@ -146,7 +131,6 @@ define(function(require) {
       }
 
     },
-
 
     /**
      * Returns Boolean if any fields are checked

--- a/lib/themes/dosomething/paraneue_dosomething/templates/home/node--home.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/home/node--home.tpl.php
@@ -76,10 +76,6 @@
             </div>
           </div>
         </div>
-
-        <div class="campaign-search">
-          <button class="button"><?php print t('Find a Campaign'); ?></button>
-        </div>
       </div>
     <?php endif; ?>
   </div>


### PR DESCRIPTION
#### What's this PR do?

This PR removes the "Find A Campaign" button that would only show up in the narrow/mobile view of the campaign finder on the homepage. Along with removing the button it also removes the JavaScript code that enabled the button.
#### How should this be reviewed?

Run the site, try the finder out in a narrow/mobile view and see if the button shows up. Does the finder still work? Great!
#### Any background context you want to provide?

It seems that [at some point](https://github.com/DoSomething/phoenix/blob/da7fd6194bf36c402bd1f18a2978f352b12448fd/lib/themes/dosomething/paraneue_dosomething/js/finder/FormView.js#L115) the button was meant to behave as a necessary item when viewing the site on mobile devices and to be able to properly submit the form. However, since then, the finder has changed a bit and it will auto-filter and update whenever any selection in the dropdowns is made both on mobile and desktop, thus the button is no longer needed. If JavaScript fails for whatever reason, the entire finder would not work and the button would serve no purpose since the filtering is handled entirely on the client side.
#### Relevant tickets

Fixes #6375

---

@DFurnes @angaither 
