### PR TITLE
Update script to safely de-activate, and keep latest active.

### DIFF
--- a/scripts/remove-duplicate-emails.php
+++ b/scripts/remove-duplicate-emails.php
@@ -6,24 +6,37 @@
  * drush --script-path=../scripts/ php-script remove-duplicate-emails.php
  */
 
-$users = db_query('SELECT uid FROM users 
-  WHERE mail IN (SELECT mail FROM users GROUP BY mail HAVING COUNT(mail) > 1)
-  AND uid NOT IN (SELECT MIN(uid) FROM users GROUP BY mail HAVING COUNT(mail) > 1)');
+$dupes = array_keys(db_query('SELECT mail FROM users GROUP BY mail HAVING COUNT(mail) > 1')->fetchAllKeyed());
+$removed = 0;
 
-foreach ($users as $user) {
-  $user = user_load($user->uid);
+foreach ($dupes as $mail) {
+  // Load all users with that duped email address, with the most recently accessed first.
+  $users = db_query('SELECT uid FROM users WHERE mail = :mail ORDER BY access DESC', [':mail' => $mail]);
+  $canonical_uid = 0;
 
-  if($user->access == 0) {
-    print 'Deleting ' . $user->uid . ' (' . $user->mail . ')' . PHP_EOL;
+  foreach ($users as $key => $user) {
+    $user = user_load($user->uid);
 
-    $northstar_id = $user->field_northstar_id[LANGUAGE_NONE][0]['value'];
-
-    if ($northstar_id !== 'NONE') {
-      print 'User ' . $user->uid . ' has a Northstar profile: ' . $northstar_id;
+    if ($key == 0) {
+      print 'Keeping ' . $user->uid . ' for ' . $user->mail . '.' . PHP_EOL;
+      $canonical_uid = $user->uid;
+      continue;
     }
 
-    user_delete($user->uid);
-  } else {
-    print 'Ignoring duplicate ' . $user->uid . ' (' . $user->mail . ')' . PHP_EOL;
+    // Set the new email for the deactivated user.
+    $new_email = 'duplicate-' . $canonical_uid . '-' . $key . '@dosomething.invalid';
+    print ' - Removing ' . $user->uid . ' (' . $user->mail . ' --> ' . $new_email . ')' . PHP_EOL;
+    user_save($user, ['mail' => $new_email, 'status' => 0]);
+    $removed++;
+
+    // Finally, make a note if that user has a Northstar profile, so we can clean that up.
+    $northstar_id = $user->field_northstar_id[LANGUAGE_NONE][0]['value'];
+    if ($northstar_id !== 'NONE') {
+      print '   ** User ' . $user->uid . ' has a Northstar profile: ' . $northstar_id;
+    }
   }
+
+  print PHP_EOL;
 }
+
+print '[✔] Renamed & deactivated ' . $removed . ' users.' . PHP_EOL;


### PR DESCRIPTION
#### What's this PR do?

So funny story, apparently I had made this script in #6475 and completely forgot about it. 👴 However, I think there were some smart things that we talked about today so I updated it based on that discussion!
1. It now keeps the most recently accessed account for each duplicated email.
2. Instead of deleting accounts, the script now deactivates the dupes & renames them to a "valid" but obviously fake email so they don't conflict when syncing to Northstar.

![screen shot 2016-08-08 at 5 57 05 pm](https://cloud.githubusercontent.com/assets/583202/17497776/8e92a9ae-5d91-11e6-8b61-b8e825c7be4b.png)
#### How should this be reviewed?

👀 
#### Any background context you want to provide?

🔥 
#### Relevant tickets

References #6409.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
