### PR TITLE
Attempt to fix setTimeout issue.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -51,6 +51,7 @@ class FeatureCard extends React.Component {
       isLoading: false,
     };
 
+    this.delay = null;
     this.signup = this.signup.bind(this);
   }
 
@@ -126,7 +127,7 @@ class FeatureCard extends React.Component {
           isSignedUp: true
         });
 
-        setTimeout(() => {
+        this.delay = setTimeout(() => {
           this.viewAnother(false);
         }, 5000);
       },
@@ -144,6 +145,8 @@ class FeatureCard extends React.Component {
   }
 
   viewAnother(buttonTrigger) {
+    clearTimeout(this.delay);
+
     let newIndex = this.state.campaignIndex + 1;
 
     // Only log to GA if someone actually pressed the button


### PR DESCRIPTION
#### What's this PR do?

This PR provides an attempt at a fix for the a bug with the delay to auto-show a new campaign after a successful signup from the `FeatureCard`. There is a `setTimeout` that waits 5 seconds before it auto-loads a new campaign. However, if the "show me another" is clicked prior to the 5 seconds completing, a new campaign immediately shows and then when the time completes, it shows another immediately after. So we need to clear the timeout whenever the `viewAnother` method is called.
#### How should this be reviewed?

Um, 👀  and let me know if this seems like a good approach or not! I needed to be able to save the `setTimeout()` to a variable or property I could call directly in the `clearTimeout()`
#### Relevant tickets

Fixes 💅  🐛 
#### Checklist
- [ ] Tested on staging.

---

@DFurnes @deadlybutter 
