### PR TITLE
Fixes for Kudos DBLog notices/warnings/errors (take 2)

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -76,7 +76,11 @@ function dosomething_campaign_preprocess_node(&$vars) {
  */
 function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
   if (isset($wrapper->field_issue)) {
-    $vars['issue'] = $wrapper->field_issue->value()->name;
+    $issue = $wrapper->field_issue->value();
+
+    if ($issue) {
+      $vars['issue'] = $issue->name;
+    }
   }
   dosomething_campaign_preprocess_facts_vars($vars, $wrapper);
   dosomething_campaign_preprocess_media_vars($vars, $wrapper);

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -195,8 +195,9 @@ function dosomething_kudos_get_totals_by_taxonomy_term($data) {
  * @return int
  */
 function dosomething_kudos_get_term_id_by_name($name) {
-  return array_pop(taxonomy_get_term_by_name($name, 'kudos'))->tid;
+  $term = taxonomy_get_term_by_name($name, 'kudos');
 
+  return array_pop($term)->tid;
 }
 
 /**
@@ -233,3 +234,62 @@ function dosomething_kudos_get_kudos_for_user_by_file($fid) {
 
   return $kudos;
 }
+
+/**
+ * Check to see if the kudos term has been selected by the user on specified
+ * reportback.
+ *
+ * @param  [type] $id
+ * @param  object $reportbackItem
+ * @return bool
+ */
+function dosomething_kudos_term_is_selected($id, $reportbackItem) {
+  if (! $reportbackItem->existing_kids) {
+    return false;
+  }
+
+  if (! isset($reportbackItem->existing_kids[$id])) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Get the icon associated with the kudos term id.
+ *
+ * @param  string $id
+ * @return string
+ * @TODO: this will eventually be changed to refere to SVG icon paths for our custom kudos icons!
+ */
+function dosomething_kudos_get_icon_by_term_id($id) {
+  settype($id, 'string');
+
+  $icons = [
+    '641' => '&#128150;',
+    '646' => '&#128169;',
+  ];
+
+  return $icons[$id];
+}
+
+/**
+ * Get the count for a kudos term on a Reportback item by the
+ * kudos term id.
+ *
+ * @param  string $id
+ * @param  object $reportbackItem
+ * @return string
+ */
+function dosomething_kudos_get_count_by_term_id($id, $reportbackItem) {
+  settype($id, 'string');
+
+  $count_term = [
+    '641' => 'likes',
+    '646' => 'poos',
+  ];
+
+  return $reportbackItem->$count_term[$id];
+}
+
+

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -239,16 +239,16 @@ function dosomething_kudos_get_kudos_for_user_by_file($fid) {
  * Check to see if the kudos term has been selected by the user on specified
  * reportback.
  *
- * @param  [type] $id
- * @param  object $reportbackItem
+ * @param  string $id
+ * @param  object $reportback_item
  * @return bool
  */
-function dosomething_kudos_term_is_selected($id, $reportbackItem) {
-  if (! $reportbackItem->existing_kids) {
+function dosomething_kudos_term_is_selected($id, $reportback_item) {
+  if (! $reportback_item->existing_kids) {
     return false;
   }
 
-  if (! isset($reportbackItem->existing_kids[$id])) {
+  if (! isset($reportback_item->existing_kids[$id])) {
     return false;
   }
 

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -239,12 +239,18 @@ function dosomething_kudos_get_kudos_for_user_by_file($fid) {
  * Check to see if the kudos term has been selected by the user on specified
  * reportback.
  *
- * @param  string $id
  * @param  object $reportback_item
+ * @param  string $term
  * @return bool
  */
-function dosomething_kudos_term_is_selected($id, $reportback_item) {
+function dosomething_kudos_term_is_selected($reportback_item, $term) {
   if (! $reportback_item->existing_kids) {
+    return false;
+  }
+
+  $id = dosomething_kudos_get_term_id_by_name($term);
+
+  if (! $id) {
     return false;
   }
 
@@ -253,43 +259,6 @@ function dosomething_kudos_term_is_selected($id, $reportback_item) {
   }
 
   return true;
-}
-
-/**
- * Get the icon associated with the kudos term id.
- *
- * @param  string $id
- * @return string
- * @TODO: this will eventually be changed to refere to SVG icon paths for our custom kudos icons!
- */
-function dosomething_kudos_get_icon_by_term_id($id) {
-  $id = (string) $id;
-
-  $icons = [
-    '641' => '&#128150;',
-    '646' => '&#128169;',
-  ];
-
-  return $icons[$id];
-}
-
-/**
- * Get the count for a kudos term on a Reportback item by the
- * kudos term id.
- *
- * @param  string $id
- * @param  object $reportbackItem
- * @return string
- */
-function dosomething_kudos_get_count_by_term_id($id, $reportbackItem) {
-  $id = (string) $id;
-
-  $count_term = [
-    '641' => 'likes',
-    '646' => 'poos',
-  ];
-
-  return $reportbackItem->$count_term[$id];
 }
 
 

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -263,7 +263,7 @@ function dosomething_kudos_term_is_selected($id, $reportback_item) {
  * @TODO: this will eventually be changed to refere to SVG icon paths for our custom kudos icons!
  */
 function dosomething_kudos_get_icon_by_term_id($id) {
-  settype($id, 'string');
+  $id = (string) $id;
 
   $icons = [
     '641' => '&#128150;',
@@ -282,7 +282,7 @@ function dosomething_kudos_get_icon_by_term_id($id) {
  * @return string
  */
 function dosomething_kudos_get_count_by_term_id($id, $reportbackItem) {
-  settype($id, 'string');
+  $id = (string) $id;
 
   $count_term = [
     '641' => 'likes',

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -356,7 +356,7 @@ function paraneue_dosomething_get_themed_reportback_item($data) {
     return NULL;
   }
 
-  if ($data->allow_reactions) {
+  if ($data->id && $data->allow_reactions) {
     // Aggregate a like and poo count based on the tid.
     $data->likes = dosomething_kudos_get_total_for_file_by_term_name($data->id, 'heart');
     $data->poos = dosomething_kudos_get_total_for_file_by_term_name($data->id, 'poo');
@@ -398,6 +398,7 @@ function paraneue_dosomething_get_placeholder_reportbacks($count = 6) {
 
   for ($i = 0; $i < $count; $i++) {
     $placeholder = (object) [];
+    $placeholder->id = NULL;
     $placeholder->caption = $placeholder_captions[$i];
     $placeholder->media['uri'] = $placeholder_urls[$i];
     $placeholder->media['type'] = 'image';

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -357,9 +357,10 @@ function paraneue_dosomething_get_themed_reportback_item($data) {
   }
 
   if ($data->id && $data->allow_reactions) {
-    // Aggregate a like and poo count based on the tid.
-    $data->likes = dosomething_kudos_get_total_for_file_by_term_name($data->id, 'heart');
-    $data->poos = dosomething_kudos_get_total_for_file_by_term_name($data->id, 'poo');
+    $data->reaction_totals = [
+      'heart' => dosomething_kudos_get_total_for_file_by_term_name($data->id, 'heart'),
+    ];
+
     $data->existing_kids = dosomething_kudos_get_kudos_for_user_by_file($data->id);
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -246,12 +246,15 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars, $count = 6) 
   else {
     $reportbackItems = $promotedReportbackItems;
   }
+
   $allow_reactions = dosomething_helpers_get_variable('node', $vars['nid'], 'allow_reactions');
+
   $allowed_tids = [];
+
   if ($allow_reactions) {
     array_push($allowed_tids, dosomething_kudos_get_term_id_by_name('heart'));
-    array_push($allowed_tids, dosomething_kudos_get_term_id_by_name('poo'));
   };
+
   foreach ($reportbackItems as $item) {
     $item->allow_reactions = $allow_reactions;
     $item->allowed_reactions = $allowed_tids;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_counter.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_counter.scss
@@ -4,6 +4,7 @@
   color: $med-gray;
   font-weight: $weight-bold;
   font-size: 13px !important;
+  padding-left: 3px;
 
   &.is-active {
     color: $purple;

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -15,9 +15,16 @@
   </figure>
 
   <?php if ($content->id && $content->allow_reactions): ?>
+
     <ul class="form-actions -inline photo__actions">
-      <li><a class="button -mini js-kudos-button <?php print ! empty($content->existing_kids[$content->allowed_reactions[0]]->kid) ? 'is-active' : '' ?>" data-kudo-id="<?php print $content->allowed_reactions[0] ?>" data-kid="<?php print dosomething_helpers_isset($content->existing_kids[$content->allowed_reactions[0]], 'kid') ?>">&#128150;</a> <span class="counter"><?php print $content->likes ?></span></li>
-      <li><a class="button -mini js-kudos-button <?php print ! empty($content->existing_kids[$content->allowed_reactions[1]]->kid) ? 'is-active' : '' ?>" data-kudo-id="<?php print $content->allowed_reactions[1] ?>" data-kid="<?php print dosomething_helpers_isset($content->existing_kids[$content->allowed_reactions[1]], 'kid') ?>">&#128169;</a> <span class="counter"><?php print $content->poos ?></span></li>
+
+      <?php foreach($content->allowed_reactions as $key => $id): ?>
+        <li>
+          <a class="button -mini js-kudos-button <?php print dosomething_kudos_term_is_selected($id, $content) ? 'is-active' : '' ?>" data-kudo-id="<?php print $id ?>"><?php print dosomething_kudos_get_icon_by_term_id($id) ?></a>
+          <span class="counter"><?php print dosomething_kudos_get_count_by_term_id($id, $content) ?></span>
+        </li>
+      <?php endforeach; ?>
+
     </ul>
   <?php endif; ?>
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -15,16 +15,11 @@
   </figure>
 
   <?php if ($content->id && $content->allow_reactions): ?>
-
     <ul class="form-actions -inline photo__actions">
-
-      <?php foreach($content->allowed_reactions as $key => $id): ?>
-        <li>
-          <a class="button -mini js-kudos-button <?php print dosomething_kudos_term_is_selected($id, $content) ? 'is-active' : '' ?>" data-kudo-id="<?php print $id ?>"><?php print dosomething_kudos_get_icon_by_term_id($id) ?></a>
-          <span class="counter"><?php print dosomething_kudos_get_count_by_term_id($id, $content) ?></span>
-        </li>
-      <?php endforeach; ?>
-
+      <li>
+        <a class="button -mini js-kudos-button <?php print dosomething_kudos_term_is_selected($content, 'heart') ? 'is-active' : '' ?>" data-kudo-id="<?php print array_pop($content->allowed_reactions); ?>">&#128150;</a>
+        <span class="counter"><?php print $content->reaction_totals['heart']; ?></span>
+      </li>
     </ul>
   <?php endif; ?>
 


### PR DESCRIPTION
#### What's this PR do?

This PR fixes a bunch of notices/warnings/errors that were showing up in the DBLog for a bunch of kudos related things, particularly for when a placeholder is used in the gallery instead of an actual Reportback Item. Placeholders shouldn't be treated as RB items otherwise a bunch of values that are expected to exist on the placeholder lead to errors when they're not there.
#### How should this be reviewed?

Load a campaign with reportbacks and one that's fresh and has a bunch of placeholders still in the gallery, then check the dblog in the Drupal CMS.
#### Any background context you want to provide?

Ref #6560 This PR takes a simpler approach to only account for a single kudos item on RB items in gallery at the moment, instead of accounting for multiple.
#### Relevant tickets

Fixes # 💅 

---

@DFurnes @angaither 
