### PR TITLE
Updates to feature card

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -22,9 +22,19 @@ function checkForSponsor(campaign) {
 }
 
 function sortCampaigns(a, b) {
-  const aScore = a.time_commitment - (checkForSponsor(a) ? 1 : 0);
-  const bScore = b.time_commitment - (checkForSponsor(b) ? 1 : 0);
-  return aScore - bScore;
+  // const aScore = a.time_commitment - (checkForSponsor(a) ? 1 : 0) + (a.staff_pick ? 2 : 0);
+  // const bScore = b.time_commitment - (checkForSponsor(b) ? 1 : 0) + (a.staff_pick ? 2 : 0);
+  // return aScore - bScore;
+
+  // something like
+  // if only one is a sponsor
+  // return 1 or -1
+  // else if one is a corporate
+  // return 1 or -1
+  // else
+  // return based on least time commit
+
+  return 0;
 }
 
 /**
@@ -37,26 +47,21 @@ class FeatureCard extends React.Component {
 
     this.requests = [];
     this.state = {
-      campaigns: [],
-      current_campaign: '',
-      signup_animation: ''
+      signupAnimation: '',
+      campaignPage: 1,
+      campaigns: []
     };
   }
 
   componentDidMount() {
     // First load staff pick campaigns to quickly initialize the card
-    this.getCampaigns({staffPick: true, campaigns: []}, 1, campaigns => {
+    this.getCampaigns(1, campaigns => {
       this.setState({
-        campaigns: campaigns,
-        current_campaign_index: 0
+        campaigns: campaigns
       });
 
-      // Then backfill with all of the other campaigns
-      this.getCampaigns({staff_pick: 0, campaigns: campaigns}, 1, campaigns => {
-        this.setState({
-          campaigns: campaigns
-        });
-      });
+      // For our crazy super users, double check they actually have campaigns to see!
+      this.checkCampaignsRemaining();
     });
   }
 
@@ -68,42 +73,42 @@ class FeatureCard extends React.Component {
     }
   }
 
-  getCampaigns(data, page, cb) {
-    this.requests.push($.get(`${API_URL}campaigns?staff_pick=${data.staff_pick}&page=${page}`, result => {
-      let rawCampaigns = result.data;
+  checkCampaignsRemaining() {
+    // If we're almost out of campaigns let's get more
+    if (this.state.campaigns.length < 4) {
+      // First update the API page
+      this.setState({campaignPage: this.state.campaignPage + 1});
+      // Then grab campaigns for that page & update the state
+      this.getCampaigns(this.state.campaignPage, campaigns => {
+        // this.setState({
+        //   campaigns: campaigns
+        // })
+      });
+    }
+  }
+
+  getCampaigns(page, cb) {
+    // Grab all campaigns for given page
+    // The staff_pick=true is embedded within the template string intentionally,
+    // it seems like the precense alone of the param causes it to execute..
+    this.requests.push($.get(`${API_URL}campaigns?page=${page}`, result => {
+      let rawCampaigns = result.data;console.log(result);
 
       // Filter out campaigns users have signed up for
       const userSignups = Drupal.settings.dsUser.activity.signups;
       rawCampaigns = rawCampaigns.filter(campaign => userSignups.indexOf(parseInt(campaign.id)) == -1);
 
-      // Remove any non staff picks
-      if (!data.staffPick) {
-        rawCampaigns = rawCampaigns.filter(campaign => campaign.staff_pick == false);
-      }
-
       // Finally sort by weight values
       rawCampaigns = rawCampaigns.sort(sortCampaigns)
 
       // Join previous campaigns with newly retrieved
-      const campaigns = data.campaigns.concat(rawCampaigns);
-
-      if (result.pagination.total_pages > page) {
-        data.campaigns = campaigns;
-        this.getCampaigns(data, page + 1, cb);
-        return;
-      }
+      const campaigns = this.state.campaigns.concat(rawCampaigns);
 
       cb(campaigns);
     }));
   }
 
-  signup() {
-    const campaign = this.state.campaigns[this.state.current_campaign_index];
-
-    if (!campaign) {
-      return;
-    }
-
+  signup(campaign) {
     this.requests.push($.ajax({
       url: `${API_URL}campaigns/${campaign.id}/signup`,
       type: 'POST',
@@ -119,29 +124,35 @@ class FeatureCard extends React.Component {
         }, 1000);
 
         this.setState({ //TODO: Fancy animation
-          signup_animation: 'tada'
+          signupAnimation: 'tada'
         });
       }
     }));
   }
 
   viewAnother() {
-    let newIndex = this.state.current_campaign_index + 1;
-    if (newIndex >= this.state.campaigns.length) {
-      newIndex = 0;
-    }
+    // Remove current campaign
+    this.state.campaigns.splice(0, 1);
 
+    // Remove temp animation class
     this.setState({
-      current_campaign_index: newIndex,
-      signup_animation: ''
+      signupAnimation: '',
     });
+
+    // Make sure we didn't run out of campaigns!
+    this.checkCampaignsRemaining();
   }
 
   render() {
-    const campaign = this.state.campaigns[this.state.current_campaign_index];
+    const campaign = this.state.campaigns[0];
 
     if (!campaign) {
       return null;
+    }
+
+    // Local campaign files are sometimes borked, quick fix (DS Logo)
+    if (campaign.cover_image.default == undefined) {
+      campaign.cover_image.default = {sizes: {square: {uri: ''}}};
     }
 
     return (
@@ -166,7 +177,7 @@ class FeatureCard extends React.Component {
               <h2 className="heading -delta">{campaign.title}</h2>
               <p className="tagline">{campaign.tagline}</p>
               <ul className="form-actions">
-                <li><button className={`${this.state.signup_animation} button`} onClick={()=>this.signup()}>Sign Up</button></li>
+                <li><button className={`${this.state.signupAnimation} button`} onClick={()=>this.signup()}>Sign Up</button></li>
                 <li><a className="button -tertiary" onClick={()=>this.viewAnother()}>Show me another</a></li>
               </ul>
             </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -104,7 +104,7 @@ class FeatureCard extends React.Component {
       return;
     }
 
-    $.ajax({
+    this.requests.push($.ajax({
       url: `${API_URL}campaigns/${campaign.id}/signup`,
       type: 'POST',
       headers: {
@@ -122,7 +122,7 @@ class FeatureCard extends React.Component {
           signup_animation: 'tada'
         });
       }
-    });
+    }));
   }
 
   viewAnother() {

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -35,6 +35,7 @@ class FeatureCard extends React.Component {
   constructor(props) {
     super(props);
 
+    this.requests = [];
     this.state = {
       campaigns: [],
       current_campaign: '',
@@ -43,22 +44,57 @@ class FeatureCard extends React.Component {
   }
 
   componentDidMount() {
-    this.serverRequest = $.get(`${API_URL}campaigns?random=true&staff_pick=true`, result => {
-      // Filter out campaigns users have signed up for & then sort remaining campaigns
-      const userSignups = Drupal.settings.dsUser.activity.signups;
-      const campaigns = result.data.filter(campaign => userSignups.indexOf(parseInt(campaign.id)) == -1).sort(sortCampaigns);
-
+    // First load staff pick campaigns to quickly initialize the card
+    this.getCampaigns({staffPick: true, campaigns: []}, 1, campaigns => {
       this.setState({
         campaigns: campaigns,
         current_campaign_index: 0
+      });
+
+      // Then backfill with all of the other campaigns
+      this.getCampaigns({staff_pick: 0, campaigns: campaigns}, 1, campaigns => {
+        this.setState({
+          campaigns: campaigns
+        });
       });
     });
   }
 
   componentWillUnmount() {
-    if (this.serverRequest) {
-      this.serverRequest.abort();
+    if (this.requests) {
+      for (var request in this.requests) {
+        request.abort();
+      }
     }
+  }
+
+  getCampaigns(data, page, cb) {
+    this.requests.push($.get(`${API_URL}campaigns?staff_pick=${data.staff_pick}&page=${page}`, result => {
+      let rawCampaigns = result.data;
+
+      // Filter out campaigns users have signed up for
+      const userSignups = Drupal.settings.dsUser.activity.signups;
+      rawCampaigns = rawCampaigns.filter(campaign => userSignups.indexOf(parseInt(campaign.id)) == -1);
+
+      // Remove any non staff picks
+      if (!data.staffPick) {
+        rawCampaigns = rawCampaigns.filter(campaign => campaign.staff_pick == false);
+      }
+
+      // Finally sort by weight values
+      rawCampaigns = rawCampaigns.sort(sortCampaigns)
+
+      // Join previous campaigns with newly retrieved
+      const campaigns = data.campaigns.concat(rawCampaigns);
+
+      if (result.pagination.total_pages > page) {
+        data.campaigns = campaigns;
+        this.getCampaigns(data, page + 1, cb);
+        return;
+      }
+
+      cb(campaigns);
+    }));
   }
 
   signup() {


### PR DESCRIPTION
#### What's this PR do?
- Fetches all of the campaigns for the feature card
- Adds signup request to the features array
#### How should this be reviewed?

If you're a super user who already signed up for every staff pick campaign, do you now see more staff pick campaigns?
#### Any background context you want to provide?

See: https://github.com/DoSomething/phoenix/issues/6818#issuecomment-237594809

> For the sake of performance / load time, I think the best approach is to only retrieve the staff pick campaigns to initialize the card. After the card is initially rendered, we can then do a larger pagination to retrieve all non staff pick campaigns & apply the same boost logic. Since most users are not going to be signed up for every staff pick campaign, this should be incredibly seamless.

in practice it seems to work as I thought it would ^^
#### Relevant tickets

Fixes #6818 
#### Checklist
- [ ] Tested on staging.
