### PR TITLE
Fix up that custom social share link!

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -212,18 +212,18 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
 
   // 1) Materials
 
-  // Build the share link here in case registering organ donors
-  $campaign_path = dosomething_global_url(current_path(), array('absolute' => TRUE));
+  // Build the unique share link.
   $share_path = 'user/' . $vars['user']->uid;
-  $custom_organ_share_link = dosomething_global_url($campaign_path, array('query' => array('source' => $share_path)));
+  $custom_social_share_link = dosomething_global_url(current_path(), array('absolute' => TRUE,'query' => array('source' => $share_path)));
 
   if (isset($campaign->items_needed)) {
     $materials['category'] = 'materials';
     $materials['title'] = t('Stuff You Need');
     $materials['content'] = $campaign->items_needed;
     // if organ donation campaign, add in the share link here
-    if (array_key_exists('register_organ_donors', $campaign->variables) && $campaign->variables['register_organ_donors']) {
-      $materials['content'] .= '<ul><li>Copy and paste your custom link to invite friends and family to become an organ donor: <code>' . $custom_organ_share_link . '</code></li></ul>';
+    if (array_key_exists('social_share_unique_link', $campaign->variables) && $campaign->variables['social_share_unique_link']) {
+      $copy = $campaign->variables['social_share_custom_text'] ?: t("Share your link!");
+      $materials['content'] .= '<ul><li> ' . $copy . '<code>' . $custom_social_share_link . '</code></li></ul>';
       drupal_add_js(
         array('dosomethingUser' =>
           array('userInfo' =>

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -259,6 +259,8 @@ function dosomething_helpers_get_variable_names() {
     'signup_form_submit_label',
     'sms_game_mp_story_id',
     'sms_game_mp_story_type',
+    'social_share_unique_link',
+    'social_share_custom_text',
   ];
 }
 


### PR DESCRIPTION
#### What's this PR do?
- Get custom social share links to work without organs.
- Fix up the config, so values will actually save.
- Display the link and copy if the values are set in the config.
#### How should this be reviewed?

🎱 
#### Any background context you want to provide?
- @ngjo we should decide on a default text to display if the custom text isn't set
- how do we want this to actually look, currently it's like 
  ![image](https://cloud.githubusercontent.com/assets/645205/17217862/e17006bc-54b3-11e6-9da9-34142db65119.png)
#### Relevant tickets

Fixes #6583
#### Checklist
- [ ] Tested on staging.
- [x] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
