### PR TITLE
Add custom share link to stuff you need

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -204,11 +204,19 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   // Plan.
 
   // 1) Materials
+
+  // Build the share link here in case registering organ donors
+  $campaign_path = url(current_path(), array('absolute' => TRUE));
+  $custom_organ_share_link = $campaign_path . '?source=user/' . $vars['user']->uid;
+
   if (isset($campaign->items_needed)) {
     $materials['category'] = 'materials';
     $materials['title'] = t('Stuff You Need');
     $materials['content'] = $campaign->items_needed;
-    // @TODO: if organ donation campaign, add in the share link here
+    // if organ donation campaign, add in the share link here
+    if ($campaign->variables['register_organ_donors']) {
+      $materials['content'] .= '<ul><li><a href=' . $custom_organ_share_link . '>Your Custom Share Link</a></li></ul>';
+    }
     $vars['plan'][] = $materials;
   }
 
@@ -374,7 +382,6 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $base_url = url(base_path(), array('absolute'=> TRUE, 'language' => 'en-global'));
   $country_prefix_for_organ_donation_share = (dosomething_global_get_current_prefix()) ? strtoupper(dosomething_global_get_current_prefix()) : 'global';
   $organ_donation_share_image = $base_url . 'sites/default/files/images/problem-' . $campaign->nid . '-' . $country_prefix_for_organ_donation_share . '.png';
-  $campaign_path = url(current_path(), array('absolute' => TRUE));
 
   // Add social share bar.
   $organ_donation_share_types = array(
@@ -393,8 +400,6 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
       'caption' => t("This is REAL, do something about this with me: "),
     ),
   );
-
-  $custom_organ_share_link = $campaign_path . '?source=user/' . $vars['user']->uid;;
 
   $organ_donations_share_button_markup = dosomething_helpers_share_bar($custom_organ_share_link, $organ_donation_share_types, 'organ_donation_referral', 'social-menu');
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -207,7 +207,8 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
 
   // Build the share link here in case registering organ donors
   $campaign_path = url(current_path(), array('absolute' => TRUE));
-  $custom_organ_share_link = $campaign_path . '?source=user/' . $vars['user']->uid;
+  $share_path = 'user/' . $vars['user']->uid;
+  $custom_organ_share_link = url($campaign_path, array('query' => array('source' => $share_path)));
 
   if (isset($campaign->items_needed)) {
     $materials['category'] = 'materials';
@@ -215,7 +216,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     $materials['content'] = $campaign->items_needed;
     // if organ donation campaign, add in the share link here
     if ($campaign->variables['register_organ_donors']) {
-      $materials['content'] .= '<ul><li><a href=' . $custom_organ_share_link . '>Your Custom Share Link</a></li></ul>';
+      $materials['content'] .= '<ul><li>Copy and paste your custom link to invite friends and family to become an organ donor: <code>' . $custom_organ_share_link . '</code></li></ul>';
     }
     $vars['plan'][] = $materials;
   }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -208,6 +208,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     $materials['category'] = 'materials';
     $materials['title'] = t('Stuff You Need');
     $materials['content'] = $campaign->items_needed;
+    // @TODO: if organ donation campaign, add in the share link here
     $vars['plan'][] = $materials;
   }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -206,9 +206,9 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   // 1) Materials
 
   // Build the share link here in case registering organ donors
-  $campaign_path = url(current_path(), array('absolute' => TRUE));
+  $campaign_path = dosomething_global_url(current_path(), array('absolute' => TRUE));
   $share_path = 'user/' . $vars['user']->uid;
-  $custom_organ_share_link = url($campaign_path, array('query' => array('source' => $share_path)));
+  $custom_organ_share_link = dosomething_global_url($campaign_path, array('query' => array('source' => $share_path)));
 
   if (isset($campaign->items_needed)) {
     $materials['category'] = 'materials';

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/OrganDonation.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/OrganDonation.js
@@ -164,6 +164,8 @@ class OrganDonation extends Takeover {
           if (field.field_name === entry[0]) {
             field.validate = true;
             field.validation_name = entry[1];
+            // @TODO - set custom default here
+            // field.value =
           }
         }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/OrganDonation.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/OrganDonation.js
@@ -164,8 +164,7 @@ class OrganDonation extends Takeover {
           if (field.field_name === entry[0]) {
             field.validate = true;
             field.validation_name = entry[1];
-            // @TODO - set custom default here
-            // field.value =
+            // @TODO - set custom default here (field.value = value)
           }
         }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/templates/OrganDonation/field.tpl.html
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/templates/OrganDonation/field.tpl.html
@@ -1,3 +1,4 @@
+<!-- @TODO: add value property to these to add in the default -->
 <!-- Text Fields -->
 <% if (type === 'string' && typeof(choices) === 'undefined' || type === 'date') { %>
   <div class="form-item">


### PR DESCRIPTION
#### What's this PR do?

Adds the user's custom share link into the "Stuff You Need" section if the campaign is setup to register organ donors.
#### How should this be reviewed?

Go to a campaign page for an organ donor campaign and make sure the link is there. Go to a non organ donor campaign and make sure the link is not there.
#### Relevant tickets

Fixes #6583
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
