### PR TITLE
Issue6439 api campaign signup transactionals

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -264,6 +264,7 @@ function _campaign_resource_index($ids, $staff_pick, $term_ids, $count, $random,
  *   - uid: The user uid (int).  Optional, uses global $user if not set.
  *   - source (string).
  *   - transactionals (bool). Optional flag to disable sending transactional messages.
+ *       Defaults to sending messages.
  */
 function _campaign_resource_signup($nid, $values) {
   global $user;
@@ -274,7 +275,7 @@ function _campaign_resource_signup($nid, $values) {
     $values['source'] = NULL;
   }
   if (!isset($values['transactionals'])) {
-    $values['transactionals'] = NULL;
+    $values['transactionals'] = TRUE;
   }
   if (DOSOMETHING_SIGNUP_LOG_SIGNUPS) {
     watchdog('dosomething_api', '_campaign_resource_signup values:' . json_encode($values));

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -263,6 +263,7 @@ function _campaign_resource_index($ids, $staff_pick, $term_ids, $count, $random,
  *   The signup data to post. Expected keys:
  *   - uid: The user uid (int).  Optional, uses global $user if not set.
  *   - source (string).
+ *   - transactionals (bool). Optional flag to disable sending transactional messages.
  */
 function _campaign_resource_signup($nid, $values) {
   global $user;
@@ -272,13 +273,14 @@ function _campaign_resource_signup($nid, $values) {
   if (!isset($values['source'])) {
     $values['source'] = NULL;
   }
+  if (!isset($values['transactionals'])) {
+    $values['transactionals'] = NULL;
+  }
   if (DOSOMETHING_SIGNUP_LOG_SIGNUPS) {
     watchdog('dosomething_api', '_campaign_resource_signup values:' . json_encode($values));
   }
-  // @todo: Pass parameter into signup_create whether or not to send SMS.
-  // Since SMS campaign signups would hit this endpoint, would not want
-  // to send an additional "You've signed up text".
-  return dosomething_signup_create($nid, $values['uid'], $values['source']);
+  // transactionals = FALSE will result in neither email or SMS transactional messages being sent.
+  return dosomething_signup_create($nid, $values['uid'], $values['source'], NULL, $values['transactionals']);
 }
 
 

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -105,26 +105,25 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
     ),
   );
 
-  if (isset($params['transactionals'])) {
-    $payload['transactionals'] = $params['transactionals'];
+  // Optional values
+  $optional_params = [
+    'transactionals',
+    'source',
+    'user_language',
+    'campaign_language',
+    'campaign_country',
+  ];
+  foreach ($optional_params as $op) {
+    if (isset($params[$op])) {
+      $payload[$op] = $params[$op];
+    }
   }
-  if (isset($params['source'])) {
-    $payload['source'] = $params['source'];
-  }
+
   if (isset($params['user_country'])) {
     $payload['user_country'] = $params['user_country'];
   }
   else {
     $payload['user_country'] = dosomething_settings_get_geo_country_code();
-  }
-  if (isset($params['user_language'])) {
-    $payload['user_language'] = $params['user_language'];
-  }
-  if (isset($params['campaign_language'])) {
-    $payload['campaign_language'] = $params['campaign_language'];
-  }
-  if (isset($params['campaign_country'])) {
-    $payload['campaign_country'] = $params['campaign_country'];
   }
 
   // If email template wasn't set use request details to define template name.

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -104,6 +104,10 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
       'MEMBER_COUNT' => dosomething_user_get_member_count(TRUE),
     ),
   );
+
+  if (isset($params['transactionals'])) {
+    $payload['transactionals'] = $params['transactionals'];
+  }
   if (isset($params['user_country'])) {
     $payload['user_country'] = $params['user_country'];
   }

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -108,6 +108,9 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
   if (isset($params['transactionals'])) {
     $payload['transactionals'] = $params['transactionals'];
   }
+  if (isset($params['source'])) {
+    $payload['source'] = $params['source'];
+  }
   if (isset($params['user_country'])) {
     $payload['user_country'] = $params['user_country'];
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -229,11 +229,14 @@ function dosomething_signup_get_query_source() {
  * @param int $timestamp
  *   (optional) The timestamp of the signup.
  *   If not provided, uses @dries time.
+ * @param bool $transactionals
+ *   (optional) A flag to disable sending transactional messaging.
+ *   The default is to send messaging.
  *
  * @return mixed
  *   The sid of the newly inserted signup, or FALSE if error.
  */
-function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp = NULL) {
+function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp = NULL, $transactionals = NULL) {
   global $user;
 
   if (!isset($uid)) {
@@ -257,6 +260,7 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
     'run_nid' => $run->nid,
     'source'=> $source,
     'timestamp' => $timestamp,
+    'transactionals' => $transactionals,
   );
 
   try {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -512,6 +512,7 @@ function dosomething_signup_entity_insert($entity, $type) {
 
   $account = user_load($entity->uid);
   $node = node_load($entity->nid);
+  $transactionals = $entity->transactionals;
 
   // If this is a SMS Game Campaign node:
   if (module_exists('dosomething_campaign') && dosomething_campaign_get_campaign_type($node) == 'sms_game') {
@@ -522,7 +523,7 @@ function dosomething_signup_entity_insert($entity, $type) {
   }
 
   // Send relevant third-party subscribe requests.
-  dosomething_signup_third_party_subscribe($account, $node);
+  dosomething_signup_third_party_subscribe($account, $node, transactionals);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -596,8 +596,9 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL) {
  *   Details about the node that the signup was made on.
  * @param int $opt_in
  *   The opt-in path to use for opt-in.
+ * @param bool $transactionals
  */
-function dosomething_signup_mbp_request($account, $node, $opt_in) {
+function dosomething_signup_mbp_request($account, $node, $opt_in, $transactionals) {
   // Send MBP request.
   if (!module_exists('dosomething_mbp')) {
     return;
@@ -614,7 +615,7 @@ function dosomething_signup_mbp_request($account, $node, $opt_in) {
   }
 
   // Gather mbp params for the signup.
-  $params = dosomething_signup_get_mbp_params($account, $node, $opt_in);
+  $params = dosomething_signup_get_mbp_params($account, $node, $opt_in, $transactionals);
 
   // Send campaign mbp request.
   if ($node->type == 'campaign') {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -528,8 +528,15 @@ function dosomething_signup_entity_insert($entity, $type) {
 
 /**
  * Sends third-party subscription requests for given $account and $node.
+ *
+ * @param object $account
+ *    User details who signed up for a campaign.
+ * @param object $node
+ *   Details about the campaign the user signed up to.
+ * @parm bool $trasactionals
+ *    A flag to prevent sending transactionals when FALSE. Defaults to TRUE when NULL.
  */
-function dosomething_signup_third_party_subscribe($account, $node) {
+function dosomething_signup_third_party_subscribe($account, $node, $transactionals = NULL) {
   $var_name  = 'mobilecommons_opt_in_path';
   // Is there an override set on this campaign?
   $opt_in = dosomething_helpers_get_variable('node', $node->nid, $var_name);
@@ -540,7 +547,7 @@ function dosomething_signup_third_party_subscribe($account, $node) {
     $opt_in = variable_get($var_name);
   }
   // Send message broker request.
-  dosomething_signup_mbp_request($account, $node, $opt_in);
+  dosomething_signup_mbp_request($account, $node, $opt_in), $transactionals;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -536,8 +536,10 @@ function dosomething_signup_entity_insert($entity, $type) {
  *   Details about the campaign the user signed up to.
  * @parm bool $trasactionals
  *    A flag to prevent sending transactionals when FALSE. Defaults to TRUE when NULL.
+ * @parm string $source
+ *    A value defining where the request to sign a user up to a campaign originated.
  */
-function dosomething_signup_third_party_subscribe($account, $node, $transactionals = NULL) {
+function dosomething_signup_third_party_subscribe($account, $node, $transactionals = NULL, $source = NULL) {
   $var_name  = 'mobilecommons_opt_in_path';
   // Is there an override set on this campaign?
   $opt_in = dosomething_helpers_get_variable('node', $node->nid, $var_name);
@@ -548,7 +550,7 @@ function dosomething_signup_third_party_subscribe($account, $node, $transactiona
     $opt_in = variable_get($var_name);
   }
   // Send message broker request.
-  dosomething_signup_mbp_request($account, $node, $opt_in), $transactionals;
+  dosomething_signup_mbp_request($account, $node, $opt_in, $transactionals, $source);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -236,7 +236,8 @@ function dosomething_signup_get_query_source() {
  * @return mixed
  *   The sid of the newly inserted signup, or FALSE if error.
  */
-function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp = NULL, $transactionals = TRUE) {
+function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp = NULL, $transactionals = TRUE
+) {
   global $user;
 
   if (!isset($uid)) {
@@ -510,11 +511,6 @@ function dosomething_signup_entity_insert($entity, $type) {
   // If not a signup, exit out of function.
   if ($type != 'signup') { return; }
 
-  $account = user_load($entity->uid);
-  $node = node_load($entity->nid);
-  $transactionals = $entity->transactionals;
-  $source = $entity->source;
-
   // If this is a SMS Game Campaign node:
   if (module_exists('dosomething_campaign') && dosomething_campaign_get_campaign_type($node) == 'sms_game') {
     // Third party subscription is handled elsewhere,
@@ -523,8 +519,13 @@ function dosomething_signup_entity_insert($entity, $type) {
     return;
   }
 
+  $account = user_load($entity->uid);
+  $node = node_load($entity->nid);
+  $options['transactionals'] = $entity->transactionals;
+  $options['source'] = $entity->source;
+
   // Send relevant third-party subscribe requests.
-  dosomething_signup_third_party_subscribe($account, $node, $source, $transactionals);
+  dosomething_signup_third_party_subscribe($account, $node, $options);
 }
 
 /**
@@ -534,12 +535,14 @@ function dosomething_signup_entity_insert($entity, $type) {
  *    User details who signed up for a campaign.
  * @param object $node
  *   Details about the campaign the user signed up to.
- * @parm string $source
- *    A value defining where the request to sign a user up to a campaign originated.
- * @parm bool $trasactionals
- *    A flag to prevent sending transactionals when FALSE. Defaults to TRUE when NULL.
+ * @parm array $options
+ *   Possible options used for the subscribe request.
+ *   - source
+ *     A value defining where the request to sign a user up to a campaign originated.
+ *   - trasactionals
+ *     A flag to prevent sending transactionals when FALSE. Defaults to TRUE when NULL.
  */
-function dosomething_signup_third_party_subscribe($account, $node, $source = NULL, $transactionals = NULL) {
+function dosomething_signup_third_party_subscribe($account, $node, $options) {
   $var_name  = 'mobilecommons_opt_in_path';
   // Is there an override set on this campaign?
   $opt_in = dosomething_helpers_get_variable('node', $node->nid, $var_name);
@@ -550,7 +553,7 @@ function dosomething_signup_third_party_subscribe($account, $node, $source = NUL
     $opt_in = variable_get($var_name);
   }
   // Send message broker request.
-  dosomething_signup_mbp_request($account, $node, $opt_in, $transactionals, $source);
+  dosomething_signup_mbp_request($account, $node, $opt_in, $options['transactionals'], $options['source']);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -542,7 +542,7 @@ function dosomething_signup_entity_insert($entity, $type) {
  *   - trasactionals
  *     A flag to prevent sending transactionals when FALSE. Defaults to TRUE when NULL.
  */
-function dosomething_signup_third_party_subscribe($account, $node, $options) {
+function dosomething_signup_third_party_subscribe($account, $node, $options = []) {
   $var_name  = 'mobilecommons_opt_in_path';
   // Is there an override set on this campaign?
   $opt_in = dosomething_helpers_get_variable('node', $node->nid, $var_name);

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -632,11 +632,13 @@ function dosomething_signup_mbp_request($account, $node, $opt_in, $transactional
  *   Details about the node that the signup was made on.
  * @param int $opt_in
  *   The opt-in path to use for opt-in.
+ * @param bool $transactionals
+ *   Control if transactional messaging should be sent.
  *
  * @return array
  *   Associative array of values to use as params to a mbp_request.
  */
-function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
+function dosomething_signup_get_mbp_params($account, $node, $opt_in, $transactionals) {
   if (!($node->type == 'campaign')) {
     return FALSE;
   }
@@ -681,6 +683,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in) {
     'user_country' => $user_country,
     'campaign_language' => $campaign_language->language,
     'campaign_country' => $campaign_country_code,
+    'transactionals' => $transactionals,
   ];
 
   // Don't subscribe 26+ yo users for Mobile Commons.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -524,7 +524,7 @@ function dosomething_signup_entity_insert($entity, $type) {
   }
 
   // Send relevant third-party subscribe requests.
-  dosomething_signup_third_party_subscribe($account, $node, transactionals, $source);
+  dosomething_signup_third_party_subscribe($account, $node, $transactionals, $source);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -553,7 +553,7 @@ function dosomething_signup_third_party_subscribe($account, $node, $options = []
     $opt_in = variable_get($var_name);
   }
   // Send message broker request.
-  dosomething_signup_mbp_request($account, $node, $opt_in, $options['transactionals'], $options['source']);
+  dosomething_signup_mbp_request($account, $node, $opt_in, $options);
 }
 
 /**
@@ -602,12 +602,13 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL) {
  *   Details about the node that the signup was made on.
  * @param int $opt_in
  *   The opt-in path to use for opt-in.
- * @param bool $transactionals
+ * @param array $options
+ *   - transactionals
  *   (optional) A flag to disable sending transactional messages.
- * @param string $source
+ *   - source
  *   (optional) A idendify name of the original source that requested the campaign signup.
  */
-function dosomething_signup_mbp_request($account, $node, $opt_in, $transactionals = NULL, $source = NULL) {
+function dosomething_signup_mbp_request($account, $node, $opt_in, $options) {
   // Send MBP request.
   if (!module_exists('dosomething_mbp')) {
     return;
@@ -624,7 +625,7 @@ function dosomething_signup_mbp_request($account, $node, $opt_in, $transactional
   }
 
   // Gather mbp params for the signup.
-  $params = dosomething_signup_get_mbp_params($account, $node, $opt_in, $transactionals, $source);
+  $params = dosomething_signup_get_mbp_params($account, $node, $opt_in, $options);
 
   // Send campaign mbp request.
   if ($node->type == 'campaign') {
@@ -641,16 +642,17 @@ function dosomething_signup_mbp_request($account, $node, $opt_in, $transactional
  *   Details about the node that the signup was made on.
  * @param int $opt_in
  *   The opt-in path to use for opt-in.
- * @param bool $source
+ * @param array $options
+ *   - source
  *   (optional) The source of the user campaign signup. Can be internal to this application ("campaigns") or a
  *   souce defined in a call to the Campaign Signup API endpoint.
- * @param bool $transactionals
+ *   - transactionals
  *   (optional) Control if transactional messaging should be sent.
  *
  * @return array
  *   Associative array of values to use as params to a mbp_request.
  */
-function dosomething_signup_get_mbp_params($account, $node, $opt_in, $transactionals = NULL, $source = NULL) {
+function dosomething_signup_get_mbp_params($account, $node, $opt_in, $options) {
   if (!($node->type == 'campaign')) {
     return FALSE;
   }
@@ -697,11 +699,11 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in, $transactio
     'campaign_country' => $campaign_country_code,
   ];
 
-  if (isset($transactionals)) {
-    $params['transactionals'] = $transactionals;
+  if (isset($options['transactionals'])) {
+    $params['transactionals'] = $options['transactionals'];
   }
-  if (isset($source)) {
-    $params['source'] = $source;
+  if (isset($options['source'])) {
+    $params['source'] = $options['source'];
   }
 
   // Don't subscribe 26+ yo users for Mobile Commons.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -600,8 +600,11 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL) {
  * @param int $opt_in
  *   The opt-in path to use for opt-in.
  * @param bool $transactionals
+ *   (optional) A flag to disable sending transactional messages.
+ * @param string $source
+ *   (optional) A idendify name of the original source that requested the campaign signup.
  */
-function dosomething_signup_mbp_request($account, $node, $opt_in, $transactionals) {
+function dosomething_signup_mbp_request($account, $node, $opt_in, $transactionals = NULL, $source = NULL) {
   // Send MBP request.
   if (!module_exists('dosomething_mbp')) {
     return;
@@ -618,7 +621,7 @@ function dosomething_signup_mbp_request($account, $node, $opt_in, $transactional
   }
 
   // Gather mbp params for the signup.
-  $params = dosomething_signup_get_mbp_params($account, $node, $opt_in, $transactionals);
+  $params = dosomething_signup_get_mbp_params($account, $node, $opt_in, $transactionals, $source);
 
   // Send campaign mbp request.
   if ($node->type == 'campaign') {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -608,7 +608,7 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL) {
  *   - source
  *   (optional) A idendify name of the original source that requested the campaign signup.
  */
-function dosomething_signup_mbp_request($account, $node, $opt_in, $options) {
+function dosomething_signup_mbp_request($account, $node, $opt_in, $options = []) {
   // Send MBP request.
   if (!module_exists('dosomething_mbp')) {
     return;
@@ -652,7 +652,7 @@ function dosomething_signup_mbp_request($account, $node, $opt_in, $options) {
  * @return array
  *   Associative array of values to use as params to a mbp_request.
  */
-function dosomething_signup_get_mbp_params($account, $node, $opt_in, $options) {
+function dosomething_signup_get_mbp_params($account, $node, $opt_in, $options = []) {
   if (!($node->type == 'campaign')) {
     return FALSE;
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -639,12 +639,14 @@ function dosomething_signup_mbp_request($account, $node, $opt_in, $transactional
  * @param int $opt_in
  *   The opt-in path to use for opt-in.
  * @param bool $transactionals
- *   Control if transactional messaging should be sent.
+ *   (optional) Control if transactional messaging should be sent.
+ * @param bool $transactionals
+ *   (optional) Control if transactional messaging should be sent.
  *
  * @return array
  *   Associative array of values to use as params to a mbp_request.
  */
-function dosomething_signup_get_mbp_params($account, $node, $opt_in, $transactionals) {
+function dosomething_signup_get_mbp_params($account, $node, $opt_in, $transactionals = NULL, $source = NULL) {
   if (!($node->type == 'campaign')) {
     return FALSE;
   }
@@ -689,8 +691,14 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in, $transactio
     'user_country' => $user_country,
     'campaign_language' => $campaign_language->language,
     'campaign_country' => $campaign_country_code,
-    'transactionals' => $transactionals,
   ];
+
+  if (isset($transactionals)) {
+    $params['transactionals'] = $transactionals;
+  }
+  if (isset($source)) {
+    $params['source'] = $source;
+  }
 
   // Don't subscribe 26+ yo users for Mobile Commons.
   $user_is_old = dosomething_user_is_old_person($account);

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -638,8 +638,9 @@ function dosomething_signup_mbp_request($account, $node, $opt_in, $transactional
  *   Details about the node that the signup was made on.
  * @param int $opt_in
  *   The opt-in path to use for opt-in.
- * @param bool $transactionals
- *   (optional) Control if transactional messaging should be sent.
+ * @param bool $source
+ *   (optional) The source of the user campaign signup. Can be internal to this application ("campaigns") or a
+ *   souce defined in a call to the Campaign Signup API endpoint.
  * @param bool $transactionals
  *   (optional) Control if transactional messaging should be sent.
  *

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -513,6 +513,7 @@ function dosomething_signup_entity_insert($entity, $type) {
   $account = user_load($entity->uid);
   $node = node_load($entity->nid);
   $transactionals = $entity->transactionals;
+  $source = $entity->source;
 
   // If this is a SMS Game Campaign node:
   if (module_exists('dosomething_campaign') && dosomething_campaign_get_campaign_type($node) == 'sms_game') {
@@ -523,7 +524,7 @@ function dosomething_signup_entity_insert($entity, $type) {
   }
 
   // Send relevant third-party subscribe requests.
-  dosomething_signup_third_party_subscribe($account, $node, transactionals);
+  dosomething_signup_third_party_subscribe($account, $node, transactionals, $source);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -524,7 +524,7 @@ function dosomething_signup_entity_insert($entity, $type) {
   }
 
   // Send relevant third-party subscribe requests.
-  dosomething_signup_third_party_subscribe($account, $node, $transactionals, $source);
+  dosomething_signup_third_party_subscribe($account, $node, $source, $transactionals);
 }
 
 /**
@@ -534,12 +534,12 @@ function dosomething_signup_entity_insert($entity, $type) {
  *    User details who signed up for a campaign.
  * @param object $node
  *   Details about the campaign the user signed up to.
- * @parm bool $trasactionals
- *    A flag to prevent sending transactionals when FALSE. Defaults to TRUE when NULL.
  * @parm string $source
  *    A value defining where the request to sign a user up to a campaign originated.
+ * @parm bool $trasactionals
+ *    A flag to prevent sending transactionals when FALSE. Defaults to TRUE when NULL.
  */
-function dosomething_signup_third_party_subscribe($account, $node, $transactionals = NULL, $source = NULL) {
+function dosomething_signup_third_party_subscribe($account, $node, $source = NULL, $transactionals = NULL) {
   $var_name  = 'mobilecommons_opt_in_path';
   // Is there an override set on this campaign?
   $opt_in = dosomething_helpers_get_variable('node', $node->nid, $var_name);

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -236,7 +236,7 @@ function dosomething_signup_get_query_source() {
  * @return mixed
  *   The sid of the newly inserted signup, or FALSE if error.
  */
-function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp = NULL, $transactionals = NULL) {
+function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp = NULL, $transactionals = TRUE) {
   global $user;
 
   if (!isset($uid)) {


### PR DESCRIPTION
#### What's this PR do?

Adds support for `transactionals` and `source` parameters in call to **Campaign Signup** endpoint: https://github.com/DoSomething/phoenix/wiki/API#campaign-signup that will result in transactional messaging being able to be prevented on campaign signups via Phoenix API calls as well as respond to `source` values.
#### How should this be reviewed?

```
curl http://dev.dosomething.org:8888/api/v1/campaigns/23/signup -X POST 
--header "Content-type: application/json" 
--header "Accept: application/json" 
--header "X-CSRF-Token: G136HF5yB5ZZawvrsOfU4gw0poUOaQygPrsJlaFakMU" 
--header "Cookie:SESSd57f2aef87e6d4352ce5db4659184fa7=mKI5_yfoXYBz3r4o95utui4fwBV_lUO1JNN1nEVsPRg" 
-d '{
  "uid": 123456,
  "source": "niche",
  "tranasactionals": 0
}'
```

Should result in a campaign signup `dosomething_mbp` message generated with a `transactional` value of `FALSE / 0`. This message value will be consumed by `mbc-transactional-email` and `mbc-registration-mobile` to suppress sending transactional messaging.
#### Any background context you want to provide?

Niche user imports include automatic signup to certain campaigns. The messaging sent to Niche users includes details about being signed up to a campaign. The additional generic campaign signup messages needs to be disabled to prevent redundant messaging.
#### Relevant tickets

Fixes #6439
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] cURL call to `/api/v1/campaigns/23/signup` results in `transactionals` and `source` value in mbp message.
