### PR TITLE
Adds email masking on RB perma link

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -247,6 +247,13 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#required' => TRUE,
     '#default_value' => t(variable_get('dosomething_campaign_permalink_nonowners_page_title')),
   );
+  $form['permalink']['nonowners']['dosomething_campaign_permalink_nonowners_page_title_backup'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Permalink non-owners page title backup'),
+    '#description' => t('If the title contains sensitive user information this is used as a backup.'),
+    '#required' => TRUE,
+    '#default_value' => t(variable_get('dosomething_campaign_permalink_nonowners_page_title_backup')),
+  );
   $form['permalink']['nonowners']['dosomething_campaign_permalink_nonowners_closed_cta'] = array(
     '#type' => 'textfield',
     '#title' => t('Permalink non-owners campaign closed CTA'),

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -252,7 +252,7 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#title' => t('Permalink non-owners page title backup'),
     '#description' => t('If the title contains sensitive user information this is used as a backup.'),
     '#required' => TRUE,
-    '#default_value' => t(variable_get('dosomething_campaign_permalink_nonowners_page_title_backup')),
+    '#default_value' => t(variable_get('dosomething_campaign_permalink_nonowners_page_title_backup', 'Join DoSomething.org!')),
   );
   $form['permalink']['nonowners']['dosomething_campaign_permalink_nonowners_closed_cta'] = array(
     '#type' => 'textfield',

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -472,6 +472,15 @@ function _dosomething_reportback_get_permalink_copy_vars($user) {
   if (!$user->field_first_name ) {
     $user->field_first_name[LANGUAGE_NONE][0]['value'] = t('your friend');
   }
+  $first_name = dosomething_helpers_extract_field_data($user->field_first_name, LANGUAGE_NONE);
+
+  if (strpos($user->field_first_name, '@') !== FALSE) {
+    $non_owners_title = t(variable_get('dosomething_campaign_permalink_nonowners_page_title_backup', ''));
+  }
+  else {
+    $non_owners_title = token_replace(t(variable_get('dosomething_campaign_permalink_nonowners_page_title', '')), array('user' => $user));
+  }
+
   return array(
     'owners_rb_subtitle' => t(variable_get('dosomething_campaign_permalink_confirmation_owners_page_subtitle', '')),
     'owners_rb_scholarship' => t(variable_get('dosomething_campaign_permalink_confirmation_owners_scholarship', '')),
@@ -479,7 +488,7 @@ function _dosomething_reportback_get_permalink_copy_vars($user) {
     'owners_rb_social_cta' => t(variable_get('dosomething_campaign_permalink_confirmation_owners_social_cta', '')),
     'owners_title' => t(variable_get('dosomething_campaign_permalink_owners_page_title', '')),
     'owners_subtitle' => t(variable_get('dosomething_campaign_permalink_owners_page_subtitle', '')),
-    'non_owners_title' => token_replace(t(variable_get('dosomething_campaign_permalink_nonowners_page_title', '')), array('user' => $user)),
+    'non_owners_title' => $non_owners_title,
     'non_owners_closed_cta' => t(variable_get('dosomething_campaign_permalink_nonowners_closed_cta', '')),
     'non_owners_closed_button' => t(variable_get('dosomething_campaign_permalink_nonowners_closed_button_copy', '')),
   );
@@ -1225,7 +1234,7 @@ function dosomething_reportback_mark_reportback_as_excluded($fid) {
     }
   }
 
-  // If there are no flagged reportback item files, change the reportback flagged status to 0. 
+  // If there are no flagged reportback item files, change the reportback flagged status to 0.
   if (empty($flagged_fids)) {
     $reportback->flagged = 0;
     entity_save('reportback', $reportback);


### PR DESCRIPTION
#### What's this PR do?

Hides a users email address on RB perma link page
#### How should this be reviewed?

First set the "non owners title backup" in the permalink settings 
`admin/config/dosomething/dosomething_campaign`

Then go to a RB perma link page as logged out user.
<img width="1434" alt="screen shot 2016-05-26 at 1 23 59 pm" src="https://cloud.githubusercontent.com/assets/897368/15585058/91adc1f8-234b-11e6-99ed-9ba36b25876f.png">

After that change the first name to something that resembles an email
<img width="186" alt="screen shot 2016-05-26 at 2 07 02 pm" src="https://cloud.githubusercontent.com/assets/897368/15585069/9fa264a8-234b-11e6-911a-634529b0ed7b.png">

run `drush cc all`

Visit that perma link page again and witness magic
<img width="1529" alt="screen shot 2016-05-26 at 2 06 49 pm" src="https://cloud.githubusercontent.com/assets/897368/15585137/e2cbd5f2-234b-11e6-9a38-7dea117c2f6b.png">
#### Any background context you want to provide?

In theory I could have figured out a complex regex which made sure the string was a true email, and not just a string with @ in it. But why in the world would someone put @ in there first name?
#### Relevant tickets

Fixes #5997 
#### Checklist
- [ ] Set the backup non owner title in `admin/config/dosomething/dosomething_campaign` (I have it as Join DoSomething.org instead of Join [first name] and DoSomething.org)
