### PR TITLE
Organ donation module

### DIFF
--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.info
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.info
@@ -1,0 +1,11 @@
+name = DoSomething Organ Donation
+description = Functionality for collecting organ donation registrations
+core = 7.x
+package = DoSomething
+version = 7.x-0.3
+dependencies[] = entity
+dependencies[] = dosomething_helpers
+dependencies[] = dosomething_signup
+dependencies[] = dosomething_campaign
+
+

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.info
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.info
@@ -7,5 +7,3 @@ dependencies[] = entity
 dependencies[] = dosomething_helpers
 dependencies[] = dosomething_signup
 dependencies[] = dosomething_campaign
-
-

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.install
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.install
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @file
+ * Installation and schema hooks for dosomething_organ_donation.module
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function dosomething_organ_donation_schema() {
+  $schema = array();
+  $schema['dosomething_organ_donation'] = array(
+    'description' => 'Table for tracking organ donation registrations',
+    'fields' => array(
+      'sid' => array(
+        'description' => 'The signup id associated with this registration',
+        'type' => 'serial',
+        'not null' => TRUE,
+      ),
+      'uid' => array(
+        'description' => 'The {users}.uid that registered.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'signup_data_form_timestamp' => array(
+        'description' => 'The Unix timestamp when the valid registration went through.',
+        'type' => 'int',
+        'not null' => FALSE,
+      ),
+      'drop_screen' => array(
+        'description' => 'The screen the user was on when the registration modal closed',
+        'type' => 'int',
+        'not null' => FALSE,
+      ),
+    ),
+    'primary key' => array('sid'),
+    'indexes' => array(
+      'uid' => array('uid'),
+    ),
+  );
+
+  return $schema;
+}

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.install
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.install
@@ -14,7 +14,7 @@ function dosomething_organ_donation_schema() {
     'fields' => array(
       'sid' => array(
         'description' => 'The signup id associated with this registration',
-        'type' => 'serial',
+        'type' => 'int',
         'not null' => TRUE,
       ),
       'uid' => array(
@@ -23,7 +23,7 @@ function dosomething_organ_donation_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
-      'signup_data_form_timestamp' => array(
+      'registration_form_timestamp' => array(
         'description' => 'The Unix timestamp when the valid registration went through.',
         'type' => 'int',
         'not null' => FALSE,

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -42,12 +42,15 @@ function dosomething_organ_donation_store_registration() {
       $response = [
         'status' => 'Required parameters not found.',
       ];
+
+      watchdog('dosomething_organ_donation', $response, NULL, WATCHDOG_ERROR);
     }
 
     drupal_json_output($response);
   }
   catch (Exception $e) {
     drupal_json_output($e);
+    watchdog('dosomething_organ_donation', $e, NULL, WATCHDOG_ERROR);
   }
 
   return;

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -22,7 +22,7 @@ function dosomething_organ_donation_menu() {
 }
 
 /*
- * Stores meta data about the organ registration in the dosomething_organ_registration table.
+ * Stores meta data about the organ registration in the dosomething_organ_donation table.
  *
  */
 function dosomething_organ_donation_store_registration() {

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -1,0 +1,1 @@
+dosomething_organ_donation.module

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -26,12 +26,14 @@ function dosomething_organ_donation_menu() {
  *
  */
 function dosomething_organ_donation_store_registration() {
+  $params = drupal_get_query_parameters();
+
   try {
-    if ($_GET['sid'] && $_GET['uid']) {
+    if ($params['sid'] && $params['uid']) {
       db_insert('dosomething_organ_donation')
         ->fields([
-          'sid' => $_GET['sid'],
-          'uid' => $_GET['uid'],
+          'sid' => $params['sid'],
+          'uid' => $params['uid'],
           'registration_form_timestamp' =>  REQUEST_TIME,
       ])->execute();
 
@@ -50,6 +52,7 @@ function dosomething_organ_donation_store_registration() {
   }
   catch (Exception $e) {
     drupal_json_output($e);
+
     watchdog('dosomething_organ_donation', $e, NULL, WATCHDOG_ERROR);
   }
 

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -1,1 +1,41 @@
-dosomething_organ_donation.module
+<?php
+/**
+ * @file
+ * Code for the dosomething_organ_donation feature.
+ */
+
+/*
+ * Implements hook_menu()
+ *
+ * @TODO - figure out security stuff.
+ */
+function dosomething_organ_donation_menu() {
+  $items = array();
+
+  $items['organ-donation/registration'] = array(
+    'page callback' => 'dosomething_organ_donation_store_registration',
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  );
+
+  // Return the $items array to register the path
+  return $items;
+}
+
+function dosomething_organ_donation_store_registration() {
+  $sid = $_GET['sid'];
+
+  if ($sid) {
+    db_insert('dosomething_organ_donation')
+      ->fields([
+        'sid' => $sid,
+        // 'registration_form_timestamp' =>  REQUEST_TIME,
+    ])->execute();
+  }
+
+  $response = [
+    'sid' => $sid,
+  ];
+
+  drupal_json_output($response);
+}

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -7,14 +7,13 @@
 /*
  * Implements hook_menu()
  *
- * @TODO - figure out security stuff.
  */
 function dosomething_organ_donation_menu() {
   $items = array();
 
   $items['organ-donation/registration'] = array(
     'page callback' => 'dosomething_organ_donation_store_registration',
-    'access arguments' => array('access content'),
+    'access callback' => 'user_is_logged_in',
     'type' => MENU_CALLBACK,
   );
 
@@ -22,20 +21,27 @@ function dosomething_organ_donation_menu() {
   return $items;
 }
 
+/*
+ * Stores meta data about the organ registration in the dosomething_organ_registration table.
+ *
+ */
 function dosomething_organ_donation_store_registration() {
-  $sid = $_GET['sid'];
-
-  if ($sid) {
+  if ($_GET['sid']) {
     db_insert('dosomething_organ_donation')
       ->fields([
-        'sid' => $sid,
-        // 'registration_form_timestamp' =>  REQUEST_TIME,
+        'sid' => $_GET['sid'],
+        'uid' => $_GET['uid'],
+        'registration_form_timestamp' =>  REQUEST_TIME,
     ])->execute();
-  }
 
-  $response = [
-    'sid' => $sid,
-  ];
+    $response = [
+      'status' => 'registration data stored',
+    ];
+  } else {
+    $response = [
+      'status' => 'no signup id provided',
+    ];
+  }
 
   drupal_json_output($response);
 }

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -26,22 +26,29 @@ function dosomething_organ_donation_menu() {
  *
  */
 function dosomething_organ_donation_store_registration() {
-  if ($_GET['sid']) {
-    db_insert('dosomething_organ_donation')
-      ->fields([
-        'sid' => $_GET['sid'],
-        'uid' => $_GET['uid'],
-        'registration_form_timestamp' =>  REQUEST_TIME,
-    ])->execute();
+  try {
+    if ($_GET['sid'] && $_GET['uid']) {
+      db_insert('dosomething_organ_donation')
+        ->fields([
+          'sid' => $_GET['sid'],
+          'uid' => $_GET['uid'],
+          'registration_form_timestamp' =>  REQUEST_TIME,
+      ])->execute();
 
-    $response = [
-      'status' => 'registration data stored',
-    ];
-  } else {
-    $response = [
-      'status' => 'no signup id provided',
-    ];
+      $response = [
+        'status' => 'registration data stored',
+      ];
+    } else {
+      $response = [
+        'status' => 'Required parameters not found.',
+      ];
+    }
+
+    drupal_json_output($response);
+  }
+  catch (Exception $e) {
+    drupal_json_output($e);
   }
 
-  drupal_json_output($response);
+  return;
 }

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -93,6 +93,7 @@ dependencies[] = dosomething_image
 dependencies[] = dosomething_kudos
 dependencies[] = dosomething_mbp
 dependencies[] = dosomething_northstar
+dependencies[] = dosomething_organ_donation
 dependencies[] = dosomething_helpers
 dependencies[] = dosomething_home
 dependencies[] = dosomething_reportback

--- a/lib/profiles/dosomething/dosomething.make
+++ b/lib/profiles/dosomething/dosomething.make
@@ -109,6 +109,12 @@ projects[dosomething_notfound][download][type] = local
 projects[dosomething_notfound][download][source] = './lib/modules/dosomething/dosomething_notfound'
 projects[dosomething_notfound][subdir] = "dosomething"
 
+; Dosomething Organ Donation
+projects[dosomething_organ_donation][type] = "module"
+projects[dosomething_organ_donation][download][type] = local
+projects[dosomething_organ_donation][download][source] = './lib/modules/dosomething/dosomething_organ_donation'
+projects[dosomething_organ_donation][subdir] = "dosomething"
+
 ; Dosomething Payment
 projects[dosomething_payment][type] = "module"
 projects[dosomething_payment][download][type] = local


### PR DESCRIPTION
#### What's this PR do?

This PR adds a new module `dosomething_organ_donation`. 

This module sets up a new table that we will use for tracking organ donation registration data. With this PR we will be able to track: 
- The signup id of the registration
- The user id
- the timestamp of when they registered
- the screen the user was on when the registration modal closes

TBD if we will need to track more thangs.

This module also sets up an endpoint, `organ-donation/registration` that we can hit from js to store that data. It accepts two parameters so far `sid` and `uid`

TBD what else we will be passing to this endpoint.
#### How should this be reviewed?

Pull down, enable the new module, make a get request with the required params, `sid` and `uid` and you should get a response back that the registration was stored...

Also you should see your info in the DB in the `dosomething_organ_donation` table.
#### Any background context you want to provide?

Still waiting on a response from Organize about getting access to their api so we can see what other info we might want to track. 
#### Relevant tickets

Fixes #6491 

cc @chloealee 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
