### PR TITLE
Adding current user signups to Drupal JS object.

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -688,16 +688,40 @@ function dosomething_helpers_get_current_language_content_code() {
 /**
  * Get the current, logged in user.
  *
+ * @param  null|object $user
  * @return null|array
  */
-function dosomething_helpers_get_current_user() {
-  global $user;
+function dosomething_helpers_get_current_user($user = NULL) {
+  if (!$user) {
+    global $user;
+  }
 
   if (!$user->uid) {
-    return null;
+    return NULL;
   }
 
   return dosomething_helpers_get_user_info($user->uid);
+}
+
+/**
+ * Get activity for the current, logged in user.
+ *
+ * @param  null|object $user
+ * @return null|array
+ */
+function dosomething_helpers_get_current_user_activity($user = NULL) {
+  if (!$user) {
+    global $user;
+  }
+
+  if (!$user->uid) {
+    return NULL;
+  }
+
+  return [
+    // @TODO: add other user activity info to this array.
+    'signups' => dosomething_signup_get_signup_nids_by_uid($user->uid),
+  ];
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -238,10 +238,8 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
   drupal_add_js(
     [
       'dsUser' => [
-        'info' => dosomething_helpers_get_current_user(),
-        // @TODO: add a way to include user activity if it is a feature that is needed.
-        // Maybe a function like: dosomething_helpers_get_current_user_activity();
-        'activity' => NULL,
+        'info' => dosomething_helpers_get_current_user($vars['user']),
+        'activity' => dosomething_helpers_get_current_user_activity($vars['user']),
       ],
       'dsCampaign' => $current_campaign,
     ],


### PR DESCRIPTION
#### What's this PR do?

This PR exposes current user campaign signups to the `Drupal.settings.dsUser` JS object for use in front-end work. It provides the signups as an array of ids as a property, `Drupal.settings.dsUser.activity.signups`.
#### How should this be reviewed?

Load a campaign action page and see if the above property on the Drupal JS object contains signup IDs. If not authenticated, then the value for `Drupal.settings.dsUser.activity` is `NULL`.
#### Any background context you want to provide?

This will be useful for the Onboarding component feature.
#### Relevant tickets

Refs #6662
#### Checklist
- [ ] Tested on staging.

---

@DFurnes @deadlybutter @angaither 

cc: @jessleenyc 
