### PR TITLE
Adding correct page layout limits and additional container styles.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ContextSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ContextSlide.js
@@ -29,7 +29,7 @@ class ContextSlide extends React.Component {
           <div className="wrapper">
 
             <div className="container__row">
-              <div className="container__block -two-thirds">
+              <div className="container__block -primary">
                 <h2 className="heading -beta">Woohoo! You're signed up.</h2>
                 <p>Nice! By joining {this.props.campaign.title} campaign, you've teamed up with 5.4 million other members who are making an impact on the causes affecting your world.</p>
                 <p>As a DoSomething.org member, you're part of something bigger. You're part of a global movement for good.</p>
@@ -38,7 +38,7 @@ class ContextSlide extends React.Component {
                 <p>You'll get all the tools you need to create impact. You've already joing {this.props.campaign.title}. Now sign up for other popular campaigns!</p>
               </div>
 
-              <div className="container__block -third">
+              <div className="container__block -secondary">
                 <FeatureCard content={card} />
               </div>
             </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ContextSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ContextSlide.js
@@ -29,7 +29,7 @@ class ContextSlide extends React.Component {
           <div className="wrapper">
 
             <div className="container__row">
-              <div className="container__block">
+              <div className="container__block -two-thirds">
                 <h2 className="heading -beta">Woohoo! You're signed up.</h2>
                 <p>Nice! By joining {this.props.campaign.title} campaign, you've teamed up with 5.4 million other members who are making an impact on the causes affecting your world.</p>
                 <p>As a DoSomething.org member, you're part of something bigger. You're part of a global movement for good.</p>
@@ -37,14 +37,12 @@ class ContextSlide extends React.Component {
                 <h2 className="heading -beta">Campaigns are a way to make impact.</h2>
                 <p>You'll get all the tools you need to create impact. You've already joing {this.props.campaign.title}. Now sign up for other popular campaigns!</p>
               </div>
+
+              <div className="container__block -third">
+                <FeatureCard content={card} />
+              </div>
             </div>
 
-          </div>
-        </div>
-
-        <div className="container">
-          <div className="wrapper">
-            <FeatureCard content={card} />
           </div>
         </div>
       </div>

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
@@ -4,6 +4,8 @@
   position: relative;
 
   > .wrapper {
+    max-width: 1440px;
+    margin: 0 auto;
     padding: $base-spacing 0 $section-spacing;
   }
 }
@@ -76,5 +78,23 @@
 
   .button--next {
     left: 100%
+  }
+}
+
+/**
+ * @TODO: move into Forge pattern library if approved.
+ * Add to the _regions/_container pattern.
+ */
+.container__block  {
+  &.-third {
+    @include media($tablet) {
+      @include span(4 of 12)
+    }
+  }
+
+  &.-two-thirds {
+    @include media($tablet) {
+      @include span(8 of 12)
+    }
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
@@ -86,15 +86,23 @@
  * Add to the _regions/_container pattern.
  */
 .container__block  {
-  &.-third {
+  &.-primary {
     @include media($tablet) {
-      @include span(4 of 12)
+      @include span(6 of 12)
+    }
+
+    @include media($desktop) {
+      @include span(8 of 12)
     }
   }
 
-  &.-two-thirds {
+  &.-secondary {
     @include media($tablet) {
-      @include span(8 of 12)
+      @include span(6 of 12)
+    }
+
+    @include media($desktop) {
+      @include span(4 of 12)
     }
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_card.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_card.scss
@@ -50,8 +50,6 @@
   background-color: $white;
   border-radius: 4px;
   color: $dark-gray;
-  // @TODO: remove width restriction once slide layout updated.
-  max-width: 330px;
 
   .beta-card__header,
   .beta-card__body {


### PR DESCRIPTION
#### What's this PR do?

This PR adds some quick layout styles to get things more in line with the design. It also adds a couple new modifiers to the `container__block` class from the `container` pattern, to allow for a `primary` and `secondary` layout which consists of a 50/50 split on tablet, but a two-thirds/one-third split on desktop which corresponds to a primary content area with a secondary aside area (based on [suggestion by @DFurnes](https://github.com/DoSomething/phoenix/issues/6725#issuecomment-233388350)).
#### How should this be reviewed?

👀 
#### Any background context you want to provide?

How it looks:
![image](https://cloud.githubusercontent.com/assets/105849/16922440/839403ae-4ce3-11e6-8a3c-b39f264aebcb.png)
#### Relevant tickets

Fixes #6725
#### Checklist
- [ ] Tested on staging.

---

@DFurnes @sbsmith86 

cc: @deadlybutter @jessleenyc 
