### PR TITLE
voter reg and custom sharing

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -1205,10 +1205,20 @@ function dosomething_campaign_node_validate($node, $form, &$form_state) {
    *   Campaign variables
    * @param string $feature
    *   Checking if this feature is on
+   * @param bool $us_only
+   *   If true, make sure the user is in the US
+   *
+   * @return bool
    */
-  function dosomething_campaign_feature_on($campaign, $feature) {
+  function dosomething_campaign_feature_on($campaign, $feature, $us_only = FALSE) {
     if (array_key_exists($feature, $campaign->variables) && $campaign->variables[$feature]) {
-      return TRUE;
+      if ($us_only && dosomething_global_get_current_prefix() == 'us') {
+        return TRUE;
+      }
+      elseif (!$us_only) {
+        return TRUE;
+      }
     }
+
     return FALSE;
   }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -1199,3 +1199,16 @@ function dosomething_campaign_node_validate($node, $form, &$form_state) {
     }
   }
 }
+
+  /**
+   * @param object $campaign
+   *   Loaded campaign node to check if given feature is on
+   * @param string $feature
+   *   Checking if this featuer is on
+   */
+  function dosomething_campaign_feature_on($campaign, $feature) {
+    if (array_key_exists($feature, $campaign->variables) && $campaign->variables[$feature]) {
+      return TRUE;
+    }
+    return FALSE;
+  }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -1202,9 +1202,9 @@ function dosomething_campaign_node_validate($node, $form, &$form_state) {
 
   /**
    * @param object $campaign
-   *   Loaded campaign node to check if given feature is on
+   *   Campaign variables
    * @param string $feature
-   *   Checking if this featuer is on
+   *   Checking if this feature is on
    */
   function dosomething_campaign_feature_on($campaign, $feature) {
     if (array_key_exists($feature, $campaign->variables) && $campaign->variables[$feature]) {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -439,7 +439,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $vars['register_voters'] = dosomething_campaign_feature_on($campaign, 'enable_voter_registration') ? true : false;
 
   // If we are registering voters check to see if the user will be 18 by the election
-  if ($vars['register_voters']) {
+  if ($vars['register_voters'] && (dosomething_global_get_current_prefix() == 'us')) {
     // Calculate the user's age on election day
     $election_day_age = dosomething_user_age_on_date('Nov 8 2016');
     $vars['can_vote'] = (!($election_day_age < 18)) ? true : false;

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -436,10 +436,10 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $vars['custom_social_share_link'] = $custom_social_share_link;
 
   // Pass along whether or not voter registration is enabled
-  $vars['register_voters'] = dosomething_campaign_feature_on($campaign, 'enable_voter_registration') ? true : false;
+  $vars['register_voters'] = (dosomething_campaign_feature_on($campaign, 'enable_voter_registration') && dosomething_global_get_current_prefix() == 'us') ? true : false;
 
   // If we are registering voters check to see if the user will be 18 by the election
-  if ($vars['register_voters'] && (dosomething_global_get_current_prefix() == 'us')) {
+  if ($vars['register_voters']) {
     // Calculate the user's age on election day
     $election_day_age = dosomething_user_age_on_date('Nov 8 2016');
     $vars['can_vote'] = (!($election_day_age < 18)) ? true : false;

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -213,7 +213,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   // 1) Materials
 
   // Build the unique share link.
-  $share_path = 'user/' . $vars['user']->uuid;
+  $share_path = 'user/' . dosomething_user_get_field('field_northstar_id');
   $custom_social_share_link = dosomething_global_url(current_path(), array('absolute' => TRUE,'query' => array('source' => $share_path)));
 
   if (isset($campaign->items_needed)) {
@@ -435,11 +435,15 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $vars['social_share_bar'] = $share_button_markup;
   $vars['custom_social_share_link'] = $custom_social_share_link;
 
+  // Pass along whether or not voter registration is enabled
+  $vars['register_voters'] = dosomething_campaign_feature_on($campaign, 'enable_voter_registration') ? true : false;
+
   // If we are registering voters check to see if the user will be 18 by the election
-  if (dosomething_campaign_feature_on($campaign, 'enable_voter_registration')) {
+  if ($vars['register_voters']) {
     // Calculate the user's age on election day
     $election_day_age = dosomething_user_age_on_date('Nov 8 2016');
     $vars['can_vote'] = (!($election_day_age < 18)) ? true : false;
+    $vars['voter_reg_form'] = '<iframe src="https://register2.rockthevote.com/registrants/map/?source=iframe&partner=35164" width="100%" height="1000" marginheight="0" frameborder="0"></iframe>';
   }
 }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -213,17 +213,17 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   // 1) Materials
 
   // Build the unique share link.
-  $share_path = 'user/' . $vars['user']->uid;
+  $share_path = 'user/' . $vars['user']->uuid;
   $custom_social_share_link = dosomething_global_url(current_path(), array('absolute' => TRUE,'query' => array('source' => $share_path)));
 
   if (isset($campaign->items_needed)) {
     $materials['category'] = 'materials';
     $materials['title'] = t('Stuff You Need');
     $materials['content'] = $campaign->items_needed;
-    // if organ donation campaign, add in the share link here
-    if (array_key_exists('social_share_unique_link', $campaign->variables) && $campaign->variables['social_share_unique_link']) {
+    // If the campaign is setup to create a custom social share link, get that all setup
+    if (dosomething_campaign_feature_on($campaign, 'social_share_unique_link')) {
       $copy = $campaign->variables['social_share_custom_text'] ?: t("Share your link!");
-      $materials['content'] .= '<ul><li> ' . $copy . '<code>' . $custom_social_share_link . '</code></li></ul>';
+      $materials['content'] .= '<ul><li><a href="#" data-modal-href="#modal-share"> ' . $copy . '</li></ul>';
       drupal_add_js(
         array('dosomethingUser' =>
           array('userInfo' =>
@@ -409,15 +409,15 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
 
   // Pass custom share links to the front end. Unique by UID.
   $base_url = url(base_path(), array('absolute'=> TRUE, 'language' => 'en-global'));
-  $country_prefix_for_organ_donation_share = (dosomething_global_get_current_prefix()) ? strtoupper(dosomething_global_get_current_prefix()) : 'global';
-  $organ_donation_share_image = $base_url . 'sites/default/files/images/problem-' . $campaign->nid . '-' . $country_prefix_for_organ_donation_share . '.png';
+  $country_prefix_for_share = (dosomething_global_get_current_prefix()) ? strtoupper(dosomething_global_get_current_prefix()) : 'global';
+  $share_image = $base_url . 'sites/default/files/images/problem-' . $campaign->nid . '-' . $country_prefix_for_share . '.png';
 
   // Add social share bar.
   $social_share_types = array(
     'facebook' => array(
       'type' => 'feed_dialog',
       'parameters' => array(
-      'picture' => $organ_donation_share_image, // @TODO: change this to be generic
+      'picture' => $share_image,
     ),
   ),
     'twitter' => array(
@@ -425,21 +425,18 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     ),
     'tumblr' => array(
       'posttype' => 'photo',
-      'content' => $organ_donation_share_image, // @TODO: change this to be generic
+      'content' => $share_image,
       'caption' => t("This is REAL, do something about this with me: "),
     ),
   );
 
-  $share_button_markup = dosomething_helpers_share_bar($custom_organ_share_link, $social_share_types, 'organ_donation_referral', 'social-menu');
+  $share_button_markup = dosomething_helpers_share_bar($custom_social_share_link, $social_share_types, $campaign->nid . '_referral', 'social-menu');
 
-  $vars['custom_organ_share_link'] = $custom_organ_share_link;
-  $vars['organ_share_bar'] = $share_button_markup;
   $vars['social_share_bar'] = $share_button_markup;
   $vars['custom_social_share_link'] = $custom_social_share_link;
 
   // If we are registering voters check to see if the user will be 18 by the election
-  // @TODO: we need a function to check if X feature is enabled
-  if (array_key_exists('enable_voter_registration', $campaign->variables) && $campaign->variables['enable_voter_registration']) {
+  if (dosomething_campaign_feature_on($campaign, 'enable_voter_registration')) {
     // Calculate the user's age on election day
     $election_day_age = dosomething_user_age_on_date('Nov 8 2016');
     $vars['can_vote'] = (!($election_day_age < 18)) ? true : false;

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -436,7 +436,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $vars['custom_social_share_link'] = $custom_social_share_link;
 
   // Pass along whether or not voter registration is enabled
-  $vars['register_voters'] = (dosomething_campaign_feature_on($campaign, 'enable_voter_registration') && dosomething_global_get_current_prefix() == 'us') ? true : false;
+  $vars['register_voters'] = dosomething_campaign_feature_on($campaign, 'enable_voter_registration', TRUE) ? true : false;
 
   // If we are registering voters check to see if the user will be 18 by the election
   if ($vars['register_voters']) {

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -207,14 +207,10 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
     }
   }
 
-  if (array_key_exists('enable_voter_registration', $campaign->variables) && $campaign->variables['enable_voter_registration']) {
+  if (dosomething_campaign_feature_on($campaign, 'enable_voter_registration')) {
     // Add JS to open the signup data form modal.
       $id = 'modal-voter-registration';
       $closeButton = 'skip';
-
-      // @TODO - New function?
-      $js = 'jQuery(document).ready(function() { DSModal.open( jQuery("#' . $id . '"), {animated: false, closeButton: "' . $closeButton . '"}); });';
-      drupal_add_js($js, 'inline');
   }
 
   // If this is not the pitch page:

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -207,12 +207,6 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
     }
   }
 
-  if (dosomething_campaign_feature_on($campaign, 'enable_voter_registration')) {
-    // Add JS to open the signup data form modal.
-      $id = 'modal-voter-registration';
-      $closeButton = 'skip';
-  }
-
   // If this is not the pitch page:
   if (!isset($vars['is_pitch_page'])) {
     $vars['reportbacks_gallery'] = paraneue_dosomething_preprocess_reportback_gallery($vars);

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -405,6 +405,7 @@
 
 
         <?php // Voter Registration Modal // ?>
+        <?php if (dosomething_campaign_feature_on($campaign, 'enable_voter_registration')) : ?>
           <div data-modal id="modal-voter-registration" role="dialog">
             <iframe src="https://register2.rockthevote.com/registrants/map/?source=iframe&partner=35164" width="100%" height="1000" marginheight="0" frameborder="0"></iframe>
             <div class="modal__block">
@@ -412,7 +413,7 @@
               <code><?php print $custom_social_share_link ?></code>
             </div>
           </div>
-
+       <?php endif; ?>
 
 
       <?php // Custom Share Modal // ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -231,7 +231,7 @@
           <?php if (isset($skip_signup_data_form)): ?>
             <div><?php print render($skip_signup_data_form); ?></div>
           <?php endif; ?>
-          <?php if (dosomething_campaign_feature_on($campaign, 'enable_voter_registration')) : ?>
+          <?php if (dosomething_campaign_feature_on($campaign, 'enable_voter_registration') && dosomething_campaign_feature_on($campaign, 'social_share_unique_link')) : ?>
             <div class="modal__block">
               <p>Copy and paste your share link:</p>
               <code><?php print $custom_social_share_link ?></code>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -173,10 +173,8 @@
                     <li><a href="#" data-modal-href="#modal-shipment-form"><?php print $shipment_form_link; ?></a></li>
                   <?php endif; ?>
 
-                  <?php if (dosomething_campaign_feature_on($campaign, 'enable_voter_registration')) : ?>
-                    <?php if ($can_vote) : ?>
-                      <li><a href="#" data-modal-href="#modal-voter-registration">Register to Vote</a></li>
-                    <?php endif; ?>
+                  <?php if ($register_voters && $can_vote) : ?>
+                    <li><a href="#" data-modal-href="#modal-voter-registration">Register to Vote</a></li>
                   <?php endif; ?>
 
                 </ul>
@@ -223,19 +221,19 @@
 
       <?php if (isset($signup_data_form)): ?>
         <div data-modal id="modal-signup-data-form" class="modal--signup-data" role="dialog" >
-          <?php if (dosomething_campaign_feature_on($campaign, 'enable_voter_registration') && $can_vote) : ?>
-            <iframe src="https://register2.rockthevote.com/registrants/map/?source=iframe&partner=35164" width="100%" height="1000" marginheight="0" frameborder="0"></iframe>
+          <?php if ($register_voters && $can_vote) : ?>
+            <?php print $voter_reg_form ?>
           <?php else: ?>
             <div><?php print render($signup_data_form); ?></div>
           <?php endif; ?>
-          <?php if (isset($skip_signup_data_form)): ?>
-            <div><?php print render($skip_signup_data_form); ?></div>
-          <?php endif; ?>
-          <?php if (dosomething_campaign_feature_on($campaign, 'enable_voter_registration') && dosomething_campaign_feature_on($campaign, 'social_share_unique_link')) : ?>
+          <?php if ($register_voters && dosomething_campaign_feature_on($campaign, 'social_share_unique_link')) : ?>
             <div class="modal__block">
               <p>Copy and paste your share link:</p>
               <code><?php print $custom_social_share_link ?></code>
             </div>
+          <?php endif; ?>
+          <?php if (isset($skip_signup_data_form)): ?>
+            <div><?php print render($skip_signup_data_form); ?></div>
           <?php endif; ?>
         </div>
       <?php endif; ?>
@@ -405,9 +403,9 @@
 
 
         <?php // Voter Registration Modal // ?>
-        <?php if (dosomething_campaign_feature_on($campaign, 'enable_voter_registration')) : ?>
+        <?php if ($register_voters) : ?>
           <div data-modal id="modal-voter-registration" role="dialog">
-            <iframe src="https://register2.rockthevote.com/registrants/map/?source=iframe&partner=35164" width="100%" height="1000" marginheight="0" frameborder="0"></iframe>
+            <?php print $voter_reg_form ?>
             <div class="modal__block">
               <p>Copy and paste your share link:</p>
               <code><?php print $custom_social_share_link ?></code>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -166,7 +166,7 @@
                   <?php endif; ?>
 
                   <?php if (isset($signup_data_form_link)): ?>
-                    <li><a href="#" data-modal-href="#modal-signup-data-form"><?php print $signup_data_form_link; ?></a></li>
+                    <li><a href="#" data-modal-href="#modal-signup-data-form" ><?php print $signup_data_form_link; ?></a></li>
                   <?php endif; ?>
 
                   <?php if (isset($shipment_form_link)): ?>
@@ -174,7 +174,9 @@
                   <?php endif; ?>
 
                   <?php if (array_key_exists('enable_voter_registration', $campaign->variables) && $campaign->variables['enable_voter_registration']) : ?>
-                    <li><a href="#" data-modal-href="#modal-voter-registration">Register to Vote</a></li>
+                    <?php if ($can_vote) : ?>
+                      <li><a href="#" data-modal-href="#modal-voter-registration">Register to Vote</a></li>
+                    <?php endif; ?>
                   <?php endif; ?>
 
                 </ul>
@@ -220,10 +222,20 @@
       <?php endif; ?>
 
       <?php if (isset($signup_data_form)): ?>
-        <div data-modal id="modal-signup-data-form" class="modal--signup-data" role="dialog">
-          <div><?php print render($signup_data_form); ?></div>
+        <div data-modal id="modal-signup-data-form" class="modal--signup-data" role="dialog" >
+          <?php if (dosomething_campaign_feature_on($campaign, 'enable_voter_registration') && $can_vote) : ?>
+            <iframe src="https://register2.rockthevote.com/registrants/map/?source=iframe&partner=35164" width="100%" height="1000" marginheight="0" frameborder="0"></iframe>
+          <?php else: ?>
+            <div><?php print render($signup_data_form); ?></div>
+          <?php endif; ?>
           <?php if (isset($skip_signup_data_form)): ?>
-          <div><?php print render($skip_signup_data_form); ?></div>
+            <div><?php print render($skip_signup_data_form); ?></div>
+          <?php endif; ?>
+          <?php if (dosomething_campaign_feature_on($campaign, 'enable_voter_registration')) : ?>
+            <div class="modal__block">
+              <p>Copy and paste your share link:</p>
+              <code><?php print $custom_social_share_link ?></code>
+            </div>
           <?php endif; ?>
         </div>
       <?php endif; ?>
@@ -391,33 +403,29 @@
         </div>
       </div>
 
-      <?php // Voter Registration Modal // ?>
-      <?php if (array_key_exists('enable_voter_registration', $campaign->variables) && $campaign->variables['enable_voter_registration']) : ?>
-      <?php // @TODO: if user is not registered and is eligible, pop this up ?>
-        <?php if ($can_vote) : ?>
+
+        <?php // Voter Registration Modal // ?>
           <div data-modal id="modal-voter-registration" role="dialog">
-            <div class="floatbox" data-fb-options="width:618 height:max scrolling:yes">
-              <iframe src="https://register2.rockthevote.com/registrants/map/?source=iframe&partner=35164" width="100%" height="1200" marginheight="0" frameborder="0"></iframe>
-            </div>
-          </div>
-        <?php else : ?>
-          <?php // @TODO: fix the styling in hurr ?>
-          <div data-modal id="modal-voter-registration" role="dialog">
+            <iframe src="https://register2.rockthevote.com/registrants/map/?source=iframe&partner=35164" width="100%" height="1000" marginheight="0" frameborder="0"></iframe>
             <div class="modal__block">
-              <br>
-              <h3>Bummer! Since you aren't 18 yet, you can't register to vote.</h3><br>
-              <h3>BUT YOU CAN STILL MAKE A DIFFERENCE.</h3><br>
-              <h3>Share this Campaign:</h3><br>
-              <p><?php print $social_share_bar ?></p>
               <p>Copy and paste your share link:</p>
               <code><?php print $custom_social_share_link ?></code>
-              <div class="form-item -padded submit-done-container">
-                <input type="submit" class="button js-close-modal" value="Done" />
-              </div>
             </div>
           </div>
-        <?php endif; ?>
-      <?php endif; ?>
+
+
+
+      <?php // Custom Share Modal // ?>
+      <?php if ($custom_social_share_link) : ?>
+        <div data-modal id="modal-share" role="dialog">
+          <div class="modal__block">
+            <h3>Share this Campaign</h3><br>
+            <p>Copy and paste your share link:</p>
+            <code><?php print $custom_social_share_link ?></code>
+          </div>
+        </div>
+       <?php endif; ?>
+
 
   <?php // Missing Photo Modal // ?>
   <div data-modal id="modal-missing-photos" role="dialog">
@@ -494,7 +502,7 @@
                   <h3>Share with your friends!</h3>
                   <p><?php print $social_share_bar ?></p>
                   <p>Copy and paste your share link:</p>
-                  <code><?php print $custom_organ_share_link ?></code>
+                  <code><?php print $custom_social_share_link ?></code>
                   <div class="form-item -padded submit-done-container">
                     <input type="submit" class="button js-close-modal" value="Done" />
                   </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -166,7 +166,7 @@
                   <?php endif; ?>
 
                   <?php if (isset($signup_data_form_link)): ?>
-                    <li><a href="#" data-modal-href="#modal-signup-data-form" ><?php print $signup_data_form_link; ?></a></li>
+                    <li><a href="#" data-modal-href="#modal-signup-data-form"><?php print $signup_data_form_link; ?></a></li>
                   <?php endif; ?>
 
                   <?php if (isset($shipment_form_link)): ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -173,7 +173,7 @@
                     <li><a href="#" data-modal-href="#modal-shipment-form"><?php print $shipment_form_link; ?></a></li>
                   <?php endif; ?>
 
-                  <?php if (array_key_exists('enable_voter_registration', $campaign->variables) && $campaign->variables['enable_voter_registration']) : ?>
+                  <?php if (dosomething_campaign_feature_on($campaign, 'enable_voter_registration')) : ?>
                     <?php if ($can_vote) : ?>
                       <li><a href="#" data-modal-href="#modal-voter-registration">Register to Vote</a></li>
                     <?php endif; ?>


### PR DESCRIPTION
#### What's this PR do?

Lots of voter reg and custom sharing 🔮 !
- If voter reg is enabled and the user is eligible to register, the voter reg form will popup upon signup AND a link to open the modal is added to "Stuff You Need"
- Custom social share link now uses Northstar ID (uuid) instead of phoenix ID
- If custom social sharing is enabled and voter reg is enabled, we include the custom social link in the signup form modal
- Changed some names of custom social share variables from being specific to organs
- Added function to check if a campaign feature is enabled (for instance, voter reg or custom social sharing)
- If custom social sharing is enabled, include a link to the share modal in "Stuff You Need" instead of just text including the custom link
#### How should this be reviewed?

Peruse for logic flaws.

Make sure that all features worked as described above. Be sure to test on campaigns with custom sharing and voter reg both disabled and enabled, and with one on and the other off. 
#### Any background context you want to provide?

You know how sometimes in Drupal you work on something for a long time and then there is a lot less actual code than it felt like? Everything is also very closely related so I had trouble trying to break it out into separate PRs 😬 
#### Relevant tickets

Fixes #6780
Fixes #6775
Fixes #6773
Fixes #6832
Fixes #6872
#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love. @ngjo 
