### PR TITLE
And phone cleanup script

### DIFF
--- a/scripts/remove-duplicate-emails.php
+++ b/scripts/remove-duplicate-emails.php
@@ -13,9 +13,10 @@ $removed = 0;
 // Watch out, because we're gonna make a database table. Yee-haw!
 db_query('
   CREATE TABLE IF NOT EXISTS `dosomething_northstar_delete_queue` (
+    `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
     `uid` int(11) unsigned NOT NULL,
     `northstar_id` varchar(32) DEFAULT NULL,
-    PRIMARY KEY (`uid`))
+    PRIMARY KEY (`id`));
 ');
 
 foreach ($dupes as $mail) {

--- a/scripts/remove-duplicate-emails.php
+++ b/scripts/remove-duplicate-emails.php
@@ -23,17 +23,17 @@ foreach ($dupes as $mail) {
   $users = db_query('SELECT uid FROM users WHERE mail = :mail ORDER BY access DESC', [':mail' => $mail]);
   $canonical_uid = 0;
 
-  foreach ($users as $key => $user) {
+  foreach ($users as $index => $user) {
     $user = user_load($user->uid);
 
-    if ($key == 0) {
+    if ($index == 0) {
       print 'Keeping ' . $user->uid . ' for ' . $user->mail . '.' . PHP_EOL;
       $canonical_uid = $user->uid;
       continue;
     }
 
     // Set the new email for the deactivated user.
-    $new_email = 'duplicate-' . $canonical_uid . '-' . $key . '@dosomething.invalid';
+    $new_email = 'duplicate-' . $canonical_uid . '-' . $index . '@dosomething.invalid';
     print ' - Removing ' . $user->uid . ' (' . $user->mail . ' --> ' . $new_email . ')' . PHP_EOL;
     user_save($user, ['mail' => $new_email, 'status' => 0]);
     $removed++;

--- a/scripts/unset-duplicate-mobiles.php
+++ b/scripts/unset-duplicate-mobiles.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Script to unset duplicate mobile numbers (keeping only the most recently logged in).
+ *
+ * to run:
+ * drush --script-path=../scripts/ php-script unset-duplicate-mobiles.php
+ */
+
+$dupes = array_keys(db_query('SELECT field_mobile_value FROM field_data_field_mobile WHERE field_mobile_value != \'\'
+  GROUP BY field_mobile_value HAVING COUNT(field_mobile_value) > 1')->fetchAllKeyed());
+$removed = 0;
+
+// Watch out, because we're gonna make a database table. Yee-haw!
+db_query('
+  CREATE TABLE IF NOT EXISTS `dosomething_northstar_delete_queue` (
+    `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+    `uid` int(11) unsigned NOT NULL,
+    `northstar_id` varchar(32) DEFAULT NULL,
+    PRIMARY KEY (`id`));
+');
+
+foreach ($dupes as $mobile) {
+  // Load all users with that duped mobile field, with the most recently accessed first.
+  $users = db_query('SELECT u.uid FROM users u 
+    LEFT JOIN field_data_field_mobile m on u.uid = m.entity_id
+    WHERE m.field_mobile_value = :mobile ORDER BY u.access DESC', [':mobile' => $mobile]);
+
+  foreach ($users as $index => $user) {
+    $user = user_load($user->uid);
+
+    // Since the most recently accessed account with that mobile number is first, skip it.
+    if ($index == 0) {
+      print 'Keeping ' . $user->uid . ' for ' . $mobile . '.' . PHP_EOL;
+      continue;
+    }
+
+    // Remove the mobile field for that user.
+    print ' - Removing mobile from ' . $user->uid . ' (' . $mobile . ')' . PHP_EOL;
+    $entity = entity_load_single('user', $user->uid);
+    $entity->field_mobile[LANGUAGE_NONE] = [];
+    entity_save('user', $entity);
+
+    $removed++;
+
+    // Finally, make a note if that user has a Northstar profile, so we can clean that up.
+    $northstar_id = $user->field_northstar_id[LANGUAGE_NONE][0]['value'];
+    if ($northstar_id !== 'NONE') {
+      db_insert('dosomething_northstar_delete_queue')->fields(['uid' => $user->uid, 'northstar_id' => $northstar_id])->execute();
+      print '   ** User ' . $user->uid . ' has a Northstar profile: ' . $northstar_id . PHP_EOL;
+    }
+  }
+
+  print PHP_EOL;
+}
+
+print '[✔] Removed duplicate mobile field from ' . $removed . ' users.' . PHP_EOL;


### PR DESCRIPTION
#### What's this PR do?

Alongside #6835, this should clear up the last of our duplicate data problems so we can update the schema to make those fields unique! The `unset-duplicate-mobiles` finds all users where there are duplicates for `field_mobile`, and removes the field for all but the most recently active user.

![screen shot 2016-08-09 at 2 36 56 pm](https://cloud.githubusercontent.com/assets/583202/17528791/bd46be22-5e3e-11e6-8889-06b15d51d2ab.png)
#### How should this be reviewed?

👀
#### Any background context you want to provide?

📴
#### Relevant tickets

References #6409.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
