### PR TITLE
Added a script to retrofix user languages.

### DIFF
--- a/scripts/correct-language-for-users.php
+++ b/scripts/correct-language-for-users.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * Script to correct languages on users.
+ *
+ * If we have the address for a user, and it's the US, set the lang to english.
+ * Or if the user comes from niche, or a mobile app, set the lang to english as well.
+ *
+ * drush --script-path=../scripts php-script correct-language-for-users.php
+ *
+ */
+
+
+$global_peeps = db_query("SELECT u.uid, s.field_user_registration_source_value as source, a.field_address_country as country
+                          FROM users u
+                          LEFT JOIN field_data_field_user_registration_source s on s.entity_id = u.uid
+                          LEFT JOIN field_data_field_address a on a.entity_id = u.uid
+                          WHERE u.language = 'en-global';");
+
+
+$possible_sources = ['niche', 'Nice', 'niche-import-service', 'letsdothis_ios', 'mobileapp_android'];
+
+foreach($global_peeps as $peep) {
+  if ($peep->country == 'US' || in_array($peep->field_address_country, $possible_sources)) {
+    $user = user_load($peep->uid);
+    $user->language = 'en';
+    print "Saving user " . $user->uid . "\n";
+    user_save($user);
+  }
+}
+print "done";

--- a/scripts/correct-language-for-users.php
+++ b/scripts/correct-language-for-users.php
@@ -20,11 +20,11 @@ $global_peeps = db_query("SELECT u.uid, s.field_user_registration_source_value a
 $possible_sources = ['niche', 'Nice', 'niche-import-service', 'letsdothis_ios', 'mobileapp_android'];
 
 foreach($global_peeps as $peep) {
-  if ($peep->country == 'US' || in_array($peep->field_address_country, $possible_sources)) {
+  if ($peep->country == 'US' || in_array($peep->source, $possible_sources)) {
     $user = user_load($peep->uid);
     $user->language = 'en';
-    print "Saving user " . $user->uid . "\n";
+    print 'Saving user ' . $user->uid . "\n";
     user_save($user);
   }
 }
-print "done";
+print 'done';


### PR DESCRIPTION
#### What's this PR do?

Update user language from `en-global` to `en` if
1. we have the address for the user, and they live in the US
2. the user came from niche, or the mobile apps.
#### How should this be reviewed?

🔍 
#### Any background context you want to provide?

When we switched the default language from `en` to `en-global` users who were created via the API were assigned the wrong language. This means if they come back to the site, they get a bad experience
#### Relevant tickets

Fixes #6748
#### Checklist
- [ ] Tested on staging.
