### PR TITLE
Minor updates to the order of things in a campaign run node

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.features.field_instance.inc
@@ -391,7 +391,7 @@ function dosomething_campaign_run_field_default_field_instances() {
         'size' => 60,
       ),
       'type' => 'text_textfield',
-      'weight' => -5,
+      'weight' => -4,
     ),
   );
 
@@ -519,7 +519,7 @@ function dosomething_campaign_run_field_default_field_instances() {
         'size' => 60,
       ),
       'type' => 'entityreference_autocomplete',
-      'weight' => -4,
+      'weight' => -3,
     ),
   );
 

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.field_group.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.field_group.inc
@@ -49,26 +49,26 @@ function dosomething_campaign_run_field_group_info() {
   $field_group->mode = 'form';
   $field_group->parent_name = '';
   $field_group->data = array(
-    'label' => 'goals',
-    'weight' => '12',
+    'label' => 'Goals',
+    'weight' => '2',
     'children' => array(
-      0 => 'field_external_signup_goal',
+      0 => 'field_external_impact_goal',
       1 => 'field_external_new_member_goal',
-      2 => 'field_external_impact_goal',
-      3 => 'field_internal_signup_goal',
+      2 => 'field_external_signup_goal',
+      3 => 'field_internal_impact_goal',
       4 => 'field_internal_new_member_goal',
-      5 => 'field_internal_impact_goal',
+      5 => 'field_internal_signup_goal',
     ),
     'format_type' => 'fieldset',
     'format_settings' => array(
-      'label' => 'goals',
+      'label' => 'Goals',
       'instance_settings' => array(
         'required_fields' => 0,
         'id' => '',
         'classes' => 'group-goals field-group-fieldset',
-        'description' => '',
+        'description' => 'Internal and external goals (for internal use only... this is used to feed data dashboards)',
       ),
-      'formatter' => 'collapsible',
+      'formatter' => 'collapsed',
     ),
   );
   $field_groups['group_goals|node|campaign_run|form'] = $field_group;
@@ -84,7 +84,7 @@ function dosomething_campaign_run_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'The Buzz',
-    'weight' => '3',
+    'weight' => '4',
     'children' => array(
       0 => 'field_additional_text',
       1 => 'field_additional_text_title',
@@ -173,7 +173,7 @@ function dosomething_campaign_run_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'What You Did',
-    'weight' => '2',
+    'weight' => '3',
     'children' => array(
       0 => 'field_intro',
       1 => 'group_totals',
@@ -202,7 +202,7 @@ function dosomething_campaign_run_field_group_info() {
   $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Winners',
-    'weight' => '4',
+    'weight' => '5',
     'children' => array(
       0 => 'field_winners',
     ),
@@ -222,12 +222,12 @@ function dosomething_campaign_run_field_group_info() {
   // Translatables
   // Included for use with string extractors like potx.
   t('Basic Info');
+  t('Goals');
   t('The Buzz');
   t('Timing');
   t('Totals');
   t('What You Did');
   t('Winners');
-  t('goals');
 
   return $field_groups;
 }

--- a/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_campaign_run/dosomething_campaign_run.strongarm.inc
@@ -32,22 +32,22 @@ function dosomething_campaign_run_strongarm() {
     'extra_fields' => array(
       'form' => array(
         'metatags' => array(
-          'weight' => '9',
+          'weight' => '10',
         ),
         'title' => array(
           'weight' => '1',
         ),
         'path' => array(
-          'weight' => '8',
+          'weight' => '9',
         ),
         'redirect' => array(
-          'weight' => '7',
+          'weight' => '8',
         ),
         'xmlsitemap' => array(
-          'weight' => '6',
+          'weight' => '7',
         ),
         'language' => array(
-          'weight' => '5',
+          'weight' => '6',
         ),
       ),
       'display' => array(),


### PR DESCRIPTION
#### What's this PR do?

Updating campaign run node feature to
- put the title before the description
- collapse the 'goal' group
- re-order goals to near the date, since that should be filled out when you make the node
#### How should this be reviewed?

it looks like this now
![image](https://cloud.githubusercontent.com/assets/645205/17377822/88f4ef7c-5989-11e6-8dd6-8880a0b29d20.png)
#### Any background context you want to provide?

it used to look like this 
![image](https://cloud.githubusercontent.com/assets/645205/17377845/9a4c69d0-5989-11e6-95a4-9b18bfd9a07d.png)
#### Relevant tickets

there are none, this was just annoying me. and it was easier than image recovery. 
#### Checklist
- [x] Tested on staging.
