### PR TITLE
Forward users unless query-string is set.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -144,11 +144,14 @@ function _member_resource_access($op) {
  *   Object of the newly created user if successful. String if errors.
  */
 function _member_resource_create($request) {
+  $query = drupal_get_query_parameters();
+  
   if (!isset($request['email'])) {
     return services_error("Email is required.");
   }
-  $email = $request['email'];
+  
   // Check if email is formatted correctly and not already in use.
+  $email = $request['email'];
   if ($user = user_load_by_mail($email)) {
     return services_error(t('Email @email is registered to User uid @uid.', ['@email' => $email, '@uid' => $user->uid]), 403);
   }
@@ -198,6 +201,15 @@ function _member_resource_create($request) {
     // @see: dosomething_user_user_insert
     user_save($user, ['name' => $user->uid]);
     
+    // Forward users to Northstar, unless `?forward=false` is explicitly set.
+    $should_forward = isset($query['forward']) ? filter_var($query['forward'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) : true;
+    if ($should_forward && module_exists('dosomething_northstar')) {
+      $payload = dosomething_northstar_transform_user($user);
+      $payload['password'] = $edit['pass'];
+      
+      dosomething_northstar_register_user($user, $payload);
+    }
+
     return $user;
   }
   catch (Exception $e) {


### PR DESCRIPTION
#### What's this PR do?

Users added through Phoenix's `POST /api/v1/users` endpoint are now automatically forwarded to Northstar, unless the `?forward=` query string is passed with a falsy value.
#### How should this be reviewed?

Is there a better way to get, cast, and set default values for query parameters?
#### Any background context you want to provide?

The default behavior is now to forward users to Northstar. This way we don't need to make any changes to consumers of this API (e.g. Message Broker, SMS responder, maybe other things?) but can specifically opt-out of making an extra "circular" request when hitting this via Northstar.
#### Relevant tickets

References #6406.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
