### PR TITLE
Creates GET Postal Code endpoint to Organize API   

### DIFF
--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -54,6 +54,13 @@ function dosomething_organ_donation_send_postal_code() {
   $params = drupal_get_query_parameters();
 
   if ($params['postal_code'] && $params['nid']) {
+    if (!node_load($params['nid'])) {
+      $response = [
+        'error' => 'Node id not found.'
+      ];
+      return drupal_json_output($response);
+    }
+
     $client = _dosomething_organ_donation_build_http_client($params['nid']);
 
     $response = drupal_http_request($client['base_url'] . 'postal-codes/' . $params['postal_code'] . '/', [
@@ -63,7 +70,7 @@ function dosomething_organ_donation_send_postal_code() {
 
     if ($response->error) {
       $response = [
-        'error' => 'Postal code not found.',
+        'error' => 'Postal code not found.'
       ];
     }
     return drupal_json_output($response);

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -17,9 +17,59 @@ function dosomething_organ_donation_menu() {
     'type' => MENU_CALLBACK,
   ];
 
+  $items['organ-donation/send-postal-code'] = [
+    'page callback' => 'dosomething_organ_donation_send_postal_code',
+    'access callback' => 'user_is_logged_in',
+    'type' => MENU_CALLBACK,
+  ];
+
   // Return the $items array to register the path
   return $items;
 }
+
+/**
+ * Build the drupal_http_request object for Organize calls.
+ * @returns array
+ */
+function _dosomething_organ_donation_build_http_client($nid) {
+  $base_url = 'https://fiftythree-dev.organize.org/api/v2/postal-codes/';
+  $organize_api_token = dosomething_helpers_get_variables('node', $nid, 'organize_api_token');
+  $organize_api_token = $organize_api_token['organize_api_token'];
+
+  $client = [
+    'base_url' => $base_url,
+    'headers' => [
+      'Authorization' => 'Token ' . $organize_api_token,
+    ],
+  ];
+
+  return $client;
+}
+
+/*
+ * Sends user postal code to Organize's PostalCode GET API endpoint.
+ *
+ */
+function dosomething_organ_donation_send_postal_code() {
+  $params = drupal_get_query_parameters();
+
+  if ($params['postal_code'] && $params['nid']) {
+    $client = _dosomething_organ_donation_build_http_client($params['nid']);
+
+    $response = drupal_http_request($client['base_url'] . $params['postal_code'] . '/', [
+      'headers' => $client['headers'],
+      'method' => 'GET',
+    ]);
+  }
+  else {
+    $response = [
+      'status' => 'Postal code not found.',
+    ];
+  }
+
+  return drupal_json_output($response);
+}
+
 
 /*
  * Stores meta data about the organ registration in the dosomething_organ_donation table.

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -32,7 +32,7 @@ function dosomething_organ_donation_menu() {
  * @returns array
  */
 function _dosomething_organ_donation_build_http_client($nid) {
-  $base_url = 'https://fiftythree-dev.organize.org/api/v2/postal-codes/';
+  $base_url = 'https://fiftythree-dev.organize.org/api/v4/';
   $organize_api_token = dosomething_helpers_get_variables('node', $nid, 'organize_api_token');
   $organize_api_token = $organize_api_token['organize_api_token'];
 
@@ -56,18 +56,18 @@ function dosomething_organ_donation_send_postal_code() {
   if ($params['postal_code'] && $params['nid']) {
     $client = _dosomething_organ_donation_build_http_client($params['nid']);
 
-    $response = drupal_http_request($client['base_url'] . $params['postal_code'] . '/', [
+    $response = drupal_http_request($client['base_url'] . 'postal-codes/' . $params['postal_code'] . '/', [
       'headers' => $client['headers'],
       'method' => 'GET',
     ]);
-  }
-  else {
-    $response = [
-      'status' => 'Postal code not found.',
-    ];
-  }
 
-  return drupal_json_output($response);
+    if ($response->error) {
+      $response = [
+        'error' => 'Postal code not found.',
+      ];
+    }
+    return drupal_json_output($response);
+  }
 }
 
 


### PR DESCRIPTION
#### What's this PR do?

Creates `/organ-donation/send-postal-code` endpoint that accepts `postal_code` and `nid` params to make `GET` request to Organize's Postal Code API. 
#### How should this be reviewed?
- Hit `http://dev.dosomething.org:8888/organ-donation/send-postal-code?postal_code=10028&nid=1631` endpoint to return results. 
- Hit `http://dev.dosomething.org:8888/organ-donation/send-postal-code?postal_code=10028&nid=z` to receive incorrect `nid` error.
- Hit `http://dev.dosomething.org:8888/organ-donation/send-postal-code?postal_code=1002z&nid=1631` to receive incorrect postal code error. 
#### Any background context you want to provide?

We need to have the `nid` as a param because we are storing our API token as a variable in the feature flag. In order to access this, we'll need the `nid`. 
#### Relevant tickets

Fixes first checkbox in #6547 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
