### PR TITLE
Campaign run node description

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.field_base.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.field_base.inc
@@ -10,6 +10,29 @@
 function dosomething_campaign_run_field_default_field_bases() {
   $field_bases = array();
 
+  // Exported field_base: 'field_description_field'
+  $field_bases['field_description_field'] = array(
+    'active' => 1,
+    'cardinality' => -1,
+    'deleted' => 0,
+    'entity_types' => array(),
+    'field_name' => 'field_description_field',
+    'indexes' => array(
+      'revision_id' => array(
+        0 => 'revision_id',
+      ),
+    ),
+    'locked' => 0,
+    'module' => 'field_collection',
+    'settings' => array(
+      'entity_translation_sync' => FALSE,
+      'hide_blank_items' => 1,
+      'path' => '',
+    ),
+    'translatable' => 0,
+    'type' => 'field_collection',
+  );
+
   // Exported field_base: 'field_gallery_collection'.
   $field_bases['field_gallery_collection'] = array(
     'active' => 1,

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.field_instance.inc
@@ -830,6 +830,49 @@ function dosomething_campaign_run_field_default_field_instances() {
     ),
   );
 
+  // Exported field_instance: 'node-campaign_run-description_field'.
+  $field_instances['node-campaign_run-description_field'] = array(
+    'bundle' => 'campaign_run',
+    'default_value' => NULL,
+    'deleted' => 0,
+    'description' => 'Describe why you are creating a new run. Write it with enough context so that a future campaign lead could read it and immediately understand why a new run was created. Will this run have a scholarship? Is there a celebrity endorsing the campaign? Does the campaign have a new sponsor? In which countries is this run going to be available? etc.',
+    'display' => array(
+      'default' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 13,
+      ),
+      'teaser' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+    ),
+    'entity_type' => 'node',
+    'field_name' => 'description_field',
+    'label' => 'Description',
+    'required' => TRUE,
+    'settings' => array(
+      'entity_translation_sync' => FALSE,
+      'hide_label' => array(
+        'entity' => FALSE,
+        'page' => FALSE,
+      ),
+      'text_processing' => 0,
+      'user_register_form' => FALSE,
+    ),
+    'widget' => array(
+      'module' => 'text',
+      'settings' => array(
+        'size' => 60,
+      ),
+      'type' => 'text_textfield',
+      'weight' => -5,
+    ),
+  );
+
   // Translatables
   // Included for use with string extractors like potx.
   t('Additional Text');

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.field_group.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.field_group.inc
@@ -24,7 +24,8 @@ function dosomething_campaign_run_field_group_info() {
     'weight' => '0',
     'children' => array(
       0 => 'field_campaigns',
-      1 => 'title_field',
+      1 => 'description_field',
+      2 => 'title_field',
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
@@ -12,7 +12,12 @@
 </h4>
 
 <h4>Run Description:
-  <p><?php print_r($field_campaigns); ?></p>
+  <p>
+  	<?php
+  		$run_nid = node_load($field_campaigns[0]['entity']->field_current_run['en'][0]['target_id']);
+  		print render($run_nid->description_field['en'][0]['value']);
+  	?>
+  </p>
 </h4>
 
 <?php

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
@@ -1,17 +1,21 @@
-<?php 
+<?php
 /**
  * Returns the HTML for the Campaign Run page.
  */
 ?>
-<h4>Campaign: 
+<h4>Campaign:
   <p><?php print l($campaign_title, 'node/' . $field_campaigns[0]['target_id']); ?></p>
+</h4>
+
+<h4>Run Description:
+  <p><?php print render($field_instances['node-campaign_run-description_field']['description']); ?></p>
 </h4>
 
 <h4>Campaign Closed State:
   <p><?php print l($campaign_title . ': Closed State', 'node/' . $field_campaigns[0]['target_id'] . '/closed'); ?></p>
 </h4>
 
-<?php 
+<?php
   print render($content['field_winners']);
   print render($content['field_gallery_collection']);
   print render($content['field_run_date']);

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_run/node--campaign_run.tpl.php
@@ -7,12 +7,12 @@
   <p><?php print l($campaign_title, 'node/' . $field_campaigns[0]['target_id']); ?></p>
 </h4>
 
-<h4>Run Description:
-  <p><?php print render($field_instances['node-campaign_run-description_field']['description']); ?></p>
-</h4>
-
 <h4>Campaign Closed State:
   <p><?php print l($campaign_title . ': Closed State', 'node/' . $field_campaigns[0]['target_id'] . '/closed'); ?></p>
+</h4>
+
+<h4>Run Description:
+  <p><?php print_r($field_campaigns); ?></p>
 </h4>
 
 <?php


### PR DESCRIPTION
#### What's this PR do?

Adds a description field to a run to campaign run node so campaign leads can give context for new campaign run. This will also display on campaign run node view page. 
#### How should this be reviewed?
- On your local, visit http://dev.dosomething.org:8888/us/node/1903. 
- Click the "edit" tab and add a campaign run description (under Title). 
  ![screen shot 2016-06-03 at 1 22 57 pm](https://cloud.githubusercontent.com/assets/9019452/15787118/74a01252-298e-11e6-9d92-1fdd9a3fa03a.png)
- Save. 
- On view page, your description should show up under "Campaign Closed State" link. 
  ![screen shot 2016-06-03 at 1 23 33 pm](https://cloud.githubusercontent.com/assets/9019452/15787122/7c678560-298e-11e6-9add-ecb58f67a99f.png)
#### Relevant tickets

Fixes #6526 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
