### PR TITLE
Only log failed requests from export script.

### DIFF
--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -40,10 +40,14 @@ foreach ($users as $user) {
     'data' => json_encode($ns_user),
   ]);
 
-  // Output progress to stdout & log request details for later review.
-  dosomething_northstar_log_request('migrate', $user, $ns_user, $response);
+  // Output progress to stdout so we can see our good work.
   echo 'Migrated user ' . $user->uid . ' to Northstar [' . $response->code . ']' . PHP_EOL;
   $response_data = json_decode($response->data);
+
+  // Save any failed requests to the request log for debugging.
+  if(! in_array($response->code, [200, 201])) {
+    dosomething_northstar_log_request('migrate', $user, $ns_user, $response);
+  }
 
   // If a user cannot be migrated due to a Drupal ID index conflict, we should delete the conflicting Northstar record.
   if ($response->code == 400 && !empty($response_data->error->context->id)) {


### PR DESCRIPTION
#### What's this PR do?

This updates the `export-users-to-northstar` script to not log successful responses, since that'd just fill up the `dosomething_northstar_request_log` table _real fast_ for no significant benefit.
#### How should this be reviewed?

Does this do the thing it's supposed to?
#### Any background context you want to provide?

🏭
#### Relevant tickets

References #6260.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
