### PR TITLE
hardcodes version of api per endpoint

### DIFF
--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.admin.inc
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.admin.inc
@@ -23,14 +23,6 @@ function dosomething_organize_config_form($form, &$form_state) {
     '#default_value' => variable_get('dosomething_organize_url', 'https://fiftythree-dev.organize.org/api'),
   );
 
-  $form['organize']['dosomething_organize_api_version'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Organize API version number'),
-    '#description' => t('Again, no slashes needed'),
-    '#required' => TRUE,
-    '#default_value' => variable_get('dosomething_organize_api_version', 'v4'),
-  );
-
   $form['organize']['dosomething_organize_auth_token'] = array(
     '#type' => 'textfield',
     '#title' => t('App key'),

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -54,7 +54,7 @@ function dosomething_organ_donation_menu() {
  * @returns array
  */
 function _dosomething_organ_donation_build_http_client() {
-  $base_url = ORGANIZE_API_URL . '/' . ORGANIZE_API_VERSION . '/';
+  $base_url = ORGANIZE_API_URL;
   $token = 'Token ' . ORGANIZE_API_AUTH_TOKEN;
 
   $client = [
@@ -83,9 +83,9 @@ function dosomething_organ_donation_post_registration($values) {
     'headers' => $client['headers'],
     'data' =>
       json_encode($values),
-  ];
+];
 
-  $response = drupal_http_request($client['base_url'] . 'registrations/', $options);
+  $response = drupal_http_request($client['base_url'] . '/v2/registrations/', $options);
 
   return drupal_json_output(json_decode($response->data));
 }
@@ -99,7 +99,7 @@ function dosomething_organ_donation_send_postal_code() {
 
   $client = _dosomething_organ_donation_build_http_client();
 
-  $response = drupal_http_request($client['base_url'] . 'postal-codes/' . $params['postal_code'] . '/', [
+  $response = drupal_http_request($client['base_url'] . '/v4/postal-codes/' . $params['postal_code'] . '/', [
     'headers' => $client['headers'],
     'method' => 'GET',
   ]);


### PR DESCRIPTION
#### What's this PR do?

Hard codes version of Organize API depending on endpoint. 
#### How should this be reviewed?
- To test `http://dev.dosomething.org:8888/organize/registration`, first hard code user information in the first lines of `dosomething_organ_donation_post_registration` function: 

```
  $values = [
    'email' => 'clee@dosomething.org',
    'first_name' => 'Chloe',
    'last_name' => 'Lee',
    'street_address' => '150 E 83rd Street',
    'city' => 'New York',
    'state' => 'NY',
    'postal_code' => '10028',
    'license_id' => 'S39fdsaf3df5',
    'gender' => 'F',
    'source_url' => 'www.dosomething.org',
    'middle_name' => 'Alessandra',
    'agree_to_tos' => TRUE,
    'birthdate' => '4/12/1989',
    'subscribe_to_email_list' => FALSE,
    'ssn' => '3419'
  ];
```
- For the above, you should get a `uuid` as the response.
- `http://dev.dosomething.org:8888/organize/postal-code?postal_code=10028` should return information for postal code `10028`
#### Relevant tickets

Fixes #6574 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
