### PR TITLE
Add GA tracking to view more button

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -148,7 +148,7 @@ function dosomething_helpers_share_bar($path, $share_types, $share_description, 
     }
 
     if ($share_intents[$type]) {
-      $share_bar .= '<li><a class="social-icon -' . $type . ' js-share-link ga-click" href="' . $share_intents[$type] . '" data-category="Share" data-label="' . $type .'" data-action="' . $share_description .'"><span>'. $type . '</span></a></li>';
+      $share_bar .= '<li><a class="social-icon -' . $type . ' js-share-link ga-click" href="' . $share_intents[$type] . '" data-ga-category="Share" data-ga-label="' . $type .'" data-ga-action="' . $share_description .'"><span>'. $type . '</span></a></li>';
     }
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -172,7 +172,7 @@ const Reportback = {
     const buttonText = Drupal.t('View more');
 
     this.$viewMoreContainer = $(`<div class="reportback__view-more"></div>`);
-    this.$viewMoreButton = $(`<button id="view-more-button" class="button button--view-more -tertiary inline-alt-text-color ga-click" data-category="Gallery" data-action="click" data-label="View More Clicks">${buttonText}</button>`);
+    this.$viewMoreButton = $(`<button id="view-more-button" class="button button--view-more -tertiary inline-alt-text-color ga-click" data-ga-category="Gallery" data-ga-action="click" data-ga-label="View More Clicks">${buttonText}</button>`);
 
     this.$viewMoreContainer.append(this.$viewMoreButton);
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -172,7 +172,7 @@ const Reportback = {
     const buttonText = Drupal.t('View more');
 
     this.$viewMoreContainer = $(`<div class="reportback__view-more"></div>`);
-    this.$viewMoreButton = $(`<button id="view-more-button" class="button button--view-more -tertiary inline-alt-text-color">${buttonText}</button>`);
+    this.$viewMoreButton = $(`<button id="view-more-button" class="button button--view-more -tertiary inline-alt-text-color ga-click" data-category="Gallery" data-action="click" data-label="View More Clicks">${buttonText}</button>`);
 
     this.$viewMoreContainer.append(this.$viewMoreButton);
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -46,9 +46,9 @@ function subscribeEvents() {
  * Google Analytics Event Tracking
  * Requires an element with the 'ga-event' class on it
  * and the required data attributes:
- *   data-category
- *   data-action
- *   data-label
+ *   data-ga-category
+ *   data-ga-action
+ *   data-ga-label
  *
  * @param {jQuery} $el - The element being tracked.
  *
@@ -57,9 +57,9 @@ function subscribeEvents() {
 **/
 function clickEvents($el) {
   $el.on('click', function() {
-    const category = (typeof ($(this).data('category')) !== 'undefined') ? $(this).data('category') : null;
-    const action = (typeof ($(this).data('action')) !== 'undefined') ? $(this).data('action') : null;
-    const label = (typeof ($(this).data('label')) !== 'undefined') ? $(this).data('label') : null;
+    const category = (typeof ($(this).data('ga-category')) !== 'undefined') ? $(this).data('ga-category') : null;
+    const action = (typeof ($(this).data('ga-action')) !== 'undefined') ? $(this).data('ga-action') : null;
+    const label = (typeof ($(this).data('ga-label')) !== 'undefined') ? $(this).data('ga-label') : null;
 
     ga('send', 'event', category, action, label);
   });


### PR DESCRIPTION
#### What's this PR do?

Adds GA tracking to the `View More` button on the reportback gallery. 
#### How should this be reviewed?

Probably need to check in GA that the event is being tracked properly..

Also, if you check the Network log in inspector, you should see a `http://www.google-analytics.com/collect` request being made when you click the button. 
#### Relevant tickets

Fixes #6698 
#### Checklist
- [ ] Tested on staging.
