### PR TITLE
Updates to social media items in footer.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -73,9 +73,13 @@ function paraneue_dosomething_get_social_networks() {
       'id'    => 'twitter',
       'name'  => t('Twitter'),
     ),
-    'tumblr'    => array(
-      'id'    => 'tumblr',
-      'name'  => t('Tumblr'),
+    'snapchat'    => array(
+      'id'    => 'snapchat',
+      'name'  => t('Snapchat'),
+    ),
+    'weheartit'    => array(
+      'id'    => 'weheartit',
+      'name'  => t('We Heart It'),
     ),
     'instagram' => array(
       'id'    => 'instagram',

--- a/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
+++ b/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
@@ -25,21 +25,24 @@ settings[header_explore_campaigns_subtext] = 'Any cause, anytime, anywhere.'
 
 ; Footer
 ; Footer social networks menu
-settings[footer_social_facebook_enabled]  = 1
-settings[footer_social_facebook_url]      = https://www.facebook.com/dosomething
-settings[footer_social_facebook_alt]      = dosomething on Facebook
-settings[footer_social_twitter_enabled]   = 1
-settings[footer_social_twitter_url]       = https://twitter.com/dosomething
-settings[footer_social_twitter_alt]       = @dosomething on Twitter
-settings[footer_social_tumblr_enabled]    = 1
-settings[footer_social_tumblr_url]        = http://dosomething.tumblr.com/
-settings[footer_social_tumblr_alt]        = @dosomething on Tumblr
-settings[footer_social_instagram_enabled] = 1
-settings[footer_social_instagram_url]     = http://instagram.com/dosomething
-settings[footer_social_instagram_alt]     = @dosomething on Instagram
-settings[footer_social_youtube_enabled]   = 1
-settings[footer_social_youtube_url]       = http://www.youtube.com/user/DoSomething1
-settings[footer_social_youtube_alt]       = dosomething1 on YouTube
+settings[footer_social_facebook_enabled]   = 1
+settings[footer_social_facebook_url]       = https://www.facebook.com/dosomething
+settings[footer_social_facebook_alt]       = dosomething on Facebook
+settings[footer_social_twitter_enabled]    = 1
+settings[footer_social_twitter_url]        = https://twitter.com/dosomething
+settings[footer_social_twitter_alt]        = @dosomething on Twitter
+settings[footer_social_snapchat_enabled]   = 1
+settings[footer_social_snapchat_url]       = https://www.snapchat.com/add/dosomething
+settings[footer_social_snapchat_alt]       = dosomething on Snapchat
+settings[footer_social_weheartit_enabled]  = 1
+settings[footer_social_weheartit_url]      = http://weheartit.com/dosomething
+settings[footer_social_weheartit_alt]      = dosomething on We Heart It
+settings[footer_social_instagram_enabled]  = 1
+settings[footer_social_instagram_url]      = http://instagram.com/dosomething
+settings[footer_social_instagram_alt]      = @dosomething on Instagram
+settings[footer_social_youtube_enabled]    = 1
+settings[footer_social_youtube_url]        = http://www.youtube.com/user/DoSomething1
+settings[footer_social_youtube_alt]        = dosomething1 on YouTube
 
 ; Footer menu
 settings[footer_links_first_column_heading] = 'Help'


### PR DESCRIPTION
#### What's this PR do?

This PR does a quick update to the social media items in the footer. It removes Tumblr and adds Snapchat and We Heart It.
#### How should this be reviewed?

Does the footer look updated?
#### Any background context you want to provide?

Also had to do some styling updates because the WeHeartIt icon gets a bit cut off, and on a narrower view (right before it drops to single column layout) one of the icons drops out of the lineup:

![image](https://cloud.githubusercontent.com/assets/105849/16314412/8e12c726-3932-11e6-9e55-4d0d20e85c5f.png)

I made the update but it's an update on Forge, so will need to be updated separately.

Random, lemme know if it needs to be in a different order for the list of items... @namimody :)
#### Relevant tickets

Fixes #6598

---

@angaither @DFurnes 
