### PR TITLE
Removes spaces before <?php tag.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.module
@@ -1,4 +1,4 @@
-  <?php
+<?php
 /**
  * @file
  * Code for the dosomething_campaign_run feature.


### PR DESCRIPTION
#### What's this PR do?

Removes spaces before `<?php` tag.
#### Why it matters

Everything before `<?php` tag is treated as a template and will be printed out to the output buffer.
If HTTP headers are issued after that, they won't work.
