### PR TITLE
Update so "EVERYBODY gets a kudos!" --Oprah

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -249,7 +249,8 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
     $kudos = [
       'fid' => $fid,
       'uid' => $user->uid,
-      'tid' => dosomething_kudos_get_term_id_by_name(array_pop(Kudos::getApprovedReactions())),
+      // @TODO: use array_pop(Kudos::getApprovedReactions()) once new Kudos refactor is fully approved.
+      'tid' => dosomething_kudos_get_term_id_by_name('heart'),
       'created' => time(),
     ];
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -238,12 +238,20 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
  * Form submit callback for dosomething_reportback_files_form_submit.
  */
 function dosomething_reportback_files_form_submit($form, &$form_state) {
+  $user = dosomething_helpers_get_current_user();
+
   $rb_files = $form_state['values']['rb_files'];
   if (empty($rb_files) || !is_array($rb_files)) {
     return;
   }
 
   foreach ($rb_files as $fid => $values) {
+    $kudos = [
+      'fid' => $fid,
+      'uid' => $user->uid,
+      'tid' => dosomething_kudos_get_term_id_by_name(array_pop(Kudos::getApprovedReactions())),
+      'created' => time(),
+    ];
 
     $rbf = reportback_file_load($fid);
 
@@ -259,6 +267,11 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
 
     if (!$save) {
       form_set_error(t("An error has occurred."));
+    }
+
+    // Save kudos reaction from admin on RB item.
+    if ($values['status'] === 'promoted' || $values['status'] === 'approved') {
+      $record = (new KudosController)->create($kudos);
     }
 
     // Rotate the original image, if a rotation option was selected.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -271,7 +271,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
     }
 
     // Save kudos reaction from admin on RB item.
-    if ($values['status'] === 'promoted' || $values['status'] === 'approved') {
+    if ($values['status'] === 'promoted' || $values['status'] === 'approved' || $values['status'] === 'excluded') {
       $record = (new KudosController)->create($kudos);
     }
 


### PR DESCRIPTION
#### What's this PR do?

This PR updates the Admin review process, so if an admin marks a Reportback Item as "approved" or "promoted" it automagically ✨ gets a kudos created for that item by the admin.
#### How should this be reviewed?

Try reviewing a few Reportback Items and then check the gallery to make sure they have 1 kudos already (or check the database for that `fid` and confirm a new record was created)!
#### Any background context you want to provide?

![image](https://media.giphy.com/media/dcubXtnbck0RG/giphy.gif)
#### Relevant tickets

Fixes #6661

---

@angaither @DFurnes 
