### PR TITLE
Kudos reaction quick cleanup

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -2,12 +2,12 @@ import $ from 'jquery';
 import array_get from 'lodash/object/get';
 
 /**
- * Make an API request to create/delete the Kudo for that item.
+ * Make an API request to create/delete the Kudos Reaction for that item.
  *
  * @param {jQuery} $el
  * @param {String} id - An existing Kudo id
  */
-function makeKudoRequest($el, id)
+function makeKudosRequest($el, id)
 {
   return $.ajax({
     method: id ? 'DELETE' : 'POST',
@@ -20,7 +20,7 @@ function makeKudoRequest($el, id)
     data: JSON.stringify({
       'reportback_item_id': $el.closest('[data-reportback-item-id]').attr('data-reportback-item-id'),
       'user_id': $('meta[name="drupal-user-id"]').attr('content'),
-      'term_ids': [$el.attr('data-kudo-id')]
+      'term_ids': [$el.attr('data-kudos-term-id')]
     }),
   });
 }
@@ -30,17 +30,19 @@ function makeKudoRequest($el, id)
  *
  * @param {jQuery} $el
  */
-function updateKudoInterface($el)
+function updateKudosInterface($el)
 {
-  const hasKudo = $el.attr('data-kid') !== '';
+  const hasKudos = $el.attr('data-kid') !== '';
 
-  var $counter = $el.next('.counter');
-  var currentCount = parseInt($counter.text());
-  var diff = hasKudo ? 1 : -1;
+  let $counter = $el.next('.counter');
+  let currentCount = parseInt($counter.text());
+  let diff = hasKudos ? 1 : -1;
 
-  $el.toggleClass('is-active', hasKudo);
+  $el.toggleClass('is-active', hasKudos);
+
   $counter.text(currentCount + diff);
-  $counter.toggleClass('tada is-active', hasKudo);
+
+  $counter.toggleClass('tada is-active', hasKudos);
 }
 
 /*
@@ -50,10 +52,18 @@ $(document).on('click', '.js-kudos-button', function(event) {
   event.preventDefault();
 
   const $el = $(this);
-  makeKudoRequest($el, $el.attr('data-kid')).done(function(response) {
-    const kid = array_get(response, '0.kid', '');
-    $el.attr('data-kid', kid);
 
-    updateKudoInterface($el);
-  });
+  $el.attr('disabled','disabled');
+
+  makeKudosRequest($el, $el.attr('data-kid'))
+    .done(function(response) {
+      const kid = array_get(response, '0.kid', '');
+
+      $el.attr('data-kid', kid);
+
+      updateKudosInterface($el);
+    })
+    .always(function() {
+      $el.removeAttr('disabled');
+    });
 });

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -56,14 +56,14 @@ $(document).on('click', '.js-kudos-button', function(event) {
   $el.attr('disabled','disabled');
 
   makeKudosRequest($el, $el.attr('data-kid'))
-    .done(function(response) {
+    .done((response) => {
       const kid = array_get(response, '0.kid', '');
 
       $el.attr('data-kid', kid);
 
       updateKudosInterface($el);
     })
-    .always(function() {
+    .always(() => {
       $el.removeAttr('disabled');
     });
 });

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -200,6 +200,7 @@ const Reportback = {
       const termId = this.reactions.terms[term];
 
       let reaction = {
+        kudosId: null,
         term: term,
         termId: termId,
         total: 0,
@@ -215,12 +216,14 @@ const Reportback = {
             // @see https://github.com/DoSomething/phoenix/issues/6594 for potential solution.
             record.kudos_items.data.map((kudos) => {
               if (this.reactions.user === kudos.user.drupal_id) {
+                reaction.kudosId = kudos.id;
                 reaction.userReacted = true;
               }
             });
           }
         }
       });
+
 
       reactions.push(reaction);
     });

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/templates/reportback.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/templates/reportback.tpl.html
@@ -11,7 +11,7 @@
   <ul class="form-actions -inline photo__actions">
     <% for (var i = 0; i < reactions.data.length; i++) { %>
       <li>
-        <button class="photo__kudos js-kudos-button <% if (reactions.data[i].userReacted) {%>is-active<% } %>" data-kudo-id="<%= reactions.data[i].termId %>" data-kid=""></button>
+        <button class="photo__kudos js-kudos-button <% if (reactions.data[i].userReacted) { %>is-active<% } %>" data-kudos-term-id="<%= reactions.data[i].termId %>" data-kid="<% if (reactions.data[i].kudosId) { %><%= reactions.data[i].kudosId %><% } %>"></button>
         <span class="counter"><%= reactions.data[i].total %></span>
       </li>
     <% } %>

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_counter.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_counter.scss
@@ -27,6 +27,10 @@
       cursor: pointer;
     }
 
+    &:focus {
+     outline: none;
+    }
+
     &.is-active {
       background-image: url("../images/filled-heart.svg");
     }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -17,7 +17,7 @@
   <?php if ($content->id && !$content->disable_reactions): ?>
     <ul class="form-actions -inline photo__actions">
       <li>
-        <button class="js-kudos-button photo__kudos <?php print dosomething_kudos_term_is_selected($content, 'heart') ? 'is-active' : '' ?>" data-kudo-id="<?php print $content->allowed_reactions[0]; ?>" data-kid="<?php print dosomething_helpers_isset($content->existing_kids[$content->allowed_reactions[0]], 'kid') ?>"></button>
+        <button class="js-kudos-button photo__kudos <?php print dosomething_kudos_term_is_selected($content, 'heart') ? 'is-active' : '' ?>" data-kudos-term-id="<?php print $content->allowed_reactions[0]; ?>" data-kid="<?php print dosomething_helpers_isset($content->existing_kids[$content->allowed_reactions[0]], 'kid') ?>"></button>
         <span class="counter"><?php print $content->reaction_totals['heart']; ?></span>
       </li>
     </ul>


### PR DESCRIPTION
#### What's this PR do?

This PR does a little bit of code cleanup and nomenclature fixes as well as fix a bug with kudos reactions on view more items which could get a kudos reaction applied by a user, but then they couldn't remove that kudos if they desired.

This PR also addresses disabling the kudos reaction button while and AJAX request is being made and re-enabling it once the request is done to avoid issues with spam clicking the button.

It also does a quick fix for styling of the kudos reaction heart button to remove the awkward _focus_ outline which is default to browsers:

<img width="200" alt="screen shot 2016-06-13 at 11 40 31 am" src="https://cloud.githubusercontent.com/assets/105849/16016940/72b0ed38-316b-11e6-99d2-23d16a0a370a.png">
#### How should this be reviewed?

Pull down, click the _view more_ button on a campaign gallery and try to add and remove kudos. Reload the page and click _view more_ again and see if all kudos are where you added/removed them on particular items.
#### Relevant tickets

Fixes # 💅 
Fixes #6601
Fixes #6573

---

@angaither @DFurnes 
