### PR TITLE
Updating the close button to work better on mobile.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
@@ -28,9 +28,14 @@
   display: block;
   font-size: 42px;
   line-height: 1;
+  padding: ($base-spacing/2);
   position: absolute;
-  right: $base-spacing;
+  right: 0;
   top: 0;
+
+  @include media($tablet) {
+    right: ($base-spacing/2);
+  }
 
   &:hover {
     color: #ccc;


### PR DESCRIPTION
#### What's this PR do?

This PR addresses the extra spacing for the "x" close button on the Onboarding message feature when viewed on mobile.

Mobile:
![image](https://cloud.githubusercontent.com/assets/105849/17348482/679f303a-58e4-11e6-981b-bec659ce48ec.png)

Desktop:
![image](https://cloud.githubusercontent.com/assets/105849/17348498/7a216a16-58e4-11e6-961e-b3f4aefaaafb.png)
#### How should this be reviewed?

tell us, how can we review, to test that this works
#### Any background context you want to provide?

This takes a slightly different approach and I think it works well because the extra padding around the button makes the button a nice clickable size, which is ideal for mobile. Then only on tablet does the button get some additional spacing from the right edge. This is also using the multiple of `12` that the forge pattern library aims to achieve with spacing.
#### Relevant tickets

Fixes #6804 
#### Checklist
- [ ] Tested on staging.

---

@DFurnes 

cc: @jessleenyc 
