### PR TITLE
Add some validation to the users endpoint.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -168,7 +168,7 @@ function _member_resource_create($request) {
   // Initialize array to pass to user_save().
   $edit = [
     'mail' => $email,
-    'name' => $email,
+    'name' => user_password(), // Overridden below.
     'status' => 1,
     'created' => REQUEST_TIME,
   ];
@@ -192,7 +192,13 @@ function _member_resource_create($request) {
   $edit['language'] = dosomething_global_convert_country_to_language($fields['country']);
 
   try {
-    return user_save('', $edit);
+    $user = user_save('', $edit);
+    
+    // Ensure user has UID set for name, since insert hooks don't fire on API.
+    // @see: dosomething_user_user_insert
+    user_save($user, ['name' => $user->uid]);
+    
+    return $user;
   }
   catch (Exception $e) {
     services_error($e);

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -130,11 +130,11 @@ function _member_resource_access($op) {
 /**
  * Callback for User create.
  *
- * @param $account
+ * @param $request
  *   Array passed to the endpoint. Possible keys:
  *   - email (string). Required.
  *   - password (string).
- *   - birthdate (datestring).
+ *   - birthdate (date string).
  *   - first_name (string).
  *   - last_name (string).
  *   - mobile (string).
@@ -143,49 +143,56 @@ function _member_resource_access($op) {
  * @return mixed
  *   Object of the newly created user if successful. String if errors.
  */
-function _member_resource_create($account) {
-  if (!isset($account['email'])) {
+function _member_resource_create($request) {
+  if (!isset($request['email'])) {
     return services_error("Email is required.");
   }
-  $email = $account['email'];
-  // Check if account exists for email.
+  $email = $request['email'];
+  // Check if email is formatted correctly and not already in use.
   if ($user = user_load_by_mail($email)) {
     return services_error(t('Email @email is registered to User uid @uid.', ['@email' => $email, '@uid' => $user->uid]), 403);
   }
+  if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    return services_error(t('Email @email is not a valid email address.', ['@email' => $email]), 422);
+  }
+  
   // Check if account exists for phone.
-  $mobile = $account['mobile'];
+  $mobile = $request['mobile'];
   if ($mobile && $user = dosomething_user_get_user_by_mobile($mobile)) {
     return services_error(t('Mobile @mobile is registered to User uid @uid.', ['@mobile' => $mobile, '@uid' => $user->uid]), 403);
   }
-
-  // Initialize array to pass to user_save().
-  $edit = [];
-  $edit['mail'] = $email;
-  $edit['name'] = $email;
-  $edit['status'] = 1;
-  $edit['created'] = REQUEST_TIME;
-  if (isset($account['password'])) {
-    $edit['pass'] = $account['password'];
+  if (!dosomething_user_valid_mobile($mobile)) {
+    return services_error(t('Mobile @mobile is not a valid phone number.', ['@mobile' => $mobile]), 422);
   }
+  
+  // Initialize array to pass to user_save().
+  $edit = [
+    'mail' => $email,
+    'name' => $email,
+    'status' => 1,
+    'created' => REQUEST_TIME,
+  ];
 
-  // List of available properties to save:
+  // Map request input to Drupal fields, or use default values.
   $fields = [
-    'birthdate' => $account['birthdate'],
-    'first_name' => $account['first_name'],
-    'country' => !empty($account['country']) ? $account['country'] : 'US',
-    'last_name' => !empty($account['last_name']) ? $account['last_name'] : NULL,
-    'mobile' => !empty($account['mobile']) ? dosomething_user_clean_mobile_number($account['mobile']) : NULL,
-    'user_registration_source' => !empty($account['user_registration_source']) ? $account['user_registration_source'] : NULL,
+    'birthdate' => $request['birthdate'],
+    'first_name' => $request['first_name'],
+    'country' => !empty($request['country']) ? $request['country'] : 'US',
+    'last_name' => !empty($request['last_name']) ? $request['last_name'] : NULL,
+    'mobile' => !empty($request['mobile']) ? dosomething_user_clean_mobile_number($request['mobile']) : NULL,
+    'user_registration_source' => !empty($request['user_registration_source']) ? $request['user_registration_source'] : NULL,
   ];
 
   dosomething_user_set_fields($edit, $fields);
+
+  // Set given password, or generate a random one if blank.
+  $edit['pass'] = !empty($request['password']) ? $request['password'] : user_password();
 
   // Infer the user's language from their country code field.
   $edit['language'] = dosomething_global_convert_country_to_language($fields['country']);
 
   try {
-    $account = user_save('', $edit);
-    return $account;
+    return user_save('', $edit);
   }
   catch (Exception $e) {
     services_error($e);


### PR DESCRIPTION
#### What's this PR do?

This pull request should wrap up the last fixes to the `POST api/v1/users/` endpoint.

🍎 Validates email addresses (so you can't register with an email that'll later be rejected elsewhere).

☎️ Return validation errors for invalid phone numbers (rather than silently discarding the field).

🔏 Don't allow blank password field to be set. I don't think this should cause any issues since a [fake password is set](https://github.com/DoSomething/mbc-user-import/blob/89050bd5235e9f61a7fce30f88ec434f01fda66b/src/MBC_UserImport_Source_Niche.php#L91) in the Niche importer, and any "blank" passwords would never be able to be used because empty strings aren't hashed in `user_save`.

🔢 Save UID as the user's "name" like we do elsewhere.
#### How should this be reviewed?

Try to create bad accounts from that endpoint. Hopefully you can't! 😬
#### Any background context you want to provide?

This should be the last step to prevent badly formatted data from sneaking in again, so that our user data cleanup attempts don't all go to waste! 
#### Relevant tickets

References #6503.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
