### PR TITLE
Kudos endpoint new setup

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -390,9 +390,11 @@ abstract class Transformer {
    *   - media: (array) Reportback Item media.
    *   - created_at: (string) Date Reportback Item was created.
    *   - kudos: (array) Ids of kudos for Reportback Item.
+   * @param  array  $options
+   *   - current_user: (string) User id.
    * @return array
    */
-  protected function transformReportbackItem($data) {
+  protected function transformReportbackItem($data, $options) {
     $output = [
       'id' => $data->id,
       'status' => $data->status,
@@ -403,9 +405,11 @@ abstract class Transformer {
     ];
 
     $kudos = $data->kudos ?: [];
+
     try {
       $kudos = Kudos::get($kudos);
-      $kudos = dosomething_kudos_sort($kudos);
+
+      $kudos = dosomething_kudos_sort($kudos, $options);
     }
     catch (Exception $error) {
       $kudos = [];

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -91,6 +91,14 @@ function _reportback_item_resource_definition() {
             'source' => array('param' => 'load_user'),
             'default value' => FALSE,
           ],
+          [
+            'name' => 'current_user',
+            'description' => 'Provide a user id that response data should take into account when retrieving data.',
+            'optional' => TRUE,
+            'type' => 'string',
+            'source' => array('param' => 'current_user'),
+            'default value' => NULL,
+          ],
         ],
         'access callback' => '_reportback_item_resource_access',
         'access arguments' => array('index'),
@@ -135,7 +143,7 @@ function _reportback_item_resource_access($op) {
  * @param  bool    $load_user
  * @return array
  */
-function _reportback_item_resource_index($campaigns, $exclude, $status, $count, $random, $page, $load_user) {
+function _reportback_item_resource_index($campaigns, $exclude, $status, $count, $random, $page, $load_user, $current_user) {
   $parameters = array(
     'campaigns' => $campaigns,
     'exclude' => $exclude,
@@ -144,6 +152,7 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
     'random' => $random,
     'page' => $page,
     'load_user' => $load_user,
+    'current_user' => $current_user,
   );
 
   $reportbackItems = new ReportbackItemTransformer;

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -93,7 +93,7 @@ function _reportback_item_resource_definition() {
           ],
           [
             'name' => 'current_user',
-            'description' => 'Provide a user id that response data should take into account when retrieving data.',
+            'description' => 'Provide current user ID that response data should take into account when retrieving data.',
             'optional' => TRUE,
             'type' => 'string',
             'source' => array('param' => 'current_user'),

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -86,11 +86,11 @@ function dosomething_kudos_get_kudos_query($params = []) {
 /**
  * Sort kudos collection based on taxonomy term and then group them by term.
  *
- * @param array $data Collection of individual kudos items.
- * @param string $display
+ * @param  array $data Collection of individual kudos items.
+ * @param  array $options
  * @return array
  */
-function dosomething_kudos_sort($data, $display = 'teaser') {
+function dosomething_kudos_sort($data, $options = []) {
   // The array containing collection of kudos items passed to this function
   // consists of individual kudos items. However, within this collection
   // there could be multiple kudos items that all fall within the same
@@ -98,9 +98,14 @@ function dosomething_kudos_sort($data, $display = 'teaser') {
   // group the kudos based on taxonomy term, along with providing a total
   // count of kudos for each term.
 
+  // @TODO: Not sure if necessary, but setting for now to make sure not to break things.
+  if (!isset($options['display'])) {
+    $options['display'] = 'teaser';
+  }
+
   usort($data, 'dosomething_kudos_sort_by_taxonomy_term');
 
-  $data = dosomething_kudos_group_by_taxonomy_term($data, $display);
+  $data = dosomething_kudos_group_by_taxonomy_term($data, $options);
   $data = dosomething_kudos_get_totals_by_taxonomy_term($data);
   return $data;
 }
@@ -130,10 +135,11 @@ function dosomething_kudos_sort_by_taxonomy_term($a, $b) {
 /**
  * Group all kudos in collection and organize them by taxonomy term.
  *
- * @param array $data Array containing Kudos items.
+ * @param  array $data Array containing Kudos items.
+ * @param  array $options
  * @return array
  */
-function dosomething_kudos_group_by_taxonomy_term($data, $display = 'teaser') {
+function dosomething_kudos_group_by_taxonomy_term($data, $options = []) {
   $terms = [];
 
   foreach ($data as $item) {
@@ -152,7 +158,7 @@ function dosomething_kudos_group_by_taxonomy_term($data, $display = 'teaser') {
       'user' => $item->user,
     ];
 
-    if ($display === 'full') {
+    if ($options['display'] === 'full') {
       $output['reportback_item'] = $item->reportback_item;
     }
 

--- a/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
@@ -119,7 +119,7 @@ class Kudos extends Entity {
       $northstar_response = json_decode($northstar_response);
 
       if ($northstar_response && !isset($northstar_response->error)) {
-        $northstar_user = (array) $northstar_response->data;
+        $northstar_user = $northstar_response->data;
       }
     }
 

--- a/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
@@ -4,6 +4,13 @@ class Kudos extends Entity {
 
   protected $entity;
 
+  /**
+   * Approved reactions that are accessible and viewable.
+   * Edit this array to allow for additional kudos reactions.
+   * @var array
+   */
+  protected $approved_reactions = ['heart'];
+
   public $id;
   public $term;
   public $reportback_item;
@@ -86,6 +93,16 @@ class Kudos extends Entity {
   }
 
   /**
+   * Get the approved reactions.
+   * @return array
+   */
+  public static function getApprovedReactions() {
+    $kudos = new static;
+
+    return $kudos->approved_reactions;
+  }
+
+  /**
    * Build out the instantiated Kudos class object with supplied data.
    *
    * @param $data
@@ -102,7 +119,7 @@ class Kudos extends Entity {
       $northstar_response = json_decode($northstar_response);
 
       if ($northstar_response && !isset($northstar_response->error)) {
-        $northstar_user = array_shift($northstar_response->data);
+        $northstar_user = (array) $northstar_response->data;
       }
     }
 

--- a/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
@@ -6,10 +6,11 @@ class Kudos extends Entity {
 
   /**
    * Approved reactions that are accessible and viewable.
-   * Edit this array to allow for additional kudos reactions.
+   * Edit this array to allow for additional kudos reactions across the platform.
+   *
    * @var array
    */
-  protected $approved_reactions = ['heart'];
+  protected static $approved_reactions = ['heart'];
 
   public $id;
   public $term;
@@ -94,12 +95,11 @@ class Kudos extends Entity {
 
   /**
    * Get the approved reactions.
+   *
    * @return array
    */
   public static function getApprovedReactions() {
-    $kudos = new static;
-
-    return $kudos->approved_reactions;
+    return static::$approved_reactions;
   }
 
   /**

--- a/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
@@ -31,7 +31,8 @@ class KudosTransformer extends Transformer {
     }
 
     $data = $this->transformCollection($kudos);
-    $data = dosomething_kudos_sort($data, 'full');
+    // @TODO: may be better to build an $options array with items...
+    $data = dosomething_kudos_sort($data, ['display' => 'full']);
 
     return [
       'kudos' => [


### PR DESCRIPTION
#### What's this PR do?

This PR does some initial setup work for upcoming changes to the Kudos endpoint. It allows passing a current user ID that Kudos can later use (next PR) for the new Kudos response which will be more efficient and let you know if just the current user specified has reacted on a ReportbackItem.

I decided to update the names of the methods in the **ReportbackItemTransformer** class to be more obvious regarding what they are doing, now that an `$options` property was added.

`setDatabaseQueryFilters` will set the filters that get used in the database query for retrieving RB items.

`setTransformerOptions` will set any additional options (like the current user) that get passed to the transformer if it needs to take these into account for some additional logic.

It also fixes a random bug w/ the Northstar query and loading user data (not sure if NS response changed or what, but this fixes a DBLog error that was popping up).

This also sets up _one_ universal place to dictate the approved reactions for Kudos (currently only "heart"). But it's easy to retrieve them for JS or PHP via a call to `Kudos::getApprovedReactions()`.
#### How should this be reviewed?

Are kudos borked? ... no? Great!
#### Any background context you want to provide?

I'm breaking my work on #6594 into smaller digest-able PRs because @angaither bullies me when I try to submit epic PRs. It's probably warranted though 😬 

These updates were done in a way that should not break any current Kudos functionality. Tested it a bit 😉 
#### Relevant tickets

Refs #6594

---

@angaither @DFurnes 
