### PR TITLE
updates reportback hook

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.install
@@ -974,7 +974,7 @@ function dosomething_reportback_update_7036() {
   $table_name = 'dosomething_reportback_file';
   $schema = dosomething_reportback_schema();
   $field_name = 'source';
-  if (!db_field_exists($tbl_name, $fld_name)) {
+  if (!db_field_exists($table_name, $field_name)) {
     db_add_field($table_name, $field_name, $schema[$table_name]['fields'][$field_name]);
   }
 }


### PR DESCRIPTION
#### What's this PR do?

Updates the variable names in the check to see if the `source` col exists in the `dosomething_reportback_file` table
#### How should this be reviewed?

👓 
#### Any background context you want to provide?

reported by @mshmsh5000 

```
$ drush updatedb-status
 Module                  Update ID  Description
 Dosomething_reportback  7036       Add a column for the source of the reportback file
```

or 

```
 DEBUG [317d1350]   Updating database...
 DEBUG [317d1350]    Dosomething_reportback  7036  Add a column for the source of the reportback 
                               file
 DEBUG [317d1350]   Do you wish to run all pending updates? (y/n): y
 DEBUG [317d1350]   Cannot add field dosomething_reportback_file.source: field already   [error]
exists.
 DEBUG [317d1350]   Performed update: dosomething_reportback_update_7036                 [ok]
```
#### Relevant tickets

Fixes #jenkins log 
