### PR TITLE
Checks if modal is open before assigning key

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -8,6 +8,8 @@ const React = require('react');
 const ReactDom = require('react-dom');
 const Modal = require('dosomething-modal');
 
+const ONBOARDING_VERSION = '1.0';
+
 /**
  * Welcome to the Laboratory.
  * Run your experiments below.
@@ -19,7 +21,7 @@ $(document).ready(function() {
   let localStorageKey = null;
 
   if (campaign && user && !disabledByLanguage && !Modal.isOpen()) {
-    localStorageKey = `onboarding:campaign=${campaign.id}-user=${user.info.id}`;
+    localStorageKey = `onboarding:campaign=${campaign.id}-user=${user.info.id}-version=${ONBOARDING_VERSION}`;
   }
 
   // Enable the Onboarding experiment.

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -6,6 +6,7 @@ import ReportbackItemKudosSlide from './components/ReportbackItemKudosSlide';
 const $ = require('jquery');
 const React = require('react');
 const ReactDom = require('react-dom');
+const Modal = require('dosomething-modal');
 
 /**
  * Welcome to the Laboratory.
@@ -17,7 +18,7 @@ $(document).ready(function() {
   const disabledByLanguage = ['mx', 'br'].indexOf(campaign.language.language_code) != -1;
   let localStorageKey = null;
 
-  if (campaign && user && !disabledByLanguage) {
+  if (campaign && user && !disabledByLanguage && !Modal.isOpen()) {
     localStorageKey = `onboarding:campaign=${campaign.id}-user=${user.info.id}`;
   }
 


### PR DESCRIPTION
#### What's this PR do?
- Check if a modal is open before assigning a local storage key.
- Otherwise if the modal triggers a page refresh the onboarding flow is tricked & thinks you already saw it, meanwhile you didn't.
- Adds an onboarding version to the key.
#### How should this be reviewed?

Setup a campaign with a competition modal, check if onboarding works after page refresh.
Confirm normal signups also still work
#### Any background context you want to provide?

The onboarding version is used so we can make sure users see onboarding again in the future if we make a major change to it (eg: new slide).
#### Relevant tickets

Fixes #hm_nope
#### Checklist
- [ ] Tested on staging.
