### PR TITLE
Moves some code around & forces a react render after API call recieved

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -130,6 +130,11 @@ class FeatureCard extends React.Component {
 
     let newIndex = this.state.campaignIndex + 1;
 
+    // If we reached the end set our index back to the start
+    if (newIndex >= this.campaigns.length) {
+      newIndex = 0;
+    }
+
     // Only log to GA if someone actually pressed the button
     if (buttonTrigger) {
       sendEvent('Onboarding', 'View More');
@@ -139,12 +144,8 @@ class FeatureCard extends React.Component {
     if (this.getRemainingCampaigns() <= 4) {
       this.getCampaigns(false, false, this.campaignsApiPage, () => {
         this.campaignsApiPage++;
+        this.forceUpdate();
       });
-    }
-
-    // If we reached the end set our index back to the start
-    if (newIndex >= this.campaigns.length) {
-      newIndex = 0;
     }
 
     // Re-render with new index


### PR DESCRIPTION
#### What's this PR do?

see the title
#### How should this be reviewed?

if you signup for every staff pick, does onboarding show campaigns?
(to test this i just went into the staff pick table & set everything to 0)
#### Any background context you want to provide?

the code was working fine, but because campaigns arent stored to the state react had no idea it needed to re-render the page
#### Relevant tickets

Fixes #6877 
#### Checklist
- [ ] Tested on staging.
