### PR TITLE
Updating setTimeout duration to be shorter.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -112,7 +112,7 @@ class FeatureCard extends React.Component {
 
         this.delay = setTimeout(() => {
           this.viewAnother(false);
-        }, 5000);
+        }, 3000);
       },
       beforeSend: () => {
         this.setState({


### PR DESCRIPTION
#### What's this PR do?

This PR speeds up the duration (3 seconds instead of 5 seconds) it takes for the next Campaign to show in FeatureCard after user signs up for campaign using the card. ⌛ 
#### How should this be reviewed?

👀 
#### Relevant tickets

Fixes #6854
#### Checklist
- [ ] Tested on staging.

---

@deadlybutter @lkpttn 
