### PR TITLE
Really, really sanitize those mobiles.

### DIFF
--- a/scripts/sanitize-mobile-numbers.php
+++ b/scripts/sanitize-mobile-numbers.php
@@ -14,8 +14,8 @@ $wild_typers = db_query('SELECT entity_id as uid, field_mobile_value as mobile
 
 foreach($wild_typers as $wilder) {
   if ($wilder->mobile) {
-    $mobile = preg_replace('[^0-9]+', '', $wilder->mobile);
-    $fresh_and_clean_digits = dosomething_user_clean_mobile_number($mobile);
+    $mobile = $wilder->mobile;
+    $fresh_and_clean_digits = dosomething_user_clean_mobile_number(preg_replace('[^0-9]', '', $mobile));
     if ($fresh_and_clean_digits) {
       print 'Updated user ' . $wilder->uid . "\n";
       $edit = ['field_mobile' => [ LANGUAGE_NONE => [ 0 => [ 'value' => $fresh_and_clean_digits ] ] ] ];

--- a/scripts/sanitize-mobile-numbers.php
+++ b/scripts/sanitize-mobile-numbers.php
@@ -9,8 +9,10 @@
  */
 
 $wild_typers = db_query('SELECT entity_id as uid, field_mobile_value as mobile
-                        FROM field_data_field_mobile
-                        WHERE field_mobile_value NOT REGEXP :regex', [':regex' => '^[0-9]+$']);
+              FROM field_data_field_mobile
+              WHERE field_mobile_value NOT REGEXP(\'^[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]$\')');
+//                                                    ^ whaaa? drupal removes all brackets w/ no way to opt-out, so
+//                                                      it seems like we have to repeat the [0-9] manually 10 times.
 
 foreach($wild_typers as $wilder) {
   if ($wilder->mobile) {

--- a/scripts/sanitize-mobile-numbers.php
+++ b/scripts/sanitize-mobile-numbers.php
@@ -17,7 +17,7 @@ foreach($wild_typers as $wilder) {
     $mobile = $wilder->mobile;
     $fresh_and_clean_digits = dosomething_user_clean_mobile_number(preg_replace('[^0-9]', '', $mobile));
     if ($fresh_and_clean_digits) {
-      print 'Updated user ' . $wilder->uid . "\n";
+      print 'Updated user ' . $wilder->uid . '(' . $wilder->mobile . ' --> ' . $fresh_and_clean_digits . ')' . PHP_EOL;
       $edit = ['field_mobile' => [ LANGUAGE_NONE => [ 0 => [ 'value' => $fresh_and_clean_digits ] ] ] ];
     }
     else {

--- a/scripts/sanitize-mobile-numbers.php
+++ b/scripts/sanitize-mobile-numbers.php
@@ -8,9 +8,9 @@
  *
  */
 
-$wild_typers = db_query("SELECT entity_id as uid, field_mobile_value as mobile
+$wild_typers = db_query('SELECT entity_id as uid, field_mobile_value as mobile
                         FROM field_data_field_mobile
-                        WHERE field_mobile_value NOT REGEXP '^[0-9]{10}$';");
+                        WHERE field_mobile_value NOT REGEXP :regex', [':regex' => '^[0-9]+$']);
 
 foreach($wild_typers as $wilder) {
   if ($wilder->mobile) {

--- a/scripts/sanitize-mobile-numbers.php
+++ b/scripts/sanitize-mobile-numbers.php
@@ -10,8 +10,7 @@
 
 $wild_typers = db_query("SELECT entity_id as uid, field_mobile_value as mobile
                         FROM field_data_field_mobile
-                        WHERE field_mobile_value NOT REGEXP '^[0-9]+$';");
-
+                        WHERE field_mobile_value NOT REGEXP '^[0-9]{10}$';");
 
 foreach($wild_typers as $wilder) {
   if ($wilder->mobile) {


### PR DESCRIPTION
#### What's this PR do?

This PR uses a bastardized form of the `^[0-9]{10}$` regex used in the issue, since we can't apparently use brackets with `db_query` without them getting find-replaced as table prefixes.

It also adds logging of "before and after" values for sanitized numbers so we can easily verify.
#### How should this be reviewed?

🌵. Blahhhh. It's not pretty, but at least it seems to work.
#### Any background context you want to provide?

🐮 
#### Relevant tickets

Fixes #6886.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
