### PR TITLE
Issue6439 campaign signup transactional flag

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -263,6 +263,9 @@ function _campaign_resource_index($ids, $staff_pick, $term_ids, $count, $random,
  *   The signup data to post. Expected keys:
  *   - uid: The user uid (int).  Optional, uses global $user if not set.
  *   - source (string).
+ *
+ * @return
+ *   dosomething_signup_create($nid, $values['uid'], $values['source'], $values['transactional'])
  */
 function _campaign_resource_signup($nid, $values) {
   global $user;
@@ -272,13 +275,15 @@ function _campaign_resource_signup($nid, $values) {
   if (!isset($values['source'])) {
     $values['source'] = NULL;
   }
+  if (!isset($values['transactional'])) {
+    $values['transactional'] = TRUE;
+  }
   if (DOSOMETHING_SIGNUP_LOG_SIGNUPS) {
     watchdog('dosomething_api', '_campaign_resource_signup values:' . json_encode($values));
   }
-  // @todo: Pass parameter into signup_create whether or not to send SMS.
-  // Since SMS campaign signups would hit this endpoint, would not want
-  // to send an additional "You've signed up text".
-  return dosomething_signup_create($nid, $values['uid'], $values['source']);
+
+  // transactional = FALSE will result in neither email or SMS transactional messages from being sent.
+  return dosomething_signup_create($nid, $values['uid'], $values['source'], $values['transactional']);
 }
 
 

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -283,7 +283,7 @@ function _campaign_resource_signup($nid, $values) {
   }
 
   // transactional = FALSE will result in neither email or SMS transactional messages from being sent.
-  return dosomething_signup_create($nid, $values['uid'], $values['source'], $values['transactional']);
+  return dosomething_signup_create($nid, $values['uid'], $values['source'], NULL, $values['transactional']);
 }
 
 

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -99,6 +99,7 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
   $payload = array(
     'activity' => $origin,
     'email' => $params['email'],
+    'transactional' => $params['transactional'],
     'uid' => $params['uid'],
     'merge_vars' => array(
       'MEMBER_COUNT' => dosomething_user_get_member_count(TRUE),

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -715,3 +715,19 @@ function dosomething_signup_update_7024() {
     db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
   }
 }
+
+/**
+ * Adds transactional column to the dosomething_signup table.
+ */
+function dosomething_signup_update_7025() {
+  $tbl_name = 'dosomething_signup';
+  // Load schema to get table definition.
+  $schema = dosomething_signup_schema();
+  // New field to add.
+  $field_name = 'transactional';
+  // If the field doesn't exist already:
+  if (!db_field_exists($tbl_name, $field_name)) {
+    // Add it per the schema field definition.
+    db_add_field($tbl_name, $field_name, $schema[$tbl_name]['fields'][$field_name]);
+  }
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -69,6 +69,11 @@ function dosomething_signup_schema() {
         'type' => 'int',
         'not null' => FALSE,
       ),
+      transactional' => array(
+        'description' => 'Boolean indicating if transactional messaging should be sent',
+        'type' => 'int',
+        'not null' => TRUE,
+      ),
     ),
     'primary key' => array('sid'),
     'unique keys' => array(

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -537,8 +537,11 @@ function dosomething_signup_third_party_subscribe($account, $node) {
     $var_name = 'dosomething_signup_mobilecommons_opt_in_path_general_campaign';
     $opt_in = variable_get($var_name);
   }
+
+  $var_name  = 'transactional';
+  $transactional = dosomething_helpers_get_variable('node', $node->nid, $var_name);
   // Send message broker request.
-  dosomething_signup_mbp_request($account, $node, $opt_in);
+  dosomething_signup_mbp_request($account, $node, $opt_in, $transactional);
 }
 
 /**
@@ -588,7 +591,7 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL) {
  * @param int $opt_in
  *   The opt-in path to use for opt-in.
  */
-function dosomething_signup_mbp_request($account, $node, $opt_in) {
+function dosomething_signup_mbp_request($account, $node, $opt_in, $transactional) {
   // Send MBP request.
   if (!module_exists('dosomething_mbp')) {
     return;
@@ -605,7 +608,7 @@ function dosomething_signup_mbp_request($account, $node, $opt_in) {
   }
 
   // Gather mbp params for the signup.
-  $params = dosomething_signup_get_mbp_params($account, $node, $opt_in);
+  $params = dosomething_signup_get_mbp_params($account, $node, $opt_in, $transactional);
 
   // Send campaign mbp request.
   if ($node->type == 'campaign') {
@@ -622,11 +625,13 @@ function dosomething_signup_mbp_request($account, $node, $opt_in) {
  *   Details about the node that the signup was made on.
  * @param int $opt_in
  *   The opt-in path to use for opt-in.
+ * @param bool $transactional
+ *   A flag to disable sending transactional messaging.
  *
  * @return array
  *   Associative array of values to use as params to a mbp_request.
  */
-function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
+function dosomething_signup_get_mbp_params($account, $node, $opt_in, $transactional) {
   if (!($node->type == 'campaign')) {
     return FALSE;
   }
@@ -671,6 +676,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     'user_country' => $user_country,
     'campaign_language' => $campaign_language->language,
     'campaign_country' => $campaign_country_code,
+    'transactional' => $transactional,
   ];
 
   // Don't subscribe 26+ yo users for Mobile Commons.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -229,11 +229,13 @@ function dosomething_signup_get_query_source() {
  * @param int $timestamp
  *   (optional) The timestamp of the signup.
  *   If not provided, uses @dries time.
+ * @param bool $transactional
+ *   (optional) Flag to trigger sending transactional messages related to signup.
  *
  * @return mixed
  *   The sid of the newly inserted signup, or FALSE if error.
  */
-function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp = NULL) {
+function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp = NULL, $transactional = TRUE) {
   global $user;
 
   if (!isset($uid)) {
@@ -257,6 +259,7 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
     'run_nid' => $run->nid,
     'source'=> $source,
     'timestamp' => $timestamp,
+    'transactional' => $transactional,
   );
 
   try {


### PR DESCRIPTION
#### What's this PR do?

Adds support for transactional parameter in call to **Campaign Signup** endpoint: https://github.com/DoSomething/phoenix/wiki/API#campaign-signup that will result in transactional messaging being able to be prevented on campaign signups via Phoenix API calls.
#### How should this be reviewed?

```
curl http://dev.dosomething.org:8888/api/v1/campaigns/23/signup -X POST 
--header "Content-type: application/json" 
--header "Accept: application/json" 
--header "X-CSRF-Token: G136HF5yB5ZZawvrsOfU4gw0poUOaQygPrsJlaFakMU" 
--header "Cookie:SESSd57f2aef87e6d4352ce5db4659184fa7=mKI5_yfoXYBz3r4o95utui4fwBV_lUO1JNN1nEVsPRg" 
-d '{
  "uid": 123uid456,
  "source": "niche",
  "tranasactional": 0
}'
```

Should result in a campaign signup `dosomething_mbp` message generated with a `transactional` value of `FALSE / 0`. This message value will be consumed by `mbc-transactional-email` and `mbc-registration-mobile` to suppress sending transactional messaging.
#### Any background context you want to provide?

Niche user imports include automatic signup to certain campaigns. The messaging sent to Niche users includes details about being signed up to a campaign. The additional generic campaign signup messages needs to be disabled to prevent redundant messaging.
#### Relevant tickets

Fixes #6439
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] cURL call to `/api/v1/campaigns/23/signup` results in `transactional` value in mbp message.
