### PR TITLE
in some environments register_organ_donors isn't in the campaign variables

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -215,7 +215,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     $materials['title'] = t('Stuff You Need');
     $materials['content'] = $campaign->items_needed;
     // if organ donation campaign, add in the share link here
-    if ($campaign->variables['register_organ_donors']) {
+    if (array_key_exists('register_organ_donors', $campaign->variables) && $campaign->variables['register_organ_donors']) {
       $materials['content'] .= '<ul><li>Copy and paste your custom link to invite friends and family to become an organ donor: <code>' . $custom_organ_share_link . '</code></li></ul>';
       drupal_add_js(
         array('dosomethingUser' =>


### PR DESCRIPTION
#### What's this PR do?

In some environments the `register_organ_donors` variable does not exist, so now we make sure it's in the array before pulling the value.
#### How should this be reviewed?

If you were seeing this error before on global campaigns, make sure this gets rid of it.
#### Any background context you want to provide?

@deadlybutter and @weerd were seeing this. I was unable to recreate locally but @deadlybutter wasn't seeing the error anymore with this line changed.
