### PR TITLE
Organ Registration Form Bugs

### DIFF
--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -24,14 +24,14 @@ function dosomething_organ_donation_menu() {
 
   $items['organize/registration'] = [
     'page callback' => 'dosomething_organ_donation_post_registration',
-    'access callback' => 'user_access',
+    'access callback' => 'user_is_logged_in',
     'access arguments' => array('administer modules'),
     'type' => MENU_CALLBACK,
   ];
 
   $items['organize/postal-code'] = [
     'page callback' => 'dosomething_organ_donation_send_postal_code',
-    'access callback' => 'user_access',
+    'access callback' => 'user_is_logged_in',
     'access arguments' => array('administer modules'),
     'type' => MENU_CALLBACK,
   ];

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/OrganDonation.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/OrganDonation.js
@@ -4,6 +4,7 @@ const template = require('lodash/string/template');
 
 import setting from '../utilities/Setting';
 import Takeover from 'takeover/Takeover';
+import Validation from 'dosomething-validation';
 
 // Field template.
 import fieldTpl from 'campaign/templates/OrganDonation/field.tpl.html';
@@ -93,34 +94,35 @@ class OrganDonation extends Takeover {
 
     this.prepareFieldValidation(this.$el.find("[data-validate]"));
 
-    $registrationForm.submit(e => {
-      e.preventDefault();
+    // Sorta a hack, the Validation package adds a submit handler to forms on the page to kick off validation
+    // this just highjacks that handler and tells it not to refresh the page since we need to handle succesful
+    // validation our own way.
+    $('body').submit(e => {
+      return false;
+    });
 
-      // Grab all fields, and all field values.
+    // Send the actual request, if ds validation has passed.
+    Validation.Events.subscribe('Validation:Submitted', (topic, args) => {
       const values = $registrationForm.serialize();
 
-      // Send the actual request, if ds validation has passed.
-      if (!$registrationForm.find('input').hasClass('has-error')) {
+      this.toggleSpinner($registrationButton);
+
+      this.sendRequest({
+        url    : `${this.registrationUrl}?${values}`,
+        method : 'GET',
+      })
+      .then(json => {
+        if (typeof json.uuid !== 'undefined') {
+          this.loadShare();
+          this.set()
+        } else if (typeof json.error !== 'undefined') {
+          $('<div class="validation__message has-error">Something went wrong on our end, please try again later.</div>').insertBefore($registrationButton);
+        }
+
         this.toggleSpinner($registrationButton);
-
-        this.sendRequest({
-          url    : `${this.registrationUrl}?${values}`,
-          method : 'GET',
-        })
-        .then(json => {
-          console.log(json);
-          if (typeof json.uuid !== 'undefined') {
-            this.loadShare();
-            this.set()
-            return false;
-          } else if (typeof json.error !== 'undefined') {
-            $('<div class="validation__message has-error">Something went wrong on our end, please try again later.</div>').insertBefore($registrationButton);
-          }
-
-          this.toggleSpinner($registrationButton);
-        });
-      }
+      });
     });
+
     this.goBack();
 
     // @TODO - temporary hack. Should try doing this with better CSS animations using margins


### PR DESCRIPTION
#### What's this PR do?

1) Changes access to the api wrapper endpoints so that logged in users can use them. The `user_access` permission was not allowing non-admins to submit forms.

2) Updates how I was handling submission of the registration form so it worked with our validation package better. The validation package [binds a submit handler to all forms](https://github.com/DoSomething/validation/blob/master/src/validation.js#L264) and that was conflict with our more specific handler causing use to submit info to organize twice. 

The update I made is a bit of a hack that just stops the body form handler from refreshing the page when it is done, but still runs the validation. And then, I subscribe to the successful validation event that that validation package throws to know when to actually submit the info to Organize. This seemed like the simplest solution. But i'm open to other suggestions, i'm sure there is some fancy propagation stuff we could do. 

Overall, I think a combo of both of these things will fix an issue we were seeing with the form hanging sometimes.
#### Relevant tickets

Fixes #6655 
