### PR TITLE
add help text to campaign run timing

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.field_group.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.field_group.inc
@@ -88,7 +88,9 @@ function dosomething_campaign_run_field_group_info() {
     'format_settings' => array(
       'formatter' => 'collapsible',
       'instance_settings' => array(
-        'description' => '',
+        'description' => 'These dates determine whether the campaign is open or closed, and group sign up and reportback activity. If the run has no end date selected, the campaign will stay active. If the campaign run does have an end date, the campaign will automatically switch to the closed state at 12:05 AM the day after the end date. </br></br>
+
+          To select an end date, click "Show End Date" and use the dropdown menu to select a date. Be sure the date is correct, and not simply the date that autofills in the field. If the campaign is translated and open across different translations, then the start and end dates must be correctly set for every translation of the run.',
         'classes' => 'group-timing field-group-fieldset',
         'required_fields' => 1,
       ),


### PR DESCRIPTION
#### What's this PR do?

Added a description to the timing form on campaign runs. Looks like this now:
![image](https://cloud.githubusercontent.com/assets/4240292/16591409/cca2b02a-42a9-11e6-9f16-d9e453aa0b5d.png)

The text is what @namimody [provided in the issue](https://github.com/DoSomething/phoenix/issues/6659#issuecomment-230494722).
#### How should this be reviewed?

Go to edit a campaign run and make sure the text shows up in the timing box.
#### Any background context you want to provide?

This fixes point 3 of the issue. It sounds like 1 can't be done and 2 is a problem with the Drupal Date Module.
#### Relevant tickets

Refs #6659 
