### PR TITLE
Updates to address the annoying notices we always see due to #global.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -565,27 +565,38 @@ function dosomething_campaign_get_campaigns_doing($uid = NULL) {
  *   An array of variables.
  */
 function dosomething_campaign_get_campaign_block_vars($nid, $image_size = '740x480', $source = NULL) {
+  global $user;
+
   $node = node_load($nid);
   $clc = dosomething_helpers_get_current_language_content_code();
 
-  global $user;
   $language = dosomething_global_get_language($user, $node);
+
+  if (! is_object($language)) {
+    dosomething_global_get_language_by_language_code($language);
+  }
+
   // Build a global URL and remove the first slash returned
-  $path_alias = preg_replace('/\//', '', dosomething_global_url('node/' . $nid, array('language' => $language)), 1);
+  $path_alias = preg_replace('/\//', '', dosomething_global_url('node/' . $nid, ['language' => $language]), 1);
 
   if ($source) {
     $path_alias .= '?source=' . $source;
   }
+
   $image = NULL;
   $image_nid = NULL;
+
   if (!empty($node->field_image_campaign_cover)) {
     $image_nid = $node->field_image_campaign_cover[$clc][0]['target_id'];
     $image = dosomething_image_get_themed_image_url($image_nid, 'landscape', $image_size);
   }
+
   $cta = NULL;
+
   if (!empty($node->field_call_to_action)) {
     $cta = $node->field_call_to_action[$clc][0]['value'];
   }
+
   $title = $node->title_field[$clc][0]['safe_value'];
 
   return array(

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -115,7 +115,7 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
       $vars['problem_share_prompt'] = $problem_share_prompt;
     }
 
-    $base_url = url(base_path(), array('absolute'=> TRUE, 'language' => 'en-global'));
+    $base_url = url(base_path(), ['absolute'=> TRUE, 'language' => dosomething_global_get_language_by_language_code('en-global')]);
     $campaign_path = url(current_path(), array('absolute' => TRUE));
 
 

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -466,18 +466,21 @@ function dosomething_global_convert_country_to_language($country) {
  * part of supported language list then it defaults to an
  * empty string for global URL.
  *
- * @param string $language
+ * @param string $language_code
  *
  * @return string
+ *
+ * @TODO: update function name to better reflect what it does.
+ * dosomething_global_get_prefix_for_language_by_language_code?
  */
-function dosomething_global_get_prefix_for_language($language) {
-  $languages = language_list();
+function dosomething_global_get_prefix_for_language($language_code) {
+  $language = dosomething_global_get_language_by_language_code($language_code);
 
-  if (! array_key_exists($language, $languages)) {
+  if (! $language) {
     return '';
   }
 
-  return $languages[$language]->prefix;
+  return $language->prefix;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -557,6 +557,23 @@ function dosomething_global_get_language($account, stdClass $node = NULL, $respe
 }
 
 /**
+ * Get the language object for the specified language code if it exists
+ * as one of the supported languages.
+ *
+ * @param $language_code (e.g. en, en-global, es-mx, pt-br)
+ * @return null|object
+ */
+function dosomething_global_get_language_by_language_code($language_code) {
+  $languages = language_list();
+
+  if (array_key_exists($language_code, $languages)) {
+    return $languages[$language_code];
+  }
+
+  return NULL;
+}
+
+/**
  * Return an array containing only the list of language
  * prefixes supported.
  *
@@ -624,8 +641,6 @@ function dosomething_global_redirect_node_edit($node, $user_language) {
  *  - 404 the user
  */
 function dosomething_global_redirect_node($language, $node, $redirect_status) {
-  $languages = language_list();
-
   // Don't do redirects for privileged users.
   if ($redirect_status == 302) {
     if (user_access('access administration menu')) {
@@ -655,19 +670,22 @@ function dosomething_global_redirect_node($language, $node, $redirect_status) {
  */
 function dosomething_global_url($path, $options = NULL) {
   global $language;
+
   $languages = language_list();
 
   if (!isset($options['language'])) {
     if (isset($language)) {
-      $options['language'] = $language->language;
+      $options['language'] = $language;
     }
     else {
-      $options['language'] = language_default('language');
+      $options['language'] = dosomething_global_get_language_by_language_code(language_default('language'));
     }
   }
-  if (!isset($options['prefix']) && !empty($languages[$options['language']]->prefix)) {
+
+  if (!isset($options['language']->prefix) && !empty($languages[$options['language']]->prefix)) {
     $options['prefix'] = $languages[$options['language']]->prefix . '/';
   }
+
   return url($path, $options);
 }
 
@@ -680,16 +698,21 @@ function dosomething_global_url($path, $options = NULL) {
  *    The language of the URL
  * @param string $fragment
  *    Optional fragment to append
+ * @return string
  */
 function dosomething_global_node_url($nid, $language, $fragment = NULL) {
   $raw_url = 'node/' . $nid;
+
   if (isset($fragment)) {
     $raw_url .= '#' . $fragment;
   }
+
   $prefix = dosomething_global_get_prefix_for_language($language);
+
   if (!empty($prefix)) {
     $prefix .= '/';
   }
+
   return $GLOBALS['base_url'] . '/' . $prefix . drupal_get_path_alias($raw_url, $language);
 }
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -32,8 +32,8 @@ function dosomething_helpers_get_facebook_intent($link, $type = NULL, $custom_op
     // different from what is set in the metatags.
     case 'feed_dialog':
       // Build the redirect url.
-      $base_path = url(base_path(), array('absolute' => TRUE, 'language' => 'en-global'));
-      $redirect_path = url(base_path(), array('absolute' => TRUE, 'language' => 'en-global')) . 'ds-share-complete';
+      $base_path = url(base_path(), ['absolute' => TRUE, 'language' => dosomething_global_get_language_by_language_code('en-global')]);
+      $redirect_path = url(base_path(), ['absolute' => TRUE, 'language' => dosomething_global_get_language_by_language_code('en-global')]) . 'ds-share-complete';
 
       // Pass in all the feed dialog parameters
       $facebook_app_id = variable_get('dosomething_settings_facebook_app_id');

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -641,21 +641,26 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
   if (!($node->type == 'campaign' || $node->type == 'campaign_group')) {
     return FALSE;
   }
-  if (module_exists('dosomething_global')) {
-    list($user_language, $user_country) = dosomething_global_user_details($account);
-    $campaign_country_code = dosomething_global_get_current_country_code();
-    $campaign_language = dosomething_global_convert_country_to_language($campaign_country_code);
+
+  if (!module_exists('dosomething_global')) {
+    return FALSE;
   }
+
+  list($user_language, $user_country) = dosomething_global_user_details($account);
+  $campaign_country_code = dosomething_global_get_current_country_code();
+  $campaign_language_code = dosomething_global_convert_country_to_language($campaign_country_code);
+  $campaign_language = dosomething_global_get_language_by_language_code($campaign_language_code);
 
   $wrapper = entity_metadata_wrapper('node', $node);
   $language = dosomething_global_get_language($account, $node);
-  $url_options = array(
+  $url_options = [
     'language' => $campaign_language,
     'absolute' => TRUE,
     'query' => array(
       'source' => 'node/' . $node->nid,
     ),
-  );
+  ];
+
   $campaign_link = dosomething_global_url('node/' . $node->nid, $url_options);
 
   // Get node title, normal for collections, translatable for campaigns.
@@ -665,7 +670,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     $title = $node->title;
   }
 
-  $params = array(
+  $params = [
     'email' => $account->mail,
     'uid' => $account->uid,
     'first_name' => dosomething_user_get_field('field_first_name', $account),
@@ -675,9 +680,9 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     'campaign_link' => $campaign_link,
     'user_language' => $user_language,
     'user_country' => $user_country,
-    'campaign_language' => $campaign_language,
+    'campaign_language' => $campaign_language->language,
     'campaign_country' => $campaign_country_code,
-  );
+  ];
 
   // Don't subscribe 26+ yo users for Mobile Commons.
   $user_is_old = dosomething_user_is_old_person($account);
@@ -690,6 +695,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
   dosomething_signup_get_mbp_params_campaign_group($params, $wrapper);
   // Add any mailchimp params if needed.
   dosomething_signup_get_mbp_params_mailchimp($params, $node);
+
   return $params;
 }
 
@@ -833,7 +839,7 @@ function dosomething_signup_set_presignup_message($title) {
 }
 
 /**
- * Returns total number of Signups based on supplied set of filters. 
+ * Returns total number of Signups based on supplied set of filters.
  *
  * @param array $filters
  * @return int

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -897,10 +897,10 @@ function _dosomething_user_add_signup_data(&$form) {
 
     // Use the global url as the form action so the user gets redirected to the right page.
     $node = node_load($nid);
-    $lang_code = dosomething_global_get_language($user, $node);
+    $language = dosomething_global_get_language_by_language_code(dosomething_global_get_language($user, $node));
 
     $url_options = array(
-      'language' => $lang_code,
+      'language' => $language,
       'query' => array(
         'source' => $source,
       ),


### PR DESCRIPTION
#### What's this PR do?

This PR fixes a long running issue with a dblog notice report that gets reported in the logs like 5 or more times during _any_ page load. With the help of @DFurnes and some XDebugging, we were able to localize the spots in our code that were causing the swarm of notices.

The main culprit is that when we were passing an array of url options to the `url()` function, if the `language` item was present we were passing it as a language code string, but the function required it to be passed as the Drupal language object.

```
Notice: Trying to get property of non-object in locale_language_url_rewrite_url() (line 433 of /var/www/dev.dosomething.org/html/includes/locale.inc).
```
#### How should this be reviewed?

Pull down the code, load a few pages (maybe spoof a different country other than US to test language stuff) and check the DB Logs to see if the above notice is reported!
#### Any background context you want to provide?

While fixing this issue it seems like our code base in regards to languages is a bit confusing, with both confusing function names and confusing variable names.

Functions like `dosomething_global_get_language()` don't return the language object, but instead return the language code string. Variables like `$language` sometimes contain the Drupal language object (which seems to be the standard for what the variable should always hold) but at other times contains the language code string. This is very confusing and can complicate what the expected return value is from a function or variable as the variable is passed around. This is also what led to the issue this PR addresses.

I propose we standardize what we as a team consider these functions to return (and name them appropriately) along with a set of variable names that mean what they are expected to contain.

For example:

**Functions:**
Name change reflects that it returns a language code string

```
dosomething_global_get_language() -> dosomething_global_get_language_code() 
```

Name change reflects that it returns a language code string and also, the parameter is now more obvious that it needs to be the country code string

```
dosomething_global_convert_country_to_language($country) -> dosomething_global_convert_country_to_language_code($country_code)
```

**Variables:**
`$language` = stdClass object; the Drupal language object

`$language_code` = the [ISO639-1 language code](https://www.wikiwand.com/en/Language_localisation#/Language_tags_and_codes) (e.g. en, en-global, es-mx, pt-br)

`$country_code` = the [ISO-3166-1 2 letter code for a country](https://www.wikiwand.com/en/ISO_3166-1#/Officially_assigned_code_elements) (e.g. US, BR, MX)

`$prefix` = similar to the country code above but when used specifically in urls like http://dosomething.org/br/campaigns or whatever
#### Relevant tickets

Fixes #6521 

---

@angaither @DFurnes 

CC: @namimody @mikefantini 
