### PR TITLE
Adds Reportback Item to source to admin Reportback view

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemController.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemController.php
@@ -60,27 +60,25 @@ class ReportbackItemController extends EntityAPIController {
       ];
     }
 
+    $build['source'] = [
+      '#prefix' => '<p>',
+      '#markup' => t('Source') . ': ' . $entity->source,
+      '#suffix' => '</p>',
+    ];
+
     if (!empty($entity->reviewed)) {
       $reviewer = user_load($entity->reviewer);
       $reason = NULL;
       if (!empty($reportback->flagged_reason)) {
         $reason = ' ' . t('as') . ' ' . $reportback->flagged_reason;
       }
+      $summary = $reviewer->mail . ' <strong>' . $entity->status . '</strong> ';
+      $summary .= format_date($entity->reviewed, 'short') . $reason . ' from ';
+      $summary .= '<pre>' . $entity->review_source . '</pre>';
+
       $build['reviewed'] = [
-        '#prefix' => '<p>',
-        '#markup' => '<strong>' . ucfirst($entity->status) . '</strong> ' . format_date($entity->reviewed, 'short') . $reason,
-        '#suffix' => '</p>',
-      ];
-      if ($reviewer->uid > 0) {
-        $build['reviewer'] = [
-          '#prefix' => '<p>',
-          '#markup' => $reviewer->mail,
-          '#suffix' => '</p>',
-        ];
-      }
-      $build['review_source'] = [
-        '#prefix' => '<p>',
-        '#markup' => t('Source') . ': ' . $entity->review_source,
+        '#prefix' => '<p><hr />',
+        '#markup' => $summary,
         '#suffix' => '</p>',
       ];
     }


### PR DESCRIPTION
#### What's this PR do?

Displays a Reportback Item's `source` as the Source in the admin Reportback view, and refactors the Reviewer information into a single line.

<img width="803" alt="screen shot 2016-07-21 at 12 40 57 pm" src="https://cloud.githubusercontent.com/assets/1236811/17036485/5580b042-4f41-11e6-8fa6-3bcf2b3204ff.png">
#### How should this be reviewed?

Pull this branch down and review any reviewed Reportback as an admin, like https://staging.dosomething.org/admin/reportback/3229
#### Relevant tickets

Fixes #6740
#### Checklist
- [x] Tested on staging.
