### PR TITLE
More aggressively try to sanitize bad numbers, and delete any we can'…

### DIFF
--- a/scripts/sanitize-mobile-numbers.php
+++ b/scripts/sanitize-mobile-numbers.php
@@ -15,16 +15,19 @@ $wild_typers = db_query("SELECT entity_id as uid, field_mobile_value as mobile
 
 foreach($wild_typers as $wilder) {
   if ($wilder->mobile) {
-    $fresh_and_clean_digits = dosomething_user_clean_mobile_number($wilder->mobile);
+    $mobile = preg_replace('[^0-9]+', '', $wilder->mobile);
+    $fresh_and_clean_digits = dosomething_user_clean_mobile_number($mobile);
     if ($fresh_and_clean_digits) {
-      $user = user_load($wilder->uid);
-      $edit = ['field_mobile' => [ LANGUAGE_NONE => [ 0 => [ 'value' => $fresh_and_clean_digits ] ] ] ];
-      user_save($user, $edit);
       print 'Updated user ' . $wilder->uid . "\n";
+      $edit = ['field_mobile' => [ LANGUAGE_NONE => [ 0 => [ 'value' => $fresh_and_clean_digits ] ] ] ];
     }
     else {
-      print 'something terrible with ' . $wilder->uid . "\n";
+      print 'Couldn\'t salvage ' . $wilder->uid . ' (' . $wilder->mobile . ')' . PHP_EOL;
+      $edit = ['field_mobile' => [ LANGUAGE_NONE => [] ] ];
     }
+
+    $user = user_load($wilder->uid);
+    user_save($user, $edit);
   }
 }
 


### PR DESCRIPTION
#### What's this PR do?

This PR updates the `sanitize-mobile-numbers` so that it removes any non-numeric characters before sending a malformed mobile field to the `dosomething_user_clean_mobile_number` function. 

This will let us salvage especially nasty fields like `+1234561234` or `123=456-1234`, and it'll just remove the field for that user if it's something _too_ crazy like `DONT- CAL` or `no` (real values).
#### How should this be reviewed?

👀 
#### Any background context you want to provide?

🌵 
#### Relevant tickets

References #6409.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.

…t fix.
