### PR TITLE
Fix error with getting user info if Northstar module not enabled.

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -707,6 +707,10 @@ function dosomething_helpers_get_current_user() {
  * @return null|array
  */
 function dosomething_helpers_get_user_info($drupal_id) {
+  if (! module_exists('dosomething_northstar')) {
+    return NULL;
+  }
+  
   $northstar_response = dosomething_northstar_get_northstar_user($drupal_id);
   $northstar_response = json_decode($northstar_response);
 


### PR DESCRIPTION
#### What's this PR do?

This fixes a white-screen on the campaign page if the `dosomething_northstar` module is disabled.
#### How should this be reviewed?

If the `dosomething_northstar` module is disabled, you should not see a white screen on the campaign page.
#### Any background context you want to provide?

We disable the `dosomething_northstar` module when pulling the database from staging, so this function is not reliably defined in local environments. 
#### Relevant tickets

Fixes 💥.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
