### PR TITLE
Switches to landscape image for feature card

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -170,7 +170,7 @@ class FeatureCard extends React.Component {
     }
 
     // Fix for local files / data missing by preventing null error
-    const image_uri = campaign.cover_image.default != null ? campaign.cover_image.default.sizes.square.uri : '';
+    const image_uri = campaign.cover_image.default != null ? campaign.cover_image.default.sizes.landscape.uri : '';
 
     return (
       <article className="beta-card">
@@ -184,9 +184,7 @@ class FeatureCard extends React.Component {
 
         <div className="beta-card__body">
           <div className="beta-card__row">
-            <div className="beta-card__block">
-              <img src={image_uri} />
-            </div>
+            <img src={image_uri} />
           </div>
 
           <div className="beta-card__row">


### PR DESCRIPTION
#### What's this PR do?
- Switches to landscape image
- Removes padding
#### How should this be reviewed?

Phone/Tablet/Desktop
<img width="426" alt="screen shot 2016-08-09 at 10 51 51 am" src="https://cloud.githubusercontent.com/assets/897368/17520913/574629c4-5e1f-11e6-8d59-a6f4287cabf4.png">
<img width="959" alt="screen shot 2016-08-09 at 10 51 59 am" src="https://cloud.githubusercontent.com/assets/897368/17520914/574f0e68-5e1f-11e6-8958-4deb4992a451.png">
<img width="1330" alt="screen shot 2016-08-09 at 10 52 05 am" src="https://cloud.githubusercontent.com/assets/897368/17520915/574f445a-5e1f-11e6-8c33-1e085b217414.png">
#### Any background context you want to provide?

no
#### Relevant tickets

Fixes #6839 
#### Checklist
- [ ] Tested on staging.
