### PR TITLE
Add script to clean out bad Northstar data.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -464,6 +464,12 @@ function pull_db {
       echo "Disabling external modules locally."
       drush -y dis optimizely dosomething_northstar dosomething_gladiator
 
+      # Also reset Northstar settings, so enabling the module doesn't default to Northstar QA.
+      drush variable-delete dosomething_northstar_url -y
+      drush variable-delete dosomething_northstar_port -y
+      drush variable-delete dosomething_northstar_app_id -y
+      drush variable-delete dosomething_northstar_api_key -y
+
       echo "Clearing cache..."
       drush cc all
 

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.admin.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.admin.inc
@@ -9,45 +9,45 @@
  * System settings form for northstar config.
  */
 function dosomething_northstar_config_form($form, &$form_state) {
-  $form = array();
+  $form = [];
 
-  $form['northstar'] = array(
+  $form['northstar'] = [
     '#type' => 'fieldset',
     '#title' => t('Northstar Settings'),
-  );
-  $form['northstar']['dosomething_northstar_url'] = array(
+  ];
+  $form['northstar']['dosomething_northstar_url'] = [
     '#type' => 'textfield',
     '#title' => t('Northstar URL'),
     '#required' => TRUE,
     '#default_value' => variable_get('dosomething_northstar_url', 'http://northstar.dev'),
-  );
-  $form['northstar']['dosomething_northstar_port'] = array(
+  ];
+  $form['northstar']['dosomething_northstar_port'] = [
     '#type' => 'textfield',
     '#title' => t('Northstar port'),
     '#description' => t('This is most likely only needed on dev sites'),
     '#required' => FALSE,
     '#default_value' => variable_get('dosomething_northstar_port', '8000'),
-  );
-  $form['northstar']['dosomething_northstar_version'] = array(
+  ];
+  $form['northstar']['dosomething_northstar_version'] = [
     '#type' => 'textfield',
     '#title' => t('Northstar API version number'),
     '#required' => TRUE,
     '#default_value' => variable_get('dosomething_northstar_version', 'v1'),
-  );
-  $form['northstar']['dosomething_northstar_app_id'] = array(
+  ];
+  $form['northstar']['dosomething_northstar_app_id'] = [
     '#type' => 'textfield',
     '#title' => t('App id'),
     '#description' => t('The app id needed to connect to northstar (found in aurora).'),
     '#required' => TRUE,
-    '#default_value' => variable_get('dosomething_northstar_app_id', '456'),
-  );
-  $form['northstar']['dosomething_northstar_app_key'] = array(
+    '#default_value' => variable_get('dosomething_northstar_app_id', 'trusted-test-client'),
+  ];
+  $form['northstar']['dosomething_northstar_app_key'] = [
     '#type' => 'textfield',
     '#title' => t('App key'),
-    '#description' => t('The app key needed to connect to northstar (found in aurora).'),
+    '#description' => t('The app key needed to connect to northstar (found in Aurora).'),
     '#required' => TRUE,
-    '#default_value' => variable_get('dosomething_northstar_app_key', 'abc4324'),
-  );
+    '#default_value' => variable_get('dosomething_northstar_app_key', 'secret1'),
+  ];
 
   $form['log'] = [
     '#type' => 'fieldset',

--- a/scripts/delete-bad-users-in-northstar.php
+++ b/scripts/delete-bad-users-in-northstar.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Script to delete any Northstar users in the delete queue.
+ *
+ * to run:
+ * drush --script-path=../scripts/ php-script delete-bad-users-in-northstar.php
+ */
+
+include_once('../lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module');
+
+$records = db_query('SELECT id, uid, northstar_id FROM dosomething_northstar_delete_queue');
+
+foreach ($records as $record) {
+  $client = _dosomething_northstar_build_http_client();
+  $response = drupal_http_request($client['base_url'] . '/users/' . $record->northstar_id, [
+    'headers' => $client['headers'],
+    'method' => 'DELETE',
+  ]);
+
+  // Output progress to stdout & log request details for later review.
+  dosomething_northstar_log_request('delete', $record, [], $response);
+  echo 'Deleted Northstar user ' . $record->northstar_id . ' from ' . $record->uid . ' [' . $response->code . ']' . PHP_EOL;
+
+  // If a user cannot be migrated due to an index conflict, add that Northstar ID to the delete queue.
+  if ($response->code == '200') {
+    db_delete('dosomething_northstar_delete_queue')->condition('id', $record->id)->execute();
+  }
+}


### PR DESCRIPTION
#### What's this PR do?

Three things:

🚳 In the migration script, add Northstar IDs to the `dosometing_northstar_delete_queue` table if they conflict on the `drupal_id` field. This is necessary because not all of the duped users from the other two scripts had their Northstar ID field filled in.

🔥 Adds a `delete-bad-users-in-northstar` script to empty out that delete queue by deleting the offending Northstar users with extreme prejudice.

🍡 Reset the Northstar settings to their default values when running `ds pull stage --db`, since otherwise the Northstar module will still be configured to connect to Northstar QA if enabled.
#### How should this be reviewed?

👀
#### Any background context you want to provide?

👻 
#### Relevant tickets

References #6409.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
