### PR TITLE
After Signin Modal

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -288,10 +288,13 @@ function dosomething_campaign_admin_custom_settings_page($node) {
     $output .= render($signup_data_config_form);
   }
   if (module_exists('dosomething_helpers')) {
-    $form_id = 'dosomething_campaign_reportback_config_form';
-    $reportback_field_form = drupal_get_form($form_id, $node);
-    $output .= render($reportback_field_form);
+    $forms = ['dosomething_campaign_reportback_config_form', 'dosomething_campaign_organ_donation_config_form'];
+
+    foreach ($forms as $form_id) {
+      $output .= render(drupal_get_form($form_id, $node));
+    }
   }
+
   return $output;
 }
 
@@ -498,4 +501,49 @@ function dosomething_campaign_archive_activity_form_submit(&$form, &$form_state)
     '@source' => $source_nid,
     '@target' => $target_nid,
   )));
+}
+
+/*
+ * Organ donation configuration form. Allows admins to turn on/off the
+ * organ donation modal after signup.
+ *
+ */
+function dosomething_campaign_organ_donation_config_form($form, &$form_state, $node) {
+  // Load the node's helpers variables.
+  $vars = dosomething_helpers_get_variables('node', $node->nid);
+
+  $form['nid'] = array(
+    '#type' => 'hidden',
+    '#value' => $node->nid,
+  );
+
+  $form['organ_donation'] = array(
+    '#type' => 'fieldset',
+    '#title' => t("Organ Donation"),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+
+  $form['organ_donation']['register_organ_donors'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Register organ donors after signup.'),
+    '#description' => t('If set, after a user signs up for the campaign they will be presented with a modal to register as an organ donor'),
+    '#default_value' => $vars['register_organ_donors'],
+    '#size' => 20,
+  );
+
+  return $form;
+}
+
+/**
+ * Submit callback for dosomething_campaign_organ_donation_config_form().
+ */
+function dosomething_campaign_organ_donation_config_form_submit(&$form, &$form_state) {
+  $var_name = 'register_organ_donors';
+
+  $values = $form_state['values'];
+
+  dosomething_helpers_set_variable('node', $values['nid'], $var_name, $values[$var_name]);
+
+  drupal_set_message("Updated.");
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -287,12 +287,14 @@ function dosomething_campaign_admin_custom_settings_page($node) {
     $signup_data_config_form = drupal_get_form('dosomething_signup_node_signup_data_form', $node);
     $output .= render($signup_data_config_form);
   }
+  if (module_exists('dosomething_organ_donation')) {
+    $organ_donation_config_form = drupal_get_form('dosomething_organ_donation_config_form', $node);
+    $output .= render($organ_donation_config_form);
+  }
   if (module_exists('dosomething_helpers')) {
-    $forms = ['dosomething_campaign_reportback_config_form', 'dosomething_campaign_organ_donation_config_form'];
-
-    foreach ($forms as $form_id) {
-      $output .= render(drupal_get_form($form_id, $node));
-    }
+    $form_id = 'dosomething_campaign_reportback_config_form';
+    $reportback_field_form = drupal_get_form($form_id, $node);
+    $output .= render($reportback_field_form);
   }
 
   return $output;
@@ -501,57 +503,4 @@ function dosomething_campaign_archive_activity_form_submit(&$form, &$form_state)
     '@source' => $source_nid,
     '@target' => $target_nid,
   )));
-}
-
-/*
- * Organ donation configuration form. Allows admins to turn on/off the
- * organ donation modal after signup.
- *
- */
-function dosomething_campaign_organ_donation_config_form($form, &$form_state, $node) {
-  // Load the node's helpers variables.
-  $vars = dosomething_helpers_get_variables('node', $node->nid);
-
-  $form['nid'] = array(
-    '#type' => 'hidden',
-    '#value' => $node->nid,
-  );
-
-  $form['organ_donation'] = array(
-    '#type' => 'fieldset',
-    '#title' => t("Organ Donation"),
-    '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
-  );
-
-  $form['organ_donation']['register_organ_donors'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Register organ donors after signup.'),
-    '#description' => t('If set, after a user signs up for the campaign they will be presented with a modal to register as an organ donor'),
-    '#default_value' => $vars['register_organ_donors'],
-    '#size' => 20,
-  );
-
-  $form['organ_donation']['actions'] = array(
-    '#type' => 'actions',
-    'submit' => array(
-      '#type' => 'submit',
-      '#value' => 'Save',
-    ),
-  );
-
-  return $form;
-}
-
-/**
- * Submit callback for dosomething_campaign_organ_donation_config_form().
- */
-function dosomething_campaign_organ_donation_config_form_submit(&$form, &$form_state) {
-  $var_name = 'register_organ_donors';
-
-  $values = $form_state['values'];
-
-  dosomething_helpers_set_variable('node', $values['nid'], $var_name, $values[$var_name]);
-
-  drupal_set_message("Updated.");
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -532,6 +532,14 @@ function dosomething_campaign_organ_donation_config_form($form, &$form_state, $n
     '#size' => 20,
   );
 
+  $form['organ_donation']['actions'] = array(
+    '#type' => 'actions',
+    'submit' => array(
+      '#type' => 'submit',
+      '#value' => 'Save',
+    ),
+  );
+
   return $form;
 }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -759,8 +759,17 @@ function dosomething_campaign_add_signup_data_form_vars(&$node) {
  * Adds flag to the node that tells us if we need to show the organ donation modal after sign up.
  */
 function dosomething_campaign_add_oragan_donation_vars(&$node) {
-  // @TODO - Check if the form has been subitted already. If it has, then set this flag to false for the page.
-  $node->register_organ_donor = dosomething_helpers_get_variable('node', $node->nid, 'register_organ_donors');
+  $organ_registration_turned_on = dosomething_helpers_get_variable('node', $node->nid, 'register_organ_donors');
+
+  $sid = dosomething_signup_exists($node->nid);
+  $result = db_select('dosomething_organ_donation', 'od')->fields('od',['registration_form_timestamp'])->condition('sid', $sid, '=')->execute();
+  $result = $result->fetchAll();
+
+  if (count($result)) {
+    $organ_registration_turned_on = 0;
+  }
+
+  $node->register_organ_donor = $organ_registration_turned_on;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -669,6 +669,9 @@ function dosomething_campaign_node_view($node, $view_mode, $langcode) {
     // Add signup_data_form variables if needed.
     dosomething_campaign_add_signup_data_form_vars($node);
 
+    // Flag if we need to register an organ donor on the page.
+    dosomething_campaign_add_oragan_donation_vars($node);
+
     if (module_exists('dosomething_shipment')) {
       dosomething_campaign_add_shipment_form_vars($node);
     }
@@ -750,6 +753,14 @@ function dosomething_campaign_add_signup_data_form_vars(&$node) {
       $node->content['skip_signup_data_form'] = drupal_get_form('dosomething_signup_user_skip_signup_data_form', $signup);
     }
   }
+}
+
+/*
+ * Adds flag to the node that tells us if we need to show the organ donation modal after sign up.
+ */
+function dosomething_campaign_add_oragan_donation_vars(&$node) {
+  // @TODO - Check if the form has been subitted already. If it has, then set this flag to false for the page.
+  $node->register_organ_donor = dosomething_helpers_get_variable('node', $node->nid, 'register_organ_donors');
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -670,7 +670,9 @@ function dosomething_campaign_node_view($node, $view_mode, $langcode) {
     dosomething_campaign_add_signup_data_form_vars($node);
 
     // Flag if we need to register an organ donor on the page.
-    dosomething_campaign_add_oragan_donation_vars($node);
+    if (module_exists('dosomething_organ_donation')) {
+      $node->register_organ_donor = !dosomething_organ_donation_has_registered($node) ? TRUE : FALSE;
+    }
 
     if (module_exists('dosomething_shipment')) {
       dosomething_campaign_add_shipment_form_vars($node);
@@ -753,23 +755,6 @@ function dosomething_campaign_add_signup_data_form_vars(&$node) {
       $node->content['skip_signup_data_form'] = drupal_get_form('dosomething_signup_user_skip_signup_data_form', $signup);
     }
   }
-}
-
-/*
- * Adds flag to the node that tells us if we need to show the organ donation modal after sign up.
- */
-function dosomething_campaign_add_oragan_donation_vars(&$node) {
-  $organ_registration_turned_on = dosomething_helpers_get_variable('node', $node->nid, 'register_organ_donors');
-
-  $sid = dosomething_signup_exists($node->nid);
-  $result = db_select('dosomething_organ_donation', 'od')->fields('od',['registration_form_timestamp'])->condition('sid', $sid, '=')->execute();
-  $result = $result->fetchAll();
-
-  if (count($result)) {
-    $organ_registration_turned_on = 0;
-  }
-
-  $node->register_organ_donor = $organ_registration_turned_on;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -351,7 +351,6 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
 
   $optimizely_js = 'window["optimizely"] = window["optimizely"] || []; window.optimizely.push(["trackEvent", "Action Page View"]);';
   drupal_add_js($optimizely_js, 'inline');
-
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -351,6 +351,20 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
 
   $optimizely_js = 'window["optimizely"] = window["optimizely"] || []; window.optimizely.push(["trackEvent", "Action Page View"]);';
   drupal_add_js($optimizely_js, 'inline');
+
+  // Pass the signup id to the front end.
+  if (module_exists('dosomething_signup')) {
+    if ($sid = dosomething_signup_exists($vars['nid'])) {
+      drupal_add_js(
+        array('dosomethingSignup' =>
+          array(
+            'sid' => $sid,
+          ),
+        ),
+        'setting'
+      );
+    }
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -9,13 +9,13 @@
  *
  */
 function dosomething_organ_donation_menu() {
-  $items = array();
+  $items = [];
 
-  $items['organ-donation/registration'] = array(
+  $items['organ-donation/registration'] = [
     'page callback' => 'dosomething_organ_donation_store_registration',
     'access callback' => 'user_is_logged_in',
     'type' => MENU_CALLBACK,
-  );
+  ];
 
   // Return the $items array to register the path
   return $items;
@@ -57,4 +57,73 @@ function dosomething_organ_donation_store_registration() {
   }
 
   return;
+}
+
+/*
+ * Organ donation configuration form. Allows admins to turn on/off the
+ * organ donation modal after signup.
+ *
+ */
+function dosomething_organ_donation_config_form($form, &$form_state, $node) {
+  // Load the node's helpers variables.
+  $vars = dosomething_helpers_get_variables('node', $node->nid);
+
+  $form['nid'] = [
+    '#type' => 'hidden',
+    '#value' => $node->nid,
+  ];
+
+  $form['organ_donation'] = [
+    '#type' => 'fieldset',
+    '#title' => t("Organ Donation"),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  ];
+
+  $form['organ_donation']['register_organ_donors'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Register organ donors after signup.'),
+    '#description' => t('If set, after a user signs up for the campaign they will be presented with a modal to register as an organ donor'),
+    '#default_value' => $vars['register_organ_donors'],
+    '#size' => 20,
+  ];
+
+  $form['organ_donation']['actions'] = [
+    '#type' => 'actions',
+    'submit' => [
+      '#type' => 'submit',
+      '#value' => 'Save',
+    ],
+  ];
+
+  return $form;
+}
+
+/**
+ * Submit callback for dosomething_campaign_organ_donation_config_form().
+ */
+function dosomething_organ_donation_config_form_submit(&$form, &$form_state) {
+  $var_name = 'register_organ_donors';
+
+  $values = $form_state['values'];
+
+  dosomething_helpers_set_variable('node', $values['nid'], $var_name, $values[$var_name]);
+
+  drupal_set_message("Updated.");
+}
+
+/**
+ * Checks if the user has already registered.
+ *
+ * @param object $node
+ * @return bool
+ */
+function dosomething_organ_donation_has_registered($node) {
+  $organ_registration_turned_on = dosomething_helpers_get_variable('node', $node->nid, 'register_organ_donors');
+
+  $sid = dosomething_signup_exists($node->nid);
+  $result = db_select('dosomething_organ_donation', 'od')->fields('od',['registration_form_timestamp'])->condition('sid', $sid, '=')->execute();
+  $result = $result->fetchAll();
+
+  return ($organ_registration_turned_on && count($result) === 0) ? FALSE : TRUE;
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -833,7 +833,7 @@ function dosomething_signup_set_presignup_message($title) {
 }
 
 /**
- * Returns total number of Signups based on supplied set of filters. 
+ * Returns total number of Signups based on supplied set of filters.
  *
  * @param array $filters
  * @return int

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -183,6 +183,16 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
     drupal_add_js($js, 'inline');
   }
 
+  if ($vars['node']->register_organ_donor) {
+    // Add JS to open the signup data form modal.
+    $id = 'modal-organ-donation';
+    $closeButton = 'skip';
+
+    // @TODO - New function?
+    $js = 'jQuery(document).ready(function() { DSModal.open( jQuery("#' . $id . '"), {animated: false, closeButton: "' . $closeButton . '"}); });';
+    drupal_add_js($js, 'inline');
+  }
+
   // If this is not the pitch page:
   if (!isset($vars['is_pitch_page'])) {
     $vars['reportbacks_gallery'] = paraneue_dosomething_preprocess_reportback_gallery($vars);

--- a/lib/themes/dosomething/paraneue_dosomething/js/app.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/app.js
@@ -21,6 +21,7 @@ import Donate from 'donate/Donate';
 import Finder from 'finder/Finder';
 import Reportback from 'reportback/Reportback';
 import SchoolFinder from 'campaign/SchoolFinder';
+import Takeover from 'takeover/Takeover';
 
 // Patterns
 import Gallery from 'patterns/Gallery';
@@ -75,6 +76,9 @@ $(document).ready(function() {
 
   // Initialize "show more" button on permalink pages.
   ShowMore.init();
+
+  // Intialize takeover modal.
+  Takeover.init();
 
   // Add fallback for HTML5 video on mobile tiles
   Tile.init();

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
@@ -8,7 +8,7 @@ const $ = require('jquery');
 const template = require('lodash/string/template');
 
 const Takeover = {
-  baseUrl: '/api/v1/campaigns/',
+  baseUrl: $(location).attr("origin"),
 
   spinner: '<div class="spinner"></div>',
 
@@ -185,18 +185,25 @@ const Takeover = {
   },
 
   /*
-   * Resets the functionality.
-   * Currently, specific to the organ donation interactions, but would love
-   * a way of figuring out if it could be more general. Maybe we could pass in a function
-   * defined in some custom js to run when this function gets called.
+   ****************************
+   * MAJOR WIP: This is currently functionality very specific to what we need for organ donations.
+   * Will be working on separating out the Takeover/modal responsibilities from the functionality that we
+   * actually need in each "screen" of the modal in a different PR. I don't want to block other work while
+   * I work on this.
+   ****************************
+   *
+   * Sets up screen functionality.
    */
   reset: function() {
     const _this = this;
 
-    if ($('.submit-button-container').find('.spinner').length) {
-      $('.submit-button-container').html('<input type="submit" class="button submit-postal-code" value="Submit" />');
+    const $submitZipCodeContainer = $('.submit-button-container');
+
+    if ($submitZipCodeContainer.find('.spinner').length) {
+      $submitZipCodeContainer.html('<input type="submit" class="button submit-postal-code" value="Submit" />');
 
       this.submitButton = $('.submit-postal-code');
+      // @TODO - actually hit the Oraganize API.
       this.handleSubmit(this.submitButton, {
         'button' : this.submitButton,
         'method' : 'GET',
@@ -207,7 +214,9 @@ const Takeover = {
       $('.back-button').off('click');
     }
 
-    if ($('.takeover__screen .back-button').length) {
+    const $backButton = $('.takeover__screen .back-button');
+
+    if ($backButton.length) {
       $('.takeover__screen .back-button').click(function(e) {
         e.preventDefault();
 
@@ -215,14 +224,19 @@ const Takeover = {
       });
     }
 
-    if ($('.submit-registration-container').length) {
+    const $submitRegContainer = $('.submit-registration-container');
+
+    if ($submitRegContainer.length) {
       const sid = setting('dosomethingSignup.sid');
 
-      this.handleSubmit($('.submit-registration'), {
-        'button' : $('.submit-registration'),
+      this.handleSubmit($submitRegContainer.find('.submit-registration'), {
+        'button' : $submitRegContainer.find('.submit-registration'),
         'method' : 'GET',
-        'url'    : 'http://dev.dosomething.org:8888/organ-donation/registration',
-        'data'   : {'sid' : sid, 'uid' : $('meta[name="drupal-user-id"]').attr('content') },
+        'url'    : _this.baseUrl + '/organ-donation/registration',
+        'data'   : {
+          'sid' : sid,
+          'uid' : $('meta[name="drupal-user-id"]').attr('content')
+        },
       });
     }
   },

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
@@ -64,6 +64,7 @@ const Takeover = {
    */
   addTakeover: function($container, data, slide = false) {
     const markup = template(takeoverTpl);
+
     $container.html(markup(data));
     this.takeoverContent = $('.takeover');
 
@@ -81,8 +82,6 @@ const Takeover = {
    * @param  {object}   request   An object that defines the properties we need to make a request.
    */
   handleSubmit: function($button, request) {
-    const _this = this;
-
     // Create custom deferred promise object.
     let ajaxPromise = $.Deferred().resolve().promise();
 
@@ -187,8 +186,6 @@ const Takeover = {
    * Sets up screen functionality.
    */
   reset: function() {
-    const _this = this;
-
     const $submitZipCodeContainer = $('.submit-button-container');
 
     if ($submitZipCodeContainer.find('.spinner').length) {
@@ -212,7 +209,7 @@ const Takeover = {
       $('.takeover__screen .back-button').click(e => {
         e.preventDefault();
 
-        _this.changeScreens('previous');
+        this.changeScreens('previous');
       });
     }
 
@@ -224,7 +221,7 @@ const Takeover = {
       this.handleSubmit($submitRegContainer.find('.submit-registration'), {
         'button' : $submitRegContainer.find('.submit-registration'),
         'method' : 'GET',
-        'url'    : _this.baseUrl + '/organ-donation/registration',
+        'url'    : this.baseUrl + '/organ-donation/registration',
         'data'   : {
           'sid' : sid,
           'uid' : $('meta[name="drupal-user-id"]').attr('content')

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
@@ -24,7 +24,6 @@ const Signup = {
    * @param  {jQuery} $takeoverContainer the element to add the taked over to.
    */
   init: function($takeoverContainer = $('.takeover-container')) {
-    console.log($takeoverContainer);
     const data = {
       'header': 'Thanks for signing up',
       // 'caption': 'Want to do more good? Sign up for similar campaigns below!',
@@ -38,9 +37,9 @@ const Signup = {
 
     // Set up interactions
     this.screens = $('.takeover__screen');
-    this.signupButton = $('.signup-button');
+    this.submitButton = $('.submit-postal-code');
     this.scrollScreens(this.screens);
-    this.handleSignups(this.signupButton);
+    this.handleSubmit(this.submitButton);
   },
 
   /**
@@ -66,7 +65,7 @@ const Signup = {
    *
    * @param  {jQuery}   $button   Signup buttons
    */
-  handleSignups: function($button) {
+  handleSubmit: function($button) {
     const _this = this;
 
     // Create custom deferred promise object.
@@ -77,28 +76,41 @@ const Signup = {
       e.preventDefault();
 
       const $this = $(this);
-      const $buttonContainer = $this.closest('.-signup');
+      // const $buttonContainer = $this.closest('.-signup');
 
       // Make the ajax call, store the promise.
-      const promise = _this.postSignup($this);
+      const promise = _this.sendRequest($this, 'GET', 'http://jsonplaceholder.typicode.com/posts/1');
 
       // Fire done call backs in the order in which they were recieved.
       ajaxPromise = ajaxPromise.then(function() {
         return promise;
       }).done(function(data) {
-        const signupId = data[0];
+        const screenCount = _this.screens.length;
 
-        if (signupId) {
-          $this.val(_this.checkmark);
-          $this.css('background-color', _this.green);
-          $buttonContainer.html($this);
+        const $firstScreen = _this.screens.first();
+        $firstScreen.addClass("active");
+
+        // @TODO - move into function.
+        const $current = $('.takeover__screen.active');
+        // @TODO - ew, clean this up
+        let index = ($current.data("index") < screenCount) ? (($current.data("index") + 1) > (screenCount - 1)) ? 0 : ($current.data("index") + 1) : 0;
+
+        $current.removeClass("active");
+
+        $(".takeover__screen[data-index='" + index + "']").addClass("active");
+        // const signupId = data[0];
+
+        // if (signupId) {
+        //   $this.val(_this.checkmark);
+        //   $this.css('background-color', _this.green);
+        //   $buttonContainer.html($this);
         // @TODO - How should we handle campaigns folks are already signed up for.
         // Do we even need to handle this case, ideally we would only show campaigns they
         // are not signed up for.
-        } else {
-          $this.val('Signed Up');
-          $buttonContainer.html($this);
-        }
+        // } else {
+        //   $this.val('Signed Up');
+        //   $buttonContainer.html($this);
+        // }
       });
     });
   },
@@ -109,22 +121,23 @@ const Signup = {
    * @param  {jQuery}   $button   Signup buttons
    * @return {object}   The api response.
    */
-  postSignup: function($button) {
+  sendRequest: function($button, method, url, data = null) {
     const _this = this;
 
     return $.ajax({
-      method: 'POST',
-      url: this.baseUrl + $button.data('campaign-id') +'/signup',
+      method: method,
+      url: url,
       dataType: 'json',
-      headers: {
-        'Accepts': 'application/json',
-        'Content-Type': 'application/json',
-        'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content'),
-      },
-      data: JSON.stringify({
-        'uid': $('meta[name="drupal-user-id"]').attr('content'),
-        'source': 'multi-signup-module',
-      }),
+      // headers: {
+      //   'Accepts': 'application/json',
+      //   'Content-Type': 'application/json',
+      //   'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content'),
+      // },
+      // data: JSON.stringify({
+      //   'uid': $('meta[name="drupal-user-id"]').attr('content'),
+      //   'source': 'multi-signup-module',
+      // }),
+      // data: data,
       beforeSend: function() {
         _this.addSpinner($button);
       },
@@ -171,10 +184,7 @@ const Signup = {
    * @param  {jQuery}   $screens
    */
   addSpinner: function($element) {
-    console.log("add spinner");
-    console.log($element);
-    const $container = $element.closest('.-signup');
-    console.log($container);
+    const $container = $element.closest('.submit-button-container');
 
     $container.html("<div class='spinner'></div>");
   },

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
@@ -1,0 +1,183 @@
+// @IDEA - Let this just take care of screen interactions, pull in custom stuff via classes
+import takeoverTpl from 'takeover/templates/takeover.tpl.html';
+
+const $ = require('jquery');
+const debounce = require('lodash/function/debounce');
+const template = require('lodash/string/template');
+
+const Signup = {
+  baseUrl: '/api/v1/campaigns/',
+
+  green: '#33cd5f',
+
+  checkmark: $("<div>").html("&#10003;").text(),
+
+  spinner: "<div class='spinner'></div>",
+
+  screens: null,
+
+  signupButton: null,
+
+  /**
+   * Initialize the Signup interface.
+   *
+   * @param  {jQuery} $takeoverContainer the element to add the taked over to.
+   */
+  init: function($takeoverContainer = $('.takeover-container')) {
+    console.log($takeoverContainer);
+    const data = {
+      'header': 'Thanks for signing up',
+      // 'caption': 'Want to do more good? Sign up for similar campaigns below!',
+      // 'campaigns': Drupal.settings.dosomethingCampaign.recommendedCampaigns,
+    }
+
+    const slide = $takeoverContainer.hasClass('-no-slide') ? false : true;
+
+    // Add the takeover to the page.
+    this.addTakeover($takeoverContainer, data, slide);
+
+    // Set up interactions
+    this.screens = $('.takeover__screen');
+    this.signupButton = $('.signup-button');
+    this.scrollScreens(this.screens);
+    this.handleSignups(this.signupButton);
+  },
+
+  /**
+   * Adds the take over to the page with slide animation.
+   *
+   * @param  {jQuery} $container  the container to add the takeover to.
+   * @param  {object} $data       An object containing the data to inject into the templates
+   * @param  {bool}   slide       Whether or not to add the takeover with a slide animation.
+   */
+  addTakeover: function($container, data, slide = false) {
+    const markup = template(takeoverTpl);
+    $container.html(markup(data));
+    this.takeoverContent = $('.takeover');
+
+    if (slide) {
+      this.takeoverContent.hide();
+      this.takeoverContent.delay(500).slideDown("slow", function() {});
+    }
+  },
+
+  /**
+   * Binds click handlers to signup buttons that posts signs ups to phoenix.
+   *
+   * @param  {jQuery}   $button   Signup buttons
+   */
+  handleSignups: function($button) {
+    const _this = this;
+
+    // Create custom deferred promise object.
+    let ajaxPromise = $.Deferred().resolve().promise();
+
+    // Bind click handler
+    $button.click(function(e) {
+      e.preventDefault();
+
+      const $this = $(this);
+      const $buttonContainer = $this.closest('.-signup');
+
+      // Make the ajax call, store the promise.
+      const promise = _this.postSignup($this);
+
+      // Fire done call backs in the order in which they were recieved.
+      ajaxPromise = ajaxPromise.then(function() {
+        return promise;
+      }).done(function(data) {
+        const signupId = data[0];
+
+        if (signupId) {
+          $this.val(_this.checkmark);
+          $this.css('background-color', _this.green);
+          $buttonContainer.html($this);
+        // @TODO - How should we handle campaigns folks are already signed up for.
+        // Do we even need to handle this case, ideally we would only show campaigns they
+        // are not signed up for.
+        } else {
+          $this.val('Signed Up');
+          $buttonContainer.html($this);
+        }
+      });
+    });
+  },
+
+  /**
+   * Posts signs up to phoenix via the api.
+   *
+   * @param  {jQuery}   $button   Signup buttons
+   * @return {object}   The api response.
+   */
+  postSignup: function($button) {
+    const _this = this;
+
+    return $.ajax({
+      method: 'POST',
+      url: this.baseUrl + $button.data('campaign-id') +'/signup',
+      dataType: 'json',
+      headers: {
+        'Accepts': 'application/json',
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content'),
+      },
+      data: JSON.stringify({
+        'uid': $('meta[name="drupal-user-id"]').attr('content'),
+        'source': 'multi-signup-module',
+      }),
+      beforeSend: function() {
+        _this.addSpinner($button);
+      },
+    });
+  },
+
+  /**
+   * Handles the interaction of scrolling through different screens in the experience.
+   *
+   * @param  {jQuery}   $screens
+   */
+  scrollScreens: function($screens) {
+    const screenCount = $screens.length;
+
+    const $firstScreen = $screens.first();
+    $firstScreen.addClass("active");
+
+    $(".takeover__next").click(function() {
+      // @TODO - move into function.
+      const $current = $('.takeover__screen.active');
+      // @TODO - ew, clean this up
+      let index = ($current.data("index") < screenCount) ? (($current.data("index") + 1) > (screenCount - 1)) ? 0 : ($current.data("index") + 1) : 0;
+
+      $current.removeClass("active");
+
+      $(".takeover__screen[data-index='" + index + "']").addClass("active");
+    });
+
+    $(".takeover__previous").click(function() {
+      const $current = $('.takeover__screen.active');
+
+      // @todo - don't hard code these numbers.
+      let index = ($current.data("index") > 0) ? $current.data("index") - 1 : 2;
+
+      $current.removeClass("active");
+
+      $(".takeover__screen[data-index='" + index + "']").addClass("active");
+    });
+  },
+
+  /**
+   * Handles the interaction of scrolling through different screens in the experience.
+   *
+   * @param  {jQuery}   $screens
+   */
+  addSpinner: function($element) {
+    console.log("add spinner");
+    console.log($element);
+    const $container = $element.closest('.-signup');
+    console.log($container);
+
+    $container.html("<div class='spinner'></div>");
+  },
+};
+
+export default Signup;

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
@@ -8,7 +8,7 @@ const $ = require('jquery');
 const template = require('lodash/string/template');
 
 const Takeover = {
-  baseUrl: $(location).attr("origin"),
+  baseUrl: window.location.origin,
 
   spinner: '<div class="spinner"></div>',
 
@@ -20,6 +20,7 @@ const Takeover = {
 
   screenIndexes: null,
 
+  activeClass: 'is-active',
   /**
    * Initialize the Signup interface.
    *
@@ -42,7 +43,7 @@ const Takeover = {
     this.screenIndexes = this.setScreenIndexes();
     this.firstScreen = this.screens.first();
     this.lastScreen = this.screens.last();
-    this.firstScreen.addClass('active');
+    this.firstScreen.addClass(this.activeClass);
 
     // Set up submit handlers.
     this.submitButton = $('.submit-postal-code');
@@ -85,22 +86,15 @@ const Takeover = {
     // Create custom deferred promise object.
     let ajaxPromise = $.Deferred().resolve().promise();
 
-    // Bind click handler
-    $button.click(function(e) {
+    $button.click(e => {
       e.preventDefault();
-
-      const $this = $(this);
 
       if (! $('.validation__message.has-error').length) {
         // Make the ajax call, store the promise.
-        const promise = _this.sendRequest(request);
+        const promise = this.sendRequest(request);
 
         // Fire done call backs in the order in which they were recieved.
-        ajaxPromise = ajaxPromise.then(function() {
-          return promise;
-        }).done(function(data) {
-          _this.changeScreens('next');
-        });
+        ajaxPromise = ajaxPromise.then(promise => { return promise } ).done( data => this.changeScreens('next'));
       }
     });
   },
@@ -136,9 +130,7 @@ const Takeover = {
   setScreenIndexes: function() {
     let indexes = [];
 
-    $.each(this.screens, function(scr) {
-      indexes.push($(scr).data('index'));
-    });
+    $.each(this.screens, scr => indexes.push($(scr).data('index')));
 
     return indexes;
   },
@@ -154,19 +146,19 @@ const Takeover = {
       return;
     }
 
-    const $current = $('.takeover__screen.active');
+    const $current = $(`.takeover__screen.${this.activeClass}`);
     const currentIndex = $current.data('index');
     const newIndex = (direction === 'next') ? currentIndex + 1 : currentIndex - 1;
 
     // Check if the new screen exists, if so, go there, otherwise we need to loop back.
     if ($.inArray(newIndex, this.screenIndexes)) {
-      $current.removeClass('active');
-      $('.takeover__screen[data-index="' + newIndex + '"]').addClass('active');
+      $current.removeClass(this.activeClass);
+      $(`.takeover__screen[data-index="${newIndex}"]`).addClass(this.activeClass);
     } else {
       if (direction === 'next') {
-        this.firstScreen.addClass('active');
+        this.firstScreen.addClass(this.activeClass);
       } else {
-        this.lastScreen.addClass('active');
+        this.lastScreen.addClass(this.activeClass);
       }
     }
 
@@ -217,7 +209,7 @@ const Takeover = {
     const $backButton = $('.takeover__screen .back-button');
 
     if ($backButton.length) {
-      $('.takeover__screen .back-button').click(function(e) {
+      $('.takeover__screen .back-button').click(e => {
         e.preventDefault();
 
         _this.changeScreens('previous');

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
@@ -1,3 +1,5 @@
+var Validation = require("dosomething-validation");
+
 // @IDEA - Let this just take care of screen interactions, pull in custom stuff via classes
 import takeoverTpl from 'takeover/templates/takeover.tpl.html';
 
@@ -8,11 +10,9 @@ const template = require('lodash/string/template');
 const Takeover = {
   baseUrl: '/api/v1/campaigns/',
 
-  green: '#33cd5f',
+  spinner: '<div class="spinner"></div>',
 
-  checkmark: $("<div>").html("&#10003;").text(),
-
-  spinner: "<div class='spinner'></div>",
+  buttonAnimation: 'shake',
 
   screens: null,
 
@@ -30,16 +30,18 @@ const Takeover = {
       'header': 'Thanks for signing up',
     }
 
-    const slide = $takeoverContainer.hasClass('-no-slide') ? false : true;
-
     // Add the takeover to the page.
+    const slide = $takeoverContainer.hasClass('-no-slide') ? false : true;
     this.addTakeover($takeoverContainer, data, slide);
+
+    // Prepare validation fields that got entered into the DOM after page load.
+    Validation.prepareFields($('input'));
 
     // Set up interactions
     this.screens = $('.takeover__screen');
     this.screenIndexes = this.setScreenIndexes();
     this.firstScreen = this.screens.first();
-    this.firstScreen.addClass("active");
+    this.firstScreen.addClass('active');
 
     // Set up submit handlers.
     this.submitButton = $('.submit-postal-code');
@@ -60,7 +62,7 @@ const Takeover = {
 
     if (slide) {
       this.takeoverContent.hide();
-      this.takeoverContent.delay(500).slideDown("slow", function() {});
+      this.takeoverContent.delay(500).slideDown('slow', function() {});
     }
   },
 
@@ -80,17 +82,20 @@ const Takeover = {
       e.preventDefault();
 
       const $this = $(this);
-      // const $buttonContainer = $this.closest('.-signup');
 
-      // Make the ajax call, store the promise.
-      const promise = _this.sendRequest($this, 'GET', 'http://jsonplaceholder.typicode.com/posts/1');
+      if ($('.validation__message.has-error').length) {
+        $this.addClass(_this.buttonAnimation);
+      } else {
+        // Make the ajax call, store the promise.
+        const promise = _this.sendRequest($this, 'GET', 'http://jsonplaceholder.typicode.com/posts/1');
 
-      // Fire done call backs in the order in which they were recieved.
-      ajaxPromise = ajaxPromise.then(function() {
-        return promise;
-      }).done(function(data) {
-        _this.nextScreen();
-      });
+        // Fire done call backs in the order in which they were recieved.
+        ajaxPromise = ajaxPromise.then(function() {
+          return promise;
+        }).done(function(data) {
+          _this.nextScreen();
+        });
+      }
     });
   },
 
@@ -141,14 +146,14 @@ const Takeover = {
    */
   nextScreen: function() {
     const $current = $('.takeover__screen.active');
-    const currentIndex = $current.data("index");
+    const currentIndex = $current.data('index');
 
     // Check if we are on the last screen, if so, go to the first.
     if (!$.inArray(currentIndex + 1, this.screenIndexes)) {
-      this.firstScreen.addClass("active");
+      this.firstScreen.addClass('active');
     } else {
       $current.removeClass('active');
-      $(".takeover__screen[data-index='" + (currentIndex + 1) + "']").addClass("active");
+      $('.takeover__screen[data-index="' + (currentIndex + 1) + '"]').addClass('active');
     }
   },
 
@@ -160,7 +165,7 @@ const Takeover = {
   addSpinner: function($element) {
     const $container = $element.closest('.submit-button-container');
 
-    $container.html("<div class='spinner'></div>");
+    $container.html(this.spinner);
   },
 };
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
@@ -1,4 +1,5 @@
-var Validation = require("dosomething-validation");
+import Validation from 'dosomething-validation';
+import setting from '../utilities/Setting';
 
 // @IDEA - Let this just take care of screen interactions, pull in custom stuff via classes
 import takeoverTpl from 'takeover/templates/takeover.tpl.html';
@@ -45,11 +46,16 @@ const Takeover = {
 
     // Set up submit handlers.
     this.submitButton = $('.submit-postal-code');
-    this.handleSubmit(this.submitButton);
+    this.handleSubmit(this.submitButton, {
+      'button' : this.submitButton,
+      'method' : 'GET',
+      'url'    : 'http://jsonplaceholder.typicode.com/posts/1',
+      'data'   : null,
+    });
   },
 
   /**
-   * Adds the take over to the page with slide animation.
+   * Adds the takeover to the page with or without a slide animation.
    *
    * @param  {jQuery} $container  the container to add the takeover to.
    * @param  {object} $data       An object containing the data to inject into the templates
@@ -67,11 +73,13 @@ const Takeover = {
   },
 
   /**
-   * Binds click handlers to signup buttons that posts signs ups to phoenix.
+   * Binds click handlers to $button that sends an AJAX request and uses deferred promises to
+   * run callbacks in the order in which they are recieved.
    *
    * @param  {jQuery}   $button   Signup buttons
+   * @param  {object}   request   An object that defines the properties we need to make a request.
    */
-  handleSubmit: function($button) {
+  handleSubmit: function($button, request) {
     const _this = this;
 
     // Create custom deferred promise object.
@@ -85,7 +93,7 @@ const Takeover = {
 
       if (! $('.validation__message.has-error').length) {
         // Make the ajax call, store the promise.
-        const promise = _this.sendRequest($this, 'GET', 'http://jsonplaceholder.typicode.com/posts/1');
+        const promise = _this.sendRequest(request);
 
         // Fire done call backs in the order in which they were recieved.
         ajaxPromise = ajaxPromise.then(function() {
@@ -98,30 +106,26 @@ const Takeover = {
   },
 
   /**
-   * Posts signs up to phoenix via the api.
+   * Sends an AJAX request using the provided information in the request object that is passed in.
    *
-   * @param  {jQuery}   $button   Signup buttons
+   * @param  {request}   The object containing the details about the request i.e URL, method, data
    * @return {object}   The api response.
    */
-  sendRequest: function($button, method, url, data = null) {
+  sendRequest: function(request) {
     const _this = this;
 
     return $.ajax({
-      method: method,
-      url: url,
+      method: request.method,
+      url: request.url,
       dataType: 'json',
-      // headers: {
-      //   'Accepts': 'application/json',
-      //   'Content-Type': 'application/json',
-      //   'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content'),
-      // },
-      // data: JSON.stringify({
-      //   'uid': $('meta[name="drupal-user-id"]').attr('content'),
-      //   'source': 'multi-signup-module',
-      // }),
-      // data: data,
+      headers: {
+        'Accepts': 'application/json',
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content'),
+      },
+      data: request.data,
       beforeSend: function() {
-        _this.addSpinner($button);
+        _this.addSpinner(request.button);
       },
     });
   },
@@ -170,9 +174,9 @@ const Takeover = {
   },
 
   /**
-   * Handles the interaction of scrolling through different screens in the experience.
+   * Adds a spinner to $element to signify a request is in the works.
    *
-   * @param  {jQuery}   $screens
+   * @param  {jQuery}   $element
    */
   addSpinner: function($element) {
     const $container = $element.closest('.submit-button-container');
@@ -191,20 +195,34 @@ const Takeover = {
 
     if ($('.submit-button-container').find('.spinner').length) {
       $('.submit-button-container').html('<input type="submit" class="button submit-postal-code" value="Submit" />');
+
       this.submitButton = $('.submit-postal-code');
-      this.handleSubmit(this.submitButton);
+      this.handleSubmit(this.submitButton, {
+        'button' : this.submitButton,
+        'method' : 'GET',
+        'url'    : 'http://jsonplaceholder.typicode.com/posts/1',
+        'data'   : null,
+      })
 
       $('.back-button').off('click');
     }
 
     if ($('.takeover__screen .back-button').length) {
-      // @TODO - some sort of load screen function? Maybe take in the different
-      // screens as different templates, this function loads the next template and
-      // resets it's DOM.
       $('.takeover__screen .back-button').click(function(e) {
         e.preventDefault();
 
         _this.changeScreens('previous');
+      });
+    }
+
+    if ($('.submit-registration-container').length) {
+      const sid = setting('dosomethingSignup.sid');
+
+      this.handleSubmit($('.submit-registration'), {
+        'button' : $('.submit-registration'),
+        'method' : 'GET',
+        'url'    : 'http://dev.dosomething.org:8888/organ-donation/registration',
+        'data'   : {'sid' : sid, 'uid' : $('meta[name="drupal-user-id"]').attr('content') },
       });
     }
   },

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
@@ -5,7 +5,7 @@ const $ = require('jquery');
 const debounce = require('lodash/function/debounce');
 const template = require('lodash/string/template');
 
-const Signup = {
+const Takeover = {
   baseUrl: '/api/v1/campaigns/',
 
   green: '#33cd5f',
@@ -16,7 +16,9 @@ const Signup = {
 
   screens: null,
 
-  signupButton: null,
+  firstScreen: null,
+
+  screenIndexes: null,
 
   /**
    * Initialize the Signup interface.
@@ -26,8 +28,6 @@ const Signup = {
   init: function($takeoverContainer = $('.takeover-container')) {
     const data = {
       'header': 'Thanks for signing up',
-      // 'caption': 'Want to do more good? Sign up for similar campaigns below!',
-      // 'campaigns': Drupal.settings.dosomethingCampaign.recommendedCampaigns,
     }
 
     const slide = $takeoverContainer.hasClass('-no-slide') ? false : true;
@@ -37,8 +37,12 @@ const Signup = {
 
     // Set up interactions
     this.screens = $('.takeover__screen');
+    this.screenIndexes = this.setScreenIndexes();
+    this.firstScreen = this.screens.first();
+    this.firstScreen.addClass("active");
+
+    // Set up submit handlers.
     this.submitButton = $('.submit-postal-code');
-    this.scrollScreens(this.screens);
     this.handleSubmit(this.submitButton);
   },
 
@@ -85,32 +89,7 @@ const Signup = {
       ajaxPromise = ajaxPromise.then(function() {
         return promise;
       }).done(function(data) {
-        const screenCount = _this.screens.length;
-
-        const $firstScreen = _this.screens.first();
-        $firstScreen.addClass("active");
-
-        // @TODO - move into function.
-        const $current = $('.takeover__screen.active');
-        // @TODO - ew, clean this up
-        let index = ($current.data("index") < screenCount) ? (($current.data("index") + 1) > (screenCount - 1)) ? 0 : ($current.data("index") + 1) : 0;
-
-        $current.removeClass("active");
-
-        $(".takeover__screen[data-index='" + index + "']").addClass("active");
-        // const signupId = data[0];
-
-        // if (signupId) {
-        //   $this.val(_this.checkmark);
-        //   $this.css('background-color', _this.green);
-        //   $buttonContainer.html($this);
-        // @TODO - How should we handle campaigns folks are already signed up for.
-        // Do we even need to handle this case, ideally we would only show campaigns they
-        // are not signed up for.
-        // } else {
-        //   $this.val('Signed Up');
-        //   $buttonContainer.html($this);
-        // }
+        _this.nextScreen();
       });
     });
   },
@@ -144,38 +123,33 @@ const Signup = {
     });
   },
 
-  /**
-   * Handles the interaction of scrolling through different screens in the experience.
-   *
-   * @param  {jQuery}   $screens
+  /*
+   * Store the indexes of each of the screens provided in the template.
    */
-  scrollScreens: function($screens) {
-    const screenCount = $screens.length;
+  setScreenIndexes: function() {
+    let indexes = [];
 
-    const $firstScreen = $screens.first();
-    $firstScreen.addClass("active");
-
-    $(".takeover__next").click(function() {
-      // @TODO - move into function.
-      const $current = $('.takeover__screen.active');
-      // @TODO - ew, clean this up
-      let index = ($current.data("index") < screenCount) ? (($current.data("index") + 1) > (screenCount - 1)) ? 0 : ($current.data("index") + 1) : 0;
-
-      $current.removeClass("active");
-
-      $(".takeover__screen[data-index='" + index + "']").addClass("active");
+    $.each(this.screens, function(scr) {
+      indexes.push($(scr).data('index'));
     });
 
-    $(".takeover__previous").click(function() {
-      const $current = $('.takeover__screen.active');
+    return indexes;
+  },
 
-      // @todo - don't hard code these numbers.
-      let index = ($current.data("index") > 0) ? $current.data("index") - 1 : 2;
+  /**
+   * Move to the next screen in the experience.
+   */
+  nextScreen: function() {
+    const $current = $('.takeover__screen.active');
+    const currentIndex = $current.data("index");
 
-      $current.removeClass("active");
-
-      $(".takeover__screen[data-index='" + index + "']").addClass("active");
-    });
+    // Check if we are on the last screen, if so, go to the first.
+    if (!$.inArray(currentIndex + 1, this.screenIndexes)) {
+      this.firstScreen.addClass("active");
+    } else {
+      $current.removeClass('active');
+      $(".takeover__screen[data-index='" + (currentIndex + 1) + "']").addClass("active");
+    }
   },
 
   /**
@@ -190,4 +164,4 @@ const Signup = {
   },
 };
 
-export default Signup;
+export default Takeover;

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
@@ -11,8 +11,6 @@ const Takeover = {
 
   spinner: '<div class="spinner"></div>',
 
-  buttonAnimation: 'shake',
-
   screens: null,
 
   firstScreen: null,
@@ -85,9 +83,7 @@ const Takeover = {
 
       const $this = $(this);
 
-      if ($('.validation__message.has-error').length) {
-        $this.addClass(_this.buttonAnimation);
-      } else {
+      if (! $('.validation__message.has-error').length) {
         // Make the ajax call, store the promise.
         const promise = _this.sendRequest($this, 'GET', 'http://jsonplaceholder.typicode.com/posts/1');
 
@@ -95,7 +91,7 @@ const Takeover = {
         ajaxPromise = ajaxPromise.then(function() {
           return promise;
         }).done(function(data) {
-          _this.nextScreen();
+          _this.changeScreens('next');
         });
       }
     });
@@ -144,39 +140,30 @@ const Takeover = {
   },
 
   /**
-   * Move to the next screen in the experience.
+   * Handles makeing a new scren active based on the direction passed.
+   *
+   * @param  {string}   direction
    */
-  nextScreen: function() {
-    const _this = this;
-    const $current = $('.takeover__screen.active');
-    const currentIndex = $current.data('index');
-    const newIndex = currentIndex + 1;
-
-    // Check if the new screen exists, if so, go there, otherwise we need to loop back.
-    if (!$.inArray(newIndex, this.screenIndexes)) {
-      this.firstScreen.addClass('active');
-    } else {
-      $current.removeClass('active');
-      $('.takeover__screen[data-index="' + newIndex + '"]').addClass('active');
+  changeScreens: function(direction) {
+    // Check if an allowed direction was passed in.
+    if ($.inArray(direction, ['next', 'previous']) === -1) {
+      return;
     }
 
-    this.reset();
-  },
-
-  /**
-   * Move to the previous screen in the experience.
-   */
-  prevScreen: function() {
     const $current = $('.takeover__screen.active');
     const currentIndex = $current.data('index');
-    const newIndex = currentIndex - 1;
+    const newIndex = (direction === 'next') ? currentIndex + 1 : currentIndex - 1;
 
     // Check if the new screen exists, if so, go there, otherwise we need to loop back.
-    if (!$.inArray(newIndex, this.screenIndexes)) {
-      this.lastScreen.addClass('active');
-    } else {
+    if ($.inArray(newIndex, this.screenIndexes)) {
       $current.removeClass('active');
       $('.takeover__screen[data-index="' + newIndex + '"]').addClass('active');
+    } else {
+      if (direction === 'next') {
+        this.firstScreen.addClass('active');
+      } else {
+        this.lastScreen.addClass('active');
+      }
     }
 
     this.reset();
@@ -217,7 +204,7 @@ const Takeover = {
       $('.takeover__screen .back-button').click(function(e) {
         e.preventDefault();
 
-        _this.prevScreen();
+        _this.changeScreens('previous');
       });
     }
   },

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
@@ -4,7 +4,6 @@ var Validation = require("dosomething-validation");
 import takeoverTpl from 'takeover/templates/takeover.tpl.html';
 
 const $ = require('jquery');
-const debounce = require('lodash/function/debounce');
 const template = require('lodash/string/template');
 
 const Takeover = {
@@ -17,6 +16,8 @@ const Takeover = {
   screens: null,
 
   firstScreen: null,
+
+  lastScreen: null,
 
   screenIndexes: null,
 
@@ -41,6 +42,7 @@ const Takeover = {
     this.screens = $('.takeover__screen');
     this.screenIndexes = this.setScreenIndexes();
     this.firstScreen = this.screens.first();
+    this.lastScreen = this.screens.last();
     this.firstScreen.addClass('active');
 
     // Set up submit handlers.
@@ -145,16 +147,39 @@ const Takeover = {
    * Move to the next screen in the experience.
    */
   nextScreen: function() {
+    const _this = this;
     const $current = $('.takeover__screen.active');
     const currentIndex = $current.data('index');
+    const newIndex = currentIndex + 1;
 
-    // Check if we are on the last screen, if so, go to the first.
-    if (!$.inArray(currentIndex + 1, this.screenIndexes)) {
+    // Check if the new screen exists, if so, go there, otherwise we need to loop back.
+    if (!$.inArray(newIndex, this.screenIndexes)) {
       this.firstScreen.addClass('active');
     } else {
       $current.removeClass('active');
-      $('.takeover__screen[data-index="' + (currentIndex + 1) + '"]').addClass('active');
+      $('.takeover__screen[data-index="' + newIndex + '"]').addClass('active');
     }
+
+    this.reset();
+  },
+
+  /**
+   * Move to the previous screen in the experience.
+   */
+  prevScreen: function() {
+    const $current = $('.takeover__screen.active');
+    const currentIndex = $current.data('index');
+    const newIndex = currentIndex - 1;
+
+    // Check if the new screen exists, if so, go there, otherwise we need to loop back.
+    if (!$.inArray(newIndex, this.screenIndexes)) {
+      this.lastScreen.addClass('active');
+    } else {
+      $current.removeClass('active');
+      $('.takeover__screen[data-index="' + newIndex + '"]').addClass('active');
+    }
+
+    this.reset();
   },
 
   /**
@@ -166,6 +191,35 @@ const Takeover = {
     const $container = $element.closest('.submit-button-container');
 
     $container.html(this.spinner);
+  },
+
+  /*
+   * Resets the functionality.
+   * Currently, specific to the organ donation interactions, but would love
+   * a way of figuring out if it could be more general. Maybe we could pass in a function
+   * defined in some custom js to run when this function gets called.
+   */
+  reset: function() {
+    const _this = this;
+
+    if ($('.submit-button-container').find('.spinner').length) {
+      $('.submit-button-container').html('<input type="submit" class="button submit-postal-code" value="Submit" />');
+      this.submitButton = $('.submit-postal-code');
+      this.handleSubmit(this.submitButton);
+
+      $('.back-button').off('click');
+    }
+
+    if ($('.takeover__screen .back-button').length) {
+      // @TODO - some sort of load screen function? Maybe take in the different
+      // screens as different templates, this function loads the next template and
+      // resets it's DOM.
+      $('.takeover__screen .back-button').click(function(e) {
+        e.preventDefault();
+
+        _this.prevScreen();
+      });
+    }
   },
 };
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/templates/takeover.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/templates/takeover.tpl.html
@@ -21,6 +21,7 @@
   <div class="takeover__screen" data-index="1">
     <div class="modal__block">
       <h2 class="heading -emphasized">Do more good!</h2>
+      <div class="button -muted back-button">&LeftArrow; back</div>
     </div>
     <div class="modal__block">
       <p>Your committment to help youth experiencing homelessness is incredible. Thank you!

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/templates/takeover.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/templates/takeover.tpl.html
@@ -1,0 +1,28 @@
+<div class='takeover'>
+  <!-- SCREEN 1 -->
+  <div class="takeover__screen" data-index="0">
+    <h2 class="heading -emphasized"><%= header %></h2>
+    <p>Your committment to help youth experiencing homelessness is incredible. Thank you!
+      Deciding to take action is an amazing first step.</p>
+    <p>Before we take you to Thumb Wars, we just wanted to give you a quick tour of the movement you've just joined and show you how to use DoSomething.org to make the biggest impact in your community</p>
+  </div>
+  <!-- SCREEN 2 -->
+  <div class="takeover__screen" data-index="1">
+    <h2 class="heading -emphasized">Do more good!</h2>
+    <p>Your committment to help youth experiencing homelessness is incredible. Thank you!
+      Deciding to take action is an amazing first step.</p>
+    <p>Before we take you to Thumb Wars, we just wanted to give you a quick tour of the movement you've just joined and show you how to use DoSomething.org to make the biggest impact in your community</p>
+  </div>
+  <!-- SCREEN 3 -->
+  <div class="takeover__screen" data-index="2">
+    <h2 class="heading -emphasized">Another ONE</h2>
+    <p>Your committment to help youth experiencing homelessness is incredible. Thank you!
+      Deciding to take action is an amazing first step.</p>
+    <p>Before we take you to Thumb Wars, we just wanted to give you a quick tour of the movement you've just joined and show you how to use DoSomething.org to make the biggest impact in your community</p>
+  </div>
+
+  <div class="takeover__buttons">
+    <a class="button takeover__previous">Previous</a>
+    <a class="button takeover__next">Next</a>
+  </div>
+</div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/templates/takeover.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/templates/takeover.tpl.html
@@ -6,6 +6,12 @@
     </div>
     <div class="modal__block">
       <form>
+          <!-- @TODO: since the user is already logged in, we can probably use the email address associated with their account instead of making them fill it out here. -->
+          <div class="form-item -padded">
+              <label for="email"><!-- Validation errors get placed here. --></label>
+              <input type="text" name="email" id="email" data-validate="email" data-validate-required class="text-field" placeholder="Enter Email" />
+          </div>
+
           <div class="form-item -padded">
               <label for="postal_code"><!-- Validation errors get placed here. --></label>
               <input type="text" name="postal_code" id="postal_code" data-validate="zipcode" data-validate-required class="text-field" placeholder="Enter Zip Code" />
@@ -20,31 +26,25 @@
   <!-- SCREEN 2 -->
   <div class="takeover__screen" data-index="1">
     <div class="modal__block">
-      <h2 class="heading -emphasized">Do more good!</h2>
+      <h2 class="heading -emphasized">Great now you can register!</h2>
       <div class="button -muted back-button">&LeftArrow; back</div>
     </div>
     <div class="modal__block">
-      <p>Your committment to help youth experiencing homelessness is incredible. Thank you!
-        Deciding to take action is an amazing first step.</p>
-      <p>Before we take you to Thumb Wars, we just wanted to give you a quick tour of the movement you've just joined and show you how to use DoSomething.org to make the biggest impact in your community</p>
+      <p>Fill in your info here</p>
+      <form>
+          <div class="form-item -padded submit-button-container">
+              <input type="submit" class="button submit-postal-code" value="Submit" />
+          </div>
+      </form>
     </div>
   </div>
   <!-- SCREEN 3 -->
   <div class="takeover__screen" data-index="2">
     <div class="modal__block">
-      <h2 class="heading -emphasized">Another ONE</h2>
+      <h2 class="heading -emphasized">Share with your friends!</h2>
     </div>
     <div class="modal__block">
-      <p>Your committment to help youth experiencing homelessness is incredible. Thank you!
-        Deciding to take action is an amazing first step.</p>
-      <p>Before we take you to Thumb Wars, we just wanted to give you a quick tour of the movement you've just joined and show you how to use DoSomething.org to make the biggest impact in your community</p>
+      <p>share bar</p>
     </div>
   </div>
-
-<!--   <div class="takeover__buttons">
-    <div class="modal__block">
-      <a class="button takeover__previous">Previous</a>
-      <a class="button takeover__next">Next</a>
-    </div>
-  </div> -->
 </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/templates/takeover.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/templates/takeover.tpl.html
@@ -1,28 +1,48 @@
 <div class='takeover'>
   <!-- SCREEN 1 -->
   <div class="takeover__screen" data-index="0">
-    <h2 class="heading -emphasized"><%= header %></h2>
-    <p>Your committment to help youth experiencing homelessness is incredible. Thank you!
-      Deciding to take action is an amazing first step.</p>
-    <p>Before we take you to Thumb Wars, we just wanted to give you a quick tour of the movement you've just joined and show you how to use DoSomething.org to make the biggest impact in your community</p>
+    <div class="modal__block">
+      <h2 class="heading -emphasized"><%= header %></h2>
+    </div>
+    <div class="modal__block">
+      <form>
+          <div class="form-item -padded">
+              <input type="text" name="postal_code" id="postal_code" class="text-field" placeholder="Enter Zip Code" />
+          </div>
+
+          <div class="form-item -padded submit-button-container">
+              <input type="submit" class="button submit-postal-code" value="Submit" />
+          </div>
+      </form>
+    </div>
   </div>
   <!-- SCREEN 2 -->
   <div class="takeover__screen" data-index="1">
-    <h2 class="heading -emphasized">Do more good!</h2>
-    <p>Your committment to help youth experiencing homelessness is incredible. Thank you!
-      Deciding to take action is an amazing first step.</p>
-    <p>Before we take you to Thumb Wars, we just wanted to give you a quick tour of the movement you've just joined and show you how to use DoSomething.org to make the biggest impact in your community</p>
+    <div class="modal__block">
+      <h2 class="heading -emphasized">Do more good!</h2>
+    </div>
+    <div class="modal__block">
+      <p>Your committment to help youth experiencing homelessness is incredible. Thank you!
+        Deciding to take action is an amazing first step.</p>
+      <p>Before we take you to Thumb Wars, we just wanted to give you a quick tour of the movement you've just joined and show you how to use DoSomething.org to make the biggest impact in your community</p>
+    </div>
   </div>
   <!-- SCREEN 3 -->
   <div class="takeover__screen" data-index="2">
-    <h2 class="heading -emphasized">Another ONE</h2>
-    <p>Your committment to help youth experiencing homelessness is incredible. Thank you!
-      Deciding to take action is an amazing first step.</p>
-    <p>Before we take you to Thumb Wars, we just wanted to give you a quick tour of the movement you've just joined and show you how to use DoSomething.org to make the biggest impact in your community</p>
+    <div class="modal__block">
+      <h2 class="heading -emphasized">Another ONE</h2>
+    </div>
+    <div class="modal__block">
+      <p>Your committment to help youth experiencing homelessness is incredible. Thank you!
+        Deciding to take action is an amazing first step.</p>
+      <p>Before we take you to Thumb Wars, we just wanted to give you a quick tour of the movement you've just joined and show you how to use DoSomething.org to make the biggest impact in your community</p>
+    </div>
   </div>
 
-  <div class="takeover__buttons">
-    <a class="button takeover__previous">Previous</a>
-    <a class="button takeover__next">Next</a>
-  </div>
+<!--   <div class="takeover__buttons">
+    <div class="modal__block">
+      <a class="button takeover__previous">Previous</a>
+      <a class="button takeover__next">Next</a>
+    </div>
+  </div> -->
 </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/templates/takeover.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/templates/takeover.tpl.html
@@ -30,10 +30,10 @@
       <div class="button -muted back-button">&LeftArrow; back</div>
     </div>
     <div class="modal__block">
-      <p>Fill in your info here</p>
+      <p>Fill in your info here adsff</p>
       <form>
-          <div class="form-item -padded submit-button-container">
-              <input type="submit" class="button submit-postal-code" value="Submit" />
+          <div class="form-item -padded submit-registration-container">
+              <input type="submit" class="button submit-registration" value="Submit" />
           </div>
       </form>
     </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/templates/takeover.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/templates/takeover.tpl.html
@@ -7,7 +7,8 @@
     <div class="modal__block">
       <form>
           <div class="form-item -padded">
-              <input type="text" name="postal_code" id="postal_code" class="text-field" placeholder="Enter Zip Code" />
+              <label for="postal_code"><!-- Validation errors get placed here. --></label>
+              <input type="text" name="postal_code" id="postal_code" data-validate="zipcode" data-validate-required class="text-field" placeholder="Enter Zip Code" />
           </div>
 
           <div class="form-item -padded submit-button-container">

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -49,6 +49,7 @@ $asset-path: "";
 @import "content/reportback";
 @import "content/reportback-permalink";
 @import "content/search";
+@import "content/takeover";
 @import "content/user";
 
 // One-off pages

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_takeover.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_takeover.scss
@@ -17,9 +17,7 @@ $transition: .7s;
   overflow: hidden;
 
   &:after {
-    clear: both;
-    content: "";
-    display: table;
+    @include clearfix;
   }
 
   @include media($medium) {
@@ -37,7 +35,7 @@ $transition: .7s;
     transition: $transition;
     max-width: 1350px;
 
-    &.active {
+    &.is-active {
       left: 0px;
       transition: $transition;
     }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_takeover.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_takeover.scss
@@ -27,8 +27,7 @@ $transition: .7s;
   }
 
   .heading.-emphasized {
-    margin-left: 0px;
-    margin-top: 0px;
+    margin: 0px 0px 10px 0px;
     z-index: -10;
   }
 
@@ -60,5 +59,27 @@ $transition: .7s;
     position: absolute;
     bottom: 0px;
     padding-top: $base-spacing;
+  }
+
+  .button {
+    &.-muted {
+      background: none;
+      color: $med-gray;
+      font-size: $font-small;
+      font-weight: $weight-normal;
+      text-transform: none;
+      border: 0 none;
+      padding: 0px;
+
+      &:hover {
+        color: $off-black;
+        background-color: none;
+        text-decoration: underline;
+      }
+
+      &:focus {
+        box-shadow: none;
+      }
+    }
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_takeover.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_takeover.scss
@@ -1,0 +1,52 @@
+$transition: .7s;
+
+.takeover {
+  position: relative;
+  height: 600px;
+  overflow: hidden;
+
+  &:after {
+    clear: both;
+    content: "";
+    display: table;
+  }
+
+  @include media($medium) {
+    height: 525px;
+  }
+
+  .heading.-emphasized {
+    margin-left: 0px;
+    margin-top: 0px;
+  }
+
+  .takeover__screen {
+    position: absolute;
+    left: -1400px;
+    transition: $transition;
+    max-width: 1350px;
+
+    &.active {
+      left: 0px;
+      transition: $transition;
+    }
+
+    .takeover__campaign-item {
+      display: block;
+      width: 100%;
+      text-align: left;
+      padding-left: 0px;
+
+      @include media($medium) {
+        display: table-cell;
+        padding-left: $base-spacing;
+      }
+    }
+  }
+
+  .takeover__buttons {
+    position: absolute;
+    bottom: 0px;
+    padding-top: $base-spacing;
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_takeover.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_takeover.scss
@@ -1,5 +1,9 @@
 $transition: .7s;
 
+.modal-close-button {
+  z-index: 10;
+}
+
 .takeover {
   position: relative;
   height: 600px;
@@ -18,6 +22,7 @@ $transition: .7s;
   .heading.-emphasized {
     margin-left: 0px;
     margin-top: 0px;
+    z-index: -10;
   }
 
   .takeover__screen {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_takeover.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_takeover.scss
@@ -4,6 +4,13 @@ $transition: .7s;
   z-index: 10;
 }
 
+// NOTE: this is a bit of a hack cause the layout was breaking
+// when the validation displays messages. Worth figuring out what
+// is really going here.
+.validation.is-showing-message {
+  top: 0;
+}
+
 .takeover {
   position: relative;
   height: 600px;

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -388,7 +388,7 @@
       <?php if ($register_organ_donor): ?>
         <div data-modal id="modal-organ-donation" role="dialog">
           <div class="modal__block">
-            <div class="takeover-container -no-slide">asdfadf</div>
+            <div class="takeover-container -no-slide"></div>
           </div>
         </div>
       <?php endif; ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -383,6 +383,16 @@
         </div>
       </div>
 
+
+      <?php // Organ Donation Modal // ?>
+      <?php if ($register_organ_donor): ?>
+        <div data-modal id="modal-organ-donation" role="dialog">
+          <div class="modal__block">
+            <div class="takeover-container -no-slide">asdfadf</div>
+          </div>
+        </div>
+      <?php endif; ?>
+
       <?php if (isset($official_rules)): ?>
         <div class="container__block -narrow">
           <div class="footnote">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -383,13 +383,10 @@
         </div>
       </div>
 
-
       <?php // Organ Donation Modal // ?>
       <?php if ($register_organ_donor): ?>
         <div data-modal id="modal-organ-donation" role="dialog">
-          <div class="modal__block">
             <div class="takeover-container -no-slide"></div>
-          </div>
         </div>
       <?php endif; ?>
 


### PR DESCRIPTION
#### What's this PR do?

This PR does a few things:
- Sets up a configuration option on Custom Settings that allow admins to check if organ donation should be allowed. [here](https://github.com/DoSomething/phoenix/compare/after-signin-modal?diff=unified&expand=1&name=after-signin-modal#diff-1d14f80a019bcc7b992a2faa28d8f707R511)
- If that ^^ flag is turned on, after a user signs up the modal is displayed and `Takeover.js` injects content into the modal and handles everything from there. But we also check that the users hasn't yet submitted the registration form before deciding if we should show it or not. [here](https://github.com/DoSomething/phoenix/compare/after-signin-modal?diff=unified&expand=1&name=after-signin-modal#diff-ae398bb8864fc3c26317f7ccaef04c0aR765)
- in `Takeover.js`, this PR, starts to roughly mock out how the modal will work for organ donations. We pull in some underscore templates that house the content for each "screen" in the modal. Flow is like:
  - User clicks the submit button on the first "screen" 
  - We make an AJAX call to a fake endpoint. 
  - If that is successful, we move to the next screen. 
  - User hits the submit button there, an AJAX called is made to a custom endpoint in phoenix that stores data about the registration. see #6491 
#### How should this be reviewed?

Pull branch down. Make sure you have the `dosomething_organ_donation` module turned on. Go to a campaign and turn on organ donation in the custom settings form. 

Now, sign up for the campaign (preferably as a new user or anon user since that is what most of the folks will be) when you get taken to the action page, you should see the modal. And the experience should work like what is outlined above.
#### Any background context you want to provide?

This is not final at all, but covers the ability to show a modal after a user signs up for a campaign and allows us to start making API calls from within that modal. [Please see my notes here](https://github.com/DoSomething/phoenix/compare/after-signin-modal?diff=unified&expand=1&name=after-signin-modal#diff-18be182c71ce2870f0f2020d6740e029R189) about some of the JS and how I would like to refactor it. 
#### Relevant tickets

Fixes #6481 

@angaither @DFurnes @weerd @chloealee 
