### PR TITLE
Fix issue where mobile was being validated if not passed.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -161,7 +161,7 @@ function _member_resource_create($request) {
   if ($mobile && $user = dosomething_user_get_user_by_mobile($mobile)) {
     return services_error(t('Mobile @mobile is registered to User uid @uid.', ['@mobile' => $mobile, '@uid' => $user->uid]), 403);
   }
-  if (!dosomething_user_valid_mobile($mobile)) {
+  if ($mobile && !dosomething_user_valid_mobile($mobile)) {
     return services_error(t('Mobile @mobile is not a valid phone number.', ['@mobile' => $mobile]), 422);
   }
   


### PR DESCRIPTION
#### What's this PR do?

This fixes an issue introduced in #6502, where the contents of the `mobile` field would always be validated even if the field was not passed in the request. It is now only validated if the field exists.
#### How should this be reviewed?

You should be able to create a user without passing a valid `mobile`.
#### Any background context you want to provide?

💃
#### Relevant tickets

🌵 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
