### PR TITLE
Switches the variable being referenced for non owner title

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -474,7 +474,7 @@ function _dosomething_reportback_get_permalink_copy_vars($user) {
   }
   $first_name = dosomething_helpers_extract_field_data($user->field_first_name, LANGUAGE_NONE);
 
-  if (strpos($user->field_first_name, '@') !== FALSE) {
+  if (strpos($first_name, '@') !== FALSE) {
     $non_owners_title = t(variable_get('dosomething_campaign_permalink_nonowners_page_title_backup', ''));
   }
   else {


### PR DESCRIPTION
#### What's this PR do?

The variable being used to generate the non owner title on RB perma link
#### How should this be reviewed?

clear cache, go to a RB page that aint yours. then change the name to be an email and see if it hides it
#### Any background context you want to provide?

used the array of field_first_name instead of the first name i extracted
#### Relevant tickets

Fixes #nope
