### PR TITLE
remove image requirement if rb is being updated

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -103,6 +103,7 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
   else {
     // Output reportback images with date last updated.
     $form['reportback_submissions']['reportback_item']['#attributes']['is_supersized'] = FALSE;
+    $form['reportback_submissions']['reportback_item']['#attributes']['data-validate'] = '';
 
     $reportback_submissions_data = array();
     // Specify number of prior reportbacks to retrieve, including the latest one to show prominently.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -103,7 +103,9 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
   else {
     // Output reportback images with date last updated.
     $form['reportback_submissions']['reportback_item']['#attributes']['is_supersized'] = FALSE;
-    $form['reportback_submissions']['reportback_item']['#attributes']['data-validate'] = '';
+
+    // do not require a new image to be uploaded on update
+    unset($form['reportback_submissions']['reportback_item']['#attributes']['data-validate']);
 
     $reportback_submissions_data = array();
     // Specify number of prior reportbacks to retrieve, including the latest one to show prominently.


### PR DESCRIPTION
#### What's this PR do?

If we're updating a reportback, don't validate it to make sure it has an image. No image necessary. 
#### How should this be reviewed?

👀 
1. Step 4: Prove It
2. return to the action page
3. update your quantity or caption or get real wild and update BOTH
4. step 3 should work and you should end up on the permalink page 🎉 
#### Relevant tickets

Fixes #6762
#### Checklist
- [x] Tested on staging. (by @katiecrane and @ngjo)
