### PR TITLE
Remove leftover markup from Optimizely test.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -437,20 +437,6 @@ function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
 
   // Moar $tagline.
   $vars['tagline'] .= t('Any cause, anytime, anywhere.');
-
-  $campaign_progress = dosomething_reportback_get_reportback_total_plus_override($vars['nid']);
-
-  // Get sign up total and add it to cta
-  $signup_count = (int) dosomething_helpers_get_variable('node', $vars['nid'], 'web_signup_count') + (int) dosomething_helpers_get_variable('node', $vars['nid'], 'mobile_signup_count');
-
-  if ($signup_count) {
-    $vars['signup_cta'] = t('Join @signup_count people doing this.', [
-      '@signup_count' => number_format($signup_count, 0, '', ','),
-    ]);
-  }
-
-  // @TODO: format this, based on % of goal left. refs #4444
-  $time_left = $vars['campaign']->high_season_end;
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -25,27 +25,6 @@
     </div>
   </header>
 
-  <div class="cta -persistent optimizely-hide-count js-fixedsticky <?php if ($campaign_scholarship) { print 'with-scholarship'; } ?>">
-    <div class="wrapper">
-      <?php if (isset($signup_button_secondary)): ?>
-        <div class="cta__action">
-          <div class="cta__button">
-            <?php print $signup_button_secondary; ?>
-          </div>
-          <?php if ($campaign_scholarship): ?>
-            <?php print $campaign_scholarship; ?>
-          <?php endif; ?>
-        </div>
-      <?php endif; ?>
-      <?php if (isset($campaign->secondary_call_to_action)): ?>
-        <div class="cta__message">
-          <h4 class="with-count"><?php print $signup_cta; ?></h4>
-          <h4 class="without-count"><?php print $campaign->secondary_call_to_action; ?></h4>
-        </div>
-      <?php endif; ?>
-    </div>
-  </div>
-
   <?php if (isset($campaign->value_proposition)): ?>
     <div class="container">
       <div class="wrapper">
@@ -75,10 +54,9 @@
   <?php endif; ?>
 
   <?php if (isset($campaign->secondary_call_to_action)): ?>
-    <div class="cta optimizely-hide-count">
+    <div class="cta">
       <div class="wrapper">
-        <h2 class="cta__message with-count"><?php print $signup_cta; ?></h2>
-        <h2 class="cta__message without-count"><?php print $campaign->secondary_call_to_action; ?></h2>
+        <h2 class="cta__message"><?php print $campaign->secondary_call_to_action; ?></h2>
         <?php if (isset($signup_button_secondary)): ?>
           <?php print $signup_button_secondary; ?>
         <?php endif; ?>


### PR DESCRIPTION
#### What's this PR do?

Removes markup for an old Optimizely test. The styles that had been hiding this markup were removed in #6494, but not the associated markup, so they started appearing on the page again.
#### How should this be reviewed?

👀
#### Any background context you want to provide?

🙈 
#### Relevant tickets

Fixes #6516.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
