### PR TITLE
Fix get_member_count API documentation

### DIFF
--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -141,7 +141,12 @@ curl -H "Accept: application/json" http://staging.beta.dosomething.org/api/v1/us
 ## Get Member Count
 
 ```
-POST /api/v1/get_member_count
+POST /api/v1/users/get_member_count
+```
+
+**Example Request:**
+```sh
+curl -X POST http://staging.beta.dosomething.org/api/v1/users/get_member_count
 ```
 
 **Example Response:**
@@ -150,8 +155,8 @@ POST /api/v1/get_member_count
 // 200 Okay
 
 {
-   "formatted": "2,900,343",
-   "readable": "2.9 million"
+  "formatted": "3,596,441",
+  "readable": "3.5 million"
 }
 ```
 


### PR DESCRIPTION
#### What's this PR do?

`POST /api/v1/users/get_member_count` documentation: fix api endpoint path. Add `/users/` prefix.
It doesn't work without it. See [source](https://github.com/DoSomething/phoenix/blob/8841506956bb800c5a22ec7ff44c1bd6fa6861e4/lib/modules/dosomething/dosomething_api/resources/member_resource.inc#L80).
#### Any background context you want to provide?

```
curl -X POST http://staging.beta.dosomething.org/api/v1/users/get_member_count                                                                                                                                                                               init phoenix-js


{"formatted":"3,596,441","readable":"3.5 million"}
```

Also, it's better to change the request to GET, but this PR is to fix existing docs.
