### PR TITLE
Fix for video getting cut off.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/components/InstructionSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/InstructionSlide.js
@@ -1,7 +1,7 @@
 const React = require('react');
 
 const title = "This is how you do it.";
-const body = "We are PUMPED to see your photos. Complete these simple steps and upload a photo of yourself in action. Your pics will inspire others to join the movement &ndash; so don't forget to share them!";
+const body = "We are PUMPED to see your photos. Complete these simple steps and upload a photo of yourself in action. Your pics will inspire others to join the movement \u2013 so don't forget to share them!";
 
 /**
  * InstructionSlide Component

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
@@ -13,6 +13,7 @@
   // so maybe we add the border-radius to all media-* classes?
   & .media-video {
     border-radius: 4px;
+    padding-bottom: 60.4%;
   }
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
@@ -11,6 +11,9 @@
 
   // @TODO: Seems like we want border radius on media moving forward
   // so maybe we add the border-radius to all media-* classes?
+  // @TODO: Also, the aspect ratio for the video used on onboarding
+  // varies from the typical videos on the website so we need to modify
+  // the % padding value. Might be useful to turn into a mixin in the future.
   & .media-video {
     border-radius: 4px;
     padding-bottom: 60.4%;


### PR DESCRIPTION
#### What's this PR do?

This PR fixes an issue with the onboarding video for the instruction slide where the bottom part of the video, including the controls, were getting cut off. It also fixes the html entity for `&ndash;` and changes it to `\u2013` so it renders properly within the JS string.
#### How should this be reviewed?

👀 
#### Any background context you want to provide?

The video was getting cut-off because the `media-video` pattern which is very useful for displaying responsive video across browsers and mobile is dependent on a typical ratio for a video, similar to that of a video on youtube or vimeo. The video we are using has a different aspect ratio and thus the % padding that helps define the ration was incorrect.
#### Relevant tickets

Fixes #6791
Fixes #6790
#### Checklist
- [ ] Tested on staging.

---

@DFurnes @deadlybutter 

cc: @jessleenyc 
