### PR TITLE
Remove campaign group signup

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
@@ -16,7 +16,6 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
         'additional_text_title',
         'intro_title',
         'intro',
-        'signup_form_button_text',
         'call_to_action',
       ),
       'image' => array(
@@ -36,14 +35,6 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
       // Add relevant fields to set as template vars.
       $template_vars['text'][] = 'pre_launch_copy';
       $template_vars['text'][] = 'pre_launch_title';
-    }
-
-    // If current user is signed up:
-    $sid = dosomething_signup_exists($vars['node']->nid);
-    if ($sid) {
-      // Set the post_signup vars.
-      $template_vars['text'][] = 'post_signup_title';
-      $template_vars['text'][] = 'post_signup_copy';
     }
 
     foreach ($template_vars as $key => $labels) {
@@ -105,21 +96,6 @@ function dosomething_campaign_group_preprocess_node(&$vars) {
 
     // Preprocess gallery variables.
     dosomething_static_content_preprocess_galleries($vars);
-
-    if (empty($sid)) {
-      $vars['display_signup_form'] = $vars['field_display_signup_form'][0]['value'];
-      if ($vars['display_signup_form']) {
-        $label = NULL;
-        if (module_exists('dosomething_helpers')) {
-          // Check if a Signup Form Submit Label has been set.
-          $label = dosomething_helpers_get_variable('node', $node->nid, 'signup_form_submit_label');
-        }
-        // Adds signup_button_primary and signup_button_secondary vars.
-        $ids = array('primary', 'secondary');
-        dosomething_signup_preprocess_signup_button($vars, $label, NULL, $ids);
-      }
-    }
-
 
     // Theme modal items if any exist.
     $modal_items = array();

--- a/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
+++ b/lib/modules/dosomething/dosomething_campaign_group/dosomething_campaign_group.module
@@ -160,24 +160,3 @@ function dosomething_campaign_group_get_parent_nid($nid) {
     ->execute();
   return $result->fetchField(0);
 }
-
-/**
- * Returns whether a Campaign Group nid requires automatic parent signup.
- *
- * @param int $nid
- *   The Campaign Group Node nid to check.
- *
- * @return bool
- */
-function dosomething_campaign_group_is_automatic_parent_signup($nid) {
-  $query = new EntityFieldQuery();
-  $query->entityCondition('entity_type', 'node')
-    ->entityCondition('bundle', 'campaign_group')
-    ->propertyCondition('nid', $nid)
-    ->fieldCondition('field_automatic_parent_signup', 'value', 1);
-  $result = $query->execute();
-  if (isset($result['node'])) {
-    return TRUE;
-  }
-  return FALSE;
-}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -519,17 +519,6 @@ function dosomething_signup_entity_insert($entity, $type) {
 
   // Send relevant third-party subscribe requests.
   dosomething_signup_third_party_subscribe($account, $node);
-
-  // Check if inserted signup nid belongs to a Campaign Group.
-  if (module_exists('dosomething_campaign_group')) {
-    // Check if the signup node is a child of a campaign_group.
-    $group_nid = dosomething_campaign_group_get_parent_nid($entity->nid);
-    // If a parent exists and it should creare a parent signup:
-    if ($group_nid && dosomething_campaign_group_is_automatic_parent_signup($group_nid)) {
-      // Create a signup for the group nid.
-      dosomething_signup_create($group_nid);
-    }
-  }
 }
 
 /**
@@ -619,9 +608,6 @@ function dosomething_signup_mbp_request($account, $node, $opt_in) {
   if ($node->type == 'campaign') {
     dosomething_mbp_request('campaign_signup', $params);
   }
-  elseif ($node->type == 'campaign_group') {
-    dosomething_mbp_request('campaign_group_signup', $params);
-  }
 }
 
 /**
@@ -638,7 +624,7 @@ function dosomething_signup_mbp_request($account, $node, $opt_in) {
  *   Associative array of values to use as params to a mbp_request.
  */
 function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
-  if (!($node->type == 'campaign' || $node->type == 'campaign_group')) {
+  if (!($node->type == 'campaign')) {
     return FALSE;
   }
   if (module_exists('dosomething_global')) {
@@ -685,9 +671,8 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     $params['mc_opt_in_path_id'] = $opt_in;
   }
 
-  // Add additional values to $params based on campaign / campaign_group
+  // Add additional values to $params based on campaign
   dosomething_signup_get_mbp_params_campaign($params, $wrapper);
-  dosomething_signup_get_mbp_params_campaign_group($params, $wrapper);
   // Add any mailchimp params if needed.
   dosomething_signup_get_mbp_params_mailchimp($params, $node);
   return $params;
@@ -711,23 +696,6 @@ function dosomething_signup_get_mbp_params_campaign(&$params, $wrapper) {
   }
 }
 
-/**
- * Adds campaign group params in a signup mbp request.
- *
- * @param array $params
- *   Params array to be sent to a mbp request.
- * @param object $node
- *   Details about the node that the signup was made on.
- */
-function dosomething_signup_get_mbp_params_campaign_group(&$params, $node) {
-  if ($node->type == 'campaign_group') {
-    $copy = '';
-    if (isset($node->field_transactional_email_copy[$params['user_language']][0]['safe_value'])) {
-      $copy = $node->field_transactional_email_copy[$params['user_language']][0]['safe_value'];
-    }
-    $params['transactional_email_copy'] = $copy;
-  }
-}
 
 /**
  * Checks if Mailchimp params should be included in a signup mbp request.
@@ -833,7 +801,7 @@ function dosomething_signup_set_presignup_message($title) {
 }
 
 /**
- * Returns total number of Signups based on supplied set of filters. 
+ * Returns total number of Signups based on supplied set of filters.
  *
  * @param array $filters
  * @return int
@@ -894,7 +862,7 @@ function dosomething_signup_get_signup_nids_by_uid($uid) {
  */
 function dosomething_signup_node_unsignup_access($node) {
   // Only display for node types that implement signup forms.
-  if ($node->type == 'campaign' || $node->type == 'campaign_group') {
+  if ($node->type == 'campaign') {
     // Only allow access if user staff and is signed up.
     return dosomething_user_is_staff() && dosomething_signup_exists($node->nid);
   }
@@ -913,12 +881,6 @@ function dosomething_signup_get_login_signup_nid() {
     switch ($obj->type) {
       case 'campaign':
         if (module_exists('dosomething_campaign') && dosomething_campaign_get_campaign_type($obj) != 'sms_game') {
-          return $obj->nid;
-        }
-        break;
-      case 'campaign_group':
-        // Should only signup on login if the signup form is displayed.
-        if ($obj->field_display_signup_form[LANGUAGE_NONE][0]['value'] == 1) {
           return $obj->nid;
         }
         break;

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
@@ -6,7 +6,6 @@
  * - $nid: Node ID for grouped campaigns page (integer).
  * - $title: Title of grouped campaigns page (string).
  * - $subtitle: Subtitle of grouped campaigns page (string).
- * - $signup_button: Render array for outputting Signup form button (array).
  * - $call_to_action: Call To Action of grouped campaigns page (string).
  * - $scholarship: Scholarship amount (string).
  * - $partners: Array of partners for grouped campaigns (array).
@@ -80,21 +79,6 @@
     </section>
   <?php endif; ?>
 
-  <?php if (isset($post_signup_copy)): ?>
-    <section class="container">
-      <div class="wrapper">
-        <div class="container__block -narrow">
-          <?php if (isset($post_signup_title)): ?>
-            <h2 class="inline-sponsor-color"><?php print $post_signup_title; ?></h2>
-          <?php endif; ?>
-
-          <?php print $post_signup_copy; ?>
-        </div>
-      </div>
-    </section>
-  <?php endif; ?>
-
-
   <?php if (isset($pre_launch_copy)): ?>
     <section class="container">
       <div class="wrapper">
@@ -146,17 +130,6 @@
         </section>
       <?php endforeach; ?>
     </section>
-  <?php endif; ?>
-
-  <?php if (isset($signup_button_secondary)): ?>
-    <div class="cta">
-      <div class="wrapper">
-        <h2 class="cta__message"><?php print $call_to_action; ?></h2>
-        <?php if (isset($signup_button_secondary)): ?>
-          <?php print render($signup_button_secondary); ?>
-        <?php endif; ?>
-      </div>
-    </div>
   <?php endif; ?>
 
   <?php if ($info_bar): ?>


### PR DESCRIPTION
#### What's this PR do?

removes the ability to signup on campaign groups 
#### How should this be reviewed?
- 👀 
- test signups on campaign nodes
#### Any background context you want to provide?

this is a less radical approach than #6496, which for some reason was returning a WSOD for anon users on campaign pages. 
So I kept the signup config [fields on the admin section of campaign collections, for now](https://github.com/DoSomething/phoenix/pull/6496/commits/3e258360e776659d59a544d0b5055ea98fc046c3) 
#### Relevant tickets

Refs #5914
