### PR TITLE
Onboarding  slides feature flags

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -86,6 +86,22 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#title' => t('Enable onboarding'),
     '#default_value' => variable_get('dosomething_campaign_enable_onboarding'),
   );
+  $form['campaign']['action_page']['dosomething_campaign_onboarding_context_slide'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Display Context Slide'),
+    '#default_value' => variable_get('dosomething_campaign_onboarding_context_slide'),
+  ];
+  $form['campaign']['action_page']['dosomething_campaign_onboarding_instruction_slide'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Display Instruction Slide'),
+    '#default_value' => variable_get('dosomething_campaign_onboarding_instruction_slide'),
+  ];
+  $form['campaign']['action_page']['dosomething_campaign_onboarding_reportback_item_kudos_slide'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Display Reportback Item Kudos Slide'),
+    '#default_value' => variable_get('dosomething_campaign_onboarding_reportback_item_kudos_slide'),
+  ];
+
 
   // SMS Game variables.
   $form['sms_game'] = array(

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -75,27 +75,32 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#collapsible' => TRUE,
     '#collapsed' => FALSE,
   );
+
   $form['campaign']['action_page']['dosomething_campaign_problem_share_prompt'] = array(
     '#type' => 'textfield',
     '#title' => t('Problem Fact Share Prompt'),
     '#required' => TRUE,
     '#default_value' => t(variable_get('dosomething_campaign_problem_share_prompt')),
   );
+
   $form['campaign']['action_page']['dosomething_campaign_enable_onboarding'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable onboarding'),
     '#default_value' => variable_get('dosomething_campaign_enable_onboarding'),
   );
+
   $form['campaign']['action_page']['dosomething_campaign_onboarding_context_slide'] = [
     '#type' => 'checkbox',
     '#title' => t('Display Context Slide'),
     '#default_value' => variable_get('dosomething_campaign_onboarding_context_slide'),
   ];
+
   $form['campaign']['action_page']['dosomething_campaign_onboarding_instruction_slide'] = [
     '#type' => 'checkbox',
     '#title' => t('Display Instruction Slide'),
     '#default_value' => variable_get('dosomething_campaign_onboarding_instruction_slide'),
   ];
+
   $form['campaign']['action_page']['dosomething_campaign_onboarding_reportback_item_kudos_slide'] = [
     '#type' => 'checkbox',
     '#title' => t('Display Reportback Item Kudos Slide'),

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -313,6 +313,24 @@ function dosomething_helpers_add_js_onboarding() {
       'every_page' => FALSE,
       'preprocess' => FALSE,
     ]);
-    drupal_add_js(['dsOnboarding' => ['enabled' => true]], 'setting');
+
+    $onboardingSettings = [
+        'enabled' => true,
+        'slides' => [],
+    ];
+
+    if (variable_get('dosomething_campaign_onboarding_context_slide', FALSE)) {
+      $onboardingSettings['slides'][] = 'ContextSlide';
+    }
+
+    if (variable_get('dosomething_campaign_onboarding_instruction_slide', FALSE)) {
+      $onboardingSettings['slides'][] = 'InstructionSlide';
+    }
+
+    if (variable_get('dosomething_campaign_onboarding_reportback_item_kudos_slide', FALSE)) {
+      $onboardingSettings['slides'][] = 'ReportbackItemKudosSlide';
+    }
+
+    drupal_add_js(['dsOnboarding' => $onboardingSettings], 'setting');
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -28,13 +28,9 @@ $(document).ready(function() {
 
   // Enable the Onboarding experiment.
   if (Drupal.settings.dsOnboarding.enabled && localStorage.getItem(localStorageKey) !== 'true') {
-    const slideComponents = {ContextSlide, InstructionSlide, ReportbackItemKudosSlide};
     const jsxElementHook = 'jsx-onboarding';
-    let slides = [];
-
-    slides = Drupal.settings.dsOnboarding.slides.map(function (slide) {
-      return slideComponents[slide];
-    });
+    const slideComponents = {ContextSlide, InstructionSlide, ReportbackItemKudosSlide};
+    const slides = Drupal.settings.dsOnboarding.slides.map(name => slideComponents[name]);
 
     if (slides.length > 0) {
       $('.chrome').find('> .wrapper').before(`<div id="${jsxElementHook}"></div>`);

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -28,21 +28,12 @@ $(document).ready(function() {
 
   // Enable the Onboarding experiment.
   if (Drupal.settings.dsOnboarding.enabled && localStorage.getItem(localStorageKey) !== 'true') {
+    const slideComponents = {ContextSlide, InstructionSlide, ReportbackItemKudosSlide};
     const jsxElementHook = 'jsx-onboarding';
     const slides = [];
 
     Drupal.settings.dsOnboarding.slides.map(function (slide) {
-      if (slide === 'ContextSlide') {
-        slides.push(ContextSlide);
-      }
-
-      if (slide === 'InstructionSlide') {
-        slides.push(InstructionSlide);
-      }
-
-      if (slide === 'ReportbackItemKudosSlide') {
-        slides.push(ReportbackItemKudosSlide);
-      }
+      slides.push(slideComponents[slide]);
     });
 
     if (slides.length > 0) {

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -32,8 +32,8 @@ $(document).ready(function() {
     const jsxElementHook = 'jsx-onboarding';
     const slides = [];
 
-    Drupal.settings.dsOnboarding.slides.forEach(function (slide) {
-      slides.push(slideComponents[slide]);
+    slides = Drupal.settings.dsOnboarding.slides.map(function (slide) {
+      return slideComponents[slide];
     });
 
     if (slides.length > 0) {

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -30,7 +30,7 @@ $(document).ready(function() {
   if (Drupal.settings.dsOnboarding.enabled && localStorage.getItem(localStorageKey) !== 'true') {
     const slideComponents = {ContextSlide, InstructionSlide, ReportbackItemKudosSlide};
     const jsxElementHook = 'jsx-onboarding';
-    const slides = [];
+    let slides = [];
 
     slides = Drupal.settings.dsOnboarding.slides.map(function (slide) {
       return slideComponents[slide];

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -32,7 +32,7 @@ $(document).ready(function() {
     const jsxElementHook = 'jsx-onboarding';
     const slides = [];
 
-    Drupal.settings.dsOnboarding.slides.map(function (slide) {
+    Drupal.settings.dsOnboarding.slides.forEach(function (slide) {
       slides.push(slideComponents[slide]);
     });
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -29,16 +29,32 @@ $(document).ready(function() {
   // Enable the Onboarding experiment.
   if (Drupal.settings.dsOnboarding.enabled && localStorage.getItem(localStorageKey) !== 'true') {
     const jsxElementHook = 'jsx-onboarding';
-    const slides = [InstructionSlide]; // ReportbackItemKudosSlide, ContextSlide
+    const slides = [];
 
-    $('.chrome').find('> .wrapper').before(`<div id="${jsxElementHook}"></div>`);
-    $('.messages:not(.error)').remove();
+    Drupal.settings.dsOnboarding.slides.map(function (slide) {
+      if (slide === 'ContextSlide') {
+        slides.push(ContextSlide);
+      }
 
-    if (localStorageKey) {
-      localStorage.setItem(localStorageKey, true);
+      if (slide === 'InstructionSlide') {
+        slides.push(InstructionSlide);
+      }
+
+      if (slide === 'ReportbackItemKudosSlide') {
+        slides.push(ReportbackItemKudosSlide);
+      }
+    });
+
+    if (slides.length > 0) {
+      $('.chrome').find('> .wrapper').before(`<div id="${jsxElementHook}"></div>`);
+      $('.messages:not(.error)').remove();
+
+      if (localStorageKey) {
+        localStorage.setItem(localStorageKey, true);
+      }
+
+      ReactDom.render(<Onboarding slides={slides} campaign={campaign} user={user} />, document.getElementById(jsxElementHook));
     }
-
-    ReactDom.render(<Onboarding slides={slides} campaign={campaign} user={user} />, document.getElementById(jsxElementHook));
   }
 
 });


### PR DESCRIPTION
#### What's this PR do?

This PR allows toggling each slide as a feature flag in the CMS. It applies to all campaigns, so it's not something to control on a campaign by campaign basis (just FYI). 
#### How should this be reviewed?

Make sure you see the toggles in the `.../admin/config/dosomething/dosomething_campaign` settings page and as you toggle items, they show up as expected. Keep in mind we don't have pagination working on the Onboarding slideshow just yet, so maybe just toggle one on and off as you test 😉 

![image](https://cloud.githubusercontent.com/assets/105849/17342486/8d9dcde0-58c7-11e6-8900-97276025f2e6.png)
#### Any background context you want to provide?

@DFurnes @deadlybutter in the `Drupal.settings.dsOnboarding.slides` array, I have each activated slide as a string. It'd be way cleaner if I could somehow just pass this array and set it as the value for `slides` variable, but since the component names are strings in the array, they can't call the associated class. Do either of you know if there's a way to use a string to somehow call a class in JS? I was playing around with this, but couldn't get a suitable solution working.
#### Relevant tickets

Fixes #6788 
#### Checklist
- [ ] Tested on staging.

---

@DFurnes @deadlybutter 

cc: @jessleenyc 
