### PR TITLE
Move the uploaded photos out of the giant photo box.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -102,7 +102,7 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
   // Else, it's an update form.
   else {
     // Output reportback images with date last updated.
-    $form['reportback_submissions']['reportback_item']['#attributes']['is_supersized'] = FALSE;
+    $form['reportback_submissions']['reportback_item']['#attributes']['is_supersized'] = TRUE;
 
     // do not require a new image to be uploaded on update
     unset($form['reportback_submissions']['reportback_item']['#attributes']['data-validate']);
@@ -118,14 +118,6 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
 
     $reportback_prior_submissions = array_reverse($reportback_submissions_data);
     $reportback_prior_submissions = array_slice($reportback_prior_submissions, 0, $reportback__submissions_count);
-    $reportback_latest_submission = array_shift($reportback_prior_submissions);
-
-    $form['reportback_submissions']['reportback_latest_submission'] = array(
-      '#weight' => 0,
-      '#markup' => theme('reportback_latest_submission', array(
-        'reportback' => $reportback_latest_submission,
-      )),
-    );
 
     if ($reportback_prior_submissions) {
       $form['reportback_submissions']['reportback_prior_submissions'] = array(


### PR DESCRIPTION
#### What's this PR do?

After you upload a reportback photo it goes down to the bottom, instead of sitting in the 'add a photo' box.
#### How should this be reviewed?

Look at me, living the dream
![image](https://cloud.githubusercontent.com/assets/645205/17871687/a6f67922-688a-11e6-9d70-76b5d4f0ca94.png)
#### Any background context you want to provide?

this will work wonders.
#### Relevant tickets

Fixes #6916
#### Checklist
- [x] Tested on staging.
- [x] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
