### PR TITLE
store organ info, make modal disappear when you click done

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -229,6 +229,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
             'street_address_2' => dosomething_user_get_field('field_address')['premise'],
             'city' => dosomething_user_get_field('field_address')['locality'],
             'state' => dosomething_user_get_field('field_address')['administrative_area'],
+            'uid' => $vars['user']->uid,
             ),
           ),
         ),

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -250,7 +250,7 @@ function dosomething_organ_donation_update_user($params) {
     'thoroughfare' => $params['street_address'],
   ];
   // If this field is present I think it would be optional, so check if we have it first
-  if(array_key_exists('street_address_2', $params)) {
+  if (array_key_exists('street_address_2', $params)) {
     $new_field_address['premise'] = $params['street_address_2'];
   }
   $user->field_address[LANGUAGE_NONE][0] = $new_field_address;

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -130,15 +130,12 @@ function dosomething_organ_donation_store_registration() {
   // Grab this to get the sid
   $params = drupal_get_query_parameters();
 
-  // Grab this to get the uid
-  global $user;
-
   try {
-    if ($params['sid'] && $user->uid) {
+    if ($params['sid'] && $params['uid']) {
       db_insert('dosomething_organ_donation')
         ->fields([
           'sid' => $params['sid'],
-          'uid' => $user->uid,
+          'uid' => $params['uid'],
           'registration_form_timestamp' =>  REQUEST_TIME,
       ])->execute();
 

--- a/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
+++ b/lib/modules/dosomething/dosomething_organ_donation/dosomething_organ_donation.module
@@ -127,14 +127,18 @@ function dosomething_organ_donation_send_postal_code() {
  *
  */
 function dosomething_organ_donation_store_registration() {
+  // Grab this to get the sid
   $params = drupal_get_query_parameters();
 
+  // Grab this to get the uid
+  global $user;
+
   try {
-    if ($params['sid'] && $params['uid']) {
+    if ($params['sid'] && $user->uid) {
       db_insert('dosomething_organ_donation')
         ->fields([
           'sid' => $params['sid'],
-          'uid' => $params['uid'],
+          'uid' => $user->uid,
           'registration_form_timestamp' =>  REQUEST_TIME,
       ])->execute();
 
@@ -244,8 +248,11 @@ function dosomething_organ_donation_update_user($params) {
     'locality' => $params['city'],
     'postal_code' => $params['postal_code'],
     'thoroughfare' => $params['street_address'],
-    'premise' => $params['street_address_2'],
   ];
+  // If this field is present I think it would be optional, so check if we have it first
+  if(array_key_exists('street_address_2', $params)) {
+    $new_field_address['premise'] = $params['street_address_2'];
+  }
   $user->field_address[LANGUAGE_NONE][0] = $new_field_address;
 
   // Update name and birthday

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/OrganDonation.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/OrganDonation.js
@@ -16,7 +16,9 @@ class OrganDonation extends Takeover {
 
     this.postalCodeUrl       = `${this.baseUrl}/organize/postal-code`;
     this.registrationUrl     = `${this.baseUrl}/organize/registration`;
+    this.shareUrl            = `${this.baseUrl}/organ-donation/registration`;
     this.userInfo            = setting('dosomethingUser.userInfo');
+    this.sid                 = setting('dosomethingSignup.sid');
     this.$zipCodeButton      = this.$el.find('.submit-postal-code');
     this.$zipCodeScreen      = this.$el.find('.js-collect-zip-code');
     this.$registrationScreen = this.$el.find('.js-collect-registration');
@@ -137,6 +139,13 @@ class OrganDonation extends Takeover {
     this.loadScreen(this.$shareScreen);
 
     // @TODO - Handle submission of "done" button that posts to our db info about the submission being done.
+    // This happens whether they hit "done" or "skip" since at this point those are the same
+    const sid = this.sid;
+
+    this.sendRequest({
+      url    : `${this.shareUrl}?sid=${sid}`,
+      method : 'GET',
+    });
 
     this.resizeContainerHeight(this.$el.find('.takeover'), this.$shareScreen);
   }

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/OrganDonation.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/OrganDonation.js
@@ -14,15 +14,15 @@ class OrganDonation extends Takeover {
 
     super($takeoverContainer, tpl);
 
-    this.postalCodeUrl       = `${this.baseUrl}/organize/postal-code`;
-    this.registrationUrl     = `${this.baseUrl}/organize/registration`;
-    this.shareUrl            = `${this.baseUrl}/organ-donation/registration`;
-    this.userInfo            = setting('dosomethingUser.userInfo');
-    this.sid                 = setting('dosomethingSignup.sid');
-    this.$zipCodeButton      = this.$el.find('.submit-postal-code');
-    this.$zipCodeScreen      = this.$el.find('.js-collect-zip-code');
-    this.$registrationScreen = this.$el.find('.js-collect-registration');
-    this.$shareScreen        = this.$el.find('.js-share-confirmation');
+    this.postalCodeUrl        = `${this.baseUrl}/organize/postal-code`;
+    this.registrationUrl      = `${this.baseUrl}/organize/registration`;
+    this.storeRegistrationUrl = `${this.baseUrl}/organ-donation/registration`;
+    this.userInfo             = setting('dosomethingUser.userInfo');
+    this.sid                  = setting('dosomethingSignup.sid');
+    this.$zipCodeButton       = this.$el.find('.submit-postal-code');
+    this.$zipCodeScreen       = this.$el.find('.js-collect-zip-code');
+    this.$registrationScreen  = this.$el.find('.js-collect-registration');
+    this.$shareScreen         = this.$el.find('.js-share-confirmation');
 
     this.loadScreen(this.$zipCodeScreen);
     this.set();
@@ -143,7 +143,7 @@ class OrganDonation extends Takeover {
     const sid = this.sid;
 
     this.sendRequest({
-      url    : `${this.shareUrl}?sid=${sid}`,
+      url    : `${this.storeRegistrationUrl}?sid=${sid}`,
       method : 'GET',
     });
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/OrganDonation.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/OrganDonation.js
@@ -143,7 +143,7 @@ class OrganDonation extends Takeover {
     const sid = this.sid;
 
     this.sendRequest({
-      url    : `${this.storeRegistrationUrl}?sid=${sid}`,
+      url    : `${this.storeRegistrationUrl}?sid=${sid}&uid=${this.userInfo['uid']}`,
       method : 'GET',
     });
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -433,7 +433,7 @@
                   <p>Copy and paste your share link:</p>
                   <code><?php print $custom_organ_share_link ?></code>
                   <div class="form-item -padded submit-done-container">
-                    <input type="submit" class="button submit-done" value="Done" />
+                    <input type="submit" class="button js-close-modal" value="Done" />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
#### What's this PR do?
- We keep the `uid`, `sid`, and `timestamp` of the registration in `dosomething_organ_donation` table if the user get through the whole flow. 
- When you click `Done` the modal should disappear now.
- I also threw in checking if we collected the `street_address_2` from the user since (a) it seems like we are not being fed that field anymore and (b) I *think* it should be optional anyway.
#### How should this be reviewed?

Register to give your organs and make sure the data shows up in the table.
#### Relevant tickets

Refs #6647 
