### PR TITLE
Store something better than null in competition signup data

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -580,14 +580,14 @@ function dosomething_signup_update_signup_data($values, $config = NULL, $respons
     $entity = signup_load($values['sid']);
     $entity->signup_data_form_timestamp = REQUEST_TIME;
     $entity->signup_data_form_response = $response;
+
+    // Did the person say yes or no to the competition?
+    ($config['competition_signup']) ?  $entity->competition = 1 : $entity->competition = 0;
+
     // If non-skip, store any additional signup data:
     if ($response) {
       if (isset($values['why_signedup'])) {
         $entity->why_signedup = $values['why_signedup'];
-      }
-
-      if ($config['competition_signup']) {
-        $entity->competition = 1;
       }
     }
     $entity->save();


### PR DESCRIPTION
#### What's this PR do?

Moved the competition signup thing to outside of the `response` block.
That is only triggered if the user says yes, which was not saving any `0` values if a person opted out of a competition. 
This allows for either a 0/1 to be stored here if the user interacts with the modal at all.
#### How should this be reviewed?

👀 
#### Relevant tickets

Fixes #6617
