### PR TITLE
Remove the *mic drop from the pitch page footer.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -67,7 +67,6 @@
   <div class="info-bar -dark">
     <div class="wrapper">
       <?php print $tagline; ?>
-      <em><?php print t('*mic drop'); ?></em>
     </div>
   </div>
 


### PR DESCRIPTION
#### What's this PR do?

remove the 🎤 ⬇️ from the footer of pitch pages 
#### How should this be reviewed?

👀 
#### Any background context you want to provide?

We have changed our brand, and now apparently no longer enjoy the presence of Jean Ralphio and Ben Wyatt. 
![](http://uproxx.files.wordpress.com/2012/11/jeanralphio-headblown1.gif?w=650)
![](http://i58.photobucket.com/albums/g246/sey115/adamscottbam.gif)
#### Relevant tickets

Fixes #6710
#### Checklist
- [x] Tested on staging.
