### PR TITLE
Don't send "@mobile.import" fields to Northstar either.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -240,10 +240,10 @@ function dosomething_northstar_transform_user($user) {
     }
   }
 
-  // If user has a "1234565555@mobile" placeholder email, don't send
-  // that to Northstar (since it will cause a validation error and Northstar
-  // doesn't require every account to have an email like Drupal does).
-  if(preg_match('/^[0-9]+@mobile$/', $northstar_user['email'])) {
+  // If user has a "1234565555@mobile" or "1234565555@mobile.import" placeholder
+  // email address, don't send that field to Northstar (since it's made-up and
+  // Northstar doesn't require every account to have an email like Drupal does).
+  if(preg_match('/^[0-9]+@mobile(\.import)?$/', $northstar_user['email'])) {
     unset($northstar_user['email']);
   }
 


### PR DESCRIPTION
#### What's this PR do?

This PR removes the "email" field from the payload when syncing users with `@mobile.import` email addresses, like we do with `@mobile` emails (to reflect recent change in the "fake" email that Gambit uses when creating Drupal users for MobileCommons reportbacks).
#### How should this be reviewed?

Check out [that regex](https://jex.im/regulex/#!embed=false&flags=&re=%5E%5B0-9%5D%2B%40mobile%28%5C.import%29%3F%24). 
#### Any background context you want to provide?

This wasn't breaking anything, but is fake data that we don't want to have in Northstar.
#### Relevant tickets

References DoSomething/gambit#558.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
