### PR TITLE
Exposing kudos reactions on view more RB items.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -276,6 +276,25 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars, $count = 6) 
   // Get total remaining after subtracting the RB Items already retrieved.
   $gallery['remaining'] = $gallery['total_sum'] - $gallery['prefetched'];
 
+  global $user;
+
+  drupal_add_js(
+    [
+      'dsKudosReactions' => [
+        'enabled' => !$disable_reactions,
+        'user' => isset($user->uid) ? $user->uid : null,
+        'terms' => [
+          // @TODO: Ideally this would call a function that retrieves all
+          // kudos reaction terms and sets up the associative array, but
+          // for the time being we are only using a single term, "heart",
+          // so let's keep it simple ;)
+          'heart' => dosomething_kudos_get_term_id_by_name('heart'),
+        ],
+      ]
+    ],
+    'setting'
+  );
+
   return $gallery;
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -18,6 +18,13 @@ const Reportback = {
 
   apiUrl: '/api/v1/reportback-items',
 
+  reactions: {
+    approved: ['heart'],
+    inventory: {
+      heart: '641', // @TODO: totally temporary! Will be obtained via global object passed in via PHP.
+    },
+  },
+
   nid: null,
 
   itemIds: null,
@@ -179,6 +186,38 @@ const Reportback = {
     });
   },
 
+  /**
+   * Get Kudos Reactions for a Reportback item.
+   *
+   * @param  {array} data  Array of Kudos objects from API.
+   * @return {array}
+   */
+  getReactions: function(data) {
+    console.log(data);
+    let reactions = [];
+
+    for (let i = 0, count = this.reactions.approved.length; i < count; i++) {
+      const term = this.reactions.approved[i];
+      const termId = this.reactions.inventory[term];
+
+      const reaction = {
+        term: term,
+        termId: termId,
+        total: 0,
+        userReacted: false,
+      };
+
+      for (let j = 0, count = data.length; j < count; j++) {
+        if (data[j].term.name === term) {
+          reaction.total = data[j].kudos_items.total;
+        }
+      }
+
+      reactions.push(reaction);
+    }
+
+    return reactions;
+  },
 
   /**
    * Initialize the ImageUpload interface.
@@ -238,6 +277,8 @@ const Reportback = {
         }
       },
     }).done(function(response) {
+      // console.log(response);
+
       _this.apiUrl = response.meta.pagination.links.next_uri || null;
 
       _this.templatize(response);
@@ -265,11 +306,16 @@ const Reportback = {
 
     for (let i = 0, count = items.length; i < count; i++) {
       const data = {
-        'id': items[i].reportback.id,
+        'id': items[i].id,
+        'reportbackId': items[i].reportback.id,
         'image': items[i].media.uri,
         'caption': items[i].caption,
         'status': items[i].status,
-        'isListItem': true,  // @TODO: probably a better way to address this... :insert shrug emoji here:
+        'isListItem': true,  // @TODO: probably a better way to address this... :insert shruggy emoji here:
+        'reactions': {
+          enabled: true, // @TODO: reference global boolean to see if campaign should have kudos reactions or not!
+          data: this.getReactions(items[i].kudos.data),
+        }
       };
 
       data.adminLink = this.adminAccess ? `/admin/reportback/${items[i].reportback.id}` : false;

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -194,12 +194,10 @@ const Reportback = {
    * @return {array}
    */
   getReactions: function(data) {
-    const _this = this;
-
     let reactions = [];
 
-    forEach(_this.reactions.approved, function(term) {
-      const termId = _this.reactions.terms[term];
+    forEach(this.reactions.approved, (term) => {
+      const termId = this.reactions.terms[term];
 
       let reaction = {
         term: term,
@@ -208,15 +206,15 @@ const Reportback = {
         userReacted: false,
       };
 
-      forEach(data, function(record) {
+      forEach(data, (record) => {
         if (record.term.name === term) {
           reaction.total = record.kudos_items.total;
 
-          if (_this.reactions.user) {
+          if (this.reactions.user) {
             // @TODO: this could become very costly if LOTS of kudos reactions exist on RB item.
             // @see https://github.com/DoSomething/phoenix/issues/6594 for potential solution.
-            record.kudos_items.data.map(function(kudos) {
-              if (_this.reactions.user === kudos.user.drupal_id) {
+            record.kudos_items.data.map((kudos) => {
+              if (this.reactions.user === kudos.user.drupal_id) {
                 reaction.userReacted = true;
               }
             });

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -3,10 +3,12 @@
 import ImageUploadFallback from '../images/ImageUploadFallback';
 import reportbackTplSrc from 'reportback/templates/reportback.tpl.html';
 import ImageUpload from '../images/ImageUpload';
+import setting from '../utilities/Setting';
 
 const $ = require('jquery');
 const debounce = require('lodash/function/debounce');
 const template = require('lodash/string/template');
+const forEach = require('lodash/collection/forEach');
 
 const Reportback = {
 
@@ -20,9 +22,8 @@ const Reportback = {
 
   reactions: {
     approved: ['heart'],
-    inventory: {
-      heart: '641', // @TODO: totally temporary! Will be obtained via global object passed in via PHP.
-    },
+    terms: setting('dsKudosReactions.terms'),
+    user: setting('dsKudosReactions.user', null),
   },
 
   nid: null,
@@ -193,28 +194,38 @@ const Reportback = {
    * @return {array}
    */
   getReactions: function(data) {
-    console.log(data);
+    const _this = this;
+
     let reactions = [];
 
-    for (let i = 0, count = this.reactions.approved.length; i < count; i++) {
-      const term = this.reactions.approved[i];
-      const termId = this.reactions.inventory[term];
+    forEach(_this.reactions.approved, function(term) {
+      const termId = _this.reactions.terms[term];
 
-      const reaction = {
+      let reaction = {
         term: term,
         termId: termId,
         total: 0,
         userReacted: false,
       };
 
-      for (let j = 0, count = data.length; j < count; j++) {
-        if (data[j].term.name === term) {
-          reaction.total = data[j].kudos_items.total;
+      forEach(data, function(record) {
+        if (record.term.name === term) {
+          reaction.total = record.kudos_items.total;
+
+          if (_this.reactions.user) {
+            // @TODO: this could become very costly if LOTS of kudos reactions exist on RB item.
+            // @see https://github.com/DoSomething/phoenix/issues/6594 for potential solution.
+            record.kudos_items.data.map(function(kudos) {
+              if (_this.reactions.user === kudos.user.drupal_id) {
+                reaction.userReacted = true;
+              }
+            });
+          }
         }
-      }
+      });
 
       reactions.push(reaction);
-    }
+    });
 
     return reactions;
   },
@@ -277,8 +288,6 @@ const Reportback = {
         }
       },
     }).done(function(response) {
-      // console.log(response);
-
       _this.apiUrl = response.meta.pagination.links.next_uri || null;
 
       _this.templatize(response);
@@ -313,7 +322,7 @@ const Reportback = {
         'status': items[i].status,
         'isListItem': true,  // @TODO: probably a better way to address this... :insert shruggy emoji here:
         'reactions': {
-          enabled: true, // @TODO: reference global boolean to see if campaign should have kudos reactions or not!
+          enabled: setting('dsKudosReactions.enabled'),
           data: this.getReactions(items[i].kudos.data),
         }
       };

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/templates/reportback.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/templates/reportback.tpl.html
@@ -1,10 +1,21 @@
 <% if (isListItem) { %><li><% } %>
-<div class="photo -stacked -framed" data-reportback-item-id="...">
+<div class="photo -stacked -framed" data-reportback-item-id="<%= id %>">
   <figure class="wrapper">
     <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=" alt="<%= caption %>" data-src="<%= image %>" />
     <figcaption class="photo__copy">
       <p class="photo__caption"><%= caption %></p>
     </figcaption>
   </figure>
+
+  <% if (reactions.enabled) { %>
+  <ul class="form-actions -inline photo_actions">
+    <% for (i = 0, count = reactions.data.length; i < count; i++) { %>
+      <li>
+        <a class="button -mini js-kudos-button" data-kudo-id="<%= reactions.data[i].termId %>" data-kid="">&#128150;</a>
+        <span class="counter"><%= reactions.data[i].total %></span>
+      </li>
+    <% } %>
+  </ul>
+  <% } %>
 </div>
 <% if (isListItem) { %></li><% } %>

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/templates/reportback.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/templates/reportback.tpl.html
@@ -11,7 +11,7 @@
   <ul class="form-actions -inline photo_actions">
     <% for (i = 0, count = reactions.data.length; i < count; i++) { %>
       <li>
-        <a class="button -mini js-kudos-button" data-kudo-id="<%= reactions.data[i].termId %>" data-kid="">&#128150;</a>
+        <a class="button -mini js-kudos-button <% if (reactions.data[i].userReacted) {%>is-active<% } %>" data-kudo-id="<%= reactions.data[i].termId %>" data-kid="">&#128150;</a>
         <span class="counter"><%= reactions.data[i].total %></span>
       </li>
     <% } %>

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/templates/reportback.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/templates/reportback.tpl.html
@@ -8,10 +8,10 @@
   </figure>
 
   <% if (reactions.enabled) { %>
-  <ul class="form-actions -inline photo_actions">
-    <% for (i = 0, count = reactions.data.length; i < count; i++) { %>
+  <ul class="form-actions -inline photo__actions">
+    <% for (var i = 0; i < reactions.data.length; i++) { %>
       <li>
-        <a class="button -mini js-kudos-button <% if (reactions.data[i].userReacted) {%>is-active<% } %>" data-kudo-id="<%= reactions.data[i].termId %>" data-kid="">&#128150;</a>
+        <button class="photo__kudos js-kudos-button <% if (reactions.data[i].userReacted) {%>is-active<% } %>" data-kudo-id="<%= reactions.data[i].termId %>" data-kid=""></button>
         <span class="counter"><%= reactions.data[i].total %></span>
       </li>
     <% } %>


### PR DESCRIPTION
#### What's this PR do?

This PR exposes the full functionality for kudos reactions for the Reportback Items that are dynamically added via AJAX request to the API.
#### How should this be reviewed?

Pull down code, load a campaign and check the gallery. Click on "view more" to load more items into the gallery and see if the kudos appear (if kudos are activated for that campaign). Click on a kudos, etc and see if that all seems to work right.
#### Any background context you want to provide?

We'll likely need to address https://github.com/DoSomething/phoenix/issues/6594 for how kudos are accounted for and rendered in the gallery and moving forward if lots of kudos reactions get added to items. Refer to that issue for more on that...

_Also_ I need to update the JS template to account for the new changes to the kudos structure that was completed in #6577
#### Relevant tickets

Fixes #6544
Fixes #6575

---

@DFurnes 

cc: @angaither 
