### PR TITLE
Updating onboarding script to account for possible null user.info.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemKudosSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemKudosSlide.js
@@ -10,6 +10,8 @@ class ReportbackItemKudosSlide extends React.Component {
   }
 
   render() {
+    const user = this.props.user;
+
     return (
       <div className="slideshow__slide">
         <div className="container">
@@ -18,7 +20,7 @@ class ReportbackItemKudosSlide extends React.Component {
             <div className="container__row">
               <div className="container__block">
                 <h2 className="heading -gamma">These members are rocking it already!</h2>
-                <p>Tap the heart to show them some love. We can't wait to see YOUR photos, {this.props.user.info.first_name}!</p>
+                <p>Tap the heart to show them some love. We can't wait to see YOUR photos{user.info ? ', ' + user.info.first_name : ''}!</p>
               </div>
             </div>
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -10,9 +10,13 @@ const ReactDom = require('react-dom');
 const Modal = require('dosomething-modal');
 
 function getLocalStorageKey(user, campaign) {
+  // @TODO: probably need a better way to get the run ID consistently.
+  const languageCode = (Object.keys(campaign.campaign_runs.current)[0]);
+
   let key = null;
+
   if (campaign && user) {
-    key = `onboarding:campaign=${campaign.id}-user=${user.info.id}`;
+    key = `onboarding:campaign=${campaign.id}&run=${campaign.campaign_runs.current[languageCode].id}${user.info ? "&user=" + user.info.id :  ''}`;
   }
 
   return key;

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -10,13 +10,10 @@ const ReactDom = require('react-dom');
 const Modal = require('dosomething-modal');
 
 function getLocalStorageKey(user, campaign) {
-  // @TODO: probably need a better way to get the run ID consistently.
-  const languageCode = (Object.keys(campaign.campaign_runs.current)[0]);
-
   let key = null;
 
   if (campaign && user) {
-    key = `onboarding:campaign=${campaign.id}&run=${campaign.campaign_runs.current[languageCode].id}${user.info ? "&user=" + user.info.id :  ''}`;
+    key = `onboarding:campaign=${campaign.id}&user=${user.info ? user.info.id :  'null'}`;
   }
 
   return key;


### PR DESCRIPTION
#### What's this PR do?

This PR adds a fix to account for the possibility that the `user.info` returned from Northstar _might_ have responded with an error and thus the value is `null`. If so, let's not rely on having `user.info.id` be present and instead handle that a little better.
#### How should this be reviewed?

If you get a `null` response from Northstar (you can try and fake it for testing), do the Onboarding experience still show for a logged in user?
#### Any background context you want to provide?

Used `Object.keys()` since we're also added the campaign run to the localStorage key. However, these run ids are nested within objects whose keys are the language codes available for a translated run. To help avoid errors with adding the campaign run ID, I'm nabbing the first item with a key (typically `en`) and grabbing that run ID.
#### Relevant tickets

Fixes #6884
#### Checklist
- [ ] Tested on staging.

---

@DFurnes @deadlybutter 

cc: @jessleenyc 
