### PR TITLE
Adds missing user and node variables

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -892,6 +892,8 @@ function _dosomething_user_add_signup_data(&$form) {
     }
 
     // Use the global url as the form action so the user gets redirected to the right page.
+    global $user;
+    $node = node_load($nid);
     $lang_code = dosomething_global_get_language($user, $node);
 
     $url_options = array(

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -875,6 +875,8 @@ function dosomething_user_user_insert(&$edit, &$account, $category = NULL) {
 function _dosomething_user_add_signup_data(&$form) {
   if (!module_exists('dosomething_signup')) { return; }
 
+  global $user;
+
   // If we're viewing a node to signup for:
   if ($nid = dosomething_signup_get_login_signup_nid()) {
     $form['nid'] = array(
@@ -892,7 +894,6 @@ function _dosomething_user_add_signup_data(&$form) {
     }
 
     // Use the global url as the form action so the user gets redirected to the right page.
-    global $user;
     $node = node_load($nid);
     $lang_code = dosomething_global_get_language($user, $node);
 


### PR DESCRIPTION
#### What's this PR do?

Adds two variables missing in the add signup data function.
#### How should this be reviewed?

Signup on all of the things, are the params added properly?
#### Any background context you want to provide?

This has been working because the function call to get_language is pretty good at non failing from NULL values, but as Dave noted in the issue we shouldn't be passing non existent vars intentionally!
#### Relevant tickets

Fixes #6460 
