### PR TITLE
Bind the ga click event to the view more button after it has been add…

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -4,6 +4,7 @@ import ImageUploadFallback from '../images/ImageUploadFallback';
 import reportbackTplSrc from 'reportback/templates/reportback.tpl.html';
 import ImageUpload from '../images/ImageUpload';
 import setting from '../utilities/Setting';
+import Analytics from '../utilities/Analytics';
 
 const $ = require('jquery');
 const debounce = require('lodash/function/debounce');
@@ -185,6 +186,8 @@ const Reportback = {
     this.$viewMoreButton.on('click', function() {
       _this.request();
     });
+
+    Analytics.clickEvent(this.$viewMoreButton);
   },
 
   /**

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -4,7 +4,6 @@ import ImageUploadFallback from '../images/ImageUploadFallback';
 import reportbackTplSrc from 'reportback/templates/reportback.tpl.html';
 import ImageUpload from '../images/ImageUpload';
 import setting from '../utilities/Setting';
-import Analytics from '../utilities/Analytics';
 
 const $ = require('jquery');
 const debounce = require('lodash/function/debounce');
@@ -186,8 +185,6 @@ const Reportback = {
     this.$viewMoreButton.on('click', function() {
       _this.request();
     });
-
-    Analytics.clickEvent(this.$viewMoreButton);
   },
 
   /**

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -42,34 +42,32 @@ function subscribeEvents() {
   });
 }
 
-/**
- * Google Analytics Event Tracking
- * Optional data attributes:
- *   data-ga-category
- *   data-ga-action
- *   data-ga-label
- *
- * @param {jQuery} $el - The element being tracked.
- **/
-function clickEvent($el) {
-  $el.on('click', function() {
-    const category = (typeof ($(this).data('ga-category')) !== 'undefined') ? $(this).data('ga-category') : null;
-    const action = (typeof ($(this).data('ga-action')) !== 'undefined') ? $(this).data('ga-action') : null;
-    const label = (typeof ($(this).data('ga-label')) !== 'undefined') ? $(this).data('ga-label') : null;
-
-    ga('send', 'event', category, action, label);
-  });
-}
-
 function init() {
   // Only fire GA Custom Events if the GA object exists.
   if (typeof ga !== 'undefined' && ga !== null) {
     subscribeEvents();
 
-    if ($('.ga-click').length) {
-      clickEvent($('.ga-click'));
-    }
+    /**
+     * Google Analytics Event Tracking
+     * Optional data attributes:
+     *   data-ga-category
+     *   data-ga-action
+     *   data-ga-label
+     *
+     * @param {jQuery} $el - The element being tracked.
+     **/
+    $('body').on('click', e => {
+      const $el = $(e.target);
+
+      if ($el.hasClass('ga-click')) {
+        const category = (typeof ($el.data('ga-category')) !== 'undefined') ? $el.data('ga-category') : null;
+        const action = (typeof ($el.data('ga-action')) !== 'undefined') ? $el.data('ga-action') : null;
+        const label = (typeof ($el.data('ga-label')) !== 'undefined') ? $el.data('ga-label') : null;
+
+        ga('send', 'event', category, action, label);
+      }
+    });
   }
 }
 
-export default { init, clickEvent };
+export default { init };

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -44,18 +44,14 @@ function subscribeEvents() {
 
 /**
  * Google Analytics Event Tracking
- * Requires an element with the 'ga-event' class on it
- * and the required data attributes:
+ * Optional data attributes:
  *   data-ga-category
  *   data-ga-action
  *   data-ga-label
  *
  * @param {jQuery} $el - The element being tracked.
- *
- * TODO - Should we have default values for category, action, label
- * so anytime we want to track a click we can just add the .ga-click class to it with nothing else?
-**/
-function clickEvents($el) {
+ **/
+function clickEvent($el) {
   $el.on('click', function() {
     const category = (typeof ($(this).data('ga-category')) !== 'undefined') ? $(this).data('ga-category') : null;
     const action = (typeof ($(this).data('ga-action')) !== 'undefined') ? $(this).data('ga-action') : null;
@@ -71,9 +67,9 @@ function init() {
     subscribeEvents();
 
     if ($('.ga-click').length) {
-      clickEvents($('.ga-click'));
+      clickEvent($('.ga-click'));
     }
   }
 }
 
-export default { init };
+export default { init, clickEvent };

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -56,16 +56,14 @@ function init() {
      *
      * @param {jQuery} $el - The element being tracked.
      **/
-    $('body').on('click', e => {
+    $('body').on('click', '.ga-click', e => {
       const $el = $(e.target);
 
-      if ($el.hasClass('ga-click')) {
-        const category = (typeof ($el.data('ga-category')) !== 'undefined') ? $el.data('ga-category') : null;
-        const action = (typeof ($el.data('ga-action')) !== 'undefined') ? $el.data('ga-action') : null;
-        const label = (typeof ($el.data('ga-label')) !== 'undefined') ? $el.data('ga-label') : null;
+      const category = (typeof ($el.data('ga-category')) !== 'undefined') ? $el.data('ga-category') : null;
+      const action = (typeof ($el.data('ga-action')) !== 'undefined') ? $el.data('ga-action') : null;
+      const label = (typeof ($el.data('ga-label')) !== 'undefined') ? $el.data('ga-label') : null;
 
-        ga('send', 'event', category, action, label);
-      }
+      ga('send', 'event', category, action, label);
     });
   }
 }


### PR DESCRIPTION
#### What's this PR do?

Exposes the `clickEvent` function from `Analytics.js` so that it can be used to bind the ga click event to elements that have been added to the page after the DOM has loaded.
#### How should this be reviewed?

Click the view more button and you should see a `www.google-analytics.com/collect` request in the network log. Also should see the event bound to the element if you inspect it.
#### Relevant tickets

Fixes #6698 
#### Checklist
- [x] Tested on staging.
