### PR TITLE
SMS Scholarship confirmation language

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
@@ -18,10 +18,12 @@ function dosomething_campaign_reportback_confirmation_page($node) {
   $clc = dosomething_helpers_get_current_language_content_code();
 
   // Initialize $vars to pass to the reportback_confirmation theme function.
+  $scholarship_language = t('You\'ve taken the first step in being entered to win the scholarship. Next step is to complete the experience!');
+
   $vars = [
     'back_to_campaign_link' => NULL,
     'call_to_action' => NULL,
-    'copy' => $node->field_reportback_confirm_msg[$clc][0]['value'],
+    'copy' => $node->field_scholarship_amount[$clc][0]['value'] ? $scholarship_language : $node->field_reportback_confirm_msg[$clc][0]['value'],
     'more_campaigns_link' => NULL,
     'page_title' => NULL,
     'recommended' => NULL,


### PR DESCRIPTION
#### What's this PR do?

For sms campaigns, if there is a scholarship we display hardcoded language that lets the user know that they are eligible for the scholarship .

If there is no scholarship, I display the text that is customized in the `field_reportback_confirm_msg` field.
#### How should this be reviewed?

Go to a sms campaign with a scholarship attached, sign up, you should see this on the confirmation page. 

![image](https://cloud.githubusercontent.com/assets/1700409/16592016/a9c1c156-42ac-11e6-8426-f41a326d033c.png)
#### Relevant tickets

Fixes #6597 (see this issue for more background information)
