### PR TITLE
Reorders the app.js to be higher in the execution order

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/template.php
+++ b/lib/themes/dosomething/paraneue_dosomething/template.php
@@ -68,7 +68,7 @@ function paraneue_dosomething_js_alter(&$js) {
     $inline_settings = [
         'type' => 'inline',
         'group' => JS_LIBRARY,
-        'weight' => 999,
+        'weight' => 100,
         'data' => 'jQuery.extend(Drupal.settings, ' . drupal_json_encode(drupal_array_merge_deep_array($js['settings']['data'])) . ');',
         'every_page' => TRUE,
       ] + drupal_js_defaults();

--- a/lib/themes/dosomething/paraneue_dosomething/template.php
+++ b/lib/themes/dosomething/paraneue_dosomething/template.php
@@ -57,8 +57,8 @@ function paraneue_dosomething_js_alter(&$js) {
   ]);
 
   drupal_add_js(PARANEUE_PATH . '/dist/app.js', [
-    'group'      => JS_THEME,
-    'weight'     => 999,
+    'group'      => JS_LIBRARY,
+    'weight'     => 200,
     'every_page' => TRUE,
     'preprocess' => FALSE,
   ]);


### PR DESCRIPTION
#### What's this PR do?

Moves the app.js higher in the execution order (#3, after lib.js and drupal.js)

![screen shot 2016-08-23 at 12 45 22 pm](https://cloud.githubusercontent.com/assets/897368/17901029/a0904e1e-692f-11e6-8ca8-417f2d82d088.png)
#### How should this be reviewed?

Inspect any page & look at the script tags at the bottom, check the console for any odd errors
#### Any background context you want to provide?

Optimizely executes before the app.js, which I believe is preventing it from seeing onboarding.

![screen shot 2016-08-23 at 12 41 00 pm](https://cloud.githubusercontent.com/assets/897368/17900938/59721292-692f-11e6-9a06-c0786c60f61b.png)

We can't really know for sure if this fixes it until its up, but I think this is the problem
#### Relevant tickets

Fixes #6927 
#### Checklist
- [ ] Tested on staging.
