### PR TITLE
Add magic login link functionality.

### DIFF
--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -211,3 +211,18 @@ POST /api/v1/users/{uid}/password_reset_url
 [ 'http://dev.dosomething.org:8888/user/reset/1700226/1425495228/P-f-5d6kHLrOXl0VrQfXavgmMjiNz042uihpxJW4jBc' ]
 ```
 
+## Create Magic Login URL
+
+Only available to a logged in administrator. Must include UID of the user in the URL.
+
+```
+POST /api/v1/users/{uid}/magic_login_url
+```
+
+**Example Response:**
+
+```js
+// 200 Okay
+
+[ 'http://dev.dosomething.org:8888/user/magic/1700226/1425495228/P-f-5d6kHLrOXl0VrQfXavgmMjiNz042uihpxJW4jBc' ]
+```

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -215,6 +215,9 @@ POST /api/v1/users/{uid}/password_reset_url
 
 Only available to a logged in administrator. Must include UID of the user in the URL.
 
+You may optionally append a `?redirect=` query parameter to the returned link to indicate where to redirect
+after logging in. For example, use `?redirect=node/1144` to log in & redirect to Teens For Jeans.
+
 ```
 POST /api/v1/users/{uid}/magic_login_url
 ```
@@ -224,5 +227,9 @@ POST /api/v1/users/{uid}/magic_login_url
 ```js
 // 200 Okay
 
-[ 'http://dev.dosomething.org:8888/user/magic/1700226/1425495228/P-f-5d6kHLrOXl0VrQfXavgmMjiNz042uihpxJW4jBc' ]
+{
+  "url": "http://dev.dosomething.org:8888/user/magic/1700226/1425495228/P-f-5d6kHLrOXl0VrQfXavgmMjiNz042uihpxJW4jBc",
+  "expires": "2016-06-08T15:12:52+00:00"
+}
 ```
+

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -211,6 +211,9 @@ function dosomething_api_default_services_endpoint() {
         'password_reset_url' => array(
           'enabled' => '1',
         ),
+        'magic_login_url' => array(
+          'enabled' => '1',
+        ),
       ),
     ),
   );

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -110,6 +110,26 @@ function _member_resource_definition() {
         'access callback' => '_member_resource_access',
         'access arguments' => array('password_reset_url'),
       ),
+      'magic_login_url' => array(
+        'help' => 'Create a magic login link for a user.',
+        'file' => array(
+          'type' => 'inc',
+          'module' => 'dosomething_api',
+          'name' => 'resources/member_resource',
+        ),
+        'args' => array(
+          array(
+            'name' => 'uid',
+            'optional' => FALSE,
+            'source' => array('path' => 0),
+            'type' => 'int',
+            'description' => 'The UID of the user who we\'re making a magic login link for.',
+          ),
+        ),
+        'callback' => '_member_resource_magic_login_url',
+        'access callback' => '_member_resource_access',
+        'access arguments' => array('magic_login_url'),
+      ),
     ),
   );
   return $member_resource;
@@ -145,11 +165,11 @@ function _member_resource_access($op) {
  */
 function _member_resource_create($request) {
   $query = drupal_get_query_parameters();
-  
+
   if (!isset($request['email'])) {
     return services_error("Email is required.");
   }
-  
+
   // Check if email is formatted correctly and not already in use.
   $email = $request['email'];
   if ($user = user_load_by_mail($email)) {
@@ -158,7 +178,7 @@ function _member_resource_create($request) {
   if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
     return services_error(t('Email @email is not a valid email address.', ['@email' => $email]), 422);
   }
-  
+
   // Check if account exists for phone.
   $mobile = $request['mobile'];
   if ($mobile && $user = dosomething_user_get_user_by_mobile($mobile)) {
@@ -167,7 +187,7 @@ function _member_resource_create($request) {
   if ($mobile && !dosomething_user_valid_mobile($mobile)) {
     return services_error(t('Mobile @mobile is not a valid phone number.', ['@mobile' => $mobile]), 422);
   }
-  
+
   // Initialize array to pass to user_save().
   $edit = [
     'mail' => $email,
@@ -196,23 +216,23 @@ function _member_resource_create($request) {
 
   try {
     $user = user_save('', $edit);
-    
+
     // Ensure user has UID set for name, since insert hooks don't fire on API.
     // @see: dosomething_user_user_insert
     user_save($user, ['name' => $user->uid]);
-    
+
     // Forward users to Northstar, unless `?forward=false` is explicitly set.
     $should_forward = isset($query['forward']) ? filter_var($query['forward'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) : true;
     if ($should_forward && module_exists('dosomething_northstar')) {
       $payload = dosomething_northstar_transform_user($user);
       $payload['password'] = $edit['pass'];
-      
+
       dosomething_northstar_register_user($user, $payload);
     }
 
     // Don't return the hashed password in the response!
     unset($user->pass);
-    
+
     return $user;
   }
   catch (Exception $e) {
@@ -335,4 +355,13 @@ function _member_resource_reset($uid) {
   $account = user_load($uid);
   $reset_url = user_pass_reset_url($account) . '/login';
   return $reset_url;
+}
+
+/**
+ * Callback for the `/users/{nid}/magic_login_url` endpoint.
+ *
+ * @return string
+ */
+function _member_resource_magic_login_url() {
+  return '...';
 }

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -358,10 +358,25 @@ function _member_resource_reset($uid) {
 }
 
 /**
- * Callback for the `/users/{nid}/magic_login_url` endpoint.
+ * Callback for the `/users/{nid}/magic_login_url` endpoint. This creates
+ * a one-time login link for the given user.
+ * @see dosomething_user_magic_session
  *
- * @return string
+ * @return array
  */
-function _member_resource_magic_login_url() {
-  return '...';
+function _member_resource_magic_login_url($uid) {
+  $account = user_load($uid);
+  $timestamp = REQUEST_TIME;
+
+  if (! $account) {
+    return services_error('That user does not exist', 404);
+  }
+
+  // Create a one-time login URL using the same methods as built-in Drupal password reset.
+  $magic_url = url("user/magic/$uid/$timestamp/" . user_pass_rehash($account->pass, $timestamp, $account->login, $account->uid), ['absolute' => TRUE]);
+
+  return [
+    'url' => $magic_url,
+    'expires' => date('c', $timestamp),
+  ];
 }

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -373,7 +373,7 @@ function _member_resource_magic_login_url($uid) {
   }
 
   // Create a one-time login URL using the same methods as built-in Drupal password reset.
-  $magic_url = url("user/magic/$uid/$timestamp/" . user_pass_rehash($account->pass, $timestamp, $account->login, $account->uid), ['absolute' => TRUE]);
+  $magic_url = url('user/magic/' . $uid . '/' . $timestamp . '/' . user_pass_rehash($account->pass, $timestamp, $account->login, $account->uid), ['absolute' => TRUE]);
 
   return [
     'url' => $magic_url,

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1806,7 +1806,7 @@ function dosomething_user_magic_session($uid, $timestamp, $login_token) {
   // which prevents further use of the one-time login link.
   user_login_finalize();
 
-  watchdog('user', 'User %name used one-time login link at time %timestamp.', ['%name' => $account->name, '%timestamp' => $timestamp]);
+  watchdog('user', 'User %uid used one-time login link at time %timestamp.', ['%name' => $account->uid, '%timestamp' => $timestamp]);
   drupal_goto($redirect, ['external' => FALSE]);
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -109,6 +109,11 @@ function dosomething_user_menu() {
     'access callback' => 'user_view_access',
     'access arguments' => array(1),
   );
+  $items['user/magic/%'] = array(
+    'page callback' => 'dosomething_user_magic_session',
+    'page arguments' => array(2, 3, 4),
+    'access callback' => TRUE,
+  );
   return $items;
 }
 
@@ -1761,4 +1766,78 @@ function dosomething_user_mail($key, &$message, $params) {
         );
       break;
   }
+}
+
+/**
+ * Menu callback for the `/users/{uid}/magic/{timestamp}/{login_token}` route. This
+ * uses a token generated from the `magic_login_url` endpoint to create a one-time
+ * session for a user. Modeled after Drupal's password reset links.
+ * @see user_pass_reset in user.pages.inc
+ *
+ * @param $uid
+ * @param $timestamp
+ * @param $login_token
+ *
+ * @return string
+ */
+function dosomething_user_magic_session($uid, $timestamp, $login_token) {
+  global $user;
+  
+  $query = drupal_get_query_parameters();
+  $redirect = ! empty($query['redirect']) ? $query['redirect'] : '/';
+
+  // When processing the one-time login link, we have to make sure that a user
+  // isn't already logged in to a different account.
+  if ($user->uid && $user->$uid !== $uid) {
+    drupal_set_message(t('You\'re already logged in to a different account!'), 'error');
+    drupal_goto($redirect, ['external' => FALSE]);
+  }
+
+  // Load active account by UID & check validity of the login link.
+  $account = reset(user_load_multiple([$uid], ['status' => '1']));
+  if (! dosomething_user_check_magic_login_validity($account, $timestamp, $login_token)) {
+    dosomething_user_reject_magic_login_link();
+  }
+
+  // Looks good! Set the new user via the global.
+  $user = $account;
+
+  // Use user_login_finalize() to set the login timestamp of the user,
+  // which prevents further use of the one-time login link.
+  user_login_finalize();
+
+  watchdog('user', 'User %name used one-time login link at time %timestamp.', ['%name' => $account->name, '%timestamp' => $timestamp]);
+  drupal_goto($redirect, ['external' => FALSE]);
+}
+
+/**
+ * Check that a magic login link is valid: it hasn't expired, the referred account exists and
+ * hasn't logged in since generating the link, and the hash of those parameters is correct.
+ * 
+ * @param $account
+ * @param $timestamp
+ * @param $login_token
+ * @return bool
+ */
+function dosomething_user_check_magic_login_validity($account, $timestamp, $login_token) {
+  if(! $account) {
+    return false;
+  }
+  
+  $timeout = variable_get('user_password_reset_timeout', 86400);
+  $has_expired = REQUEST_TIME - $timestamp > $timeout;
+  
+  $valid_parameters = $account->uid && $timestamp >= $account->login && $timestamp <= REQUEST_TIME;
+  $valid_hash = $login_token == user_pass_rehash($account->pass, $timestamp, $account->login, $account->uid);
+  
+  return ! $has_expired && $valid_parameters && $valid_hash;
+}
+
+/**
+ * Reject an invalid magic login link by aborting, setting a flash message, and
+ * redirecting to the homepage.
+ */
+function dosomething_user_reject_magic_login_link() {
+  drupal_set_message(t('You have tried to use an invalid one-time login link.'), 'error');
+  drupal_goto('/');
 }


### PR DESCRIPTION
#### What's this PR do?

This PR adds an endpoint that allows admins to request single-use "magic" login links via the API, and the corresponding route that logs a user into the application when given the magic link.

This is heavily inspired by Drupal's built-in reset password link functionality (and uses the exact same [`user_pass_rehash`](https://api.drupal.org/api/drupal/modules%21user%21user.module/function/user_pass_rehash/7.x) method to generate the secure token), but isn't specifically coupled to sending a user to the profile page.
#### How should this be reviewed?

Check `member_resource.inc` for the admin endpoint that creates the login links, and `dosomething_user.module` for the route that logs people in. I'd also love extra special attention to the `dosomething_user_check_magic_login_validity` to make sure there aren't any mistakes in there! 👀 
#### Any background context you want to provide?

🍡 
#### Relevant tickets

Closes #6555.
#### Checklist
- [x] Documentation added for new features/changed endpoints.
