### PR TITLE
Most recent photo in user profile

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc
@@ -31,7 +31,8 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
     foreach ($reportbacks as $delta => $rbid) {
       $reportback = reportback_load((int) $rbid);
       $impact = $reportback->quantity . ' ' . $reportback->noun . ' ' . $reportback->verb;
-      $fid = $reportback->fids[0];
+      $fid_index = count($reportback->fids) - 1;
+      $fid = $reportback->fids[$fid_index];
       if (user_access('view any reportback')) {
         // Link to the full reportback entity view.
         $impact = l($impact, 'admin/reportback/' . $rbid);

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc
@@ -31,8 +31,7 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
     foreach ($reportbacks as $delta => $rbid) {
       $reportback = reportback_load((int) $rbid);
       $impact = $reportback->quantity . ' ' . $reportback->noun . ' ' . $reportback->verb;
-      $fid_index = count($reportback->fids) - 1;
-      $fid = $reportback->fids[$fid_index];
+      $fid = end($reportback->fids);
       if (user_access('view any reportback')) {
         // Link to the full reportback entity view.
         $impact = l($impact, 'admin/reportback/' . $rbid);


### PR DESCRIPTION
#### What's this PR do?

Display the most recent reportback photo in the user profile instead of the first 
#### How should this be reviewed?

Add some reportback photos and check the most recent

This was the original photo 
![screen shot 2016-08-22 at 4 01 11 pm](https://cloud.githubusercontent.com/assets/897368/17869731/a00850d4-6882-11e6-949e-56e158928962.png)

I then added another
![screen shot 2016-08-22 at 4 05 51 pm](https://cloud.githubusercontent.com/assets/897368/17869735/a3ba15fa-6882-11e6-8e5e-44be66b70a82.png)

And one more to just make sure!
![screen shot 2016-08-22 at 4 06 49 pm](https://cloud.githubusercontent.com/assets/897368/17869746/aa82bc16-6882-11e6-8bcc-04e2434b9afc.png)
#### Any background context you want to provide?

Nope!
#### Relevant tickets

Fixes #6785 
#### Checklist
- [ ] Tested on staging.
