### PR TITLE
add goal fields to custom settings form

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -86,6 +86,42 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     '#default_value' => $vars['signup_form_submit_label'],
     '#size' => 20,
   );
+  $form['campaign_goals'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Campaign Goals'),
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+  ];
+  $form['campaign_goals']['external_signup_goal'] = [
+    '#type' => 'textfield',
+    '#title' => t('External Signup Goal'),
+    '#default_value' => $vars['external_signup_goal'],
+  ];
+  $form['campaign_goals']['external_new_member_goal'] = [
+    '#type' => 'textfield',
+    '#title' => t('External New Member Goal'),
+    '#default_value' => $vars['external_new_member_goal'],
+  ];
+  $form['campaign_goals']['external_impact_goal'] = [
+    '#type' => 'textfield',
+    '#title' => t('External Impact'),
+    '#default_value' => $vars['external_impact_goal'],
+  ];
+  $form['campaign_goals']['internal_signup_goal'] = [
+    '#type' => 'textfield',
+    '#title' => t('Internal Signup Goal'),
+    '#default_value' => $vars['internal_signup_goal'],
+  ];
+  $form['campaign_goals']['internal_new_member_goal'] = [
+    '#type' => 'textfield',
+    '#title' => t('Internal New Member Goal'),
+    '#default_value' => $vars['internal_new_member_goal'],
+  ];
+  $form['campaign_goals']['internal_impact_goal'] = [
+    '#type' => 'textfield',
+    '#title' => t('internal Impact'),
+    '#default_value' => $vars['internal_impact_goal'],
+  ];
   if (module_exists('dosomething_shipment')) {
     $form['shipment'] = array(
       '#type' => 'fieldset',
@@ -227,7 +263,13 @@ function dosomething_helpers_get_variable_names() {
     'count_flagged',
     'count_pending',
     'count_promoted',
+    'external_signup_goal',
+    'external_new_member_goal',
+    'external_impact_goal',
     'goal',
+    'internal_signup_goal',
+    'internal_new_member_goal',
+    'internal_impact_goal',
     'magic_link_copy',
     'mobilecommons_opt_in_path',
     'mobilecommons_friends_opt_in_path',

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -266,7 +266,6 @@ function dosomething_helpers_get_variable_names() {
     'external_signup_goal',
     'external_new_member_goal',
     'external_impact_goal',
-    'goal',
     'internal_signup_goal',
     'internal_new_member_goal',
     'internal_impact_goal',


### PR DESCRIPTION
#### What's this PR do?

Adds field to the custom settings page of a campaign that allows admins to set sign up and impact goals. 

![image](https://cloud.githubusercontent.com/assets/1700409/16927899/db6e5164-4cfd-11e6-832c-e102b6ea781d.png)
#### How should this be reviewed?

Go to a campaign, go to the custom settings page, and test that you can set goals. 
#### Any background context you want to provide?

I put these fields on the custom settings page because they are not supposed to be translatable and this seems like a more "global" (excuse the term) way of setting these goals across all translations. See the discussion on #6699 about not making these fields translatable. 
#### Relevant tickets

Fixes #6699 
#### Checklist
- [ ] Tested on staging.
