### PR TITLE
Onboarding reportback items slide and fixes

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ContextSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ContextSlide.js
@@ -19,7 +19,7 @@ class ContextSlide extends React.Component {
       campaign: {
         title: 'Pride Over Predjudice',
         tagline: 'Post a selfie to combat anti-immigrant hate speech online.',
-        image: 'http://placekitten.com/352/337',
+        image: 'http://placekitten.com/352/264',
       }
     };
 
@@ -30,11 +30,11 @@ class ContextSlide extends React.Component {
 
             <div className="container__row">
               <div className="container__block -primary">
-                <h2 className="heading -beta">Woohoo! You're signed up.</h2>
+                <h2 className="heading -gamma">Woohoo! You're signed up.</h2>
                 <p>Nice! By joining {this.props.campaign.title} campaign, you've teamed up with 5.4 million other members who are making an impact on the causes affecting your world.</p>
                 <p>As a DoSomething.org member, you're part of something bigger. You're part of a global movement for good.</p>
 
-                <h2 className="heading -beta">Campaigns are a way to make impact.</h2>
+                <h2 className="heading -gamma">Campaigns are a way to make impact.</h2>
                 <p>You'll get all the tools you need to create impact. You've already joined {this.props.campaign.title}. Now sign up for other popular campaigns!</p>
               </div>
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/InstructionSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/InstructionSlide.js
@@ -17,7 +17,7 @@ class InstructionSlide extends React.Component {
 
             <div className="container__row">
               <div className="container__block">
-                <h2 className="heading">This is how you do it.</h2>
+                <h2 className="heading -beta">This is how you do it.</h2>
                 <p>We are PUMPED to see your photos. Complete these simple steps and upload a photo of yourself in action. Your pics will inspire others to join the movement &ndash; so don't forget to share them!</p>
               </div>
             </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/InstructionSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/InstructionSlide.js
@@ -16,14 +16,14 @@ class InstructionSlide extends React.Component {
           <div className="wrapper">
 
             <div className="container__row">
-              <div className="container__block">
-                <h2 className="heading -beta">This is how you do it.</h2>
+              <div className="container__block -narrow -centered">
+                <h2 className="heading -gamma">This is how you do it.</h2>
                 <p>We are PUMPED to see your photos. Complete these simple steps and upload a photo of yourself in action. Your pics will inspire others to join the movement &ndash; so don't forget to share them!</p>
               </div>
             </div>
 
             <div className="container__row">
-              <div className="container__block">
+              <div className="container__block -narrow -centered">
                 <div className="beta-card">
                   <img src="http://placekitten.com/1080/330" alt=""/>
                 </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemKudosSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemKudosSlide.js
@@ -17,16 +17,18 @@ class ReportbackItemKudosSlide extends React.Component {
 
             <div className="container__row">
               <div className="container__block">
-                <h2 className="heading -beta">These members are rocking it already!</h2>
-                <p>Tap the heart to show them soome love. We can't wait to see YOUR photos, {this.props.user.info.first_name}!</p>
+                <h2 className="heading -gamma">These members are rocking it already!</h2>
+                <p>Tap the heart to show them some love. We can't wait to see YOUR photos, {this.props.user.info.first_name}!</p>
               </div>
             </div>
 
+            {/*
             <div className="container__row">
               <div className="container__block">
-                {/* @TODO: Include Reportback Items for Kudos-ing here! */}
+                 <!-- @TODO: Include Reportback Items for Kudos-ing here! -->
               </div>
             </div>
+            */}
 
           </div>
         </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemKudosSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemKudosSlide.js
@@ -1,0 +1,38 @@
+const React = require('react');
+
+/**
+ * ReportbackItemKudosSlide Component
+ * <ReportbackItemKudosSlide />
+ */
+class ReportbackItemKudosSlide extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div className="slideshow__slide">
+        <div className="container">
+          <div className="wrapper">
+
+            <div className="container__row">
+              <div className="container__block">
+                <h2 className="heading -beta">These members are rocking it already!</h2>
+                <p>Tap the heart to show them soome love. We can't wait to see YOUR photos, {this.props.user.info.first_name}!</p>
+              </div>
+            </div>
+
+            <div className="container__row">
+              <div className="container__block">
+                {/* @TODO: Include Reportback Items for Kudos-ing here! */}
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ReportbackItemKudosSlide;

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/Slideshow.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/Slideshow.js
@@ -31,7 +31,7 @@ class Slideshow extends React.Component {
       <div className="slideshow">
         {slides[this.state.activeSlide]}
 
-        <SlideshowController moveSlide={this.moveSlide}/>
+        {/* <SlideshowController moveSlide={this.moveSlide}/> */}
       </div>
     );
   }

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -23,13 +23,13 @@ $(document).ready(function() {
   // Enable the Onboarding experiment.
   if (Drupal.settings.dsOnboarding.enabled && localStorage.getItem(localStorageKey) !== 'true') {
     const jsxElementHook = 'jsx-onboarding';
-    const slides = [ReportbackItemKudosSlide, ContextSlide, InstructionSlide];
+    const slides = [InstructionSlide]; // ReportbackItemKudosSlide, ContextSlide
 
     $('.chrome').find('> .wrapper').before(`<div id="${jsxElementHook}"></div>`);
 
-    // if (localStorageKey) {
-    //   localStorage.setItem(localStorageKey, true);
-    // }
+    if (localStorageKey) {
+      localStorage.setItem(localStorageKey, true);
+    }
 
     ReactDom.render(<Onboarding slides={slides} campaign={campaign} user={user} />, document.getElementById(jsxElementHook));
   }

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -1,6 +1,7 @@
 import Onboarding from './components/Onboarding';
 import ContextSlide from './components/ContextSlide';
 import InstructionSlide from './components/InstructionSlide';
+import ReportbackItemKudosSlide from './components/ReportbackItemKudosSlide';
 
 const $ = require('jquery');
 const React = require('react');
@@ -22,13 +23,13 @@ $(document).ready(function() {
   // Enable the Onboarding experiment.
   if (Drupal.settings.dsOnboarding.enabled && localStorage.getItem(localStorageKey) !== 'true') {
     const jsxElementHook = 'jsx-onboarding';
-    const slides = [ContextSlide, InstructionSlide];
+    const slides = [ReportbackItemKudosSlide, ContextSlide, InstructionSlide];
 
     $('.chrome').find('> .wrapper').before(`<div id="${jsxElementHook}"></div>`);
 
-    if (localStorageKey) {
-      localStorage.setItem(localStorageKey, true);
-    }
+    // if (localStorageKey) {
+    //   localStorage.setItem(localStorageKey, true);
+    // }
 
     ReactDom.render(<Onboarding slides={slides} campaign={campaign} user={user} />, document.getElementById(jsxElementHook));
   }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
@@ -85,24 +85,37 @@
  * @TODO: move into Forge pattern library if approved.
  * Add to the _regions/_container pattern.
  */
-.container__block  {
-  &.-primary {
-    @include media($tablet) {
-      @include span(6 of 12)
+.container {
+  > .wrapper {
+
+    .container__block  {
+      &.-primary {
+        @include media($tablet) {
+          @include span(6 of 12)
+        }
+
+        @include media($desktop) {
+          @include span(8 of 12)
+        }
+      }
+
+      &.-secondary {
+        @include media($tablet) {
+          @include span(6 of 12)
+        }
+
+        @include media($desktop) {
+          @include span(4 of 12)
+        }
+      }
+
+      &.-narrow {
+        &.-centered {
+          float: none;
+          margin: 0 auto;
+        }
+      }
     }
 
-    @include media($desktop) {
-      @include span(8 of 12)
-    }
-  }
-
-  &.-secondary {
-    @include media($tablet) {
-      @include span(6 of 12)
-    }
-
-    @include media($desktop) {
-      @include span(4 of 12)
-    }
   }
 }


### PR DESCRIPTION
#### What's this PR do?

This PR adds a new component `ReportbackItemKudosSlide` for the reportback kudoing slide for use in the future. It also does a few cleanup updates to fix some issues with how sizes correspond with the mocks and preps Slide #2 in the Onboarding experience for official launch and testing.
#### How should this be reviewed?

👀 
#### Any background context you want to provide?

The narrow container block that is centered, which is used for onboarding slide #2, is not currently a pattern in Forge. So temporarily I've extended the `container__block` pattern that can have a class of `-narrow` for narrower widths with an additional `-centered` class. This is still not exactly the size specified in the mocks, which is slightly narrower, but it's the closest I could get based on what we currently have in the pattern library.

Also, I commented out the other two slides in the experience from the array of slides, as well as the slideshow pagination controller. The code for these components is still getting imported when it's all mashed together in one file though. Figured it was fine to leave it since those items will eventually get added back in 😉 
#### Relevant tickets

Fixes #6752
#### Checklist
- [ ] Tested on staging.

---

@deadlybutter @DFurnes 

cc: @angaither @jessleenyc 
