### PR TITLE
Re-add `kid`s back into the photo template.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -17,7 +17,7 @@
   <?php if ($content->id && !$content->disable_reactions): ?>
     <ul class="form-actions -inline photo__actions">
       <li>
-        <a class="button -mini js-kudos-button <?php print dosomething_kudos_term_is_selected($content, 'heart') ? 'is-active' : '' ?>" data-kudo-id="<?php print array_pop($content->allowed_reactions); ?>">&#128150;</a>
+        <a class="button -mini js-kudos-button <?php print dosomething_kudos_term_is_selected($content, 'heart') ? 'is-active' : '' ?>" data-kudo-id="<?php print $content->allowed_reactions[0]; ?>" data-kid="<?php print dosomething_helpers_isset($content->existing_kids[$content->allowed_reactions[0]], 'kid') ?>" >&#128150;</a>
         <span class="counter"><?php print $content->reaction_totals['heart']; ?></span>
       </li>
     </ul>


### PR DESCRIPTION
#### What's this PR do?

add a kudos id back in to `photo.tpl.php`
#### How should this be reviewed?

👀 
or pull down and run through the bug described in #6573
#### Any background context you want to provide?

Without a `kid` the js was sending a `POST` request to create a new kudo, instead of a `DELETE` request to remove one. 
#### Relevant tickets

Fixes #6573
