### PR TITLE
Organ donation share link

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -115,12 +115,17 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
       $vars['problem_share_prompt'] = $problem_share_prompt;
     }
 
+<<<<<<< HEAD
     $base_url = url(base_path(), ['absolute'=> TRUE, 'language' => dosomething_global_get_language_by_language_code('en-global')]);
     $campaign_path = url(current_path(), array('absolute' => TRUE));
+=======
+    $base_url = url(base_path(), array('absolute'=> TRUE, 'language' => 'en-global'));
+    $campaign_path = dosomething_helpers_get_current_url_path();
+>>>>>>> adds share links to modal but facebook and tumblr not working quite right
 
 
     // Create the image path to the problem fact statement image generated for the node.
-    $country_prefix = (dosomething_global_get_current_prefix()) ? strtoupper(dosomething_global_get_current_prefix()) : 'global';
+    $country_prefix = dosomething_helpers_get_country_prefix();
     $problem_share_image = $base_url . 'sites/default/files/images/problem-' . $vars['nid'] . '-' . $country_prefix . '.png';
 
     $share_types = array(
@@ -365,6 +370,49 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
       );
     }
   }
+
+  // Pass custom share links to the front end. Unique by UID.
+  $country_prefix = dosomething_helpers_get_country_prefix();
+  $problem_share_image = $base_url . 'sites/default/files/images/problem-' . $campaign->nid . '-' . $country_prefix . '.png';
+  $campaign_path = dosomething_helpers_get_current_url_path();
+
+  // Add social share bar.
+  $share_types = array(
+    'facebook' => array(
+      'type' => 'feed_dialog',
+      'parameters' => array(
+        'picture' => $problem_share_image,
+      ),
+    ),
+    'twitter' => array(
+      'tweet' => (isset($campaign->fact_problem)) ? $campaign->fact_problem['fact'] : NULL,
+    ),
+    'tumblr' => array(
+      'posttype' => 'photo',
+      'content' => $problem_share_image,
+      'caption' => t("This is REAL, do something about this with me: "),
+    ),
+  );
+
+  $share_link = $campaign_path . '?source=' . $vars['user']->uid;;
+
+  $organ_donations_share_button_markup = dosomething_helpers_share_bar($share_link, $share_types, 'organ_donation_referral');
+
+  // Send 3 campaigns to signup takeover, prompting user to signup for multiple campaigns. Also send param for existing or new user.
+  drupal_add_js(
+    array(
+      'dosomethingCampaign' => array(
+        'recommendedCampaigns' => $signup_takeover_recommended_campaigns,
+      ),
+      'dosomethingUser' => array(
+        'userStatus' => $user_status,
+        'shareLink' => $share_link,
+        'sharePaths' => $share_paths,
+        'shareButtonMarkup' => $organ_donations_share_button_markup,
+      ),
+    ),
+    array('type' => 'setting')
+  );
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -115,11 +115,11 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
       $vars['problem_share_prompt'] = $problem_share_prompt;
     }
 
-    $base_url = dosomething_helpers_get_base_url();
-    $campaign_path = dosomething_helpers_get_current_url_path();
+    $base_url = url(base_path(), ['absolute'=> TRUE, 'language' => dosomething_global_get_language_by_language_code('en-global')]);
+    $campaign_path = url(current_path(), array('absolute' => TRUE));
 
     // Create the image path to the problem fact statement image generated for the node.
-    $country_prefix = dosomething_helpers_get_country_prefix();
+    $country_prefix = (dosomething_global_get_current_prefix()) ? strtoupper(dosomething_global_get_current_prefix()) : 'global';
     $problem_share_image = $base_url . 'sites/default/files/images/problem-' . $vars['nid'] . '-' . $country_prefix . '.png';
 
     $share_types = array(
@@ -366,10 +366,10 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   }
 
   // Pass custom share links to the front end. Unique by UID.
-  $base_url = dosomething_helpers_get_base_url();
-  $country_prefix_for_organ_donation_share = dosomething_helpers_get_country_prefix();
+  $base_url = url(base_path(), array('absolute'=> TRUE, 'language' => 'en-global'));
+  $country_prefix_for_organ_donation_share = (dosomething_global_get_current_prefix()) ? strtoupper(dosomething_global_get_current_prefix()) : 'global';
   $organ_donation_share_image = $base_url . 'sites/default/files/images/problem-' . $campaign->nid . '-' . $country_prefix_for_organ_donation_share . '.png';
-  $campaign_path = dosomething_helpers_get_current_url_path();
+  $campaign_path = url(current_path(), array('absolute' => TRUE));
 
   // Add social share bar.
   $organ_donation_share_types = array(

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -115,14 +115,8 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
       $vars['problem_share_prompt'] = $problem_share_prompt;
     }
 
-<<<<<<< HEAD
-    $base_url = url(base_path(), ['absolute'=> TRUE, 'language' => dosomething_global_get_language_by_language_code('en-global')]);
-    $campaign_path = url(current_path(), array('absolute' => TRUE));
-=======
-    $base_url = url(base_path(), array('absolute'=> TRUE, 'language' => 'en-global'));
+    $base_url = dosomething_helpers_get_base_url();
     $campaign_path = dosomething_helpers_get_current_url_path();
->>>>>>> adds share links to modal but facebook and tumblr not working quite right
-
 
     // Create the image path to the problem fact statement image generated for the node.
     $country_prefix = dosomething_helpers_get_country_prefix();
@@ -372,42 +366,38 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   }
 
   // Pass custom share links to the front end. Unique by UID.
-  $country_prefix = dosomething_helpers_get_country_prefix();
-  $problem_share_image = $base_url . 'sites/default/files/images/problem-' . $campaign->nid . '-' . $country_prefix . '.png';
+  $base_url = dosomething_helpers_get_base_url();
+  $country_prefix_for_organ_donation_share = dosomething_helpers_get_country_prefix();
+  $organ_donation_share_image = $base_url . 'sites/default/files/images/problem-' . $campaign->nid . '-' . $country_prefix_for_organ_donation_share . '.png';
   $campaign_path = dosomething_helpers_get_current_url_path();
 
   // Add social share bar.
-  $share_types = array(
+  $organ_donation_share_types = array(
     'facebook' => array(
       'type' => 'feed_dialog',
       'parameters' => array(
-        'picture' => $problem_share_image,
-      ),
+      'picture' => $organ_donation_share_image,
     ),
+  ),
     'twitter' => array(
       'tweet' => (isset($campaign->fact_problem)) ? $campaign->fact_problem['fact'] : NULL,
     ),
     'tumblr' => array(
       'posttype' => 'photo',
-      'content' => $problem_share_image,
+      'content' => $organ_donation_share_image,
       'caption' => t("This is REAL, do something about this with me: "),
     ),
   );
 
-  $share_link = $campaign_path . '?source=' . $vars['user']->uid;;
+  $custom_share_link = $campaign_path . '?source=' . $vars['user']->uid;;
 
-  $organ_donations_share_button_markup = dosomething_helpers_share_bar($share_link, $share_types, 'organ_donation_referral');
+  $organ_donations_share_button_markup = dosomething_helpers_share_bar($custom_share_link, $organ_donation_share_types, 'organ_donation_referral');
 
-  // Send 3 campaigns to signup takeover, prompting user to signup for multiple campaigns. Also send param for existing or new user.
+  // Send custom share links and share bar to front end.
   drupal_add_js(
     array(
-      'dosomethingCampaign' => array(
-        'recommendedCampaigns' => $signup_takeover_recommended_campaigns,
-      ),
       'dosomethingUser' => array(
-        'userStatus' => $user_status,
-        'shareLink' => $share_link,
-        'sharePaths' => $share_paths,
+        'shareLink' => $custom_share_link,
         'shareButtonMarkup' => $organ_donations_share_button_markup,
       ),
     ),

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -301,33 +301,6 @@ function dosomething_helpers_format_data($data) {
 }
 
 /**
- * Utility funciton to get base URL.
- *
- * @return string
- */
-function dosomething_helpers_get_base_url(){
-  return url(base_path(), array('absolute'=> TRUE, 'language' => 'en-global'));
-}
-
-/**
- * Utility function to get country prefix.
- *
- * @return string
- */
-function dosomething_helpers_get_country_prefix() {
-  return (dosomething_global_get_current_prefix()) ? strtoupper(dosomething_global_get_current_prefix()) : 'global';
-}
-
-/**
- * Utiliy function to get currnt URL path.
- *
- * @return string
- */
-function dosomething_helpers_get_current_url_path() {
-  return url(current_path(), array('absolute' => TRUE));
-}
-
-/**
  * Utility function to extract data translated in the specified language from an
  * array of available translations.
  *

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -301,6 +301,24 @@ function dosomething_helpers_format_data($data) {
 }
 
 /**
+ * Utility function to get country prefix.
+ *
+ * @return string
+ */
+function dosomething_helpers_get_country_prefix() {
+  return (dosomething_global_get_current_prefix()) ? strtoupper(dosomething_global_get_current_prefix()) : 'global';
+}
+
+/**
+ * Utiliy function to get currnt URL path.
+ *
+ * @return string
+ */
+function dosomething_helpers_get_current_url_path() {
+  return url(current_path(), array('absolute' => TRUE));
+}
+
+/**
  * Utility function to extract data translated in the specified language from an
  * array of available translations.
  *

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -301,6 +301,15 @@ function dosomething_helpers_format_data($data) {
 }
 
 /**
+ * Utility funciton to get base URL.
+ *
+ * @return string
+ */
+function dosomething_helpers_get_base_url(){
+  return url(base_path(), array('absolute'=> TRUE, 'language' => 'en-global'));
+}
+
+/**
  * Utility function to get country prefix.
  *
  * @return string

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
@@ -30,7 +30,6 @@ const Takeover = {
     const data = {
       'header': 'Thanks for signing up',
       'shareLink': Drupal.settings.dosomethingUser.shareLink,
-      'sharePaths': Drupal.settings.dosomethingUser.sharePaths,
       'shareButtonMarkup': Drupal.settings.dosomethingUser.shareButtonMarkup,
     }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/Takeover.js
@@ -29,6 +29,9 @@ const Takeover = {
   init: function($takeoverContainer = $('.takeover-container')) {
     const data = {
       'header': 'Thanks for signing up',
+      'shareLink': Drupal.settings.dosomethingUser.shareLink,
+      'sharePaths': Drupal.settings.dosomethingUser.sharePaths,
+      'shareButtonMarkup': Drupal.settings.dosomethingUser.shareButtonMarkup,
     }
 
     // Add the takeover to the page.

--- a/lib/themes/dosomething/paraneue_dosomething/js/takeover/templates/takeover.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/takeover/templates/takeover.tpl.html
@@ -44,7 +44,8 @@
       <h2 class="heading -emphasized">Share with your friends!</h2>
     </div>
     <div class="modal__block">
-      <p>share bar</p>
+      <p><%= shareButtonMarkup %></p>
+      <p>Copy and paste your share <a href="<%= shareLink %>">link</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
#### What's this PR do?
- Created custom share link that appends `source=[uid]` to share link.
- Adds share bar to organ donation module with custom share links. 
#### How should this be reviewed?
- Go to a campaign and enable organ donation in the custom settings form. 
- Sign up for the campaign from a user that has not signed up for this before. 
- Fill out the form until you get to the share page on the module. Click on share buttons and you should see `source=[uid]` as first param after the campaign URL. 
- Hover over or click on the share link and you should also see `source=[uid]` as the first param after campaign URL. 
#### Any background context you want to provide?

Note: design/copy is not complete but these are just placeholders with correct info. for now. 
#### Relevant tickets

Fixes #6483 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
