### PR TITLE
add missing photo modal to profile and campaign page

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -331,6 +331,9 @@
             <?php if (isset($reportback_copy)): ?>
               <p class="copy inline-alt-text-color"><?php print $reportback_copy; ?></p>
             <?php endif; ?>
+            <?php if(dosomething_reportback_exists($campaign->nid)): ?>
+              <a href="#" data-modal-href="#modal-missing-photos">Is your photo not showing up?</a>
+            <?php endif; ?>
           </div>
       </div>
 
@@ -387,6 +390,29 @@
 
         </div>
       </div>
+
+  <?php // Missing Photo Modal // ?>
+  <div data-modal id="modal-missing-photos" role="dialog">
+    <h2 class="heading -emphasized" >Is your photo not showing up?</h2>
+    <div class="modal__block with-lists">
+      <p>Last week, we had some issues with our site, and a bug deleted a bunch of images (which may have included yours).</p>
+      <p>Some good news:
+        <ul>
+          <li>We’ve fixed the issue so new photos will not be deleted. </li>
+          <li>Even though your photo isn’t showing up, your impact is being counted as is your entry into the scholarship.</li>
+        </ul>
+      </p>
+      <p>Here are a few things you can do:
+        <ul>
+          <li>If you have any new photos to add to or any campaigns you’re signed up for go ahead and upload those now to start sharing your impact.</li>
+          <li>If you still have your old photo on your phone or computer, please re-upload it now to guarantee it’s showing up on the campaign you participated in and your profile. If the campaign is now closed, feel free to reach out to us at <a href="mailto:help@dosomething.org">help@dosomething.org</a> and we'll totally upload your photo for you.</li>
+        </ul>
+      </p>
+      <p>
+        (P.S. If you have any other questions or problems uploading or viewing photos on the site, definitely let us know. Thanks so much!)</p>
+      </p>
+    </div>
+  </div>
 
       <?php // Organ Donation Modal // ?>
       <?php if (isset($register_organ_donor)): ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -395,17 +395,18 @@
   <div data-modal id="modal-missing-photos" role="dialog">
     <h2 class="heading -emphasized" >Is your photo not showing up?</h2>
     <div class="modal__block with-lists">
-      <p>Last week, we had some issues with our site, and a bug deleted a bunch of images (which may have included yours).</p>
+      <p>The other day, we had some issues with our site, and a bug deleted a bunch of images (which may have included yours).</p>
       <p>Some good news:
         <ul>
-          <li>We’ve fixed the issue so new photos will not be deleted. </li>
-          <li>Even though your photo isn’t showing up, your impact is being counted as is your entry into the scholarship.</li>
+          <li>We’ve fixed the issue so new photos will not be deleted.</li>
+          <li>Even though your photo isn’t showing up, your impact is still being counted.</li>
+          <li>And if the campaign had a scholarship opportunity, don't worry! Your entry into the scholarship was still counted.</li>
         </ul>
       </p>
       <p>Here are a few things you can do:
         <ul>
           <li>If you have any new photos to add to or any campaigns you’re signed up for go ahead and upload those now to start sharing your impact.</li>
-          <li>If you still have your old photo on your phone or computer, please re-upload it now to guarantee it’s showing up on the campaign you participated in and your profile. If the campaign is now closed, feel free to reach out to us at <a href="mailto:help@dosomething.org">help@dosomething.org</a> and we'll totally upload your photo for you.</li>
+          <li>If you still have your old photo on your phone or computer, please re-upload it now to guarantee it’s showing up on the campaign you participated in and your profile. If the campaign is now closed, feel free to reach out to us at our <a href="https://help.dosomething.org/hc/en-us">help center</a> and we'll totally upload your photo for you.</li>
         </ul>
       </p>
       <p>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/user/user-profile.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/user/user-profile.tpl.php
@@ -88,9 +88,7 @@
 
 <?php // Missing Photo Modal // ?>
 <div data-modal id="modal-missing-photos" role="dialog">
-  <div class="modal__block">
-    <h2 class="heading -emphasized" style="margin: 0;">Is your photo not showing up?</h2>
-  </div>
+  <h2 class="heading -emphasized">Is your photo not showing up?</h2>
   <div class="modal__block with-lists">
     <p>The other day, we had some issues with our site, and a bug deleted a bunch of images (which may have included yours).</p>
     <p>Some good news:

--- a/lib/themes/dosomething/paraneue_dosomething/templates/user/user-profile.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/user/user-profile.tpl.php
@@ -43,6 +43,10 @@
     <section class="container -padded">
       <h2 class="heading -banner"><span><?php print t('You Did'); ?></span></h2>
       <div class="wrapper">
+        <?php // Missing Photo Link // ?>
+        <div class="container__block">
+          <a href="#" data-modal-href="#modal-missing-photos">Is your photo not showing up?</a>
+        </div>
         <?php print $reportback_gallery; ?>
       </div>
     </section>
@@ -81,3 +85,28 @@
   </section>
 
 </article>
+
+<?php // Missing Photo Modal // ?>
+<div data-modal id="modal-missing-photos" role="dialog">
+  <div class="modal__block">
+    <h2 class="heading -emphasized" style="margin: 0;">Is your photo not showing up?</h2>
+  </div>
+  <div class="modal__block with-lists">
+    <p>Last week, we had some issues with our site, and a bug deleted a bunch of images (which may have included yours).</p>
+    <p>Some good news:
+      <ul>
+        <li>We’ve fixed the issue so new photos will not be deleted. </li>
+        <li>Even though your photo isn’t showing up, your impact is being counted as is your entry into the scholarship.</li>
+      </ul>
+    </p>
+    <p>Here are a few things you can do:
+      <ul>
+        <li>If you have any new photos to add to or any campaigns you’re signed up for go ahead and upload those now to start sharing your impact.</li>
+        <li>If you still have your old photo on your phone or computer, please re-upload it now to guarantee it’s showing up on the campaign you participated in and your profile. If the campaign is now closed, feel free to reach out to us at <a href="mailto:help@dosomething.org">help@dosomething.org</a> and we'll totally upload your photo for you.</li>
+      </ul>
+    </p>
+    <p>
+      (P.S. If you have any other questions or problems uploading or viewing photos on the site, definitely let us know. Thanks so much!)</p>
+    </p>
+  </div>
+</div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/user/user-profile.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/user/user-profile.tpl.php
@@ -92,17 +92,18 @@
     <h2 class="heading -emphasized" style="margin: 0;">Is your photo not showing up?</h2>
   </div>
   <div class="modal__block with-lists">
-    <p>Last week, we had some issues with our site, and a bug deleted a bunch of images (which may have included yours).</p>
+    <p>The other day, we had some issues with our site, and a bug deleted a bunch of images (which may have included yours).</p>
     <p>Some good news:
       <ul>
-        <li>We’ve fixed the issue so new photos will not be deleted. </li>
-        <li>Even though your photo isn’t showing up, your impact is being counted as is your entry into the scholarship.</li>
+        <li>We’ve fixed the issue so new photos will not be deleted.</li>
+        <li>Even though your photo isn’t showing up, your impact is still being counted.</li>
+        <li>And if the campaign had a scholarship opportunity, don't worry! Your entry into the scholarship was still counted.</li>
       </ul>
     </p>
     <p>Here are a few things you can do:
       <ul>
         <li>If you have any new photos to add to or any campaigns you’re signed up for go ahead and upload those now to start sharing your impact.</li>
-        <li>If you still have your old photo on your phone or computer, please re-upload it now to guarantee it’s showing up on the campaign you participated in and your profile. If the campaign is now closed, feel free to reach out to us at <a href="mailto:help@dosomething.org">help@dosomething.org</a> and we'll totally upload your photo for you.</li>
+        <li>If you still have your old photo on your phone or computer, please re-upload it now to guarantee it’s showing up on the campaign you participated in and your profile. If the campaign is now closed, feel free to reach out to us at our <a href="https://help.dosomething.org/hc/en-us">help center</a> and we'll totally upload your photo for you.</li>
       </ul>
     </p>
     <p>


### PR DESCRIPTION
#### What's this PR do?

Added modals telling members about the image situation on action pages and user profiles. Members can access modals from the `You Did` section of their profiles and the `Prove It` section of campaigns that they have reported back on.
#### How should this be reviewed?

Make sure to check as a non-admin as well.

`1.` Go to your profile, and scroll down to the `You Did` section (this section should only appear if a user has reported back before). It should look like this:

![pasted image at 2016_08_01 04_55 pm-1](https://cloud.githubusercontent.com/assets/4240292/17308962/65c11196-580a-11e6-9eae-960b468dab6a.png)

`2.` Click the link and make sure the modal looks okay.

![pasted image at 2016_08_01 04_55 pm](https://cloud.githubusercontent.com/assets/4240292/17308977/73eef260-580a-11e6-9281-9d1a0a44b9fc.png)

`3.` Go to a campaign that you have reported back on. Scroll down to `Prove It` and you should see this:

![pasted image at 2016_08_01 04_55 pm-2](https://cloud.githubusercontent.com/assets/4240292/17308995/825b0d3e-580a-11e6-97fb-e8fd480512b8.png)

`4.` Click on that link and make sure you see the same modal.

`5.` Go to a campaign you have NOT reported back on and make sure you don't see that link.
#### Any background context you want to provide?

[`dosomething_reportback_exists($campaign->nid)`](https://github.com/DoSomething/phoenix/blob/743c97e0d37360739c63d731e3a078e6fb599499/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module#L669-L711) is being used to determine whether or not the current user has a reportback for the campaign. We are not specifying a run which means it checks the current run. I *think* that is what we want, but we can change it.
#### Relevant tickets

we skipped this part as far as I know
#### Checklist
- [x] Tested on staging.

cc: @mikefantini @lkpttn 
