### PR TITLE
Potentially cleaner dedupe and one bugfix

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -92,7 +92,7 @@ function dosomething_northstar_register_user($user, $payload) {
   // Add to request log if enabled.
   dosomething_northstar_log_request('register_user', $user, $payload, $response);
 
-  if (_dosomething_northstar_is_successful_response($response)) {
+  if (! _dosomething_northstar_is_successful_response($response)) {
     watchdog('dosomething_northstar', 'User not migrated : ' . $response->code, NULL, WATCHDOG_ERROR);
     return;
   }
@@ -276,7 +276,7 @@ function dosomething_northstar_build_ns_user($user, $form_state) {
 
 /**
  * Return whether the response has a "successful" status code or not.
- * 
+ *
  * @param $response
  * @return bool
  */

--- a/scripts/remove-duplicate-emails.php
+++ b/scripts/remove-duplicate-emails.php
@@ -39,12 +39,8 @@ foreach ($dupes as $mail) {
     user_save($user, ['mail' => $new_email, 'status' => 0]);
     $removed++;
 
-    // Finally, make a note if that user has a Northstar profile, so we can clean that up.
-    $northstar_id = $user->field_northstar_id[LANGUAGE_NONE][0]['value'];
-    if ($northstar_id !== 'NONE') {
-      db_insert('dosomething_northstar_delete_queue')->fields(['uid' => $user->uid, 'northstar_id' => $northstar_id])->execute();
-      print '   ** User ' . $user->uid . ' has a Northstar profile: ' . $northstar_id . PHP_EOL;
-    }
+    // Finally, try to push the updated profile to this Drupal ID in Northstar
+    dosomething_northstar_update_user($user, ['drupal_id' => $user->uid, 'email' => $new_email]);
   }
 
   print PHP_EOL;

--- a/scripts/sanitize-mobile-numbers.php
+++ b/scripts/sanitize-mobile-numbers.php
@@ -25,10 +25,15 @@ foreach($wild_typers as $wilder) {
     else {
       print 'Couldn\'t salvage ' . $wilder->uid . ' (' . $wilder->mobile . ')' . PHP_EOL;
       $edit = ['field_mobile' => [ LANGUAGE_NONE => [] ] ];
+      $fresh_and_clean_digits = null;
     }
 
+    // Update the `field_mobile` for that user (to either sanitize or remove it).
     $user = user_load($wilder->uid);
     user_save($user, $edit);
+
+    // Now, update (or create) the corresponding profile in Northstar by Drupal ID.
+    dosomething_northstar_update_user($user, ['mobile' => $fresh_and_clean_digits, 'drupal_id' => $user->uid]);
   }
 }
 

--- a/scripts/unset-duplicate-mobiles.php
+++ b/scripts/unset-duplicate-mobiles.php
@@ -36,18 +36,12 @@ foreach ($dupes as $mobile) {
 
     // Remove the mobile field for that user.
     print ' - Removing mobile from ' . $user->uid . ' (' . $mobile . ')' . PHP_EOL;
-    $entity = entity_load_single('user', $user->uid);
-    $entity->field_mobile[LANGUAGE_NONE] = [];
-    entity_save('user', $entity);
+    user_save($user, ['field_mobile' => [ LANGUAGE_NONE => [] ] ]);
 
     $removed++;
 
-    // Finally, make a note if that user has a Northstar profile, so we can clean that up.
-    $northstar_id = $user->field_northstar_id[LANGUAGE_NONE][0]['value'];
-    if ($northstar_id !== 'NONE') {
-      db_insert('dosomething_northstar_delete_queue')->fields(['uid' => $user->uid, 'northstar_id' => $northstar_id])->execute();
-      print '   ** User ' . $user->uid . ' has a Northstar profile: ' . $northstar_id . PHP_EOL;
-    }
+    // Now, update the corresponding profile in Northstar by Drupal ID.
+    dosomething_northstar_update_user($user, ['mobile' => null, 'drupal_id' => $user->uid]);
   }
 
   print PHP_EOL;


### PR DESCRIPTION
#### What's this PR do?

This is a potentially mistaken optimization and a bug fix.

💹 **The potentially mistaken optimization:** I was thinking it might make more sense to use the `PUT /v1/users/drupal_id/:uid` route to make the corresponding change in Northstar each time we update a user in Phoenix. It'd mean we wouldn't have to build up a queue of "borked" accounts to delete and re-create.

This _should_ be a safe call since each of these scripts should always leave us with valid "updates" for Northstar's data (if run in this order `remove-duplicate-emails` → `unset-duplicate-mobiles` → `sanitize-mobile-numbers` → `unset-duplicate-mobiles`).

And the `dosomething_northstar_update_user` method already falls back to using the `POST /v1/users` endpoint if the given Drupal ID returns a 404.

🐛 **The bug fix:** the `dosomething_northstar_register_user` was logging an error to Watchdog on successful responses. It should do the _opposite_ of that.
#### How should this be reviewed?

Let's refresh Thor Phoenix & Thor Northstar from prod, and then try running the modified scripts from this branch. If we're faced with a ton of errors then it's probably not a good improvement. 😇 
#### Any background context you want to provide?

🌅
#### Relevant tickets

References #6409.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
