### PR TITLE
Fix favicon and touch icon path.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -31,8 +31,8 @@
       <script type="text/javascript" src="<?php print '/' . VENDOR_ASSET_PATH . '/respond.js/dest/respond.min.js' ?>"></script>
   <![endif]-->
 
-  <link rel="shortcut icon" href="<?php print '/' . FORGE_ASSET_PATH . '/dist/assets/images/favicon.ico' ?>">
-  <link rel="apple-touch-icon-precomposed" href="<?php print '/' . FORGE_ASSET_PATH . '/dist/assets/images/apple-touch-icon-precomposed.png' ?>">
+  <link rel="shortcut icon" href="<?php print '/' . FORGE_ASSET_PATH . '/assets/images/favicon.ico' ?>">
+  <link rel="apple-touch-icon-precomposed" href="<?php print '/' . FORGE_ASSET_PATH . '/assets/images/apple-touch-icon-precomposed.png' ?>">
   <?php print $head; ?>
 
   <script type="text/javascript" src="<?php print '/' . PARANEUE_PATH . '/dist/modernizr.js' ?>"></script>


### PR DESCRIPTION
#### What's this PR do?

Fix favicon and touch icon paths, which were 404ing because of the change to how the `dist` folder is structured in Forge 6.7.
#### How should this be reviewed?

Those paths should no longer 404.
#### Any background context you want to provide?

🎨 🔍
#### Relevant tickets

Fixes #6504.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
