### PR TITLE
Adding in command to restart php7 after deploy

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -551,6 +551,24 @@ function restart_php5_fpm {
   fi
 }
 
+#=== FUNCTION ==================================================================
+# NAME: restart_php7_fpm
+# DESCRIPTION: Restarts php7.0-fpm on servers running php7.
+#===============================================================================
+function restart_php7_fpm {
+  PHP_FPM_STATUS="$(sudo service php7.0-fpm status)"
+  PHP_VERSION="$(php -v|grep --only-matching --perl-regexp "7\.\\d+\.\\d+")"
+
+  if $(echo ${PHP_FPM_STATUS} | grep --quiet "php7.0-fpm start/running") && $(echo ${PHP_VERSION} | grep --quiet "7.0")
+  then
+    echo "Restarting PHP-FPM now"
+    sudo service php7.0-fpm restart
+  else
+    echo "Either php7.0-fpm is not running or php -v < 7.0. Not restarting."
+  fi
+}
+
+
 # ==============================================================================
 # Commands
 # ==============================================================================
@@ -668,7 +686,16 @@ fi
 #----------------------------------------------------------------------
 # restart php5-fpm
 #----------------------------------------------------------------------
-if [[ $1 == "restart_php" ]]
+if [[ $1 == "restart_php5" ]]
 then
   restart_php5_fpm
 fi
+
+#----------------------------------------------------------------------
+# restart php7.0-fpm
+#----------------------------------------------------------------------
+if [[ $1 == "restart_php7" ]]
+then
+  restart_php7_fpm
+fi
+


### PR DESCRIPTION
#### What's this PR do?

I've added a command to restart PHP7 that's analogous to the command to restart PHP5
#### How should this be reviewed?

On a box running PHP7, You can check the PID for PHP7 fpm first by running `ps aux | grep php` run `bin/ds restart_php7` and then make sure the PID has changed. There won't be any output. Or run this deploy on Thor.
#### Any background context you want to provide?

This is in preparation for upgrading the Drupal servers to PHP7. After this is merged, we should plan to halt any deploys until the servers have been updated to PHP7. It won't block deploys, but if the servers haven't been upgraded we'll need to manually restart php-fpm on all of the servers.
- Leaving in php5 restart command in case we need to roll back
