### PR TITLE
Adds framework agnostic Collections and helper functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
   },
   "require": {
     "stripe/stripe-php": "^1.18.0",
-    "zendesk/zendesk_api_client_php": "^1.2.0"
+    "zendesk/zendesk_api_client_php": "^1.2.0",
+    "tightenco/collect": "^5.2"
   },
   "require-dev": {
     "symfony/var-dumper": "^3.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "057363e39480806b5031b6623e2c64cc",
-    "content-hash": "de6f1e369b3cef9654b9066755806fd7",
+    "hash": "10ad35474cdc4d9f03316180f319cc43",
+    "content-hash": "d1e51f586b462f053d28c6aa453d6110",
     "packages": [
         {
             "name": "stripe/stripe-php",
@@ -54,6 +54,53 @@
                 "stripe"
             ],
             "time": "2015-01-22 05:01:46"
+        },
+        {
+            "name": "tightenco/collect",
+            "version": "v5.2.38",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tightenco/collect.git",
+                "reference": "fded841989fcbad4532173d32e7dfaceed99f98c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tightenco/collect/zipball/fded841989fcbad4532173d32e7dfaceed99f98c",
+                "reference": "fded841989fcbad4532173d32e7dfaceed99f98c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.4",
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Illuminate/Support/helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\": "src/Illuminate"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylorotwell@gmail.com"
+                }
+            ],
+            "description": "Collect - Illuminate Collections as a separate package.",
+            "keywords": [
+                "collection",
+                "laravel"
+            ],
+            "time": "2016-06-09 21:53:44"
         },
         {
             "name": "zendesk/zendesk_api_client_php",


### PR DESCRIPTION
#### What's this PR do?

This adds the tightenco/collect composer package which is specifically created to allow adding some of the sweet sugary Collections and helper functions that the Illuminate/Support package adds, but in a framework agnostic fashion and without a bunch of the other dependencies that Illuminate/Support normally brings with it.

Now we'll have access to the [Collection methods](https://laravel.com/docs/5.2/collections) from the Collections class, simply use the `collect()` helper method or instantiate the class.

Also have access to the [Arr methods](https://laravel.com/docs/5.2/helpers#available-methods) from the Arr class.
#### How should this be reviewed?

👀 
#### Any background context you want to provide?

Thanks @DFurnes for finding this package! Apart from not using **Illuminate/Support** because it brings with it a few dependencies that we likely won't be using on the Drupal site, it brings the full list of helper functions like `dd()` which conflict and throw a fatal exception with the Drupal Devel module `dd()` function.

Make sure to run `composer install` to download and install this new composer package.
#### Relevant tickets

Refs #6700 (will help provide a better fix for this issue)

---

@DFurnes @angaither 

Pinging you all below so that you're also aware that once merged we'll have access to some fancier shiz that you might be accustomed to in Laravel, but now in Drupal.
CC: @deadlybutter @sbsmith86 @DeeZone @aaronschachter @katiecrane 
