### PR TITLE
A tool to change user registration source to niche for specific users.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.drush.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.drush.inc
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @file
+ * Drush commands for dosomething_global.module.
+ */
+
+/**
+ *  Implements hook_drush_command
+ */
+function dosomething_user_drush_command() {
+  return [
+    'ds-user-niche-reg-source-fix' => [
+      'description' => 'Corrects user registration source to niche based on csv.',
+    ],
+  ];
+}
+
+/**
+ * Temporrary function to change user reg source of specific user subset.
+ *
+ * See https://github.com/DoSomething/devops/issues/176.
+ */
+function drush_dosomething_global_ds_user_niche_reg_source_fix() {
+  $ids = [2, 3, 4, 5, 6, 7, 8, 9, 10, 1700784, 7777777777];
+
+  $users = user_load_multiple($ids);
+  $count_total = count($users);
+  $count_current = 0;
+  foreach ($users as $user) {
+    $count_current++;
+    $metauser = entity_metadata_wrapper('user', $user);
+    $source = $metauser->field_user_registration_source->value();
+    if (!empty($source)) {
+      drush_log(
+        'Skipping "' . $user->mail . '" as it has source "' . $source . '".',
+        'status'
+      );
+      continue;
+    }
+    drush_log(
+      'Processing user for ' . $count_current .
+      ' of ' . $count_total . ' users: ' . $user->mail . ', id ' . $user->uid . '.',
+      'status'
+    );
+
+    $metauser->field_user_registration_source->set('niche');
+    $metauser->save();
+  }
+}

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.drush.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.drush.inc
@@ -11,6 +11,10 @@ function dosomething_user_drush_command() {
   return [
     'ds-user-niche-reg-source-fix' => [
       'description' => 'Corrects user registration source to niche based on csv.',
+      'arguments' => array(
+        'filename' => 'Name of the CSV file to read.',
+      ),
+      'required-arguments' => TRUE,
     ],
   ];
 }
@@ -20,12 +24,41 @@ function dosomething_user_drush_command() {
  *
  * See https://github.com/DoSomething/devops/issues/176.
  */
-function drush_dosomething_global_ds_user_niche_reg_source_fix() {
-  $ids = [2, 3, 4, 5, 6, 7, 8, 9, 10, 1700784, 7777777777];
+function drush_dosomething_global_ds_user_niche_reg_source_fix($filename) {
+  // Only local files.
+  $filename = 'file://' . $filename;
+  if (($handle = fopen($filename, "r")) === FALSE) {
+    drush_log(
+      'Can\'t  open file: ' . $filename . '.',
+      'status'
+    );
+    return;
+  }
+  drush_log('Parsing ' . $filename, 'status');
 
+  // Prepare a list of ids.
+  $row = 0;
+  $ids = [];
+  while(($data = fgetcsv($handle)) !== FALSE) {
+    $row++;
+    // Skip header.
+    if ($row === 1) {
+      continue;
+    }
+    if (empty($data[2])) {
+      continue;
+    }
+    array_push($ids, $data[2]);
+  }
+
+  // Processing users.
   $users = user_load_multiple($ids);
   $count_total = count($users);
   $count_current = 0;
+  drush_log(
+    'Processing ' . $count_current . ' records.', 'status'
+  );
+
   foreach ($users as $user) {
     $count_current++;
     $metauser = entity_metadata_wrapper('user', $user);


### PR DESCRIPTION
#### What's this PR do?

Niche users signed up between `Aug 11, 2016, 9:01 PM GMT+3` to `Aug 12, 2016, 7:16 PM GMT+3` do not have `field_user_registration_source_value` = `niche`. This PR provides a tool to change user registration source to niche for specific users.
#### How should this be reviewed?
- Copy csv file from DoSomething/devops#176 to Phoenix folder.
- Adjust few uids in the last column of csv to correspond to staging user ids
- `drush ds-user-niche-reg-source-fix /var/www/dev.dosomething.org/Niche-No-Source.csv`
- Ensure this users have `field_user_registration_source_value` set to `niche`
#### Relevant tickets

Fixes DoSomething/devops#176
#### Checklist
- [x] Tested on thor
- [x] Run on production
- [x] Remove this code

cc @mikefantini @justkika @jamjensen @mshmsh5000 
