### PR TITLE
Don't throttle queries

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/finder/Finder.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/finder/Finder.js
@@ -53,10 +53,10 @@ define(function(require) {
       // Run the Solr query
       if(!queryOffset) {
         // If no offset, we display a new set of results
-        SolrAdapter.throttledQuery(checkedFields, queryOffset, Finder.displayResults);
+        SolrAdapter.query(checkedFields, queryOffset, Finder.displayResults);
       } else {
         // Otherwise, append to existing result set
-        SolrAdapter.throttledQuery(checkedFields, queryOffset, ResultsView.appendResults);
+        SolrAdapter.query(checkedFields, queryOffset, ResultsView.appendResults);
       }
 
       // Mark the results pane as loading


### PR DESCRIPTION
#### What's this PR do?

Switched from using the `throttledQuery()` method in `SolarAdapter.js` to just use the `query()` method directly.

The `throttledQuery()` method set a delay of 400ms before sending a query to solr. Because we disable fields once we get results back from solr, the 400ms delay was allowing a user to select multiple fields within that short amount of time. 

Using the `query()` method directly removes that delay so multiple selections can not be made. 
#### How should this be reviewed?

Use the campaign finder and try to select multiple filters very quickly, you should not be able to.
#### Any background context you want to provide?

I opted to just use a new method instead of removing the throttle method entirely. If we every want to allow multiple selections, then this could be useful. Open to peoples feelings about just yanking that code, but this seemed easy enough.
#### Relevant tickets

Fixes #6581 
#### Checklist
- [ ] Tested on staging.
