### PR TITLE
Fixes revealer to support kudos

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/patterns/Gallery.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/patterns/Gallery.js
@@ -31,7 +31,7 @@ function init($galleries = $('.gallery')) {
 
     $revealGalleries.each(function(index, gallery) {
       const $gallery = $(gallery);
-      const $tiles = $gallery.find('li');
+      const $tiles = $gallery.find('> li');
       const isMosaicGallery = $gallery.hasClass('-mosaic');
       const initialItems = isMosaicGallery ? 5 : 6;
       const stepItems = isMosaicGallery ? 8 : 6;


### PR DESCRIPTION
#### What's this PR do?

Changes the selector used by the Revealer so it does not treat Kudos & Gallery items both as tiles.
#### How should this be reviewed?

Does "Show more" work on the user profile now?
#### Any background context you want to provide?

https://github.com/DoSomething/phoenix/issues/6643#issuecomment-229069511
#### Relevant tickets

Note the issue below is incorrect-- That Kudos bug was fixed already (and thus should be live on prod soon). It did however make me realize Kudos breaks the user profile Show more functionality.

Fixes #6643
