### PR TITLE
Adds GA events to onboarding

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -58,7 +58,7 @@ class FeatureCard extends React.Component {
 
       if (this.campaigns.length == 0) {
         // For our super users who already signed up for them all...
-        this.viewAnother();
+        this.viewAnother(false);
       }
       else {
         // These are all staff pick campaigns which we don't want to display twice.
@@ -101,6 +101,7 @@ class FeatureCard extends React.Component {
 
   signup() {
     const campaign = this.campaigns[this.state.campaignIndex];
+    ga('send', 'event', 'Onboarding', 'Signup');
 
     if (!campaign) {
       return;
@@ -124,7 +125,7 @@ class FeatureCard extends React.Component {
         });
 
         setTimeout(() => {
-          this.viewAnother();
+          this.viewAnother(false);
         }, 1000);
       }
     }));
@@ -134,8 +135,13 @@ class FeatureCard extends React.Component {
     return this.campaigns.length - this.state.campaignIndex;
   }
 
-  viewAnother() {
+  viewAnother(buttonTrigger) {
     let newIndex = this.state.campaignIndex + 1;
+
+    // Only log to GA if someone actually pressed the button
+    if (buttonTrigger) {
+      ga('send', 'event', 'Onboarding', 'View More');
+    }
 
     // If we're almost out of campaigns let's get more
     if (this.getRemainingCampaigns() <= 4) {
@@ -189,7 +195,7 @@ class FeatureCard extends React.Component {
               <p className="tagline">{campaign.tagline}</p>
               <ul className="form-actions">
                 {(campaign.signedUp && !this.state.isSignedUp) ? <h1>You're signed up already!</h1> : <li><button className={`${this.state.isSignedUp ? 'tada' : ''} button`} onClick={()=>this.signup()}>Sign Up</button></li>}
-                <li><a className="button -tertiary" onClick={()=>this.viewAnother()}>Show me another</a></li>
+                <li><a className="button -tertiary" onClick={()=>this.viewAnother(true)}>Show me another</a></li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
#### What's this PR do?

Adds signup event
Adds view more event
#### How should this be reviewed?

Enable GA debug with Google Analytics Debugger

Signing up should
1) Trigger a signup event
<img width="1563" alt="screen shot 2016-08-08 at 4 17 06 pm" src="https://cloud.githubusercontent.com/assets/897368/17494742/136fa5a4-5d84-11e6-8e4d-ce5d7f30f5bf.png">
2) and NOT trigger any view more events (see the boolean value in code for why this is tested)

Clicking view more should trigger a view more event
<img width="1519" alt="screen shot 2016-08-08 at 4 18 49 pm" src="https://cloud.githubusercontent.com/assets/897368/17494773/2f682d08-5d84-11e6-8bd2-01cacee66572.png">
#### Any background context you want to provide?

no
#### Relevant tickets

Fixes #6828
#### Checklist
- [ ] Tested on staging.
