### PR TITLE
fix signup source from social share

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -418,6 +418,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
 
   // Pass custom share links to the front end. Unique by UID.
   $base_url = url(base_path(), array('absolute'=> TRUE, 'language' => 'en-global'));
+  $campaign_path = url(current_path(), array('absolute' => TRUE));
   $country_prefix_for_share = (dosomething_global_get_current_prefix()) ? strtoupper(dosomething_global_get_current_prefix()) : 'global';
   $share_image = $base_url . 'sites/default/files/images/problem-' . $campaign->nid . '-' . $country_prefix_for_share . '.png';
 
@@ -439,7 +440,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     ),
   );
 
-  $share_button_markup = dosomething_helpers_share_bar($custom_social_share_link, $social_share_types, $campaign->nid . '_referral', 'social-menu');
+  $share_button_markup = dosomething_helpers_share_bar($campaign_path, $social_share_types, $campaign->nid . '_referral', 'social-menu', $share_path);
 
   $vars['social_share_bar'] = $share_button_markup;
   $vars['custom_social_share_link'] = $custom_social_share_link;

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -110,7 +110,6 @@ function dosomething_helpers_utm_share_paths($share_types, $path, $utm_campaign,
         'utm_campaign' => $utm_campaign,
       )
     );
-
     $share_paths[$type] = $path . $utm_params;
 
     // Append the custom share source to the URL if we have one

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -100,7 +100,7 @@ function dosomething_helpers_get_tumblr_intent($path, $options) {
  * @return
  *   An array of paths, indexed by type.
  */
-function dosomething_helpers_utm_share_paths($share_types, $path, $utm_campaign) {
+function dosomething_helpers_utm_share_paths($share_types, $path, $utm_campaign, $custom_share_source = NULL) {
   foreach ($share_types as $type => $options) {
     $utm_params = dosomething_helpers_utm_parameters(NULL,
       array(
@@ -108,7 +108,13 @@ function dosomething_helpers_utm_share_paths($share_types, $path, $utm_campaign)
         'utm_campaign' => $utm_campaign,
       )
     );
+
     $share_paths[$type] = $path . $utm_params;
+
+    // Append the custom share source to the URL if we have one
+    if ($custom_share_source) {
+      $share_paths[$type] .= '&source=' . $custom_share_source;
+    }
   }
 
   return $share_paths;
@@ -124,11 +130,14 @@ function dosomething_helpers_utm_share_paths($share_types, $path, $utm_campaign)
  *     including the relevant parameters needed to create the custom intents.
  * @param string $share_description
  *   A custom value to use for 'utm_campaign'.
+ * @param string $custom_share_source
+ *   If included, the custom share source to be included in the url
  * @return string
  *   Share bar markup.
  */
-function dosomething_helpers_share_bar($path, $share_types, $share_description, $classes = NULL) {
-  $share_utm_paths = dosomething_helpers_utm_share_paths($share_types, $path, $share_description);
+function dosomething_helpers_share_bar($path, $share_types, $share_description, $classes = NULL, $custom_share_source = NULL) {
+  $share_utm_paths = dosomething_helpers_utm_share_paths($share_types, $path, $share_description, $custom_share_source);
+
   $share_bar = '<ul class="' . $classes . '">';
   $share_intents = [];
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -97,6 +97,8 @@ function dosomething_helpers_get_tumblr_intent($path, $options) {
  *   The absolute path of the page being shared.
  * @param string $utm_campaign
  *   A custom value to use for 'utm_campaign'.
+ * @param string $custom_share_source
+ *   A custom value to use for 'source'.
  * @return
  *   An array of paths, indexed by type.
  */

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -421,6 +421,7 @@
             <h3>Share this Campaign</h3><br>
             <p>Copy and paste your share link:</p>
             <code><?php print $custom_social_share_link ?></code>
+            <?php print $social_share_bar ?>
           </div>
         </div>
        <?php endif; ?>


### PR DESCRIPTION
#### What's this PR do?

Previously, when building social share buttons to link to the campaign with the custom social share source parameter, the link was built incorrectly. When we added other utm parameters associated with social shares, we assumed there were no other parameters and tacked on a `?` to the url regardless of if we already had one or not, which meant that gobbledigook was getting saved in the source column. NOW we give the function that adds the utm parameters the raw campaign link and tack on the custom source after the utm parameters if there is one, which saves everything correctly.
#### How should this be reviewed?

👀 To test, make sure the regular problem share links work as expected. The social share buttons are added to the custom share link modal, so those can be tested from there.
#### Relevant tickets

Fixes #6891
#### Checklist
- [ ] Tested on staging.
