### PR TITLE
Tweak promotions width and position.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_promotion.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_promotion.scss
@@ -2,19 +2,17 @@ $btw-mobile-and-tablet: "(min-width: 860px)";
 $btw-tablet-and-desktop: "(min-width: 960px)";
 
 // Temp to be moved to the module in Neue!
-[role="banner"] .promotions {
-  clear: both;
-  padding: 18px 0 9px;
+.header .promotions {
+  // Shift it down so that the "creator" portraits are adjacent to the bottom of the Header
+  position: relative;
+  top: $base-spacing;
 
-  @include media($tablet) {
-    padding-top: 28px;
+  @include media($mobile) {
+    margin-top: $base-spacing;
   }
 
   @include media($btw-mobile-and-tablet) {
-    bottom: -28px;
-    padding: 0;
-    position: absolute;
-    right: 0;
+    float: right;
   }
 
   &.-dual {
@@ -30,9 +28,7 @@ $btw-tablet-and-desktop: "(min-width: 960px)";
   }
 
   .promotion--sponsor {
-    @include media($btw-mobile-and-tablet) {
-      padding-bottom: 28px;
-    }
+    padding-bottom: $base-spacing / 2;
   }
 }
 
@@ -141,7 +137,15 @@ $btw-tablet-and-desktop: "(min-width: 960px)";
 .promotion--sponsor {
 
   .__image {
-    max-width: 125px;
+    max-width: 175px;
+  }
+
+  .__image + .__image {
+    margin-top: $base-spacing / 2;
+
+    //@include media($btw-mobile-and-tablet) {
+    //  margin-top: 0;
+    //}
   }
 
   img {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_promotion.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_promotion.scss
@@ -1,7 +1,6 @@
 $btw-mobile-and-tablet: "(min-width: 860px)";
 $btw-tablet-and-desktop: "(min-width: 960px)";
 
-// Temp to be moved to the module in Neue!
 .header .promotions {
   // Shift it down so that the "creator" portraits are adjacent to the bottom of the Header
   position: relative;
@@ -31,8 +30,6 @@ $btw-tablet-and-desktop: "(min-width: 960px)";
     padding-bottom: $base-spacing / 2;
   }
 }
-
-
 
 
 // Promotions Grouping
@@ -142,10 +139,6 @@ $btw-tablet-and-desktop: "(min-width: 960px)";
 
   .__image + .__image {
     margin-top: $base-spacing / 2;
-
-    //@include media($btw-mobile-and-tablet) {
-    //  margin-top: 0;
-    //}
   }
 
   img {


### PR DESCRIPTION
#### What's this PR do?

This PR tweaks the `.promotions` pattern to appear on a second row, and increases the max-width for a logo from 125px to 175px. This allows wider sponsor logos like J&J to be more readable.
#### How should this be reviewed?

Check that CSS and tell me if it looks alright. 
#### Any background context you want to provide?

¯_(ツ)_/¯
#### Relevant tickets

Closes #6433.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
