### PR TITLE
Only displays partners if translated

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -514,12 +514,7 @@ function dosomething_global_get_language($account, stdClass $node = NULL, $respe
     // Respect the URL first.
     $request_path = explode('/', request_path());
     if (!empty($request_path[0])) {
-
-      // If the string is longer than a country code
-      if (strlen($request_path[0]) > 2) {
-        return DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
-      }
-
+      
       // Otherwise try & match it against configured languages
       $languages = language_list();
       foreach ($languages as $langcode => $lang_data) {

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -514,6 +514,13 @@ function dosomething_global_get_language($account, stdClass $node = NULL, $respe
     // Respect the URL first.
     $request_path = explode('/', request_path());
     if (!empty($request_path[0])) {
+
+      // If the string is longer than a country code
+      if (strlen($request_path[0]) > 2) {
+        return DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
+      }
+
+      // Otherwise try & match it against configured languages
       $languages = language_list();
       foreach ($languages as $langcode => $lang_data) {
         if ($lang_data->prefix == $request_path[0]) {

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -83,7 +83,10 @@ function dosomething_helpers_preprocess_partners_vars(&$vars) {
   if (empty($vars['field_partners'])) {
     return;
   }
-  $partners_vars = dosomething_taxonomy_get_partners_vars($vars['field_partners']);
+
+  $language_code = dosomething_global_get_language($vars['user'], $vars['node']);
+  $partners_vars = dosomething_taxonomy_get_partners_vars($vars['field_partners'], $language_code);
+
   if (empty($partners_vars)) {
     return;
   }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -84,7 +84,7 @@ function dosomething_helpers_preprocess_partners_vars(&$vars) {
     return;
   }
 
-  $language_code = dosomething_global_get_language($vars['user'], $vars['node']);
+  $language_code = dosomething_global_convert_country_to_language(dosomething_global_get_current_prefix());
   $partners_vars = dosomething_taxonomy_get_partners_vars($vars['field_partners'], $language_code);
 
   if (empty($partners_vars)) {

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -207,7 +207,7 @@ function dosomething_taxonomy_get_partners_data($field_partners, $logo_style = '
  *   Multi-dimensional array of partners/sponsors, or NULL if empty.
  *
  */
-function dosomething_taxonomy_get_partners_vars($field_partners = array(), $language_code = NULL) {
+function dosomething_taxonomy_get_partners_vars($field_partners = array(), $language_code = 'en-global') {
 
   if (empty($field_partners)) {
     return;

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -199,12 +199,15 @@ function dosomething_taxonomy_get_partners_data($field_partners, $logo_style = '
  *
  * @param array $field_partners
  *   An loaded field_partners field array.
+ * @param string $language_code
+ *   The optional language code which indicates to only return partners
+ *   translated in that lang.
  *
  * @return mixed
  *   Multi-dimensional array of partners/sponsors, or NULL if empty.
  *
  */
-function dosomething_taxonomy_get_partners_vars($field_partners = array()) {
+function dosomething_taxonomy_get_partners_vars($field_partners = array(), $language_code = NULL) {
 
   if (empty($field_partners)) {
     return;
@@ -229,6 +232,12 @@ function dosomething_taxonomy_get_partners_vars($field_partners = array()) {
 
     // Store partner term data.
     $term = taxonomy_term_load($fc_item->field_partner->value()->tid);
+
+    // First check the language matches if a code was specified
+    if (isset($language_code) && !array_key_exists($language_code, $term->translations->data)) {
+      continue;
+    }
+
     $term_wrapper = dosomething_helpers_term_metadata_wrapper($term);
     $partners[$delta]['tid'] = $term_wrapper->getIdentifier();
     $partners[$delta]['name'] = $term_wrapper->label();

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_field.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_field.inc
@@ -7,4 +7,3 @@ function paraneue_dosomething_preprocess_field_partners(&$vars) {
   $vars['partners'] = dosomething_taxonomy_get_partners_data($vars['field_partners']);
   $vars['sponsor_logos'] = paraneue_dosomething_get_sponsor_logos($vars['partners']);
 }
-

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -351,4 +351,3 @@ function paraneue_dosomething_preprocess_node_notfound(&$vars) {
     $vars['campaign_results'] = paraneue_dosomething_get_recommended_campaign_gallery(NULL, NULL, 3);
   }
 }
-

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
@@ -252,4 +252,3 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     }
   }
 }
-


### PR DESCRIPTION
#### What's this PR do?
- Does not display "Partners" in the info bar if the partner term has not been translated
- Minor fix to global get lang logic
#### How should this be reviewed?

First visit a campaign page that has a partner term set.
<img width="531" alt="screen shot 2016-05-31 at 1 34 14 pm" src="https://cloud.githubusercontent.com/assets/897368/15684624/f546b574-2735-11e6-95e6-6fc56b596a7c.png">

Then translate this campaign, but NOT the partner term. Does it show in the info bar still?
<img width="447" alt="screen shot 2016-05-31 at 1 34 32 pm" src="https://cloud.githubusercontent.com/assets/897368/15684638/05209730-2736-11e6-95f7-e2832b0d46fd.png">

Also because I changed the global get lang function, make sure the site routing still seems ok.
#### Relevant tickets

Fixes #6379 
