### PR TITLE
Global fixes

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -464,13 +464,18 @@ function dosomething_global_convert_country_to_language($country) {
  * Converts the given language into its assigned URL prefix.
  *
  * @param string $language
- *  The language to get the prefix for (eg: 'en', 'mx')
+ *  The language to get the prefix for (eg: 'en', 'en-global', 'es-mx')
  *
- * @return
- *  The URL prefix mapped to this language
+ * @return string
  */
 function dosomething_global_get_prefix_for_language($language) {
   $languages = language_list();
+
+  if (! array_key_exists($language, $languages)) {
+    // The prefix for en-global is an empty string.
+    return '';
+  }
+
   return $languages[$language]->prefix;
 }
 

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -461,10 +461,12 @@ function dosomething_global_convert_country_to_language($country) {
 }
 
 /**
- * Converts the given language into its assigned URL prefix.
+ * Converts the given language code into its assigned URL
+ * prefix (us, mx, br, etc). If language code not found as
+ * part of supported language list then it defaults to an
+ * empty string for global URL.
  *
  * @param string $language
- *  The language to get the prefix for (eg: 'en', 'en-global', 'es-mx')
  *
  * @return string
  */
@@ -472,7 +474,6 @@ function dosomething_global_get_prefix_for_language($language) {
   $languages = language_list();
 
   if (! array_key_exists($language, $languages)) {
-    // The prefix for en-global is an empty string.
     return '';
   }
 


### PR DESCRIPTION
#### What's this PR do?

This PR updates the `dosomething_global_get_prefix_for_language()` function to allow it to fallback to no prefix returned for the URL (thus a global URL) if the passed `$language` isn't found in the list of supported languages. Prior to this, if somehow a language was passed that wasn't supported, we'd get lots of logged error notices.
#### How should this be reviewed?

Pull down the branch, use ModHeader chrome extension to pretend you're coming in from Canada, load the site and check the logs. If there are no errors regarding `Undefined index: en-ca in dosomething_global_get_prefix_for_language()` then all should be good.
#### Any background context you want to provide?

This is only part of a fix that may be related to the larger issue in #6488 
#### Relevant tickets

Refs #6488

---

@angaither @joe
