### PR TITLE
put new custom link social share buttons wherever the link is

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -230,6 +230,7 @@
             <div class="modal__block">
               <p>Copy and paste your share link:</p>
               <code><?php print $custom_social_share_link ?></code>
+              <?php print $social_share_bar ?>
             </div>
           <?php endif; ?>
           <?php if (isset($skip_signup_data_form)): ?>
@@ -408,6 +409,7 @@
             <div class="modal__block">
               <?php print $voter_reg_form_copy ?>
               <code><?php print $custom_social_share_link ?></code>
+              <?php print $social_share_bar ?>
             </div>
             <?php print $voter_reg_form ?>
           </div>


### PR DESCRIPTION
#### What's this PR do?

Added the new custom social share buttons to the other places where we have the custom social link itself.
#### How should this be reviewed?

The buttons should show up:
- in signup form modal when custom link and voter reg are on
- in voter reg modal
- in custom share modal when custom link and voter reg are on
#### Relevant tickets

Fixes #6907
#### Checklist
- [ ] Tested on staging.
