### PR TITLE
Remove the letters from the end date on pitch/action pages.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -136,7 +136,7 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
     // Construct the proper end date text
     if (!empty($vars['field_high_season'])) {
       $end_date = new DateTime($vars['field_high_season'][0]['value2']);
-      $vars['campaign_end_date'] = $end_date->format('F jS');
+      $vars['campaign_end_date'] = $end_date->format('F j');
     }
 
     // Set campaign headings.


### PR DESCRIPTION
#### What's this PR do?

Takes out those stinkin letters from the campaign end date
#### How should this be reviewed?

see that [s](http://php.net/manual/en/function.date.php) in red? do you see it in the green? NOPE!
![image](https://cloud.githubusercontent.com/assets/645205/17180386/44fc2028-53ea-11e6-892d-f2983377fefd.png)
#### Any background context you want to provide?

The BrandMaster Brent Kassoy™ says it's a DEALBREAKER 
![](http://media.tumblr.com/tumblr_m8chhddLTA1qlbpw5.gif)
#### Relevant tickets

Fixes #6766
#### Checklist
- [ ] Tested on staging.
