### PR TITLE
adds email validation to password reset flow

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -316,6 +316,8 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
     break;
 
     case 'user_pass':
+      $form['name']['#attributes']['data-validate'] = "email";
+      $form['name']['#attributes']['data-validate-required'] = true;
       $form['name']['#description'] = t('Forgot your password? We’ve all been there. Reset by entering your email.');
       $form['#submit'][] = 'dosomething_user_user_pass_submit';
     break;

--- a/lib/themes/dosomething/paraneue_dosomething/js/validators/auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/validators/auth.js
@@ -13,7 +13,7 @@ import setting from '../utilities/Setting';
 define(function(require) {
   "use strict";
 
-  var Validation= require("dosomething-validation");
+  var Validation = require("dosomething-validation");
 
   // We use Mailcheck (https://github.com/mailcheck/mailcheck) to provide
   // suggestions for typos in email addresses. See the "email" validator below.


### PR DESCRIPTION
#### What's this PR do?

Adds data validation to the password reset flow.
#### How should this be reviewed?

When you type in an incorrect email, does it notify you? Does it offer email suggestions if your domain doesn't seem right?

![screen shot 2016-05-25 at 11 15 23 am](https://cloud.githubusercontent.com/assets/897368/15545583/e35370a2-226a-11e6-8c9e-51e09c31ffd2.png)

![screen shot 2016-05-25 at 11 15 10 am](https://cloud.githubusercontent.com/assets/897368/15545590/e783c15e-226a-11e6-90d8-2c0c807c4acb.png)

Not shown- This change also blocks the form from submitting if the email validation fails.
#### Any background context you want to provide?

none
#### Relevant tickets

Fixes #6441 
