### PR TITLE
Moved the node load up above so it checks the campaign type.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -510,7 +510,7 @@ function dosomething_signup_views_data() {
 function dosomething_signup_entity_insert($entity, $type) {
   // If not a signup, exit out of function.
   if ($type != 'signup') { return; }
-
+  $node = node_load($entity->nid);
   // If this is a SMS Game Campaign node:
   if (module_exists('dosomething_campaign') && dosomething_campaign_get_campaign_type($node) == 'sms_game') {
     // Third party subscription is handled elsewhere,
@@ -518,9 +518,7 @@ function dosomething_signup_entity_insert($entity, $type) {
     // Exit out of function.
     return;
   }
-
   $account = user_load($entity->uid);
-  $node = node_load($entity->nid);
   $options['transactionals'] = $entity->transactionals;
   $options['source'] = $entity->source;
 


### PR DESCRIPTION
#### What's this PR do?

Re-fix the bug that `sms-game` campaign nodes were getting transactional emails.
#### How should this be reviewed?

😍 
#### Any background context you want to provide?

This was already an issue #2315 that was fixed [a long time ago](https://github.com/DoSomething/phoenix/commit/0ad46b569a61a4ba4c4f17262bc177ffc62727db) but in refactoring it seems the `node_load` was moved below where it should be. So we were never returning out of this function since `$node` was not defined. 
#### Relevant tickets

Fixes #6635
