### PR TITLE
CSS fix for kudos when zooming in via browser.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_counter.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_counter.scss
@@ -17,11 +17,12 @@
   }
 
   .photo__kudos {
-    width: 30px;
-    height: 26px;
-    border: none;
-    background: url("../images/outline-heart.svg");
+    background: transparent url("../images/outline-heart.svg") no-repeat 0 0;
     background-size: cover;
+    border: none;
+    height: 25px;
+    padding: 0;
+    width: 29px;
 
     &:hover {
       cursor: pointer;


### PR DESCRIPTION
#### What's this PR do?

This PR updates the CSS on kudos to fix them so they are not cut-off when zoomed in. There was a slight different in the actual size of the SVG and the specified size in the `width` and `height` defined in the CSS, especially since the new CSS declared sizes didn't match in ratio with the image. Thus, when being zoomed in on, the background cover would spread and cut off part of the heart image.
#### How should this be reviewed?

Pull down, load a campaign with kudos and zoom in on the page using Safari or Firefox.
#### Any background context you want to provide?

Added a couple other things that were missing to make sure stuff doesn't look funky, like not repeating the background image!
#### Relevant tickets

Fixes #6619

---

@angaither @DFurnes 
