### PR TITLE
Improved "delete bad users" script.

### DIFF
--- a/scripts/delete-bad-users-in-northstar.php
+++ b/scripts/delete-bad-users-in-northstar.php
@@ -12,6 +12,8 @@ $records = db_query('SELECT id, uid, northstar_id FROM dosomething_northstar_del
 
 foreach ($records as $record) {
   $client = _dosomething_northstar_build_http_client();
+
+  // Delete the user with the provided conflicting Northstar ID.
   $response = drupal_http_request($client['base_url'] . '/users/' . $record->northstar_id, [
     'headers' => $client['headers'],
     'method' => 'DELETE',
@@ -21,8 +23,46 @@ foreach ($records as $record) {
   dosomething_northstar_log_request('delete', $record, [], $response);
   echo 'Deleted Northstar user ' . $record->northstar_id . ' from ' . $record->uid . ' [' . $response->code . ']' . PHP_EOL;
 
-  // If a user cannot be migrated due to an index conflict, add that Northstar ID to the delete queue.
-  if ($response->code == '200') {
+  // Remove the record from the delete queue if successfully deleted.
+  if ($response->code == 200) {
     db_delete('dosomething_northstar_delete_queue')->condition('id', $record->id)->execute();
   }
+
+  $user = user_load($record->uid);
+  $ns_user = build_northstar_user($user);
+
+  // Use old drupal_http_request method.
+  $response = drupal_http_request($client['base_url'] . '/users', [
+    'headers' => $client['headers'],
+    'method' => 'POST',
+    'data' => json_encode($ns_user),
+  ]);
+
+  // Output progress to stdout & log request details for later review.
+  dosomething_northstar_log_request('migrate', $user, $ns_user, $response);
+  echo 'Migrated user ' . $user->uid . ' to Northstar [' . $response->code . ']' . PHP_EOL;
+  $response_data = json_decode($response->data);
+
+  // If a user cannot be re-migrated due to a Drupal ID index conflict, we should add an entry for that Northstar ID.
+  if ($response->code == 400 && !empty($response_data->error->context->id)) {
+    db_insert('dosomething_northstar_delete_queue')->fields(['uid' => $user->uid, 'northstar_id' => $response_data->error->context->id])->execute();
+  }
+
+  // Store the returned Northstar ID on the user's Drupal profile.
+  dosomething_northstar_save_id_field($user->uid, $response_data);
+}
+
+/**
+ * Build a Northstar request from the $user variable.
+ */
+function build_northstar_user($user) {
+  $northstar_user = dosomething_northstar_transform_user($user);
+
+  // Since we're sending an existing user, we'll also attach their hashed password
+  // (which Northstar can understand thanks to it's DrupalPasswordHash class), and
+  // the created_at timestamp on the original account.
+  $northstar_user['drupal_password'] = $user->pass;
+  $northstar_user['created_at'] = $user->created;
+
+  return $northstar_user;
 }

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -46,7 +46,7 @@ foreach ($users as $user) {
   $response_data = json_decode($response->data);
 
   // If a user cannot be migrated due to a Drupal ID index conflict, we should delete the conflicting Northstar record.
-  if ($response->code === 400 && !empty($response_data->error->context->id)) {
+  if ($response->code == 400 && !empty($response_data->error->context->id)) {
     db_insert('dosomething_northstar_delete_queue')->fields(['uid' => $user->uid, 'northstar_id' => $response_data->error->context->id])->execute();
   }
 


### PR DESCRIPTION
#### What's this PR do?

This PR includes some improvements to the "delete bad users" and "export to Northstar" scripts:

🔁 After deleting a "conflicted" Northstar ID from the `dosomething_northstar_delete_queue` table, try to re-upload that Drupal ID's profile via the `POST users/` endpoint (same method as in the export script). This way we won't have to run the whooooole export process again after the expected validation errors.

:vs: Fixes a minor issue where I was trying to do a strict comparison of the status code (as an integer), but Drupal returns it as a float! Weird!
#### How should this be reviewed?

Does this make sense as the most efficient way to clear out bad Northstar profiles and re-fill them from the "canonical" Northstar data?
#### Any background context you want to provide?

I noticed this after trying the "cleanup" process on Staging, and then realizing there was no way to fix the users that were removed via the "delete queue" without re-syncing _eeeeveryone_. So with this change, the process for Thor/Production:
1. Run the `php artisan northstar:clean_drupal_ids` script on Northstar. This will delete any profiles with duplicate Drupal IDs on Northstar (and attempt to keep the "correct" profile based on choosing the one with the earliest creation date).
2. Run the `remove-duplicate-emails` and `unset-duplicate-mobiles` Drush scripts to fix duplicated records in Phoenix before re-syncing. This will mark changed Drupal IDs (and if field is populated, Northstar IDs) in the `dosomething_northstar_delete_queue` table.
3. Run the `delete-bad-users-in-northstar` Drush script. It'll delete the marked Northstar IDs, and try to re-sync the marked Phoenix IDs (and if that results in a conflict, it'll add the conflicting Northstar IDs to the queue). Run it again for newly added Northstar IDs.
4. Finally, re-run the `export-users-to-northstar` script as a final spot-check. The only users that should not have a successful response code are users with invalid emails.

:cactus: 
#### Relevant tickets

References #6409.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
