### PR TITLE
Fixes onboarding close button

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -93,7 +93,7 @@ class FeatureCard extends React.Component {
 
   componentWillUnmount() {
     if (this.requests) {
-      for (var request of this.requests) {
+      for (let request of this.requests) {
         request.abort();
       }
     }

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -93,7 +93,7 @@ class FeatureCard extends React.Component {
 
   componentWillUnmount() {
     if (this.requests) {
-      for (var request in this.requests) {
+      for (var request of this.requests) {
         request.abort();
       }
     }

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -92,11 +92,7 @@ class FeatureCard extends React.Component {
   }
 
   componentWillUnmount() {
-    if (this.requests) {
-      for (let request of this.requests) {
-        request.abort();
-      }
-    }
+    this.requests.forEach(request => request.abort());
   }
 
   signup() {


### PR DESCRIPTION
#### What's this PR do?

Fixes the on boarding close button
#### How should this be reviewed?

Can you close on boarding properly now?
#### Any background context you want to provide?

On first click the feature card was not unmounting correctly. This is because we were using a `for in` loop, which returned the index of the xhr object, not the object itself. Thus when we called .abort() it threw an error. 

By switching to a `for of` loop, we can get the actual xhr object. More here on this: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of#Difference_between_for...of_and_for...in
#### Relevant tickets

Fixes #6838 
#### Checklist
- [ ] Tested on staging.
