### PR TITLE
this <a> wasn't closed

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -223,7 +223,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     // If the campaign is setup to create a custom social share link, get that all setup
     if (dosomething_campaign_feature_on($campaign, 'social_share_unique_link')) {
       $copy = $campaign->variables['social_share_custom_text'] ?: t("Share your link!");
-      $materials['content'] .= '<ul><li><a href="#" data-modal-href="#modal-share"> ' . $copy . '</li></ul>';
+      $materials['content'] .= '<ul><li><a href="#" data-modal-href="#modal-share"> ' . $copy . '</a></li></ul>';
       drupal_add_js(
         array('dosomethingUser' =>
           array('userInfo' =>


### PR DESCRIPTION
#### What's this PR do?

Closed this <a> tag.
#### How should this be reviewed?

👀 
#### Any background context you want to provide?

There is a weird thing happening on thor where when voter reg is enabled, the whole signup modal is a link to the custom social share modal. It is full of 👻  and this is the only place where this modal is referenced as a link as far as I can tell, so hopefully this fixes it.
#### Relevant tickets

Fixes #6928 (hopefully)
#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love. ⬅️  @ngjo 
