### PR TITLE
Updates to fix photo structure and update based on new actions items.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -45,7 +45,7 @@ const Reportback = {
     if (!$container.length) return;
 
     this.reportbackContainer = $container;
-    this.$reportbackWrapper = this.reportbackContainer.find('.wrapper');
+    this.$reportbackWrapper = this.reportbackContainer.find('.wrapper:first');
     this.$reportbackForm = this.reportbackContainer.find('#dosomething-reportback-form');
     this.$uploadButton = this.reportbackContainer.find('.js-image-upload');
     this.$captionField = this.$reportbackForm.find('.form-item-caption');

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -99,7 +99,7 @@ const Reportback = {
       const $this = $(this);
 
       $this.load(function() {
-        $this.parent('.photo').addClass('is-unveiled');
+        $this.closest('.photo').addClass('is-unveiled');
       });
     });
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/templates/reportback.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/templates/reportback.tpl.html
@@ -1,8 +1,10 @@
 <% if (isListItem) { %><li><% } %>
-<figure class="photo -stacked -framed" data-reportback-item-id="...">
-  <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=" alt="<%= caption %>" data-src="<%= image %>" />
-  <figcaption class="__copy">
-    <p class="photo__caption"><%= caption %></p>
-  </figcaption>
-</figure>
+<div class="photo -stacked -framed" data-reportback-item-id="...">
+  <figure class="wrapper">
+    <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=" alt="<%= caption %>" data-src="<%= image %>" />
+    <figcaption class="photo__copy">
+      <p class="photo__caption"><%= caption %></p>
+    </figcaption>
+  </figure>
+</div>
 <% if (isListItem) { %></li><% } %>

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
@@ -75,7 +75,7 @@
 
   .photo {
     &.-framed {
-      .__copy {
+      .photo__copy {
         @include media($large) {
           height: 90px;
         }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_admin-edit.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_admin-edit.scss
@@ -1,5 +1,5 @@
 .admin-edit {
-  background: rgba(0,0,0,0.5);
+  background: rgba(255,255,255,0.7);
   height: 100%;
   left: 0;
   opacity: 0;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_photo.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_photo.scss
@@ -1,6 +1,10 @@
 .photo {
   position: relative;
 
+  > .wrapper {
+    position: relative;
+  }
+
   .admin-edit {
     display: none;
   }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_photo.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_photo.scss
@@ -26,34 +26,34 @@
     img {
       width: 100%;
     }
+  }
+}
 
-    .__copy {
-      font-size: $font-smaller;
-      height: 110px;
-      line-height: 1.2;
-      overflow: hidden;
-      margin-top: ($base-spacing / 2);
-      word-wrap: break-word;
+.photo__copy {
+  font-size: $font-smaller;
+  height: 110px;
+  line-height: 1.2;
+  overflow: hidden;
+  margin-top: ($base-spacing / 2);
+  word-wrap: break-word;
 
-      .photo__caption {
-        font-size: $font-smaller;
-      }
-
-      .footnote {
-        font-size: $font-small;
-      }
-
-      .form-actions {
-        margin-top: 6px;
-      }
-
-      @include media($large) {
-        font-size: $font-small;
-      }
-    }
+  .photo__caption {
+    font-size: $font-smaller;
   }
 
-  .photo--actions {
-    width: 100%;
+  .footnote {
+    font-size: $font-small;
   }
+
+  .form-actions {
+    margin-top: 6px;
+  }
+
+  @include media($large) {
+    font-size: $font-small;
+  }
+}
+
+.photo__actions {
+  width: 100%;
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_photo.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_photo.scss
@@ -37,20 +37,12 @@
   margin-top: ($base-spacing / 2);
   word-wrap: break-word;
 
-  .photo__caption {
-    font-size: $font-smaller;
-  }
-
-  .footnote {
-    font-size: $font-small;
-  }
-
-  .form-actions {
-    margin-top: 6px;
-  }
-
   @include media($large) {
     font-size: $font-small;
+  }
+
+  .photo__caption {
+    font-size: $font-smaller;
   }
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -1,17 +1,20 @@
-<figure class="photo -stacked -framed" data-reportback-item-id="<?php print $content->id; ?>">
-  <?php if (isset($content->admin_link)): ?>
-    <div class="admin-edit">
-      <a class="button -secondary" href="<?php print $content->admin_link; ?>"><?php print t('Edit Status'); ?></a>
-    </div>
-  <?php endif; ?>
-  <img src="<?php print $content->media['uri']; ?>" alt="<?php print filter_xss($content->caption); ?>" />
-  <figcaption class="__copy">
-    <p class="photo__caption"><?php print filter_xss($content->caption); ?></p>
-  </figcaption>
+<div class="photo -stacked -framed" data-reportback-item-id="<?php print $content->id; ?>">
+  <figure class=wrapper>
+    <?php if (isset($content->admin_link)): ?>
+      <div class="admin-edit">
+        <a class="button -secondary" href="<?php print $content->admin_link; ?>"><?php print t('Edit Status'); ?></a>
+      </div>
+    <?php endif; ?>
+    <img src="<?php print $content->media['uri']; ?>" alt="<?php print filter_xss($content->caption); ?>" />
+    <figcaption class="__copy">
+      <p class="photo__caption"><?php print filter_xss($content->caption); ?></p>
+    </figcaption>
+  </figure>
+
   <?php if ($content->allow_reactions): ?>
-    <div class="form-actions -inline photo--actions">
+    <ul class="form-actions -inline photo--actions">
       <li><a class="button -mini js-kudos-button <?php print ! empty($content->existing_kids[$content->allowed_reactions[0]]->kid) ? 'is-active' : '' ?>" data-kudo-id="<?php print $content->allowed_reactions[0] ?>" data-kid="<?php print dosomething_helpers_isset($content->existing_kids[$content->allowed_reactions[0]], 'kid') ?>">&#128150;</a> <span class="counter"><?php print $content->likes ?></span></li>
       <li><a class="button -mini js-kudos-button <?php print ! empty($content->existing_kids[$content->allowed_reactions[1]]->kid) ? 'is-active' : '' ?>" data-kudo-id="<?php print $content->allowed_reactions[1] ?>" data-kid="<?php print dosomething_helpers_isset($content->existing_kids[$content->allowed_reactions[1]], 'kid') ?>">&#128169;</a> <span class="counter"><?php print $content->poos ?></span></li>
-    </div>
+    </ul>
   <?php endif; ?>
-</figure>
+</div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -6,13 +6,13 @@
       </div>
     <?php endif; ?>
     <img src="<?php print $content->media['uri']; ?>" alt="<?php print filter_xss($content->caption); ?>" />
-    <figcaption class="__copy">
+    <figcaption class="photo__copy">
       <p class="photo__caption"><?php print filter_xss($content->caption); ?></p>
     </figcaption>
   </figure>
 
   <?php if ($content->allow_reactions): ?>
-    <ul class="form-actions -inline photo--actions">
+    <ul class="form-actions -inline photo__actions">
       <li><a class="button -mini js-kudos-button <?php print ! empty($content->existing_kids[$content->allowed_reactions[0]]->kid) ? 'is-active' : '' ?>" data-kudo-id="<?php print $content->allowed_reactions[0] ?>" data-kid="<?php print dosomething_helpers_isset($content->existing_kids[$content->allowed_reactions[0]], 'kid') ?>">&#128150;</a> <span class="counter"><?php print $content->likes ?></span></li>
       <li><a class="button -mini js-kudos-button <?php print ! empty($content->existing_kids[$content->allowed_reactions[1]]->kid) ? 'is-active' : '' ?>" data-kudo-id="<?php print $content->allowed_reactions[1] ?>" data-kid="<?php print dosomething_helpers_isset($content->existing_kids[$content->allowed_reactions[1]], 'kid') ?>">&#128169;</a> <span class="counter"><?php print $content->poos ?></span></li>
     </ul>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -1,5 +1,5 @@
 <div class="photo -stacked -framed" data-reportback-item-id="<?php print $content->id; ?>">
-  <figure class=wrapper>
+  <figure class="wrapper">
     <?php if (isset($content->admin_link)): ?>
       <div class="admin-edit">
         <a class="button -secondary" href="<?php print $content->admin_link; ?>"><?php print t('Edit Status'); ?></a>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -1,20 +1,24 @@
-<div class="photo -stacked -framed" data-reportback-item-id="<?php print $content->id; ?>">
+<div class="photo -stacked -framed" <?php print $content->id ? 'data-reportback-item-id="' . $content->id . '"' : ''; ?>>
+
   <figure class="wrapper">
     <?php if (isset($content->admin_link)): ?>
       <div class="admin-edit">
         <a class="button -secondary" href="<?php print $content->admin_link; ?>"><?php print t('Edit Status'); ?></a>
       </div>
     <?php endif; ?>
+
     <img src="<?php print $content->media['uri']; ?>" alt="<?php print filter_xss($content->caption); ?>" />
+
     <figcaption class="photo__copy">
       <p class="photo__caption"><?php print filter_xss($content->caption); ?></p>
     </figcaption>
   </figure>
 
-  <?php if ($content->allow_reactions): ?>
+  <?php if ($content->id && $content->allow_reactions): ?>
     <ul class="form-actions -inline photo__actions">
       <li><a class="button -mini js-kudos-button <?php print ! empty($content->existing_kids[$content->allowed_reactions[0]]->kid) ? 'is-active' : '' ?>" data-kudo-id="<?php print $content->allowed_reactions[0] ?>" data-kid="<?php print dosomething_helpers_isset($content->existing_kids[$content->allowed_reactions[0]], 'kid') ?>">&#128150;</a> <span class="counter"><?php print $content->likes ?></span></li>
       <li><a class="button -mini js-kudos-button <?php print ! empty($content->existing_kids[$content->allowed_reactions[1]]->kid) ? 'is-active' : '' ?>" data-kudo-id="<?php print $content->allowed_reactions[1] ?>" data-kid="<?php print dosomething_helpers_isset($content->existing_kids[$content->allowed_reactions[1]], 'kid') ?>">&#128169;</a> <span class="counter"><?php print $content->poos ?></span></li>
     </ul>
   <?php endif; ?>
+
 </div>


### PR DESCRIPTION
#### What's this PR do?

This PR makes a suggested update to the _photo_ pattern structure due to the new addition of actions. We originally had the photo pattern in a `<figure>` tag because the photos in the gallery consisted of an image and a caption and is essential to the gallery, so it made sense to use that tag. However, with the addition of the photo kudos actions and potentially other edits to these items adding more elements, it makes sense to use a div for the `.photo` and nest the `<figure>` with the `<img>` and `<figcaption>` and then additional elements are added outside the figure but inside the div. This follows the idea behind how the [figure tag](http://html5doctor.com/element-index/#figure) is supposed to be used.

Not crucial, but felt it could be a good update to future-proof the `photo` pattern a bit :)

Also fixes missing `ul` tags for the kudos list items that was throwing me for a whirl @_@

Also stops kudos actions from outputting on placeholder reportback gallery items.

Annnnnd also fixes issue with not being able to click on kudos action if signed in as an admin:

**Before:**
<img width="266" alt="screen shot 2016-06-06 at 1 02 45 pm" src="https://cloud.githubusercontent.com/assets/105849/15832422/2a5d448a-2bf0-11e6-96d4-d610c5036159.png">

**After:**
<img width="263" alt="screen shot 2016-06-06 at 1 57 09 pm" src="https://cloud.githubusercontent.com/assets/105849/15832426/30d4b122-2bf0-11e6-92e7-8e93618d7a8e.png">
#### How should this be reviewed?

Gallery still works?
#### Any background context you want to provide?

I didn't update the structure yet for the items that get inserted via the view more since I wanted to first see if there's buy-in on this suggestion!
#### Relevant tickets

Fixes #6542
#### Checklist
- [ ] Documentation added to pattern library docs.

---

@DoSomething/front-end 
cc: @angaither 
