### PR TITLE
Update to response data structure for kudos in RB items.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -390,11 +390,9 @@ abstract class Transformer {
    *   - media: (array) Reportback Item media.
    *   - created_at: (string) Date Reportback Item was created.
    *   - kudos: (array) Ids of kudos for Reportback Item.
-   * @param  array  $options
-   *   - current_user: (string) User id.
    * @return array
    */
-  protected function transformReportbackItem($data, $options) {
+  protected function transformReportbackItem($data) {
     $output = [
       'id' => $data->id,
       'status' => $data->status,
@@ -409,7 +407,7 @@ abstract class Transformer {
     try {
       $kudos = Kudos::get($kudos);
 
-      $kudos = dosomething_kudos_sort($kudos, $options);
+      $kudos = dosomething_kudos_sort($kudos);
     }
     catch (Exception $error) {
       $kudos = [];

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -91,14 +91,6 @@ function _reportback_item_resource_definition() {
             'source' => array('param' => 'load_user'),
             'default value' => FALSE,
           ],
-          [
-            'name' => 'current_user',
-            'description' => 'Provide current user ID that response data should take into account when retrieving data.',
-            'optional' => TRUE,
-            'type' => 'string',
-            'source' => array('param' => 'current_user'),
-            'default value' => NULL,
-          ],
         ],
         'access callback' => '_reportback_item_resource_access',
         'access arguments' => array('index'),
@@ -143,7 +135,7 @@ function _reportback_item_resource_access($op) {
  * @param  bool    $load_user
  * @return array
  */
-function _reportback_item_resource_index($campaigns, $exclude, $status, $count, $random, $page, $load_user, $current_user) {
+function _reportback_item_resource_index($campaigns, $exclude, $status, $count, $random, $page, $load_user) {
   $parameters = array(
     'campaigns' => $campaigns,
     'exclude' => $exclude,
@@ -152,7 +144,6 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
     'random' => $random,
     'page' => $page,
     'load_user' => $load_user,
-    'current_user' => $current_user,
   );
 
   $reportbackItems = new ReportbackItemTransformer;

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -32,6 +32,8 @@ function dosomething_helpers_array_is_associative(array $data) {
  * @param null $value  Set a default value to assign if $var not set.
  *
  * @return array|object|string|integer|null
+ *
+ * @todo rename this function to dosomething_helpers_get_value()
  */
 function dosomething_helpers_isset($var, $key = NULL, $value = NULL) {
   if (is_array($var) && $key) {
@@ -43,6 +45,15 @@ function dosomething_helpers_isset($var, $key = NULL, $value = NULL) {
   }
 
   return isset($var) ? $var : $value;
+}
+
+function dosomething_helpers_get_nested_value($data, $nested_key, $key, $default_value = NULL) {
+  if (gettype($data) === 'object') {
+    $data = (array) $data;
+  }
+
+
+
 }
 
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -686,6 +686,21 @@ function dosomething_helpers_get_current_language_content_code() {
 }
 
 /**
+ * Get the current, logged in user.
+ *
+ * @return null|object
+ */
+function dosomething_helpers_get_current_user() {
+  global $user;
+
+  if (!$user->uid) {
+    return null;
+  }
+
+  return $user;
+}
+
+/**
  * Get the filesystem path relative to the application root.
  *
  * @param $path

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -47,16 +47,6 @@ function dosomething_helpers_isset($var, $key = NULL, $value = NULL) {
   return isset($var) ? $var : $value;
 }
 
-function dosomething_helpers_get_nested_value($data, $nested_key, $key, $default_value = NULL) {
-  if (gettype($data) === 'object') {
-    $data = (array) $data;
-  }
-
-
-
-}
-
-
 /**
  * Implements hook_menu().
  */

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -205,7 +205,8 @@ function dosomething_kudos_resolve_current_user_activity($current_user, $data, $
 }
 
 /**
- * [dosomething_kudos_compare_current_user_activity description]
+ * Compare current user activity against specified Reportback Item data.
+ *
  * @param  object  $data
  * @param  object  $current_user
  * @return null|array

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -98,15 +98,10 @@ function dosomething_kudos_sort($data, $options = []) {
   // group the kudos based on taxonomy term, along with providing a total
   // count of kudos for each term.
 
-  // @TODO: Not sure if necessary, but setting for now to make sure not to break things.
-  if (!isset($options['display'])) {
-    $options['display'] = 'teaser';
-  }
-
   usort($data, 'dosomething_kudos_sort_by_taxonomy_term');
 
   $data = dosomething_kudos_group_by_taxonomy_term($data, $options);
-  $data = dosomething_kudos_get_totals_by_taxonomy_term($data);
+
   return $data;
 }
 
@@ -131,67 +126,120 @@ function dosomething_kudos_sort_by_taxonomy_term($a, $b) {
   return $result;
 }
 
+/**
+ * Get current user from supplied data array or global user.
+ *
+ * @param  array  $data
+ * @return null|string
+ */
+function dosomething_kudos_get_current_user($data = []) {
+  if (isset($data['current_user'])) {
+    return $data['current_user'];
+  }
+
+  global $user;
+
+  if (!$user->uid) {
+    return null;
+  }
+
+  return $user->uid;
+}
 
 /**
- * Group all kudos in collection and organize them by taxonomy term.
+ * Group all kudos in collection and organize them by taxonomy term,
+ * including current users activity on retrieved kudos records.
  *
  * @param  array $data Array containing Kudos items.
  * @param  array $options
  * @return array
  */
 function dosomething_kudos_group_by_taxonomy_term($data, $options = []) {
-  $terms = [];
+  $output = [];
+  $activity = [];
 
   foreach ($data as $item) {
     if (!($item instanceof Kudos)) {
       $item = (object) $item;
     }
 
-    if (!array_key_exists($item->term['id'], $terms)) {
-      $terms[$item->term['id']] = [
+    // If the term is not already in the $output array then add it.
+    if (!array_key_exists($item->term['id'], $output)) {
+      $output[$item->term['id']] = [
         'term' => $item->term,
       ];
     }
 
-    $output = [
-      'id' => $item->id,
-      'user' => $item->user,
-    ];
-
-    if ($options['display'] === 'full') {
-      $output['reportback_item'] = $item->reportback_item;
+    if (!isset($output[$item->term['id']]['term']['total'])) {
+      $output[$item->term['id']]['term']['total'] = 0;
     }
 
-    if (isset($item->uri)) {
-      $output['uri'] = $item->uri;
-    }
+    $output[$item->term['id']]['term']['total'] += 1;
 
-    $terms[$item->term['id']]['kudos_items']['data'][] = $output;
+    $output[$item->term['id']]['current_user'] = null;
+
+    $current_user = dosomething_kudos_get_current_user($options);
+
+    if ($current_user) {
+      $current_user_activity = dosomething_kudos_compare_current_user_activity($item, $current_user);
+
+      if ($current_user_activity) {
+        $activity[$item->term['id']] = $current_user_activity;
+      }
+    }
   }
 
-
-  return array_values($terms);
+  return dosomething_kudos_resolve_current_user_activity($current_user, $output, $activity);
 }
 
-
 /**
- * Calculate total kudos per taxonomy term for a collection of kudos.
+ * For each kudos term on a Reportback Item, append the current user's activity on that term.
  *
- * @param array $data
+ * @param  string  $current_user
+ * @param  array  $data
+ * @param  array  $activity
  * @return array
  */
-function dosomething_kudos_get_totals_by_taxonomy_term($data) {
-  $output = [];
-
-  foreach ($data as $term) {
-    $total = count($term['kudos_items']['data']);
-
-    $term['kudos_items'] = ['total' => $total] + ['data' => $term['kudos_items']['data']];
-
-    $output[] = $term;
+function dosomething_kudos_resolve_current_user_activity($current_user, $data, $activity) {
+  if (!$current_user) {
+    return $data;
   }
 
-  return $output;
+  foreach ($data as $index => $item) {
+    if (isset($activity[$index])) {
+      $data[$index]['current_user'] = $activity[$item['term']['id']];
+    } else {
+      $data[$index]['current_user'] = [
+        'drupal_id' => $current_user,
+        'reacted' => false,
+        'kudos_id' => null,
+      ];
+    }
+  }
+
+  return array_values($data);
+}
+
+/**
+ * [dosomething_kudos_compare_current_user_activity description]
+ * @param  object  $data
+ * @param  string  $current_user
+ * @return null|array
+ */
+function dosomething_kudos_compare_current_user_activity($data, $current_user) {
+  $reaction_user = $data->user;
+
+  $reacted = $reaction_user['drupal_id'] === $current_user ? true : false;
+
+  if (! $reacted) {
+    return false;
+  }
+
+  return [
+    'drupal_id' => $current_user,
+    'reacted' => $reacted,
+    'kudos_id' => $reacted ? $data->id : null,
+  ];
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -163,6 +163,11 @@ function dosomething_kudos_group_by_taxonomy_term($data, $options = []) {
       $item = (object) $item;
     }
 
+    // If term is not in approved reactions list, skip it!
+    if (!in_array($item->term['name'], Kudos::getApprovedReactions())) {
+      continue;
+    }
+
     // If the term is not already in the $output array then add it.
     if (!array_key_exists($item->term['id'], $output)) {
       $output[$item->term['id']] = [

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -90,7 +90,7 @@ function dosomething_kudos_get_kudos_query($params = []) {
  * @param  array $options
  * @return array
  */
-function dosomething_kudos_sort($data, $options = []) {
+function dosomething_kudos_sort($data) {
   // The array containing collection of kudos items passed to this function
   // consists of individual kudos items. However, within this collection
   // there could be multiple kudos items that all fall within the same
@@ -100,7 +100,7 @@ function dosomething_kudos_sort($data, $options = []) {
 
   usort($data, 'dosomething_kudos_sort_by_taxonomy_term');
 
-  $data = dosomething_kudos_group_by_taxonomy_term($data, $options);
+  $data = dosomething_kudos_group_by_taxonomy_term($data);
 
   return $data;
 }
@@ -127,34 +127,13 @@ function dosomething_kudos_sort_by_taxonomy_term($a, $b) {
 }
 
 /**
- * Get current user from supplied data array or global user.
- *
- * @param  array  $data
- * @return null|string
- */
-function dosomething_kudos_get_current_user($data = []) {
-  if (isset($data['current_user'])) {
-    return $data['current_user'];
-  }
-
-  global $user;
-
-  if (!$user->uid) {
-    return null;
-  }
-
-  return $user->uid;
-}
-
-/**
  * Group all kudos in collection and organize them by taxonomy term,
  * including current users activity on retrieved kudos records.
  *
  * @param  array $data Array containing Kudos items.
- * @param  array $options
  * @return array
  */
-function dosomething_kudos_group_by_taxonomy_term($data, $options = []) {
+function dosomething_kudos_group_by_taxonomy_term($data) {
   $output = [];
   $activity = [];
 
@@ -183,7 +162,7 @@ function dosomething_kudos_group_by_taxonomy_term($data, $options = []) {
 
     $output[$item->term['id']]['current_user'] = null;
 
-    $current_user = dosomething_kudos_get_current_user($options);
+    $current_user = dosomething_helpers_get_current_user();
 
     if ($current_user) {
       $current_user_activity = dosomething_kudos_compare_current_user_activity($item, $current_user);
@@ -200,7 +179,7 @@ function dosomething_kudos_group_by_taxonomy_term($data, $options = []) {
 /**
  * For each kudos term on a Reportback Item, append the current user's activity on that term.
  *
- * @param  string  $current_user
+ * @param  object  $current_user
  * @param  array  $data
  * @param  array  $activity
  * @return array
@@ -215,7 +194,7 @@ function dosomething_kudos_resolve_current_user_activity($current_user, $data, $
       $data[$index]['current_user'] = $activity[$item['term']['id']];
     } else {
       $data[$index]['current_user'] = [
-        'drupal_id' => $current_user,
+        'drupal_id' => $current_user->uid,
         'reacted' => false,
         'kudos_id' => null,
       ];
@@ -228,20 +207,20 @@ function dosomething_kudos_resolve_current_user_activity($current_user, $data, $
 /**
  * [dosomething_kudos_compare_current_user_activity description]
  * @param  object  $data
- * @param  string  $current_user
+ * @param  object  $current_user
  * @return null|array
  */
 function dosomething_kudos_compare_current_user_activity($data, $current_user) {
   $reaction_user = $data->user;
 
-  $reacted = $reaction_user['drupal_id'] === $current_user ? true : false;
+  $reacted = $reaction_user['drupal_id'] === $current_user->uid ? true : false;
 
   if (! $reacted) {
     return false;
   }
 
   return [
-    'drupal_id' => $current_user,
+    'drupal_id' => $current_user->uid,
     'reacted' => $reacted,
     'kudos_id' => $reacted ? $data->id : null,
   ];

--- a/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
@@ -32,7 +32,7 @@ class KudosTransformer extends Transformer {
 
     $data = $this->transformCollection($kudos);
     // @TODO: may be better to build an $options array with items...
-    $data = dosomething_kudos_sort($data, ['display' => 'full']);
+    $data = dosomething_kudos_sort($data);
 
     return [
       'kudos' => [

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -4,16 +4,12 @@ class ReportbackItemTransformer extends ReportbackTransformer {
 
   private $accessibleStatuses = ['promoted', 'approved'];
 
-  private $options = [];
-
   /**
    * @param  array $parameters Any parameters obtained from query string.
    * @return array
    */
   public function index($parameters) {
     $filters = $this->setDatabaseQueryFilters($parameters);
-
-    $this->setTransformerOptions($parameters);
 
     try {
       $reportbackItems = ReportbackItem::find($filters);
@@ -76,7 +72,7 @@ class ReportbackItemTransformer extends ReportbackTransformer {
   protected function transform($item) {
     $data = [];
 
-    $data += $this->transformReportbackItem($item, $this->options);
+    $data += $this->transformReportbackItem($item);
 
     $data['reportback'] = $this->transformReportback((object) $item->reportback);
 
@@ -170,15 +166,5 @@ class ReportbackItemTransformer extends ReportbackTransformer {
     }
 
     return $filters;
-  }
-
-  /**
-   * Set the transformer logic options based on request URL parameters.
-   *
-   * @param  array $parameters
-   * @return void
-   */
-  private function setTransformerOptions($parameters) {
-    $this->options['current_user'] = $parameters['current_user'];
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -281,8 +281,8 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars, $count = 6) 
   drupal_add_js(
     [
       'dsKudosReactions' => [
+        'approved' => Kudos::getApprovedReactions(),
         'enabled' => !$disable_reactions,
-        'user' => isset($user->uid) ? $user->uid : null,
         'terms' => [
           // @TODO: Ideally this would call a function that retrieves all
           // kudos reaction terms and sets up the associative array, but
@@ -290,6 +290,7 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars, $count = 6) 
           // so let's keep it simple ;)
           'heart' => dosomething_kudos_get_term_id_by_name('heart'),
         ],
+        'user' => isset($user->uid) ? $user->uid : null,
       ]
     ],
     'setting'

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -207,23 +207,17 @@ const Reportback = {
         userReacted: false,
       };
 
-      forEach(data, (record) => {
-        if (record.term.name === term) {
-          reaction.total = record.kudos_items.total;
-
-          if (this.reactions.user) {
-            // @TODO: this could become very costly if LOTS of kudos reactions exist on RB item.
-            // @see https://github.com/DoSomething/phoenix/issues/6594 for potential solution.
-            record.kudos_items.data.map((kudos) => {
-              if (this.reactions.user === kudos.user.drupal_id) {
-                reaction.kudosId = kudos.id;
-                reaction.userReacted = true;
-              }
-            });
+      if (data.length) {
+        forEach(data, (record) => {
+          if (record.term.name === term) {
+            reaction.kudosId = record.current_user.kudos_id;
+            reaction.term = record.term.name;
+            reaction.termId = record.term.id;
+            reaction.total = record.term.total;
+            reaction.userReacted = record.current_user.reacted;
           }
-        }
-      });
-
+        });
+      }
 
       reactions.push(reaction);
     });

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -21,7 +21,7 @@ const Reportback = {
   apiUrl: '/api/v1/reportback-items',
 
   reactions: {
-    approved: ['heart'],
+    approved: setting('dsKudosReactions.approved'),
     terms: setting('dsKudosReactions.terms'),
     user: setting('dsKudosReactions.user', null),
   },


### PR DESCRIPTION
#### What's this PR do?

This PR uses some of the work completed in #6642 to update the response when Kudos reaction data is included in the `/reportback-items` response. It makes the response much more useful (and waaaay more compact) for how we actually use the Kudos data (particularly in the campaign galleries), and also takes into account the current user and indicates in the response data whether they reacted on each Reportback Item, removing a lot of the logic we currently have to do on the client-side.

Example of the new response:
![image](https://cloud.githubusercontent.com/assets/105849/16466033/a542afba-3e0f-11e6-8bc7-480f0271415c.png)
#### How should this be reviewed?

Hit the `/reporback-items` endpoint and make sure the nested kudos objects in the data for each RB item looks correct.
#### Any background context you want to provide?

Since the response data for the reportback items is changing I will be double-checking to make sure nothing gets broken where we use Kudos now.

_NOTE:_ I think there maybe be a better approach in general for how the above is accomplished, but by modifying the query for when RB items are retrieved. Instead of getting all the Kudos IDs for each RB item, gathering totals for each item on the fly. Not sure if this is more efficient or not... someone with better SQL chops would know better 😣
#### Relevant tickets

Fixes #6594 

---
