### PR TITLE
Custom setting unique social share links and text 

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -126,6 +126,15 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
     $country_prefix = (dosomething_global_get_current_prefix()) ? strtoupper(dosomething_global_get_current_prefix()) : 'global';
     $problem_share_image = $base_url . 'sites/default/files/images/problem-' . $vars['nid'] . '-' . $country_prefix . '.png';
 
+    if (isset($campaign->variables['social_share_custom_text'])) {
+      $tweet = $campaign->variables['social_share_custom_text'];
+      $tumblr_caption = $campaign->variables['social_share_custom_text'];
+    }
+    else {
+      $tweet = isset($campaign->fact_problem) ? $campaign->fact_problem['fact'] : NULL;
+      $tumblr_caption = t("This is REAL, do something about this with me: ");
+    }
+
     $share_types = array(
       'facebook' => array(
         'type' => 'feed_dialog',
@@ -134,16 +143,22 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
         ),
       ),
       'twitter' => array(
-        'tweet' => (isset($campaign->fact_problem)) ? $campaign->fact_problem['fact'] : NULL,
+        'tweet' => $tweet,
       ),
       'tumblr' => array(
         'posttype' => 'photo',
         'content' => $problem_share_image,
-        'caption' => t("This is REAL, do something about this with me: "),
+        'caption' => $tumblr_caption,
       ),
     );
 
-    $vars['share_bar'] = dosomething_helpers_share_bar($campaign_path, $share_types, 'problem_shares', 'social-menu -with-callout');
+    if ($campaign->variables['social_share_unique_link'] == 1) {
+      $custom_share_link = $campaign_path . '?source=' . $vars['user']->uid;
+      $vars['share_bar'] = dosomething_helpers_share_bar($custom_share_link, $share_types, 'problem_shares', 'social-menu -with-callout');
+    }
+    else {
+      $vars['share_bar'] = dosomething_helpers_share_bar($campaign_path, $share_types, 'problem_shares', 'social-menu -with-callout');
+    }
   }
 }
 
@@ -393,7 +408,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     ),
   );
 
-  $custom_share_link = $campaign_path . '?source=' . $vars['user']->uid;;
+  $custom_share_link = $campaign_path . '?source=' . $vars['user']->uid;
 
   $organ_donations_share_button_markup = dosomething_helpers_share_bar($custom_share_link, $organ_donation_share_types, 'organ_donation_referral', 'social-menu');
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -153,7 +153,7 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
     );
 
     if ($campaign->variables['social_share_unique_link'] == 1) {
-      $custom_share_link = $campaign_path . '?source=' . $vars['user']->uid;
+      $custom_share_link = $campaign_path . '?source=user/' . $vars['user']->uid;
       $vars['share_bar'] = dosomething_helpers_share_bar($custom_share_link, $share_types, 'problem_shares', 'social-menu -with-callout');
     }
     else {
@@ -408,7 +408,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     ),
   );
 
-  $custom_share_link = $campaign_path . '?source=' . $vars['user']->uid;
+  $custom_share_link = $campaign_path . '?source=user/' . $vars['user']->uid;
 
   $organ_donations_share_button_markup = dosomething_helpers_share_bar($custom_share_link, $organ_donation_share_types, 'organ_donation_referral', 'social-menu');
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -126,15 +126,6 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
     $country_prefix = (dosomething_global_get_current_prefix()) ? strtoupper(dosomething_global_get_current_prefix()) : 'global';
     $problem_share_image = $base_url . 'sites/default/files/images/problem-' . $vars['nid'] . '-' . $country_prefix . '.png';
 
-    if (isset($campaign->variables['social_share_custom_text'])) {
-      $tweet = $campaign->variables['social_share_custom_text'];
-      $tumblr_caption = $campaign->variables['social_share_custom_text'];
-    }
-    else {
-      $tweet = isset($campaign->fact_problem) ? $campaign->fact_problem['fact'] : NULL;
-      $tumblr_caption = t("This is REAL, do something about this with me: ");
-    }
-
     $share_types = array(
       'facebook' => array(
         'type' => 'feed_dialog',
@@ -143,22 +134,16 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
         ),
       ),
       'twitter' => array(
-        'tweet' => $tweet,
+        'tweet' => (isset($campaign->fact_problem)) ? $campaign->fact_problem['fact'] : NULL,
       ),
       'tumblr' => array(
         'posttype' => 'photo',
         'content' => $problem_share_image,
-        'caption' => $tumblr_caption,
+        'caption' => t("This is REAL, do something about this with me: "),
       ),
     );
 
-    if ($campaign->variables['social_share_unique_link'] == 1) {
-      $custom_share_link = $campaign_path . '?source=user/' . $vars['user']->uid;
-      $vars['share_bar'] = dosomething_helpers_share_bar($custom_share_link, $share_types, 'problem_shares', 'social-menu -with-callout');
-    }
-    else {
-      $vars['share_bar'] = dosomething_helpers_share_bar($campaign_path, $share_types, 'problem_shares', 'social-menu -with-callout');
-    }
+    $vars['share_bar'] = dosomething_helpers_share_bar($campaign_path, $share_types, 'problem_shares', 'social-menu -with-callout');
   }
 }
 
@@ -408,7 +393,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     ),
   );
 
-  $custom_share_link = $campaign_path . '?source=user/' . $vars['user']->uid;
+  $custom_share_link = $campaign_path . '?source=' . $vars['user']->uid;;
 
   $organ_donations_share_button_markup = dosomething_helpers_share_bar($custom_share_link, $organ_donation_share_types, 'organ_donation_referral', 'social-menu');
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -142,6 +142,27 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
       '#value' => 'Save',
     ),
   );
+
+  $form['unique_social_share_link'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Unique Social Share Link'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  ];
+  $form['unique_social_share_link']['create_unique_link'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Create unique social share link for each user.'),
+    '#description' => t("If set, unique social share links will be created using user's id."),
+    '#default_value' => $vars['create_unique_link'],
+  ];
+  $form['organ_donation']['actions'] = [
+    '#type' => 'actions',
+    'submit' => [
+      '#type' => 'submit',
+      '#value' => 'Save',
+    ],
+  ];
+
   return $form;
 }
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -11,6 +11,27 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     '#type' => 'hidden',
     '#value' => $node->nid,
   );
+  $form['custom_social_sharing'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Custom Social Sharing'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  ];
+  $form['custom_social_sharing']['unique_link'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Create unique social share links for each user.'),
+    '#description' => t("If set, unique social share links will be created using user's id."),
+    '#default_value' => $vars['unique_link'],
+  ];
+  $form['custom_social_sharing']['custom_text'] = [
+    '#type' => 'textfield',
+    '#title' => t('Create custom text'),
+    '#description' => t("Custom text to share with the social links."),
+    '#default_value' => $node->field_call_to_action['en'][0]['value'],
+    '#attributes' => array(
+      'maxlength' => '140',
+    ),
+  ];
   $form['styles'] = array(
     '#type' => 'fieldset',
     '#title' => t('Styles'),
@@ -133,35 +154,15 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
         ),
       ),
     );
-    $form['custom_social_sharing'] = [
-      '#type' => 'fieldset',
-      '#title' => t('Custom Social Sharing'),
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
-    ];
-    $form['custom_social_sharing']['unique_link'] = [
-      '#type' => 'checkbox',
-      '#title' => t('Create unique social share links for each user.'),
-      '#description' => t("If set, unique social share links will be created using user's id."),
-      '#default_value' => $vars['unique_link'],
-    ];
-    $form['custom_social_sharing']['custom_text'] = [
-      '#type' => 'textfield',
-      '#title' => t('Create custom text'),
-      '#description' => t("Custom text to share with the social links."),
-      '#default_value' => $vars['custom_text'],
-      '#attributes' => array(
-        'maxlength' => '140',
-      ),
-    ];
-    $form['actions'] = array(
-      '#type' => 'actions',
-      'submit' => array(
-        '#type' => 'submit',
-        '#value' => 'Save',
-      ),
-    );
   }
+
+  $form['actions'] = array(
+    '#type' => 'actions',
+    'submit' => array(
+      '#type' => 'submit',
+      '#value' => 'Save',
+    ),
+  );
 
   return $form;
 }
@@ -176,6 +177,10 @@ function dosomething_helpers_variable_form_submit(&$form, &$form_state) {
 
   form_state_values_clean($form_state);
   $values = $form_state['values'];
+
+  print_r($values);
+  die();
+
   // Store hidden nid.
   $nid = $values['nid'];
   // Remove from values.

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -15,7 +15,7 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     '#type' => 'fieldset',
     '#title' => t('Custom Social Sharing'),
     '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
+    '#collapsed' => FALSE,
   ];
   $form['custom_social_sharing']['social_share_unique_link'] = [
     '#type' => 'checkbox',
@@ -36,7 +36,7 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     '#type' => 'fieldset',
     '#title' => t('Styles'),
     '#collapsible' => TRUE,
-    '#collapsed' => FALSE,
+    '#collapsed' => TRUE,
   );
   $form['styles']['sponsor_color'] = array(
     '#type' => 'textfield',

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -17,17 +17,17 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   ];
-  $form['custom_social_sharing']['unique_link'] = [
+  $form['custom_social_sharing']['social_share_unique_link'] = [
     '#type' => 'checkbox',
     '#title' => t('Create unique social share links for each user.'),
     '#description' => t("If set, unique social share links will be created using user's id."),
-    '#default_value' => $vars['unique_link'],
+    '#default_value' => $vars['social_share_unique_link'],
   ];
-  $form['custom_social_sharing']['custom_text'] = [
+  $form['custom_social_sharing']['social_share_custom_text'] = [
     '#type' => 'textfield',
-    '#title' => t('Create custom text'),
+    '#title' => t('Custom social share language'),
     '#description' => t("Custom text to share with the social links."),
-    '#default_value' => $node->field_call_to_action['en'][0]['value'],
+    '#default_value' => $vars['social_share_custom_text'],
     '#attributes' => array(
       'maxlength' => '140',
     ),
@@ -177,9 +177,6 @@ function dosomething_helpers_variable_form_submit(&$form, &$form_state) {
 
   form_state_values_clean($form_state);
   $values = $form_state['values'];
-
-  print_r($values);
-  die();
 
   // Store hidden nid.
   $nid = $values['nid'];

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -133,35 +133,35 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
         ),
       ),
     );
+    $form['custom_social_sharing'] = [
+      '#type' => 'fieldset',
+      '#title' => t('Custom Social Sharing'),
+      '#collapsible' => TRUE,
+      '#collapsed' => TRUE,
+    ];
+    $form['custom_social_sharing']['unique_link'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Create unique social share links for each user.'),
+      '#description' => t("If set, unique social share links will be created using user's id."),
+      '#default_value' => $vars['unique_link'],
+    ];
+    $form['custom_social_sharing']['custom_text'] = [
+      '#type' => 'textfield',
+      '#title' => t('Create custom text'),
+      '#description' => t("Custom text to share with the social links."),
+      '#default_value' => $vars['custom_text'],
+      '#attributes' => array(
+        'maxlength' => '140',
+      ),
+    ];
+    $form['actions'] = array(
+      '#type' => 'actions',
+      'submit' => array(
+        '#type' => 'submit',
+        '#value' => 'Save',
+      ),
+    );
   }
-
-  $form['actions'] = array(
-    '#type' => 'actions',
-    'submit' => array(
-      '#type' => 'submit',
-      '#value' => 'Save',
-    ),
-  );
-
-  $form['unique_social_share_link'] = [
-    '#type' => 'fieldset',
-    '#title' => t('Unique Social Share Link'),
-    '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
-  ];
-  $form['unique_social_share_link']['create_unique_link'] = [
-    '#type' => 'checkbox',
-    '#title' => t('Create unique social share link for each user.'),
-    '#description' => t("If set, unique social share links will be created using user's id."),
-    '#default_value' => $vars['create_unique_link'],
-  ];
-  $form['organ_donation']['actions'] = [
-    '#type' => 'actions',
-    'submit' => [
-      '#type' => 'submit',
-      '#value' => 'Save',
-    ],
-  ];
 
   return $form;
 }


### PR DESCRIPTION
#### What's this PR do?

Creates a custom setting to enable and configure unique social share links. 
#### How should this be reviewed?
- Click on a campaign 
- Go to the "CUSTOM SETTINGS" tab
- Click the "Create unique social share links for each user" check box under "CUSTOM SOCIAL SHARING" 
- Add dummy text in "Custom social share language" field
- Save and `drush cc all`. 
- Click "VIEW" tab. 
- Click on Facebook share - the link should have this pattern `https://www.facebook.com/dialog/feed?app_id=1374507732873066&display=popup&link=http%3A//dev.dosomething.org%3A8888/us/campaigns/test-campaign%3Fsource%3D1704953%` etc. with `source` = your `uid`. 
- Click on Twitter share - you should see your dummy text in the caption pop pre-populated along with a URL with the following pattern: `http://dev.dosomething.org:8888/us/campaigns/test-campaign?source=1704953?` etc. with `source` = your `uid`.
- Tumblr share should be the same (Tumblr won't allow us to can't test on dev) 
- Go back to the "CUSTOM SOCIAL SHARING" tab. 
- Uncheck box and delete your custom social share language. 
- Save and `drush cc all`
- Click on Facebook share - you should no longer see `source` with your `uid` in the URL. 
- Click on Twitter share - again, you shouldn't see `source` with your `uid` in the URL and caption should just be campaign's CTA. 
#### Relevant tickets

Fixes #6584 
