### PR TITLE
always include magic link copy (null if none) in api response

### DIFF
--- a/documentation/endpoints/campaigns.md
+++ b/documentation/endpoints/campaigns.md
@@ -233,7 +233,8 @@ Example response:
       noun: "Items",
       verb: "Recycled"
     },
-    uri: "http://dev.dosomething.org:8888/api/v1/campaigns/362"
+    uri: "http://dev.dosomething.org:8888/api/v1/campaigns/362",
+    magic_link_copy: "Here's why you should click this magic link"
   }
 }
 ```

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -267,9 +267,7 @@ abstract class Transformer {
       }
 
       $magic_link_copy = dosomething_helpers_get_variable('node', $data->id, 'magic_link_copy');
-      if ($magic_link_copy) {
-        $output['magic_link_copy'] = $magic_link_copy;
-      }
+      $output['magic_link_copy'] = $magic_link_copy ? $magic_link_copy : NULL;
     }
 
     return $output;


### PR DESCRIPTION
#### What's this PR do?

Includes the `magic_link_copy` in the API response even if it is `NULL`. Updates the docs to reflect.
#### How should this be reviewed?

Add some magic link copy and make sure you get it when you grab a campaign via the API. Remove it and make sure it is still included in the response with the value as `null`.
#### Any background context you want to provide?

The wise @aaronschachter filled me in on [our conventions surrounding this](https://github.com/DoSomething/phoenix/issues/6641#issuecomment-231414111).
#### Relevant tickets

Refs #6641
#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
