### PR TITLE
Display competition confirm msg in onboarding flow 

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -401,7 +401,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
       $competition = ['joined' => $signup->competition];
       if ($competition['joined']) {
         $signup_form = dosomething_signup_get_signup_data_form_info($signup->nid);
-        $competition['confirm_msg'] = $signup_form['confirm_msg'];
+        $competition['messages']['confirmation'] = $signup_form['confirm_msg'];
       }
 
       drupal_add_js(

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -396,12 +396,21 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   // Pass the signup id to the front end.
   if (module_exists('dosomething_signup')) {
     if ($sid = dosomething_signup_exists($vars['nid'])) {
+      // Get competition data
+      $signup = signup_load($sid);
+      $competition = ['joined' => $signup->competition];
+      if ($competition['joined']) {
+        $signup_form = dosomething_signup_get_signup_data_form_info($signup->nid);
+        $competition['confirm_msg'] = $signup_form['confirm_msg'];
+      }
+
       drupal_add_js(
-        array('dosomethingSignup' =>
-          array(
+        ['dosomethingSignup' =>
+          [
             'sid' => $sid,
-          ),
-        ),
+            'competition' => $competition
+          ],
+        ],
         'setting'
       );
     }

--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
@@ -33,7 +33,7 @@ function _dosomething_gladiator_build_http_client() {
     'base_url' => GLADIATOR_URL . '/' . GLADIATOR_VERSION,
     'headers' => ['Content-Type' => 'application/json', 'Accept' => 'application/json', 'X-DS-Gladiator-API-Key' => GLADIATOR_KEY],
   ];
-  
+
   return $client;
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -513,15 +513,6 @@ function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
   }
   // Display the signup_data_form's confirm_msg field.
   drupal_set_message($config['confirm_msg']);
-  drupal_add_js(
-    ['dosomethingSignup' =>
-      [
-        'competition' => true,
-        'confirm_msg' => $config['confirm_msg']
-      ],
-    ],
-    'setting'
-  );
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -513,6 +513,15 @@ function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
   }
   // Display the signup_data_form's confirm_msg field.
   drupal_set_message($config['confirm_msg']);
+  drupal_add_js(
+    ['dosomethingSignup' =>
+      [
+        'competition' => true,
+        'confirm_msg' => $config['confirm_msg']
+      ],
+    ],
+    'setting'
+  );
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/InstructionSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/InstructionSlide.js
@@ -13,6 +13,8 @@ class InstructionSlide extends React.Component {
   }
 
   render() {
+    const competition = Drupal.settings.dosomethingSignup.competition;
+
     return (
       <div className="slideshow__slide">
         <div className="container">
@@ -21,6 +23,7 @@ class InstructionSlide extends React.Component {
             <div className="container__row">
               <div className="container__block -narrow -centered">
                 <h2 className="heading -gamma">{title}</h2>
+                <p>{competition.joined ? competition.confirm_msg : ''}</p>
                 <p>{body}</p>
               </div>
             </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/InstructionSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/InstructionSlide.js
@@ -23,7 +23,7 @@ class InstructionSlide extends React.Component {
             <div className="container__row">
               <div className="container__block -narrow -centered">
                 <h2 className="heading -gamma">{title}</h2>
-                <p>{competition.joined ? competition.confirm_msg : ''}</p>
+                <p>{competition.joined ? competition.messages.confirmation : ''}</p>
                 <p>{body}</p>
               </div>
             </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/InstructionSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/InstructionSlide.js
@@ -23,7 +23,7 @@ class InstructionSlide extends React.Component {
             <div className="container__row">
               <div className="container__block -narrow -centered">
                 <h2 className="heading -gamma">{title}</h2>
-                <p>{competition.joined ? competition.messages.confirmation : ''}</p>
+                {competition.joined ? <p>competition.messages.confirmation</p> : ''}
                 <p>{body}</p>
               </div>
             </div>


### PR DESCRIPTION
#### What's this PR do?

^ title
#### How should this be reviewed?

If you signup for a competition is the confirm_msg  for that campaigns signup data form inserted into the onboarding flow?
#### Any background context you want to provide?

not really
#### Relevant tickets

Fixes #6801 
#### Checklist
- [ ] Tested on staging.
