### PR TITLE
add magic link copy to custom campaign settings and api response

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -266,6 +266,9 @@ abstract class Transformer {
         $output['uri'] = $data->uri;
       }
 
+      if (dosomething_helpers_get_variable('node', $data->id, 'magic_link_copy')) {
+        $output['magic_link_copy'] = dosomething_helpers_get_variable('node', $data->id, 'magic_link_copy');
+      }
     }
 
     return $output;

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -266,8 +266,9 @@ abstract class Transformer {
         $output['uri'] = $data->uri;
       }
 
-      if (dosomething_helpers_get_variable('node', $data->id, 'magic_link_copy')) {
-        $output['magic_link_copy'] = dosomething_helpers_get_variable('node', $data->id, 'magic_link_copy');
+      $magic_link_copy = dosomething_helpers_get_variable('node', $data->id, 'magic_link_copy');
+      if ($magic_link_copy) {
+        $output['magic_link_copy'] = $magic_link_copy;
       }
     }
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -154,6 +154,21 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
         ),
       ),
     );
+    $form['magic_link'] = [
+      '#type' => 'fieldset',
+      '#title' => t('Magic Link'),
+      '#collapsible' => TRUE,
+      '#collapsed' => TRUE,
+    ];
+    $form['magic_link']['magic_link_copy'] = [
+      '#type' => 'textfield',
+      '#title' => t('Magic Link Copy'),
+      '#description' => t('Custom text to explain the magic link.'),
+      '#default_value' => $vars['magic_link_copy'],
+      '#attributes' => array(
+        'maxlength' => '140',
+      ),
+    ];
   }
 
   $form['actions'] = array(
@@ -213,6 +228,7 @@ function dosomething_helpers_get_variable_names() {
     'count_pending',
     'count_promoted',
     'goal',
+    'magic_link_copy',
     'mobilecommons_opt_in_path',
     'mobilecommons_friends_opt_in_path',
     'progress',

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -163,7 +163,7 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     $form['magic_link']['magic_link_copy'] = [
       '#type' => 'textfield',
       '#title' => t('Magic Link Copy'),
-      '#description' => t('Custom text to explain the magic link.'),
+      '#description' => t('Custom text to explain the magic link. The magic link will bring the user to the web version of the site and log them in automatically.'),
       '#default_value' => $vars['magic_link_copy'],
       '#attributes' => array(
         'maxlength' => '140',


### PR DESCRIPTION
#### What's this PR do?

Added a new type of custom setting on campaigns. Include the `magic_link_copy` in the api response to get a campaign. 
#### How should this be reviewed?

Add some magic link copy and make sure you get it when you grab a campaign via the api. 
#### Relevant tickets

Fixes #6641 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.

cc: @aaronschachter & @DFurnes 
