### PR TITLE
Fixes a bug in template and adds utility function.

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -29,22 +29,56 @@ function dosomething_helpers_array_is_associative(array $data) {
  *
  * @param string|array|object $var  Variable to check.
  * @param string $key  If $var is an array or object, key to check.
- * @param null $value  Set a default value to assign if $var not set.
+ * @param null $default  Set a default value to assign if $var not set.
  *
  * @return array|object|string|integer|null
  *
  * @todo rename this function to dosomething_helpers_get_value()
  */
-function dosomething_helpers_isset($var, $key = NULL, $value = NULL) {
+function dosomething_helpers_isset($var, $key = NULL, $default = NULL) {
   if (is_array($var) && $key) {
-    return isset($var[$key]) ? $var[$key] : $value;
+    return isset($var[$key]) ? $var[$key] : $default;
   }
 
   if (is_object($var) && $key) {
-    return isset($var->$key) ? $var->$key : $value;
+    return isset($var->$key) ? $var->$key : $default;
   }
 
-  return isset($var) ? $var : $value;
+  return isset($var) ? $var : $default;
+}
+
+/**
+ * Utility function to check and obtain a nested value in an array.
+ *
+ * @param  array $data
+ * @param  string $key
+ * @param  string $parent_key
+ * @return string|null
+ *
+ * @todo  should update to check if array or object and just make it smarter in general.
+ */
+function dosomething_helpers_get_nested_value($data, $key, $parent_key = NULL) {
+  if (!$data) {
+    return NULL;
+  }
+
+  // Search a specific item in array for key.
+  if ($parent_key) {
+    if (isset($data[$parent_key])) {
+      return dosomething_helpers_isset($data[$parent_key], $key);
+    }
+  }
+
+  // Search all items in array for key.
+  foreach ($data as $item) {
+    $result = dosomething_helpers_isset($item, $key);
+
+    if ($result) {
+      return $result;
+    }
+  }
+
+  return NULL;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -48,40 +48,6 @@ function dosomething_helpers_isset($var, $key = NULL, $default = NULL) {
 }
 
 /**
- * Utility function to check and obtain a nested value in an array.
- *
- * @param  array $data
- * @param  string $key
- * @param  string $parent_key
- * @return string|null
- *
- * @todo  should update to check if array or object and just make it smarter in general.
- */
-function dosomething_helpers_get_nested_value($data, $key, $parent_key = NULL) {
-  if (!$data) {
-    return NULL;
-  }
-
-  // Search a specific item in array for key.
-  if ($parent_key) {
-    if (isset($data[$parent_key])) {
-      return dosomething_helpers_isset($data[$parent_key], $key);
-    }
-  }
-
-  // Search all items in array for key.
-  foreach ($data as $item) {
-    $result = dosomething_helpers_isset($item, $key);
-
-    if ($result) {
-      return $result;
-    }
-  }
-
-  return NULL;
-}
-
-/**
  * Implements hook_menu().
  */
 function dosomething_helpers_menu() {

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -282,9 +282,7 @@ function dosomething_kudos_get_kudos_for_user_by_file($fid) {
  * @return bool
  */
 function dosomething_kudos_term_is_selected($kudos, $term) {
-  $kudos = (object) $kudos;
-
-  if (! $kudos->existing_kids) {
+  if (! $kudos['existing_kids']) {
     return false;
   }
 
@@ -294,7 +292,7 @@ function dosomething_kudos_term_is_selected($kudos, $term) {
     return false;
   }
 
-  if (! isset($kudos->existing_kids[$id])) {
+  if (! isset($kudos['existing_kids'][$id])) {
     return false;
   }
 

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -275,16 +275,16 @@ function dosomething_kudos_get_kudos_for_user_by_file($fid) {
 
 /**
  * Check to see if the kudos term has been selected by the user on specified
- * reportback.
+ * reportback item kudos data.
  *
- * @param  object $reportback_item
+ * @param  array $kudos
  * @param  string $term
  * @return bool
  */
-function dosomething_kudos_term_is_selected($reportback_item, $term) {
-  $reportback_item = (object) $reportback_item;
+function dosomething_kudos_term_is_selected($kudos, $term) {
+  $kudos = (object) $kudos;
 
-  if (! $reportback_item->existing_kids) {
+  if (! $kudos->existing_kids) {
     return false;
   }
 
@@ -294,7 +294,7 @@ function dosomething_kudos_term_is_selected($reportback_item, $term) {
     return false;
   }
 
-  if (! isset($reportback_item->existing_kids[$id])) {
+  if (! isset($kudos->existing_kids[$id])) {
     return false;
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -16,7 +16,7 @@
   <?php if (isset($content->kudos) && isset($content->kudos['fid'])): ?>
     <ul class="form-actions -inline kudos">
       <li>
-        <button class="js-kudos-button kudos__icon <?php print dosomething_kudos_term_is_selected($content->kudos, 'heart') ? 'is-active' : '' ?>" data-kudos-term-id="<?php print $content->kudos['allowed_reactions'][0]; ?>" data-kid="<?php print dosomething_helpers_isset($content->kudos['existing_kids'][$content->kudos['allowed_reactions'][0]], 'kid') ?>"></button>
+        <button class="js-kudos-button kudos__icon <?php print dosomething_kudos_term_is_selected($content->kudos, 'heart') ? 'is-active' : '' ?>" data-kudos-term-id="<?php print $content->kudos['allowed_reactions'][0]; ?>" data-kid="<?php print dosomething_helpers_get_nested_value($content->kudos['existing_kids'], 'kid') ?>"></button>
         <span class="counter"><?php print $content->kudos['reaction_totals']['heart']; ?></span>
       </li>
     </ul>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -16,7 +16,7 @@
   <?php if (isset($content->kudos) && isset($content->kudos['fid'])): ?>
     <ul class="form-actions -inline kudos">
       <li>
-        <button class="js-kudos-button kudos__icon <?php print dosomething_kudos_term_is_selected($content->kudos, 'heart') ? 'is-active' : '' ?>" data-kudos-term-id="<?php print $content->kudos['allowed_reactions'][0]; ?>" data-kid="<?php print dosomething_helpers_get_nested_value($content->kudos['existing_kids'], 'kid') ?>"></button>
+        <button class="js-kudos-button kudos__icon <?php print dosomething_kudos_term_is_selected($content->kudos, 'heart') ? 'is-active' : '' ?>" data-kudos-term-id="<?php print $content->kudos['allowed_reactions'][0]; ?>" data-kid="<?php print data_get($content->kudos['existing_kids'], [$content->kudos['allowed_reactions'][0], 'kid']) ?>"></button>
         <span class="counter"><?php print $content->kudos['reaction_totals']['heart']; ?></span>
       </li>
     </ul>


### PR DESCRIPTION
#### What's this PR do?

This PR fixes an issue where on every campaign action page load, there are about 6 or less (because of the number of initial gallery items) notices regarding an undefined offset `641`. The issue is that the function in the template that is called to find a particular _nested_ array item won't work because the `dosomething_helpers_isset()` function cannot handle dealing with grabbing values if the value is nested. 

Now we use the handy `data_get()` helper function brought in by the **tightenco/collect** package (amongst a bunch of other awesome stuff that package brings in).

This PR also cleans up: 
- `dosomething_helpers_isset()` function to rename a param to help make it more obvious what it is.
- `dosomething_kudos_term_is_selected()` since the param name no longer reflected what was being passed in to it.. it is no longer a `$reportback_item` object, but a `$kudos` array.
#### How should this be reviewed?

Load a campaign action page. If you don't see any `Notice: Undefined offset: 641` errors, then all is well!
#### Relevant tickets

Fixes #6700
#### Checklist
- [ ] Tested on staging.

---

@deadlybutter @angaither @jessleenyc 
