### PR TITLE
Only display the competition modal for US

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -681,7 +681,7 @@ function dosomething_campaign_node_view($node, $view_mode, $langcode) {
     }
 
     // Add signup_data_form variables if needed.
-    dosomething_campaign_add_signup_data_form_vars($node);
+    dosomething_campaign_add_signup_data_form_vars($node, $langcode);
 
     // Flag if we need to register an organ donor on the page.
     if (module_exists('dosomething_organ_donation')) {
@@ -715,9 +715,15 @@ function dosomething_campaign_node_view($node, $view_mode, $langcode) {
 /**
  * Adds relevant signup_data_form variables into the $node.
  */
-function dosomething_campaign_add_signup_data_form_vars(&$node) {
+function dosomething_campaign_add_signup_data_form_vars(&$node, $langcode) {
   // Load signup_data_form configuration data.
   $config = dosomething_signup_get_signup_data_form_info($node->nid);
+
+  // Don't serve competitions for non EN users
+  if ($langcode != 'en' && $config['competition_signup']) {
+    return;
+  }
+
   // If it doesn't exist, or is not active.
   if (!$config || $config['status'] != 1) {
     // Nothing to see here.


### PR DESCRIPTION
#### What's this PR do?

Displays the competition modal for US users only
#### How should this be reviewed?

Test the competition flow for both US + MX, BR, ETC

Heres what it looks like on BR
![6849-1](https://cloud.githubusercontent.com/assets/897368/17869433/376e67f8-6881-11e6-815d-56382df27b02.gif)

Heres what it looks like on the same campaign but for US
![6849-2](https://cloud.githubusercontent.com/assets/897368/17869439/3d936b88-6881-11e6-9a5d-3294756517d3.gif)
#### Any background context you want to provide?

Nope!
#### Relevant tickets

Fixes #6849 
#### Checklist
- [ ] Tested on staging.
