### PR TITLE
Fixes en global english login/logout experience

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -573,7 +573,7 @@ function dosomething_campaign_get_campaign_block_vars($nid, $image_size = '740x4
   $language = dosomething_global_get_language($user, $node);
 
   if (! is_object($language)) {
-    dosomething_global_get_language_by_language_code($language);
+    $language = dosomething_global_get_language_by_language_code($language);
   }
 
   // Build a global URL and remove the first slash returned
@@ -586,18 +586,22 @@ function dosomething_campaign_get_campaign_block_vars($nid, $image_size = '740x4
   $image = NULL;
   $image_nid = NULL;
 
-  if (!empty($node->field_image_campaign_cover)) {
+  if (!empty($node->field_image_campaign_cover) && array_key_exists($clc, $node->field_image_campaign_cover)) {
     $image_nid = $node->field_image_campaign_cover[$clc][0]['target_id'];
     $image = dosomething_image_get_themed_image_url($image_nid, 'landscape', $image_size);
   }
 
   $cta = NULL;
 
-  if (!empty($node->field_call_to_action)) {
+  if (!empty($node->field_call_to_action) && array_key_exists($clc, $node->field_call_to_action)) {
     $cta = $node->field_call_to_action[$clc][0]['value'];
   }
 
-  $title = $node->title_field[$clc][0]['safe_value'];
+  $title = NULL;
+
+  if (array_key_exists($clc, $node->title_field)) {
+    $title = $node->title_field[$clc][0]['safe_value'];
+  }
 
   return array(
     'nid' => $nid,

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -67,7 +67,10 @@ function dosomething_global_init() {
   if ($url_variables['url_path_prefix'] != dosomething_global_get_prefix_for_language(DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE)) {
     return;
   }
-  else if($user_variables['user_language'] == DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE) {
+  else if ($user_variables['user_language'] == DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE) {
+    return;
+  }
+  else if (!array_key_exists($user_variables['user_language'], $languages)) {
     return;
   }
 


### PR DESCRIPTION
#### What's this PR do?
- Fixes the too many redirects which occurs on a Canadian user trying to login / out.

In fixing this, I unleashed a bunch of en-global index errors within the campaign module where we didn't do a safety check on the field before accessing the translation lang index. So i just quickly added those checks in.
#### How should this be reviewed?

tell us, how can we review, to test that this works
#### Any background context you want to provide?

The reason this code works because the "user_language" in this case is en-ca, which is not a defined language by our system according to the languages array.
#### Relevant tickets

Fixes #6488 
