### PR TITLE
copy to go to help center in contact us if campaign closed

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -83,7 +83,8 @@ function paraneue_dosomething_add_info_bar(&$vars) {
 
       // If the campaign is closed, link to the help center
       // If the campaign is open, link to the FAQs if there are any
-      if (isset($vars['field_campaign_status'][0]['value']) && $vars['field_campaign_status'][0]['value'] == 'closed') {
+      $node = node_load($vars['nid']);
+      if (dosomething_campaign_is_closed($node)) {
         $info_bar_vars['help_center'] = true;
         $info_bar_vars['faqs'] = NULL;
       }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -80,8 +80,20 @@ function paraneue_dosomething_add_info_bar(&$vars) {
       // All other countries get the zendesk form.
     }
     else {
+
+      // If the campaign is closed, link to the help center
+      // If the campaign is open, link to the FAQs if there are any
+      if (isset($vars['field_campaign_status'][0]['value']) && $vars['field_campaign_status'][0]['value'] == 'closed') {
+        $info_bar_vars['help_center'] = true;
+        $info_bar_vars['faqs'] = NULL;
+      }
+      else {
+        $info_bar_vars['faqs'] = !empty($vars['field_faq']);
+        $info_bar_vars['help_center'] = NULL;
+      }
+
       $zendesk_form_header = t(variable_get('dosomething_zendesk_form_header'));
-      $info_bar_vars['faqs'] = !empty($vars['field_faq']);
+
       $info_bar_vars['zendesk_form_header'] = $zendesk_form_header;
 
       if (isset($vars['zendesk_form'])) {

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/info-bar.tpl.php
@@ -26,6 +26,9 @@
             <?php if($faqs): ?>
               <p>Or get your question answered right away by first <a href="#" data-modal-href="#modal-faq">checking our FAQs</a>  which are updated regularly.</p>
             <?php endif; ?>
+            <?php if($help_center): ?>
+              <p>Before submitting your question, be sure to check out our in-depth <a href="https://help.dosomething.org/hc">Help Center</a> to see if it's been answered before!</p>
+            <?php endif; ?>
           </div>
           <div class="modal__block">
             <?php print render($zendesk_form); ?>


### PR DESCRIPTION
#### What's this PR do?

In the `Contact Us` modal, added in some new logic and copy surrounding closed campaigns. If a campaign is closed, we include copy to send the user to the help center. Otherwise, we include a link to the campaign FAQs if there are any (this part is the same as before).
#### How should this be reviewed?
1. Go to a closed campaign and make sure the `Contact Us` box looks like this:
   ![image](https://cloud.githubusercontent.com/assets/4240292/16742398/8f9278a2-4775-11e6-87b5-5cc60e922ac4.png)
   Also make sure the link works.
2. Make sure the the FAQs still show up/link works on an open campaign with FAQs.
3. Make sure neither of things things show up for an open campaign with no FAQs.
#### Relevant tickets

Fixes #6705
#### Checklist
- [x] Tested on staging.

cc: @namimody , @ngjo (If you want to change the copy on this before we merge, that is not hard, just let me know)
