### PR TITLE
Organize Dblog errors and other organ code cleanup

### DIFF
--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -29,7 +29,7 @@ function dosomething_organ_donation_menu() {
   ];
 
    $items['admin/config/services/organs'] = [
-    'title' => 'Oranize API Settings',
+    'title' => 'Organize API Settings',
     'description' => 'Manage Organize connection settings.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('dosomething_organize_config_form'),

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -166,12 +166,11 @@ function dosomething_organ_donation_config_form($form, &$form_state, $node) {
  * Submit callback for dosomething_campaign_organ_donation_config_form().
  */
 function dosomething_organ_donation_config_form_submit(&$form, &$form_state) {
-  $var_names = ['register_organ_donors', 'organize_api_token'];
+  $var_name = 'register_organ_donors';
 
-  foreach($var_names as $var_name) {
-    $values = $form_state['values'];
-    dosomething_helpers_set_variable('node', $values['nid'], $var_name, $values[$var_name]);
-  }
+  $values = $form_state['values'];
+
+  dosomething_helpers_set_variable('node', $values['nid'], $var_name, $values[$var_name]);
 
   drupal_set_message("Updated.");
 }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -183,7 +183,7 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
     drupal_add_js($js, 'inline');
   }
 
-  if (function_exists('dosomething_organ_donation_store_registration')) {
+  if (module_exists('dosomething_organ_donation')) {
     if ($vars['node']->register_organ_donor) {
       // Add JS to open the signup data form modal.
       $id = 'modal-organ-donation';

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -183,14 +183,16 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
     drupal_add_js($js, 'inline');
   }
 
-  if ($vars['node']->register_organ_donor) {
-    // Add JS to open the signup data form modal.
-    $id = 'modal-organ-donation';
-    $closeButton = 'skip';
+  if (function_exists('dosomething_organ_donation_store_registration')) {
+    if ($vars['node']->register_organ_donor) {
+      // Add JS to open the signup data form modal.
+      $id = 'modal-organ-donation';
+      $closeButton = 'skip';
 
-    // @TODO - New function?
-    $js = 'jQuery(document).ready(function() { DSModal.open( jQuery("#' . $id . '"), {animated: false, closeButton: "' . $closeButton . '"}); });';
-    drupal_add_js($js, 'inline');
+      // @TODO - New function?
+      $js = 'jQuery(document).ready(function() { DSModal.open( jQuery("#' . $id . '"), {animated: false, closeButton: "' . $closeButton . '"}); });';
+      drupal_add_js($js, 'inline');
+    }
   }
 
   // If this is not the pitch page:

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -384,10 +384,12 @@
       </div>
 
       <?php // Organ Donation Modal // ?>
-      <?php if ($register_organ_donor): ?>
-        <div data-modal id="modal-organ-donation" role="dialog">
-            <div class="takeover-container -no-slide"></div>
-        </div>
+      <?php if (function_exists('dosomething_organ_donation_store_registration')): ?>
+        <?php if ($register_organ_donor): ?>
+          <div data-modal id="modal-organ-donation" role="dialog">
+              <div class="takeover-container -no-slide"></div>
+          </div>
+        <?php endif; ?>
       <?php endif; ?>
 
       <?php if (isset($official_rules)): ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -384,7 +384,7 @@
       </div>
 
       <?php // Organ Donation Modal // ?>
-      <?php if (function_exists('dosomething_organ_donation_store_registration')): ?>
+      <?php if (module_exists('dosomething_organ_donation')): ?>
         <?php if ($register_organ_donor): ?>
           <div data-modal id="modal-organ-donation" role="dialog">
               <div class="takeover-container -no-slide"></div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -384,12 +384,10 @@
       </div>
 
       <?php // Organ Donation Modal // ?>
-      <?php if (module_exists('dosomething_organ_donation')): ?>
-        <?php if ($register_organ_donor): ?>
-          <div data-modal id="modal-organ-donation" role="dialog">
-              <div class="takeover-container -no-slide"></div>
-          </div>
-        <?php endif; ?>
+      <?php if (isset($register_organ_donor)): ?>
+        <div data-modal id="modal-organ-donation" role="dialog">
+            <div class="takeover-container -no-slide"></div>
+        </div>
       <?php endif; ?>
 
       <?php if (isset($official_rules)): ?>


### PR DESCRIPTION
#### What's this PR do?
- Adds a check to make sure the `dosomething_organ_donation` module is enabled to get rid of errors in dblog. 
- Fixes typo on `/admin/config/services/organs` (from Oranize API Settings to Organize API Settings)
- Gets rid of unnecessary code - `organize_api_token` in dosomething_organ_donation_config_form_submit` function with update from #6553
#### How should this be reviewed?
- If `dosomething_organ_donation` is enabled, disable it by running `drush pm-disable dosomething_organ_donation -y` in your vagrant box (inside `/var/www/dev.dosomething.org/html`)
- Click on a campaign. 
- Check the dblogs. You should **not** see the following errors:

```
Notice: Undefined variable: register_organ_donor in include() (line 387 of /var/www/dev.dosomething.org/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php).`
```

or 

```
Notice: Undefined property: stdClass::$register_organ_donor in paraneue_dosomething_preprocess_node_campaign() (line 186 of /var/www/dev.dosomething.org/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc).
```
- Enable the module by running `drush pm-enable dosomething_organ_donation -y` in same directory of your vagrant box. 
- Click on a campaign > Custom Settings and check off "Register organ donors after signup" under the "ORGAN DONATION" section. 
- Click on a campaign and the organ donation module should pop up. 
- Click on a different campaign and the organ donation module should not pop up.  
#### Relevant tickets

Fixes #6562 
