### PR TITLE
Update to expose current campaign data to Drupal JS object.

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -710,7 +710,7 @@ function dosomething_helpers_get_user_info($drupal_id) {
   if (! module_exists('dosomething_northstar')) {
     return NULL;
   }
-  
+
   $northstar_response = dosomething_northstar_get_northstar_user($drupal_id);
   $northstar_response = json_decode($northstar_response);
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -112,7 +112,6 @@ function paraneue_dosomething_add_info_bar(&$vars) {
  * @see paraneue_dosomething_preprocess_node().
  */
 function paraneue_dosomething_preprocess_node_campaign(&$vars) {
-
   // List of partials to add as $vars.
   $partials = array(
     'campaign_creator',
@@ -228,6 +227,14 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
     $vars['show_persistent_signup'] = theme_get_setting('show_persistent_signup');
   }
 
+  // Get prepared Campaign data.
+  try {
+    $current_campaign = Campaign::get($vars['nid']);
+  }
+  catch (Exception $error) {
+    $current_campaign = NULL;
+  }
+
   drupal_add_js(
     [
       'dsUser' => [
@@ -235,7 +242,8 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
         // @TODO: add a way to include user activity if it is a feature that is needed.
         // Maybe a function like: dosomething_helpers_get_current_user_activity();
         'activity' => NULL,
-      ]
+      ],
+      'dsCampaign' => $current_campaign,
     ],
     'setting'
   );

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ContextSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ContextSlide.js
@@ -35,7 +35,7 @@ class ContextSlide extends React.Component {
                 <p>As a DoSomething.org member, you're part of something bigger. You're part of a global movement for good.</p>
 
                 <h2 className="heading -beta">Campaigns are a way to make impact.</h2>
-                <p>You'll get all the tools you need to create impact. You've already joing {this.props.campaign.title}. Now sign up for other popular campaigns!</p>
+                <p>You'll get all the tools you need to create impact. You've already joined {this.props.campaign.title}. Now sign up for other popular campaigns!</p>
               </div>
 
               <div className="container__block -secondary">

--- a/lib/themes/dosomething/paraneue_dosomething/js/lab.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/lab.js
@@ -15,10 +15,7 @@ $(document).ready(function() {
   if (Drupal.settings.dsOnboarding.enabled) {
     const jsxElementHook = 'jsx-onboarding';
     const slides = [ContextSlide, ContextSlide] // @TODO: create other slide components.
-    const campaign = {
-      // @TODO: switch to use Drupal.settings.dsCampaign once it is available.
-      title: 'Awesome Campaign Placeholder'
-    }
+    const campaign = Drupal.settings.dsCampaign || null;
     const user = Drupal.settings.dsUser || null;
 
     $('.chrome').find('> .wrapper').before(`<div id="${jsxElementHook}"></div>`);


### PR DESCRIPTION
#### What's this PR do?

This PR updates the `paraneue_dosomething_preprocess_node_campaign()` function to expose current campaign data for pitch and action pages in the `Drupal.settings` object as a `dsCampaign` property.
#### How should this be reviewed?

Load a few campaigns and check if you see the `dsCampaigns` property with data regarding the current campaign.
#### Relevant tickets

Fixes #6730
#### Checklist
- [ ] Tested on staging.

---

@DFurnes @deadlybutter 

cc: @jessleenyc 
