### PR TITLE
change the text with the run date checkbox

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -274,9 +274,6 @@ function dosomething_campaign_run_add_campaign_run_info(&$form, &$form_state) {
  * Implements hook_form_NODE_TYPE_alter().
  */
 function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$form_state, $form_id) {
-  // Add title help text.
-  $form['title']['#description'] = t('The title is not user facing, it just helps when searching for content. Suggestion: Use campaign name and year campaign ended (i.e. Comeback Clothes 2014).');
-
   // Alter the Run Date text
   $form['#after_build'][] = 'dosomething_campaign_run_after_build';
 
@@ -290,11 +287,15 @@ function dosomething_campaign_run_after_build($form, &$form_state) {
   if (!isset($form['nid']['#value'])) {
     $form['field_run_date'][LANGUAGE_NONE][0]['show_todate']['#title'] = t('Select End Date');
   }
-
-  // Make sure to account for all the language options as well
-  $prefixes = dosomething_global_get_language_prefix_list();
-  foreach ($prefixes as $lang) {
-    $form['field_run_date'][$lang][0]['show_todate']['#title'] = t('Select End Date');
+  else {
+    // Make sure to account for all the language options as well
+    $prefixes = dosomething_global_get_language_prefix_list();
+    foreach ($prefixes as $lang) {
+      if (isset($form['field_run_date'][$lang]))
+      {
+        $form['field_run_date'][$lang][0]['show_todate']['#title'] = t('Select End Date');
+      }
+    }
   }
 
   return $form;

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -284,19 +284,20 @@ function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$fo
  * Customize the Run Date form
  */
 function dosomething_campaign_run_after_build($form, &$form_state) {
+  // Make sure we change for the relevant language
   if (!isset($form['nid']['#value'])) {
-    $form['field_run_date'][LANGUAGE_NONE][0]['show_todate']['#title'] = t('Select End Date');
+    $language = LANGUAGE_NONE;
   }
   else {
-    // Make sure to account for all the language options as well
-    $prefixes = dosomething_global_get_language_prefix_list();
-    foreach ($prefixes as $lang) {
-      if (isset($form['field_run_date'][$lang]))
-      {
-        $form['field_run_date'][$lang][0]['show_todate']['#title'] = t('Select End Date');
+    $language_list = dosomething_global_get_language_prefix_list();
+    foreach($language_list as $lang) {
+      if (isset($form['field_run_date'][$lang])) {
+          $language = $lang;
       }
     }
   }
+
+  $form['field_run_date'][$language][0]['show_todate']['#title'] = t('Select End Date');
 
   return $form;
 }

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -277,7 +277,27 @@ function dosomething_campaign_run_form_campaign_run_node_form_alter(&$form, &$fo
   // Add title help text.
   $form['title']['#description'] = t('The title is not user facing, it just helps when searching for content. Suggestion: Use campaign name and year campaign ended (i.e. Comeback Clothes 2014).');
 
+  // Alter the Run Date text
+  $form['#after_build'][] = 'dosomething_campaign_run_after_build';
+
   drupal_add_css(drupal_get_path('module', 'dosomething_campaign_run') . '/campaign_run_node.css');
+}
+
+/**
+ * Customize the Run Date form
+ */
+function dosomething_campaign_run_after_build($form, &$form_state) {
+  if (!isset($form['nid']['#value'])) {
+    $form['field_run_date'][LANGUAGE_NONE][0]['show_todate']['#title'] = t('Select End Date');
+  }
+
+  // Make sure to account for all the language options as well
+  $prefixes = dosomething_global_get_language_prefix_list();
+  foreach ($prefixes as $lang) {
+    $form['field_run_date'][$lang][0]['show_todate']['#title'] = t('Select End Date');
+  }
+
+  return $form;
 }
 
 /*


### PR DESCRIPTION
#### What's this PR do?

It adds an `#after_build` to the campaign run form to call a function that edits the text next to the checkbox under `RUN DATE`.
#### How should this be reviewed?

Go to create a new run and edit a run (check every language) and make sure the text next to the checkbox under `RUN DATE` in the `TIMING` box says `Select End Date`
#### Relevant tickets

Refs #6659
#### Checklist
- [x] Tested on staging.
