### PR TITLE
Adding Symfony Var-Dumper package via composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,8 @@
   "require": {
     "stripe/stripe-php": "^1.18.0",
     "zendesk/zendesk_api_client_php": "^1.2.0"
+  },
+  "require-dev": {
+    "symfony/var-dumper": "^3.1"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,11 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "eea86c837efda216671b620e473afb0d",
+    "hash": "057363e39480806b5031b6623e2c64cc",
+    "content-hash": "de6f1e369b3cef9654b9066755806fd7",
     "packages": [
         {
             "name": "stripe/stripe-php",
@@ -89,7 +90,130 @@
             "time": "2015-05-31 00:16:34"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-05-18 14:26:46"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "39492b8b8fe514163e677bf154fd80f6cc995759"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/39492b8b8fe514163e677bf154fd80f6cc995759",
+                "reference": "39492b8b8fe514163e677bf154fd80f6cc995759",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "twig/twig": "~1.20|~2.0"
+            },
+            "suggest": {
+                "ext-symfony_debug": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "time": "2016-06-29 05:41:56"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],


### PR DESCRIPTION
#### What's this PR do?

This PR includes the Symfony Var-Dumper package to make `var_dump()` results much easer to understand and see all top level items in one easily viewable, collapsed collection. It is added as a dev dependency via composer. 

Instead of using `var_dump($variable)` to see something like this that you have to scroll forever on:
<img width="914" alt="screen shot 2016-07-05 at 5 21 46 pm" src="https://cloud.githubusercontent.com/assets/105849/16600542/9791a43c-42d5-11e6-8243-47471a104740.png">

 You can now simply use `dump($variable)` to get this:
<img width="846" alt="screen shot 2016-07-05 at 5 22 15 pm" src="https://cloud.githubusercontent.com/assets/105849/16600547/9b1f8a6a-42d5-11e6-9ee3-6aca4b279d2c.png">
#### How should this be reviewed?

Try it out!
#### Any background context you want to provide?

Not super keen on the colors, but we could maybe do some editing to it kinda like Laravel does, when it uses the `dd()` function.
#### Relevant tickets

Fixes 💅 

---

@angaither @DFurnes 
