### PR TITLE
Filters out closed campaigns

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -72,7 +72,7 @@ class FeatureCard extends React.Component {
 
       // Filter out campaigns that are closed, users have signed up for and then rank remaining campaigns
       const campaigns = result.data
-        .filter(campaign => campaign.status != 'closed')
+        .filter(campaign => campaign.status !== 'closed')
         .filter(campaign => this.campaignsToExclude.indexOf(parseInt(campaign.id)) == -1)
         .sort(rankCampaigns);
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -70,8 +70,11 @@ class FeatureCard extends React.Component {
   getCampaigns(staffPickOnly, paginate, page, callback) {
     this.requests.push(this.serverRequest = $.get(`${API_URL}campaigns?${staffPickOnly ? 'staff_pick=true&' : ''}${page != -1 ? 'page=' + page : ''}`, result => {
 
-      // Filter out campaigns users have signed up for & then rank remaining campaigns
-      const campaigns = result.data.filter(campaign => this.campaignsToExclude.indexOf(parseInt(campaign.id)) == -1).sort(rankCampaigns);
+      // Filter out campaigns that are closed, users have signed up for and then rank remaining campaigns
+      const campaigns = result.data
+        .filter(campaign => campaign.status != 'closed')
+        .filter(campaign => this.campaignsToExclude.indexOf(parseInt(campaign.id)) == -1)
+        .sort(rankCampaigns);
 
       // Add it to the master list
       this.campaigns = this.campaigns.concat(campaigns);


### PR DESCRIPTION
#### What's this PR do?

Filters out closed campaigns
#### How should this be reviewed?

Used this to do a check of the statuses
`console.log(result.data.map(campaign =>`${campaign.status} + ${campaign.title}`));`

Then just verified the right things weren't there manually
#### Any background context you want to provide?

no
#### Relevant tickets

Fixes #6845
#### Checklist
- [ ] Tested on staging.
