### PR TITLE
add textarea field to voter reg custom setting

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -454,6 +454,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     $election_day_age = dosomething_user_age_on_date('Nov 8 2016');
     $vars['can_vote'] = (!($election_day_age < 18)) ? true : false;
     $vars['voter_reg_form'] = '<iframe src="https://register2.rockthevote.com/registrants/map/?source=iframe&partner=35164" width="100%" height="1000" marginheight="0" frameborder="0"></iframe>';
+    $vars['voter_reg_form_copy'] = $campaign->variables['registration_form_copy'];
   }
 }
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -185,6 +185,12 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     '#description' => t(''),
     '#default_value' => $vars['enable_voter_registration'],
   ];
+  $form['voter_registration']['registration_form_copy'] = [
+    '#type' => 'textarea',
+    '#title' => t('Registration Form Copy'),
+    '#description' => t('The text that will appear above the voter registration form.'),
+    '#default_value' => $vars['registration_form_copy'],
+  ];
 
   $form['onboarding'] = [
     '#type' => 'fieldset',
@@ -261,6 +267,7 @@ function dosomething_helpers_get_variable_names() {
     'mobilecommons_opt_in_path',
     'mobilecommons_friends_opt_in_path',
     'progress',
+    'registration_form_copy',
     'shipment_form_confirm_msg',
     'shipment_form_copy',
     'shipment_form_header',

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -405,11 +405,11 @@
         <?php // Voter Registration Modal // ?>
         <?php if ($register_voters) : ?>
           <div data-modal id="modal-voter-registration" role="dialog">
-            <?php print $voter_reg_form ?>
             <div class="modal__block">
-              <p>Copy and paste your share link:</p>
+              <?php print $voter_reg_form_copy ?>
               <code><?php print $custom_social_share_link ?></code>
             </div>
+            <?php print $voter_reg_form ?>
           </div>
        <?php endif; ?>
 


### PR DESCRIPTION
#### What's this PR do?

Added a textarea form field to the voter reg custom setting. The text gets passed along to the template and included above the voter reg form with the custom social share link.
#### How should this be reviewed?

To test, fill out the field (using html!!) and make sure it shows up above the form as expected. Clear it and make sure nothing crashes when there's nothing in there.
#### Any background context you want to provide?

This feature was wanted so that admins can include notes about registration deadlines and keep altering the text based on which ones have passed/are coming up/etc.
#### Relevant tickets

Fixes #6903
#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love. @ngjo 👋 
