### PR TITLE
Campaign template updates

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_base.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_base.inc
@@ -71,6 +71,7 @@ function dosomething_campaign_field_default_field_bases() {
     'module' => 'list',
     'settings' => array(
       'allowed_values' => array(
+        '0.1' => 'instant',
         '0.5' => 0.5,
         1 => 1,
         2 => 2,

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.features.field_instance.inc
@@ -3179,12 +3179,13 @@ function dosomething_campaign_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-campaign-title_field'
+  // Exported field_instance: 'node-campaign-title_field'.
   $field_instances['node-campaign-title_field'] = array(
     'bundle' => 'campaign',
     'default_value' => NULL,
     'deleted' => 0,
-    'description' => '',
+    'description' => ' i.e. "Protect your Pills", "Birthday Mail", or "Teens for Jeans" <b> Limit: 20 characters. </b> <br/>
+The title determines the URL of the page. This means that if you are changing the title on an already published page, the URL of the page will change too. If you need to update the title, you <b>must request a redirect </b> from the Product Team.',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -3233,6 +3234,8 @@ function dosomething_campaign_field_default_field_instances() {
   t(' Any tips for what the user should do after the action is finished. "Thank everyone who helped you put on the drive with a handwritten note."
 <br/>
 <strong> Limit: 135 characters </strong>');
+  t(' i.e. "Protect your Pills", "Birthday Mail", or "Teens for Jeans" <b> Limit: 20 characters. </b> <br/>
+The title determines the URL of the page. This means that if you are changing the title on an already published page, the URL of the page will change too. If you need to update the title, you <b>must request a redirect </b> from the Product Team.');
   t('Action Guide');
   t('Action Type');
   t('Active Hours');

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -21,7 +21,6 @@ define('DOSOMETHING_CAMPAIGN_PIC_STEP_HEADER', t('Snap a Pic'));
  */
 function dosomething_campaign_form_campaign_node_form_alter(&$form, &$form_state, $form_id) {
   unset($form['field_active_hours'][LANGUAGE_NONE]['#options']['_none']);
-  $form['title']['#description'] = t('Title - i.e. "Protect your Pills", "Birthday Mail", or "Teens for Jeans" <br/><strong> Limit: 20 characters. </strong>');
   // Add in campaign close info.
   dosomething_campaign_run_add_campaign_run_info($form, $form_state);
   // Use #after_build to add JS even on validation errors: https://drupal.org/node/1253520#comment-4881588


### PR DESCRIPTION
#### What's this PR do?
- Adds option for `instant` campaigns (new time in the active hours field)
- Updates the title help text. 
#### How should this be reviewed?

👀 
#### Relevant tickets

Fixes #6825
Fixes #6876
#### Checklist
- [x] Tested on staging.
