### PR TITLE
Adds more onboarding options

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -323,10 +323,6 @@ function dosomething_campaign_admin_custom_settings_page($node) {
   $third_party_form = drupal_get_form($form_id, $node);
   $output .= render($third_party_form);
 
-  $form_id = 'dosomething_campaign_onboarding_config_form';
-  $onboarding_config_form = drupal_get_form($form_id, $node);
-  $output .= render($onboarding_config_form);
-
   if (module_exists('dosomething_signup')) {
     $signup_data_config_form = drupal_get_form('dosomething_signup_node_signup_data_form', $node);
     $output .= render($signup_data_config_form);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -89,6 +89,13 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#default_value' => variable_get('dosomething_campaign_enable_onboarding'),
   );
 
+  $form['campaign']['action_page']['dosomething_campaign_onboarding_developer_mode'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Onboarding developer mode'),
+    '#description' => t('Obviously don\'t enable this on prod'),
+    '#default_value' => variable_get('dosomething_campaign_onboarding_developer_mode'),
+  ];
+
   $form['campaign']['action_page']['dosomething_campaign_onboarding_context_slide'] = [
     '#type' => 'checkbox',
     '#title' => t('Display Context Slide'),
@@ -315,6 +322,10 @@ function dosomething_campaign_admin_custom_settings_page($node) {
   $form_id = 'dosomething_helpers_third_party_variable_form';
   $third_party_form = drupal_get_form($form_id, $node);
   $output .= render($third_party_form);
+
+  $form_id = 'dosomething_campaign_onboarding_config_form';
+  $onboarding_config_form = drupal_get_form($form_id, $node);
+  $output .= render($onboarding_config_form);
 
   if (module_exists('dosomething_signup')) {
     $signup_data_config_form = drupal_get_form('dosomething_signup_node_signup_data_form', $node);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -72,7 +72,7 @@ function dosomething_campaign_preprocess_node(&$vars) {
   }
 
   // Include the JS for Onboarding.
-  dosomething_helpers_add_js_onboarding();
+  dosomething_helpers_add_js_onboarding($node->nid);
 
   // Preprocess the vars for the campaign action page.
   dosomething_campaign_preprocess_action_page($vars, $wrapper);

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -305,12 +305,12 @@ function dosomething_helpers_add_js_campaign_and_user_data($vars) {
  * @return void
  */
 function dosomething_helpers_add_js_onboarding($nid) {
-  $global_enable = variable_get('dosomething_campaign_enable_onboarding', FALSE);
-  $developer_enable = variable_get('dosomething_campaign_onboarding_developer_mode', FALSE);
-  $campaign_enable = !dosomething_helpers_get_variable('node', $nid, 'disable_onboarding');
+  $onboarding_enabled = variable_get('dosomething_campaign_enable_onboarding', FALSE);
+  $developer_mode_enabled = variable_get('dosomething_campaign_onboarding_developer_mode', FALSE);
+  $campaign_enabled = !dosomething_helpers_get_variable('node', $nid, 'disable_onboarding');
 
   // @Temporary: add onboarding.js with Onboarding experiment.
-  if ($developer_enable || ($global_enable && $campaign_enable)) {
+  if ($developer_mode_enabled || ($onboarding_enabled && $campaign_enabled)) {
     drupal_add_js(PARANEUE_PATH . '/dist/onboarding.js', [
       'group'      => JS_THEME,
       'weight'     => 1000,
@@ -319,9 +319,9 @@ function dosomething_helpers_add_js_onboarding($nid) {
     ]);
 
     $onboardingSettings = [
-      'globalEnable' => $global_enable,
-      'campaignEnable' => $campaign_enable,
-      'developerEnable' => $developer_enable,
+      'globalEnabled' => $onboarding_enabled,
+      'campaignEnabled' => $campaign_enabled,
+      'developerEnabled' => $developer_mode_enabled,
       'slides' => [],
     ];
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -305,12 +305,12 @@ function dosomething_helpers_add_js_campaign_and_user_data($vars) {
  * @return void
  */
 function dosomething_helpers_add_js_onboarding($nid) {
-  $globalEnable = variable_get('dosomething_campaign_enable_onboarding', FALSE);
-  $developerEnable = variable_get('dosomething_campaign_onboarding_developer_mode', FALSE);
-  $campaignEnable = !dosomething_helpers_get_variable('node', $nid, 'disable_onboarding');
+  $global_enable = variable_get('dosomething_campaign_enable_onboarding', FALSE);
+  $developer_enable = variable_get('dosomething_campaign_onboarding_developer_mode', FALSE);
+  $campaign_enable = !dosomething_helpers_get_variable('node', $nid, 'disable_onboarding');
 
   // @Temporary: add onboarding.js with Onboarding experiment.
-  if ($developerEnable || ($globalEnable && $campaignEnable)) {
+  if ($developer_enable || ($global_enable && $campaign_enable)) {
     drupal_add_js(PARANEUE_PATH . '/dist/onboarding.js', [
       'group'      => JS_THEME,
       'weight'     => 1000,
@@ -319,9 +319,9 @@ function dosomething_helpers_add_js_onboarding($nid) {
     ]);
 
     $onboardingSettings = [
-      'globalEnable' => $globalEnable,
-      'campaignEnable' => $campaignEnable,
-      'developerEnable' => $developerEnable,
+      'globalEnable' => $global_enable,
+      'campaignEnable' => $campaign_enable,
+      'developerEnable' => $developer_enable,
       'slides' => [],
     ];
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -319,9 +319,9 @@ function dosomething_helpers_add_js_onboarding($nid) {
     ]);
 
     $onboardingSettings = [
-      'globalEnabled' => $onboarding_enabled,
+      'onboardingEnabled' => $onboarding_enabled,
       'campaignEnabled' => $campaign_enabled,
-      'developerEnabled' => $developer_mode_enabled,
+      'developerModeEnabled' => $developer_mode_enabled,
       'slides' => [],
     ];
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.theme.inc
@@ -304,9 +304,13 @@ function dosomething_helpers_add_js_campaign_and_user_data($vars) {
  *
  * @return void
  */
-function dosomething_helpers_add_js_onboarding() {
+function dosomething_helpers_add_js_onboarding($nid) {
+  $globalEnable = variable_get('dosomething_campaign_enable_onboarding', FALSE);
+  $developerEnable = variable_get('dosomething_campaign_onboarding_developer_mode', FALSE);
+  $campaignEnable = !dosomething_helpers_get_variable('node', $nid, 'disable_onboarding');
+
   // @Temporary: add onboarding.js with Onboarding experiment.
-  if (variable_get('dosomething_campaign_enable_onboarding', FALSE)) {
+  if ($developerEnable || ($globalEnable && $campaignEnable)) {
     drupal_add_js(PARANEUE_PATH . '/dist/onboarding.js', [
       'group'      => JS_THEME,
       'weight'     => 1000,
@@ -315,8 +319,10 @@ function dosomething_helpers_add_js_onboarding() {
     ]);
 
     $onboardingSettings = [
-        'enabled' => true,
-        'slides' => [],
+      'globalEnable' => $globalEnable,
+      'campaignEnable' => $campaignEnable,
+      'developerEnable' => $developerEnable,
+      'slides' => [],
     ];
 
     if (variable_get('dosomething_campaign_onboarding_context_slide', FALSE)) {

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -171,11 +171,12 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
       'maxlength' => '140',
     ),
   ];
+
   $form['voter_registration'] = [
-  '#type' => 'fieldset',
-  '#title' => t('Rock the Vote Registration'),
-  '#collapsible' => TRUE,
-  '#collapsed' => TRUE,
+    '#type' => 'fieldset',
+    '#title' => t('Rock the Vote Registration'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
   ];
   $form['voter_registration']['enable_voter_registration'] = [
     '#type' => 'textfield',
@@ -183,6 +184,19 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     '#title' => t('Enable Voter Registration'),
     '#description' => t(''),
     '#default_value' => $vars['enable_voter_registration'],
+  ];
+
+  $form['onboarding'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Onboarding'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  ];
+  $form['onboarding']['disable_onboarding'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Disable onboarding'),
+    '#description' => t('Suggested for campaigns with irregular signup process like voter reg.'),
+    '#default_value' => $vars['disable_onboarding']
   ];
 
   $form['actions'] = array(
@@ -241,6 +255,7 @@ function dosomething_helpers_get_variable_names() {
     'count_flagged',
     'count_pending',
     'count_promoted',
+    'disable_onboarding',
     'enable_voter_registration',
     'magic_link_copy',
     'mobilecommons_opt_in_path',

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -27,9 +27,9 @@ function getLocalStorageKey(user, campaign) {
 }
 
 function shouldOnboardingBeEnabled(localStorageKey) {
-  const developerEnabled = setting('dsOnboarding.developerEnable', false);
-  const moduleEnabled = setting('dsOnboarding.globalEnable', false);
-  const campaignEnabled = setting('dsOnboarding.campaignEnable', false);
+  const developerEnabled = setting('dsOnboarding.developerEnabled', false);
+  const moduleEnabled = setting('dsOnboarding.globalEnabled', false);
+  const campaignEnabled = setting('dsOnboarding.campaignEnabled', false);
 
   if (developerEnabled) {
     return true;

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -26,6 +26,22 @@ function getLocalStorageKey(user, campaign) {
   return key;
 }
 
+function shouldOnboardingBeEnabled(localStorageKey) {
+  const developerEnabled = setting('dsOnboarding.developerEnable', false);
+  const moduleEnabled = setting('dsOnboarding.globalEnable', false);
+  const campaignEnabled = setting('dsOnboarding.campaignEnable', false);
+
+  if (developerEnabled) {
+    return true;
+  }
+
+  if (moduleEnabled && campaignEnabled) {
+    return localStorage.getItem(localStorageKey) !== 'true';
+  }
+
+  return false
+}
+
 /**
  * Enable the Onboarding experience based on certain conditions.
  *
@@ -65,7 +81,7 @@ $(document).ready(function() {
   if (isOutsideUnitedStates || Modal.isOpen()) {
     return;
   }
-  else if (Drupal.settings.dsOnboarding.enabled && localStorage.getItem(localStorageKey) !== 'true') {
+  else if (shouldOnboardingBeEnabled(localStorageKey)) {
     enableOnboarding(localStorageKey, user, campaign);
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/onboarding.js
@@ -27,8 +27,8 @@ function getLocalStorageKey(user, campaign) {
 }
 
 function shouldOnboardingBeEnabled(localStorageKey) {
-  const developerEnabled = setting('dsOnboarding.developerEnabled', false);
-  const moduleEnabled = setting('dsOnboarding.globalEnabled', false);
+  const developerEnabled = setting('dsOnboarding.developerModeEnabled', false);
+  const moduleEnabled = setting('dsOnboarding.onboardingEnabled', false);
   const campaignEnabled = setting('dsOnboarding.campaignEnabled', false);
 
   if (developerEnabled) {


### PR DESCRIPTION
#### What's this PR do?
- Adds a developer override mode. This is because we're constantly clearing local storage & commenting out code when developing so we can refresh our changes.
- Adds a per campaign disable option. This is for vcard and other campaigns in the future which have a more in depth signup process. 
#### How should this be reviewed?

If you enable onboarding dev, does on boarding show up every time?
If you disable ^, then disable onboarding, does onboard show up?
If you enable onboarding, then disable it on a campaign, does it show up?
If you enable it on the campaign, does it show up?
#### Any background context you want to provide?

Everything is described above I think
#### Relevant tickets

Fixes #6817 
#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
