### PR TITLE
Adding new Button component.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/components/Button.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/Button.js
@@ -7,15 +7,17 @@ const React = require('react');
  * @return {[type]}       [description]
  */
 const Button = (props) => {
+    // console.log(props);
     const classes = ['button'].concat(props.classes);
 
     return (
-      <button className={classes.join(' ')} onClick={props.action}>{props.text}</button>
+      <button className={classes.join(' ')} onClick={props.action()}>{props.text}</button>
     );
 }
 
 Button.defaultProps = {
   loading: false,
+  success: false,
   text: 'Submit',
 };
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/Button.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/Button.js
@@ -5,7 +5,6 @@ const React = require('react');
  * <Button />
  */
 const Button = (props) => {
-    console.log(props.children);
     const classes = ['button'].concat(props.classes);
 
     if (props.loading === true) {
@@ -14,6 +13,14 @@ const Button = (props) => {
 
     if (props.success === true) {
       classes.push('is-successful');
+    }
+
+    if (props.type) {
+      classes.push(props.type);
+    }
+
+    if (props.reactive) {
+      classes.push('-reactive');
     }
 
     return (
@@ -32,6 +39,8 @@ Button.propTypes = {
   disabled: React.PropTypes.bool,
   loading: React.PropTypes.bool,
   onClick: React.PropTypes.func.isRequired,
+  reactive: React.PropTypes.bool,
+  type: React.PropTypes.oneOf(['-secondary', '-tertiary']),
 };
 
 export default Button;

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/Button.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/Button.js
@@ -16,7 +16,7 @@ const Button = (props) => {
     }
 
     if (props.type) {
-      classes.push(props.type);
+      classes.push('-' + props.type);
     }
 
     if (props.reactive) {
@@ -40,7 +40,7 @@ Button.propTypes = {
   loading: React.PropTypes.bool,
   onClick: React.PropTypes.func.isRequired,
   reactive: React.PropTypes.bool,
-  type: React.PropTypes.oneOf(['-secondary', '-tertiary']),
+  type: React.PropTypes.oneOf(['secondary', 'tertiary']),
 };
 
 export default Button;

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/Button.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/Button.js
@@ -3,27 +3,34 @@ const React = require('react');
 /**
  * Button Component
  * <Button />
- * @param  {[type]} props [description]
- * @return {[type]}       [description]
  */
 const Button = (props) => {
-    // console.log(props);
     const classes = ['button'].concat(props.classes);
 
+    if (props.loading === true) {
+      classes.push('is-loading');
+    }
+
+    if (props.success === true) {
+      classes.push('is-successful');
+    }
+
     return (
-      <button className={classes.join(' ')} onClick={props.action()}>{props.text}</button>
+      <button className={classes.join(' ')} onClick={props.onClick} disabled={props.disabled}>{props.text}</button>
     );
 }
 
 Button.defaultProps = {
+  disabled: false,
   loading: false,
   success: false,
   text: 'Submit',
 };
 
 Button.propTypes = {
-  action: React.PropTypes.func.isRequired,
+  disabled: React.PropTypes.bool,
   loading: React.PropTypes.bool,
+  onClick: React.PropTypes.func.isRequired,
   text: React.PropTypes.string,
 };
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/Button.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/Button.js
@@ -5,6 +5,7 @@ const React = require('react');
  * <Button />
  */
 const Button = (props) => {
+    console.log(props.children);
     const classes = ['button'].concat(props.classes);
 
     if (props.loading === true) {
@@ -16,7 +17,7 @@ const Button = (props) => {
     }
 
     return (
-      <button className={classes.join(' ')} onClick={props.onClick} disabled={props.disabled}>{props.text}</button>
+      <button className={classes.join(' ')} onClick={props.onClick} disabled={props.disabled}>{props.children}</button>
     );
 }
 
@@ -24,14 +25,13 @@ Button.defaultProps = {
   disabled: false,
   loading: false,
   success: false,
-  text: 'Submit',
+  children: 'Submit',
 };
 
 Button.propTypes = {
   disabled: React.PropTypes.bool,
   loading: React.PropTypes.bool,
   onClick: React.PropTypes.func.isRequired,
-  text: React.PropTypes.string,
 };
 
 export default Button;

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/Button.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/Button.js
@@ -1,0 +1,28 @@
+const React = require('react');
+
+/**
+ * Button Component
+ * <Button />
+ * @param  {[type]} props [description]
+ * @return {[type]}       [description]
+ */
+const Button = (props) => {
+    const classes = ['button'].concat(props.classes);
+
+    return (
+      <button className={classes.join(' ')} onClick={props.action}>{props.text}</button>
+    );
+}
+
+Button.defaultProps = {
+  loading: false,
+  text: 'Submit',
+};
+
+Button.propTypes = {
+  action: React.PropTypes.func.isRequired,
+  loading: React.PropTypes.bool,
+  text: React.PropTypes.string,
+};
+
+export default Button;

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -45,10 +45,13 @@ class FeatureCard extends React.Component {
     this.campaignsApiPage = 1;
 
     this.state = {
+      actionDisabled: false,
       campaignIndex: -1,
       isSignedUp: false,
       isLoading: false,
     };
+
+    this.signup = this.signup.bind(this);
   }
 
   componentDidMount() {
@@ -102,11 +105,6 @@ class FeatureCard extends React.Component {
   }
 
   signup() {
-    console.log(this);
-    // this.setState({
-    //   isLoading: true,
-    // });
-
     const campaign = this.campaigns[this.state.campaignIndex];
     ga('send', 'event', 'Onboarding', 'Signup');
 
@@ -133,11 +131,17 @@ class FeatureCard extends React.Component {
         });
 
         setTimeout(() => {
+<<<<<<< 9cc2f6f61c1065bf9c6b5f5d37a1a46ddbb54544
           this.viewAnother(false);
         }, 1000);
+=======
+          this.viewAnother();
+        }, 5000);
+>>>>>>> Progress on animated Button component.
       },
       beforeSend: () => {
         this.setState({
+          actionDisabled: true,
           isLoading: true
         })
       }
@@ -163,13 +167,14 @@ class FeatureCard extends React.Component {
       });
     }
 
-    // If we reeached the end set our index back to the start
+    // If we reached the end set our index back to the start
     if (newIndex >= this.campaigns.length) {
       newIndex = 0;
     }
 
     // Re-render with new index
     this.setState({
+      actionDisabled: false,
       campaignIndex: newIndex,
       isSignedUp: false
     });
@@ -207,7 +212,7 @@ class FeatureCard extends React.Component {
               <h2 className="heading -delta">{campaign.title}</h2>
               <p className="tagline">{campaign.tagline}</p>
               <ul className="form-actions">
-                <li><Button loading={this.state.isLoading} success={this.state.isSignedUp} action={this.signup}></Button></li>
+                <li><Button classes={['-reactive']} text="Sign Up" loading={this.state.isLoading} disabled={this.state.actionDisabled} success={this.state.isSignedUp} onClick={this.signup}></Button></li>
                 <li><a className="button -tertiary" onClick={()=>this.viewAnother(true)}>Show me another</a></li>
               </ul>
             </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -131,13 +131,8 @@ class FeatureCard extends React.Component {
         });
 
         setTimeout(() => {
-<<<<<<< 9cc2f6f61c1065bf9c6b5f5d37a1a46ddbb54544
           this.viewAnother(false);
-        }, 1000);
-=======
-          this.viewAnother();
         }, 5000);
->>>>>>> Progress on animated Button component.
       },
       beforeSend: () => {
         this.setState({

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -2,7 +2,6 @@ const $ = require('jquery');
 const React = require('react');
 
 import Button from './Button';
-
 import setting from '../utilities/Setting';
 
 const API_HOST = window.location.hostname;
@@ -47,7 +46,8 @@ class FeatureCard extends React.Component {
 
     this.state = {
       campaignIndex: -1,
-      isSignedUp: ''
+      isSignedUp: false,
+      isLoading: false,
     };
   }
 
@@ -102,6 +102,11 @@ class FeatureCard extends React.Component {
   }
 
   signup() {
+    console.log(this);
+    // this.setState({
+    //   isLoading: true,
+    // });
+
     const campaign = this.campaigns[this.state.campaignIndex];
     ga('send', 'event', 'Onboarding', 'Signup');
 
@@ -122,13 +127,19 @@ class FeatureCard extends React.Component {
       },
       success: (data) => {
         this.campaigns[this.state.campaignIndex].signedUp = true;
-        this.setState({ //TODO: Fancy animation
+        this.setState({
+          isLoading: false,
           isSignedUp: true
         });
 
         setTimeout(() => {
           this.viewAnother(false);
         }, 1000);
+      },
+      beforeSend: () => {
+        this.setState({
+          isLoading: true
+        })
       }
     }));
   }
@@ -196,7 +207,7 @@ class FeatureCard extends React.Component {
               <h2 className="heading -delta">{campaign.title}</h2>
               <p className="tagline">{campaign.tagline}</p>
               <ul className="form-actions">
-                <li><Button action={this.signup}></Button></li>
+                <li><Button loading={this.state.isLoading} success={this.state.isSignedUp} action={this.signup}></Button></li>
                 <li><a className="button -tertiary" onClick={()=>this.viewAnother(true)}>Show me another</a></li>
               </ul>
             </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -1,5 +1,7 @@
-const React = require('react');
 const $ = require('jquery');
+const React = require('react');
+
+import Button from './Button';
 
 import setting from '../utilities/Setting';
 
@@ -194,7 +196,7 @@ class FeatureCard extends React.Component {
               <h2 className="heading -delta">{campaign.title}</h2>
               <p className="tagline">{campaign.tagline}</p>
               <ul className="form-actions">
-                {(campaign.signedUp && !this.state.isSignedUp) ? <h1>You're signed up already!</h1> : <li><button className={`${this.state.isSignedUp ? 'tada' : ''} button`} onClick={()=>this.signup()}>Sign Up</button></li>}
+                <li><Button action={this.signup}></Button></li>
                 <li><a className="button -tertiary" onClick={()=>this.viewAnother(true)}>Show me another</a></li>
               </ul>
             </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -208,7 +208,7 @@ class FeatureCard extends React.Component {
               <p className="tagline">{campaign.tagline}</p>
               <ul className="form-actions">
                 <li><Button reactive={true} loading={this.state.isLoading} disabled={this.state.actionDisabled} success={this.state.isSignedUp} onClick={this.signup}></Button></li>
-                <li><Button type="-tertiary" onClick={()=>this.viewAnother(true)}>Show me another</Button></li>
+                <li><Button type="tertiary" onClick={()=>this.viewAnother(true)}>Show me another</Button></li>
               </ul>
             </div>
           </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -207,7 +207,7 @@ class FeatureCard extends React.Component {
               <h2 className="heading -delta">{campaign.title}</h2>
               <p className="tagline">{campaign.tagline}</p>
               <ul className="form-actions">
-                <li><Button classes={['-reactive']} text="Sign Up" loading={this.state.isLoading} disabled={this.state.actionDisabled} success={this.state.isSignedUp} onClick={this.signup}></Button></li>
+                <li><Button classes={['-reactive']} loading={this.state.isLoading} disabled={this.state.actionDisabled} success={this.state.isSignedUp} onClick={this.signup}></Button></li>
                 <li><a className="button -tertiary" onClick={()=>this.viewAnother(true)}>Show me another</a></li>
               </ul>
             </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -207,8 +207,8 @@ class FeatureCard extends React.Component {
               <h2 className="heading -delta">{campaign.title}</h2>
               <p className="tagline">{campaign.tagline}</p>
               <ul className="form-actions">
-                <li><Button classes={['-reactive']} loading={this.state.isLoading} disabled={this.state.actionDisabled} success={this.state.isSignedUp} onClick={this.signup}></Button></li>
-                <li><a className="button -tertiary" onClick={()=>this.viewAnother(true)}>Show me another</a></li>
+                <li><Button reactive={true} loading={this.state.isLoading} disabled={this.state.actionDisabled} success={this.state.isSignedUp} onClick={this.signup}></Button></li>
+                <li><Button type="-tertiary" onClick={()=>this.viewAnother(true)}>Show me another</Button></li>
               </ul>
             </div>
           </div>

--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -30,8 +30,9 @@
     "lodash": "^3.6.0",
     "mailcheck": "~1.1.1",
     "raf.js": "~0.0.4",
-    "react": "^15.2.0",
-    "react-dom": "^15.2.0",
+    "react": "^15.3.0",
+    "react-addons-css-transition-group": "^15.3.0",
+    "react-dom": "^15.3.0",
     "respond.js": "~1.4.2",
     "unveil": "DFurnes/unveil.git#umd"
   },

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_button.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_button.scss
@@ -1,14 +1,69 @@
-// @TODO: Should this become a real modifier?
-.button.-mini {
-  font-size: 13px !important;
-  padding-top: 6px !important;
-  padding-bottom: 4px !important;
-  background: $light-gray;
-  color: $dark-gray;
-  text-transform: none;
+%animated {
+  animation-fill-mode: both;
+}
 
-  &.is-active {
-    background-color: $purple;
-    color: #fff;
+// @TODO: Should this become a real modifier?
+.button {
+  border: 1px solid $blue;
+  position: relative;
+
+  &.-mini {
+    font-size: 13px !important;
+    padding-top: 6px !important;
+    padding-bottom: 4px !important;
+    background: $light-gray;
+    color: $dark-gray;
+    text-transform: none;
+
+    &.is-active {
+      background-color: $purple;
+      color: #fff;
+    }
+  }
+
+  &.-reactive {
+    &::after {
+      content: '\02713';
+      display: block;
+      font-size: $font-large;
+      left: 50%;
+      line-height: 1;
+      opacity: 0;
+      position: absolute;
+      text-align: center;
+      transform: translate(-50%, -50%);
+      top: 50%;
+      color: $white;
+    }
+
+    &.is-successful {
+      @extend %animated;
+      animation-duration: 0.5s;
+      animation-name: isSuccesful;
+
+      &::after {
+        @extend %animated;
+        animation-delay: 0.5s;
+        animation-duration: 1s;
+        animation-name: showCheckmark;
+        animation-timing-function: ease-out;
+      }
+    }
+  }
+
+}
+
+@keyframes isSuccesful {
+  100% {
+    background-color: #7fd02e;
+    border: 1px solid #7fd02e;
+    box-shadow: 0 0 3px #7fd02e;
+    color: #7fd02e;
+  }
+}
+
+@keyframes showCheckmark {
+  100% {
+    opacity: 0.9;
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_button.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_button.scss
@@ -3,6 +3,12 @@
   border: 1px solid $blue;
   position: relative;
 
+  &.-tertiary {
+    &:focus {
+      box-shadow: none;
+    }
+  }
+
   &.-mini {
     font-size: 13px !important;
     padding-top: 6px !important;

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_button.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_button.scss
@@ -21,6 +21,10 @@
     }
   }
 
+  &.is-loading {
+    border-color: #eee;
+  }
+
   &.-reactive {
     &::after {
       content: '\02713';

--- a/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_button.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/patterns/_button.scss
@@ -1,7 +1,3 @@
-%animated {
-  animation-fill-mode: both;
-}
-
 // @TODO: Should this become a real modifier?
 .button {
   border: 1px solid $blue;
@@ -42,7 +38,6 @@
 
     &.is-successful {
       @extend %animated;
-      animation-duration: 0.5s;
       animation-name: isSuccesful;
 
       &::after {


### PR DESCRIPTION
#### What's this PR do?

This PR adds a new reusable `Button` component that accepts a few different `props`. It adds the new Button component to the `FeatureCard` and also enables an animation on the button to indicate to the user that they have successfully signed up to the campaign indicated on the card.

Example animation:

![image](https://d17oy1vhnax1f7.cloudfront.net/items/0F3Z3u1W3Z172l3L0036/Screen%20Recording%202016-08-09%20at%2009.40%20AM.gif?v=d683a5eb)

The button gets disabled when it's in the green "success" state, to avoid further clicking since it's no longer really a button but a confirmation indicator.
#### How should this be reviewed?

To help with testing and not actually signup to each campaign indicated on the card, I switched the AJAX request to hit a specific campaign and just do a GET request :trollface: 
#### Any background context you want to provide?

We can tweak the animation if needed. I used CSS `@keyframes`, and both the checkmark is a separate pseudo element that can be animated separately. Might be useful to eventually move this into Forge, and/or maybe optimize to allow for more versatility.
#### Relevant tickets

Fixes #6819
#### Checklist
- [ ] Tested on staging.

---

@DFurnes @deadlybutter 

cc: @jessleenyc 
