### PR TITLE
Store the timestamp for a new kudos.

### DIFF
--- a/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
@@ -74,6 +74,7 @@ class KudosTransformer extends Transformer {
     $values = [
       'fid' => $parameters['fid'],
       'uid' => $parameters['uid'],
+      'created' => time(),
     ];
 
     foreach($parameters['tids'] as $id) {


### PR DESCRIPTION
#### What's this PR do?

This PR just makes it so that a timestamp is _actually_ stored for a new kudos in the database.
#### How should this be reviewed?

Add a Kudos reaction to an RB item and check the database to make sure a timestamp is added.
#### Relevant tickets

Fixes #6638

---

@sbsmith86 @DFurnes 
