### PR TITLE
Only disable validation messages inside Takeover container.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_takeover.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_takeover.scss
@@ -7,7 +7,7 @@ $transition: .7s;
 // NOTE: this is a bit of a hack cause the layout was breaking
 // when the validation displays messages. Worth figuring out what
 // is really going here.
-.validation.is-showing-message {
+.takeover .validation.is-showing-message {
   top: 0;
 }
 


### PR DESCRIPTION
#### What's this PR do?

This fixes an issue where validation messages were not being displayed anywhere on the site.
#### How should this be reviewed?

Check that this doesn't break whatever this was fixing in the Takeover module.
#### Any background context you want to provide?

🉑 
#### Relevant tickets

Fixes #6625.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
