### PR TITLE
Don't try to dedupe the anonymous user.

### DIFF
--- a/scripts/remove-duplicate-emails.php
+++ b/scripts/remove-duplicate-emails.php
@@ -21,7 +21,7 @@ db_query('
 
 foreach ($dupes as $mail) {
   // Load all users with that duped email address, with the most recently accessed first.
-  $users = db_query('SELECT uid FROM users WHERE mail = :mail ORDER BY access DESC', [':mail' => $mail]);
+  $users = db_query('SELECT uid FROM users WHERE mail = :mail AND uid != 0 ORDER BY access DESC', [':mail' => $mail]);
   $canonical_uid = 0;
 
   foreach ($users as $index => $user) {


### PR DESCRIPTION
#### What's this PR do?

It turns out we have a couple of users (414 of them!) who have an empty-string as their email, which is crazy because I didn't think Drupal allowed that. 👮 Anyways, the existing de-dupe script would try to update the anonymous user which wasn't _at all_ what we wanted, so this fixes that.
#### How should this be reviewed?

👀
#### Any background context you want to provide?

With the `AND uid != 0`, this seems to work as expected when tested on Thor.
#### Relevant tickets

References #6409.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
