### PR TITLE
ApiClient class & Reportback Items Slide

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -101,10 +101,10 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#default_value' => variable_get('dosomething_campaign_onboarding_instruction_slide'),
   ];
 
-  $form['campaign']['action_page']['dosomething_campaign_onboarding_reportback_item_kudos_slide'] = [
+  $form['campaign']['action_page']['dosomething_campaign_onboarding_reportback_items_slide'] = [
     '#type' => 'checkbox',
-    '#title' => t('Display Reportback Item Kudos Slide'),
-    '#default_value' => variable_get('dosomething_campaign_onboarding_reportback_item_kudos_slide'),
+    '#title' => t('Display Reportback Items Slide'),
+    '#default_value' => variable_get('dosomething_campaign_onboarding_reportback_items_slide'),
   ];
 
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -327,8 +327,8 @@ function dosomething_helpers_add_js_onboarding() {
       $onboardingSettings['slides'][] = 'InstructionSlide';
     }
 
-    if (variable_get('dosomething_campaign_onboarding_reportback_item_kudos_slide', FALSE)) {
-      $onboardingSettings['slides'][] = 'ReportbackItemKudosSlide';
+    if (variable_get('dosomething_campaign_onboarding_reportback_items_slide', FALSE)) {
+      $onboardingSettings['slides'][] = 'ReportbackItemsSlide';
     }
 
     drupal_add_js(['dsOnboarding' => $onboardingSettings], 'setting');

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ContextSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ContextSlide.js
@@ -1,4 +1,5 @@
 import FeatureCard from './FeatureCard';
+import ApiClient from '../utilities/ApiClient';
 
 const React = require('react');
 
@@ -9,6 +10,10 @@ const React = require('react');
 class ContextSlide extends React.Component {
   constructor(props) {
     super(props);
+
+    const apiClient = new ApiClient(window.location.hostname, '/api/v1/', window.location.port);
+
+    console.log(apiClient);
   }
 
   render() {

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ContextSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ContextSlide.js
@@ -1,5 +1,4 @@
 import FeatureCard from './FeatureCard';
-import ApiClient from '../utilities/ApiClient';
 
 const React = require('react');
 
@@ -10,10 +9,6 @@ const React = require('react');
 class ContextSlide extends React.Component {
   constructor(props) {
     super(props);
-
-    const apiClient = new ApiClient(window.location.hostname, '/api/v1/', window.location.port);
-
-    console.log(apiClient);
   }
 
   render() {

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -59,8 +59,6 @@ class FeatureCard extends React.Component {
   }
 
   getCampaigns(staffPickOnly, paginate, page, callback) {
-    console.log('requesting...');
-
     this.requests.push(this.serverRequest = $.get(`${this.apiClient.url}campaigns?${staffPickOnly ? 'staff_pick=true&' : ''}${page != -1 ? 'page=' + page : ''}`, result => {
       // Get campaigns ordered by relevance & handle exclusions.
       const campaigns = sortCampaignsByRelevance(result.data).filter(campaign => this.campaignsToExclude.indexOf(parseInt(campaign.id)) == -1);

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -19,7 +19,7 @@ class FeatureCard extends React.Component {
     this.campaigns = [];
     this.campaignsToExclude = setting('dsUser.activity.signups', []);
     this.campaignsApiPage = 1;
-    this.apiClient = new ApiClient(window.location.hostname, '/api/v1/', window.location.port);
+    this.apiClient = new ApiClient('v1');
 
     this.state = {
       actionDisabled: false,

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -5,6 +5,8 @@ import Button from './Button';
 import setting from '../utilities/Setting';
 import { sortCampaignsByRelevance } from '../campaign/helpers';
 
+import ApiClient from '../utilities/ApiClient';
+
 const API_HOST = window.location.hostname;
 const API_PORT = window.location.port || undefined;
 const API_VERSION = '/api/v1/';

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -3,14 +3,8 @@ const React = require('react');
 
 import Button from './Button';
 import setting from '../utilities/Setting';
-import { sortCampaignsByRelevance } from '../campaign/helpers';
-
 import ApiClient from '../utilities/ApiClient';
-
-const API_HOST = window.location.hostname;
-const API_PORT = window.location.port || undefined;
-const API_VERSION = '/api/v1/';
-const API_URL = `//${API_HOST}${API_PORT ? ':' + API_PORT : ''}${API_VERSION}`;
+import { sortCampaignsByRelevance } from '../campaign/helpers';
 
 /**
  * Card Component
@@ -25,6 +19,15 @@ class FeatureCard extends React.Component {
     this.campaigns = [];
     this.campaignsToExclude = setting('dsUser.activity.signups', []);
     this.campaignsApiPage = 1;
+    this.apiClient = new ApiClient(window.location.hostname, '/api/v1/', window.location.port);
+
+    // TESTING
+    this.apiClient.get('campaigns', {
+      'staff_pick': true,
+      'count': 20
+    });
+
+    this.apiClient.get('campaigns/1283');
 
     this.state = {
       actionDisabled: false,
@@ -56,7 +59,9 @@ class FeatureCard extends React.Component {
   }
 
   getCampaigns(staffPickOnly, paginate, page, callback) {
-    this.requests.push(this.serverRequest = $.get(`${API_URL}campaigns?${staffPickOnly ? 'staff_pick=true&' : ''}${page != -1 ? 'page=' + page : ''}`, result => {
+    console.log('requesting...');
+
+    this.requests.push(this.serverRequest = $.get(`${this.apiClient.url}campaigns?${staffPickOnly ? 'staff_pick=true&' : ''}${page != -1 ? 'page=' + page : ''}`, result => {
       // Get campaigns ordered by relevance & handle exclusions.
       const campaigns = sortCampaignsByRelevance(result.data).filter(campaign => this.campaignsToExclude.indexOf(parseInt(campaign.id)) == -1);
 
@@ -96,8 +101,10 @@ class FeatureCard extends React.Component {
     this.campaignsToExclude.push(campaign.id);
 
     this.requests.push($.ajax({
-      url: `${API_URL}campaigns/${campaign.id}/signup`,
-      type: 'POST',
+      // url: `${API_URL}campaigns/${campaign.id}/signup`,
+      // type: 'POST',
+      url: `${this.apiClient.url}campaigns/1283`,
+      type: 'GET',
       headers: {
         "X-CSRF-Token": $('meta[name=csrf-token]').attr("content")
       },

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -21,13 +21,13 @@ class FeatureCard extends React.Component {
     this.campaignsApiPage = 1;
     this.apiClient = new ApiClient(window.location.hostname, '/api/v1/', window.location.port);
 
-    // TESTING
-    this.apiClient.get('campaigns', {
-      'staff_pick': true,
-      'count': 20
-    });
-
-    this.apiClient.get('campaigns/1283');
+    // // TESTING
+    // this.apiClient.get('campaigns', {
+    //   'staff_pick': true,
+    //   'count': 20
+    // });
+    // this.apiClient.get('campaigns/1283');
+    // //
 
     this.state = {
       actionDisabled: false,

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/FeatureCard.js
@@ -21,14 +21,6 @@ class FeatureCard extends React.Component {
     this.campaignsApiPage = 1;
     this.apiClient = new ApiClient(window.location.hostname, '/api/v1/', window.location.port);
 
-    // // TESTING
-    // this.apiClient.get('campaigns', {
-    //   'staff_pick': true,
-    //   'count': 20
-    // });
-    // this.apiClient.get('campaigns/1283');
-    // //
-
     this.state = {
       actionDisabled: false,
       campaignIndex: -1,
@@ -99,10 +91,8 @@ class FeatureCard extends React.Component {
     this.campaignsToExclude.push(campaign.id);
 
     this.requests.push($.ajax({
-      // url: `${API_URL}campaigns/${campaign.id}/signup`,
-      // type: 'POST',
-      url: `${this.apiClient.url}campaigns/1283`,
-      type: 'GET',
+      url: `${this.apiClient.url}campaigns/${campaign.id}/signup`,
+      type: 'POST',
       headers: {
         "X-CSRF-Token": $('meta[name=csrf-token]').attr("content")
       },

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItem.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItem.js
@@ -1,0 +1,29 @@
+const React = require('react');
+
+/**
+ * ReportbackItem Component
+ * <ReportbackItem />
+ */
+class ReportbackItem extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render () {
+    const reportbackItem = this.props.data;
+
+    return (
+      <div className="photo -stacked -framed" data-reportback-item-id={reportbackItem.id}>
+        <figure className="wrapper">
+          <img src={reportbackItem.media.uri} alt={reportbackItem.caption} />
+
+          <figcaption className="photo__copy">
+            <p className="photo__caption">{reportbackItem.caption}</p>
+          </figcaption>
+        </figure>
+      </div>
+    );
+  }
+}
+
+export default ReportbackItem;

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemKudosSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemKudosSlide.js
@@ -1,6 +1,7 @@
 const React = require('react');
 
 import ApiClient from '../utilities/ApiClient';
+import ReportbackItem from './ReportbackItem';
 
 /**
  * ReportbackItemKudosSlide Component
@@ -10,24 +11,43 @@ class ReportbackItemKudosSlide extends React.Component {
   constructor(props) {
     super(props);
 
+    this.state = {
+      reportbackItems: null
+    };
+
     this.apiClient = new ApiClient(window.location.hostname, '/api/v1/', window.location.port);
     this.reportbackItems = null;
   }
 
   componentDidMount() {
     const reportbackItems = this.apiClient.get('reportback-items', {
-      'campaigns': '1283', // make dynamic
+      'campaigns': this.props.campaign.id,
       'random': true,
-      'count': 4
+      'count': 4,
+      'status': 'promoted,approved'
     }, (response) => {
-      this.reportbackItems = response.data;
+      this.setState({
+        reportbackItems: response.data
+      });
     });
+  }
+
+  renderReportbackItems(data, index) {
+    return <li key={`list-item-${index}`}><ReportbackItem key={index} data={data} /></li>;
   }
 
   render() {
     const user = this.props.user;
 
-    console.log(this);
+    let listContent = 'Waiting for content...';
+
+    if (!this.state.reportbackItems) {
+      // @TODO: Add loading spinnner??
+    }
+
+    if (this.state.reportbackItems) {
+      listContent = this.state.reportbackItems.map(this.renderReportbackItems);
+    }
 
     return (
       <div className={`slideshow__slide ${this.props.isActive ? '-active fade-in': ''}`}>
@@ -37,14 +57,14 @@ class ReportbackItemKudosSlide extends React.Component {
             <div className="container__row">
               <div className="container__block">
                 <h2 className="heading -gamma">These members are rocking it already!</h2>
-                <p>Tap the heart to show them some love. We can't wait to see YOUR photos{user.info ? ', ' + user.info.first_name : ''}!</p>
+                <p>{/*Tap the heart to show them some love. */}We can't wait to see YOUR photos{user.info ? ', ' + user.info.first_name : ''}!</p>
               </div>
             </div>
 
             <div className="container__row">
               <div className="container__block">
                 <ul className="gallery -quartet">
-                  <li>// items here</li>
+                  {listContent}
                 </ul>
               </div>
             </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemKudosSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemKudosSlide.js
@@ -1,5 +1,7 @@
 const React = require('react');
 
+import ApiClient from '../utilities/ApiClient';
+
 /**
  * ReportbackItemKudosSlide Component
  * <ReportbackItemKudosSlide />
@@ -7,6 +9,12 @@ const React = require('react');
 class ReportbackItemKudosSlide extends React.Component {
   constructor(props) {
     super(props);
+
+    this.apiClient = new ApiClient(window.location.hostname, '/api/v1/', window.location.port);
+  }
+
+  componentDidMount() {
+    // retrieve the RB Items via API
   }
 
   render() {

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemKudosSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemKudosSlide.js
@@ -11,17 +11,26 @@ class ReportbackItemKudosSlide extends React.Component {
     super(props);
 
     this.apiClient = new ApiClient(window.location.hostname, '/api/v1/', window.location.port);
+    this.reportbackItems = null;
   }
 
   componentDidMount() {
-    // retrieve the RB Items via API
+    const reportbackItems = this.apiClient.get('reportback-items', {
+      'campaigns': '1283', // make dynamic
+      'random': true,
+      'count': 4
+    }, (response) => {
+      this.reportbackItems = response.data;
+    });
   }
 
   render() {
     const user = this.props.user;
 
+    console.log(this);
+
     return (
-      <div className="slideshow__slide">
+      <div className={`slideshow__slide ${this.props.isActive ? '-active fade-in': ''}`}>
         <div className="container">
           <div className="wrapper">
 
@@ -32,13 +41,13 @@ class ReportbackItemKudosSlide extends React.Component {
               </div>
             </div>
 
-            {/*
             <div className="container__row">
               <div className="container__block">
-                 <!-- @TODO: Include Reportback Items for Kudos-ing here! -->
+                <ul className="gallery -quartet">
+                  <li>// items here</li>
+                </ul>
               </div>
             </div>
-            */}
 
           </div>
         </div>

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemKudosSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemKudosSlide.js
@@ -15,7 +15,7 @@ class ReportbackItemKudosSlide extends React.Component {
       reportbackItems: null
     };
 
-    this.apiClient = new ApiClient(window.location.hostname, '/api/v1/', window.location.port);
+    this.apiClient = new ApiClient('v1');
     this.reportbackItems = null;
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemsSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemsSlide.js
@@ -4,10 +4,10 @@ import ApiClient from '../utilities/ApiClient';
 import ReportbackItem from './ReportbackItem';
 
 /**
- * ReportbackItemKudosSlide Component
- * <ReportbackItemKudosSlide />
+ * ReportbackItemsSlide Component
+ * <ReportbackItemsSlide />
  */
-class ReportbackItemKudosSlide extends React.Component {
+class ReportbackItemsSlide extends React.Component {
   constructor(props) {
     super(props);
 
@@ -76,4 +76,4 @@ class ReportbackItemKudosSlide extends React.Component {
   }
 }
 
-export default ReportbackItemKudosSlide;
+export default ReportbackItemsSlide;

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -1,7 +1,7 @@
 import Onboarding from './components/Onboarding';
 import ContextSlide from './components/ContextSlide';
 import InstructionSlide from './components/InstructionSlide';
-import ReportbackItemKudosSlide from './components/ReportbackItemKudosSlide';
+import ReportbackItemsSlide from './components/ReportbackItemsSlide';
 import setting from './utilities/Setting';
 
 const $ = require('jquery');
@@ -36,7 +36,7 @@ function getLocalStorageKey(user, campaign) {
  */
 function enableOnboarding(localStorageKey, user, campaign) {
   const jsxElementHook = 'jsx-onboarding';
-  const slideComponents = {ContextSlide, InstructionSlide, ReportbackItemKudosSlide};
+  const slideComponents = {ContextSlide, InstructionSlide, ReportbackItemsSlide};
   const slides = Drupal.settings.dsOnboarding.slides.map(name => slideComponents[name]);
 
   if (slides.length == 0) {

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -9,6 +9,13 @@ const React = require('react');
 const ReactDom = require('react-dom');
 const Modal = require('dosomething-modal');
 
+/**
+ * Get the local storage key for Onboarding.
+ *
+ * @param  {Object} user
+ * @param  {Object} campaign
+ * @return {String}
+ */
 function getLocalStorageKey(user, campaign) {
   let key = null;
 
@@ -19,6 +26,14 @@ function getLocalStorageKey(user, campaign) {
   return key;
 }
 
+/**
+ * Enable the Onboarding experience based on certain conditions.
+ *
+ * @param  {String} localStorageKey
+ * @param  {Object} user
+ * @param  {Object} campaign
+ * @return {Void}
+ */
 function enableOnboarding(localStorageKey, user, campaign) {
   const jsxElementHook = 'jsx-onboarding';
   const slideComponents = {ContextSlide, InstructionSlide, ReportbackItemKudosSlide};
@@ -39,8 +54,7 @@ function enableOnboarding(localStorageKey, user, campaign) {
 }
 
 /**
- * Welcome to the Laboratory.
- * Run your experiments below.
+ * Document ready... ENGAGE!
  */
 $(document).ready(function() {
   const campaign = Drupal.settings.dsCampaign || null;

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/ApiClient.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/ApiClient.js
@@ -1,0 +1,32 @@
+/**
+ * ApiClient class to make calls to different services.
+ * This could eventually be a class that other classes more
+ * specific to certain endpoints extend and define the url
+ * request structure on their own so it can accommodate
+ * various endpoint URL structures.
+ * For example: class PhoenixApiClient extends ApiClient { .. }
+ */
+class ApiClient {
+
+  constructor(host, version, port = '') {
+    console.log(host);
+    console.log(version);
+    console.log(port);
+    this.api = {
+      host,
+      port,
+      version
+    };
+
+    // this.api.port = port;
+    // this.api.verstion = version;
+    // this.api.url = `http://${this.api.host}${this.api.port}${this.api.version}`;
+  }
+
+  request(endpoint) {
+    return 'hello';
+  }
+
+}
+
+export default ApiClient;

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/ApiClient.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/ApiClient.js
@@ -1,30 +1,105 @@
+require('whatwg-fetch');
+
 /**
  * ApiClient class to make calls to different services.
  * This could eventually be a class that other classes more
  * specific to certain endpoints extend and define the url
  * request structure on their own so it can accommodate
- * various endpoint URL structures.
+ * various endpoint URL structures... a boy can dream.
  * For example: class PhoenixApiClient extends ApiClient { .. }
  */
 class ApiClient {
 
-  constructor(host, version, port = '') {
-    console.log(host);
-    console.log(version);
-    console.log(port);
-    this.api = {
-      host,
-      port,
-      version
-    };
-
-    // this.api.port = port;
-    // this.api.verstion = version;
-    // this.api.url = `http://${this.api.host}${this.api.port}${this.api.version}`;
+  // @TODO: potentially reconsider order of params...
+  // might be best to use default host = window.location.hostname
+  constructor(host, version, port = null) {
+    this.host = host;
+    this.port = port === '' ? null : port;
+    this.version = version;
+    this.url = `//${this.host}${this.port ? ':' + this.port : ''}${this.version}`;
   }
 
-  request(endpoint) {
-    return 'hello';
+  /**
+   * Check the HTTP status of API response.
+   *
+   * @param  {Object} response
+   * @return {Object}
+   * @throws {Object}
+   */
+  checkStatus(response) {
+    if (response.status >= 200 && response.status < 300) {
+      return response;
+    } else {
+      const error = new Error(response.statusText);
+
+      error.response = response;
+
+      throw error;
+    }
+  }
+
+  /**
+   * Convert object with query parameters into string.
+   *
+   * @param  {Object} query
+   * @return {String}
+   */
+  stringifyQuery(query = {}) {
+    let urlParams = [];
+
+    Object.keys(query).forEach((key) => {
+      urlParams.push(`${encodeURIComponent(key)}=${encodeURIComponent(query[key])}`);
+    });
+
+    if (urlParams.length === 0) {
+      return '';
+    }
+
+    return `?${urlParams.join('&')}`;
+  }
+
+  /**
+   * Return the JSON data from API response.
+   *
+   * @param  {Object} response
+   * @return {Object}
+   */
+  parseJson(response) {
+    return response.json();
+  }
+
+  /**
+   * Send a GET request to the given path URI.
+   *
+   * @param  {String} path
+   * @param  {Object} query
+   * @return {Object}
+   */
+  get(path, query = {}) {
+    const url = `${this.url}${path}${this.stringifyQuery(query)}`;
+
+    console.log(url);
+
+    fetch(url)
+      .then(this.checkStatus)
+      .then(this.parseJson)
+      .then(function(data) {
+        console.log(data);
+      }).catch(function(data) {
+        console.log('um, there was an error');
+      });
+  }
+
+  /**
+   * Send a POST request to the given path URI.
+   * @param  {String} path
+   * @param  {Object} query
+   * @return {Object}
+   *
+   * @TODO: More to come; build out later!
+   */
+  post(path, query = {}) {
+    return 'hello, and thanks for POSTing!';
   }
 
 }

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/ApiClient.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/ApiClient.js
@@ -79,8 +79,6 @@ class ApiClient {
   get(path, query = {}, callback) {
     const url = `${this.url}${path}${this.stringifyQuery(query)}`;
 
-    console.log(url);
-
     fetch(url)
       .then(this.checkStatus)
       .then(this.parseJson)

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/ApiClient.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/ApiClient.js
@@ -9,13 +9,10 @@ require('whatwg-fetch');
  * For example: class PhoenixApiClient extends ApiClient { .. }
  */
 class ApiClient {
-
-  // @TODO: potentially reconsider order of params...
-  // might be best to use default host = window.location.hostname
-  constructor(host, version, port = null) {
+  constructor(version, host = window.location.hostname, port = window.location.port) {
     this.host = host;
     this.port = port === '' ? null : port;
-    this.version = version;
+    this.version = `/api/${version}/`;
     this.url = `//${this.host}${this.port ? ':' + this.port : ''}${this.version}`;
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/ApiClient.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/ApiClient.js
@@ -73,9 +73,10 @@ class ApiClient {
    *
    * @param  {String} path
    * @param  {Object} query
+   * @param  {Function} callback
    * @return {Object}
    */
-  get(path, query = {}) {
+  get(path, query = {}, callback) {
     const url = `${this.url}${path}${this.stringifyQuery(query)}`;
 
     console.log(url);
@@ -84,9 +85,9 @@ class ApiClient {
       .then(this.checkStatus)
       .then(this.parseJson)
       .then(function(data) {
-        console.log(data);
+        return callback(data);
       }).catch(function(data) {
-        console.log('um, there was an error');
+        console.log('um, there was an error! handle that shizzzzz!');
       });
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -34,7 +34,8 @@
     "react-addons-css-transition-group": "^15.3.0",
     "react-dom": "^15.3.0",
     "respond.js": "~1.4.2",
-    "unveil": "DFurnes/unveil.git#umd"
+    "unveil": "DFurnes/unveil.git#umd",
+    "whatwg-fetch": "^1.0.0"
   },
   "devDependencies": {
     "@dosomething/eslint-config": "^1.1.1",

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
@@ -13,9 +13,15 @@
   // @TODO: Also, the aspect ratio for the video used on onboarding
   // varies from the typical videos on the website so we need to modify
   // the % padding value. Might be useful to turn into a mixin in the future.
-  & .media-video {
+  .media-video {
     border-radius: 4px;
     padding-bottom: 60.4%;
+  }
+
+  // @TODO: convert this to an extension of the card pattern.
+  .photo {
+    border-radius: 4px;
+    color: #444;
   }
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/webpack.config.js
+++ b/lib/themes/dosomething/paraneue_dosomething/webpack.config.js
@@ -3,7 +3,7 @@ var buildConfig = require('@dosomething/webpack-config');
 
 var config = buildConfig({
   entry: {
-    app: ['babel-polyfill', './js/app.js'],
+    app: ['babel-polyfill', 'whatwg-fetch', './js/app.js'],
     lib: './js/lib.js',
     onboarding: './js/onboarding.js',
   },


### PR DESCRIPTION
#### What's this PR do?

This PR adds a new `ApiClient` class to help remove the need to duplicate A LOT of API related code, and universalize how we do API calls to our services 🎉, based on a couple conversations that @DFurnes and I had as we saw how we're doing more API calls in JS and none of them are standardized/repeating code. This leads to more bugs instead of having a single class with sole purpose to handle API calls.

Currently the API calls only apply to Phoenix, but can eventually be made to apply to our other services. It uses the `whatwg-fetch` library recommended by @DFurnes which is super easy to use and use the modern approach to making API calls on the web with JS Promises.

This PR also includes a new `ReportbackItem` component that we can ideally have handle all representations of a Reportback Items across the site. It is used specifically for Slide 3 of the Onboarding feature, which is also built out in this PR.

<img width="1438" alt="screen shot 2016-08-18 at 3 45 30 pm" src="https://cloud.githubusercontent.com/assets/105849/17788699/fbec93b6-655c-11e6-9d4b-e562426bc51b.png">
#### How should this be reviewed?

Download the code and run it. Make sure the other slides in Onboarding didn't break, and then check the 3rd slide to see that all looks as expected.
#### Any background context you want to provide?

The ReportbackItems outputted in Slide 3 do not include Reactions on them. The data is available and can be easily output, but I need to add a `post()` method to the `ApiClient` class to support registering these reactions. That is next on my list.

The way the RB items are retrieved, in this PR but will be updated soon. It grabs 4 RB items for specified campaign from promoted or approved RBs and does so at random.
#### Relevant tickets

Refs #6666
#### Checklist
- [ ] Tested on staging.

---

@deadlybutter @DFurnes 

cc: @jessleenyc 
