### PR TITLE
Add a check to unset help text from reportback view

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -291,7 +291,7 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     ),
   );
 
-  if (!user_access('edit any reportback')) {
+  if (!user_access('edit any reportback') || !path_is_admin(current_path())) {
     unset($form['reportback_submissions']['reportback_item']['#prefix']);
     unset($form['reportback_submissions']['reportback_item']['#suffix']);
     unset($form['reportback_inputs']['caption']['#description']);


### PR DESCRIPTION
#### What's this PR do?

hide the admin help text from the reportback add page, because it looked so silly. 
so now the help text only shows up on the `admin/add/reportback` form
#### How should this be reviewed?

watch this page go from bland to glam
![image](https://cloud.githubusercontent.com/assets/645205/17871051/e4781b6e-6887-11e6-9bd7-05acabee3416.png)

![image](https://cloud.githubusercontent.com/assets/645205/17871036/da32f98a-6887-11e6-93f0-fc834fd6ab85.png)
#### Relevant tickets

Fixes #6184
