### PR TITLE
adds padded gray box and styles the share link all pretty

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -27,6 +27,7 @@ $asset-path: "";
 @import "patterns/card";
 @import "patterns/counter";
 @import "patterns/gallery";
+@import "patterns/padded-gray-box";
 @import "patterns/photo";
 @import "patterns/promotion";
 @import "patterns/statistic";
@@ -55,3 +56,6 @@ $asset-path: "";
 
 // One-off pages
 @import "content/campaign/hunt-mcc";
+
+// Variables
+$off-white: #f7f7f7;

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -228,9 +228,11 @@
           <?php endif; ?>
           <?php if ($register_voters && dosomething_campaign_feature_on($campaign, 'social_share_unique_link')) : ?>
             <div class="modal__block">
-              <p>Copy and paste your share link:</p>
-              <code><?php print $custom_social_share_link ?></code>
               <?php print $social_share_bar ?>
+              <p>Copy and paste your share link:</p>
+              <div class="padded-gray-box">
+                <?php print $custom_social_share_link ?>
+              </div>
             </div>
           <?php endif; ?>
           <?php if (isset($skip_signup_data_form)): ?>
@@ -410,8 +412,10 @@
           <div data-modal id="modal-voter-registration" role="dialog">
             <div class="modal__block">
               <?php print $voter_reg_form_copy ?>
-              <code><?php print $custom_social_share_link ?></code>
               <?php print $social_share_bar ?>
+              <div class="padded-gray-box">
+                <?php print $custom_social_share_link ?>
+              </div>
             </div>
             <?php print $voter_reg_form ?>
           </div>
@@ -423,9 +427,11 @@
         <div data-modal id="modal-share" role="dialog">
           <div class="modal__block">
             <h3>Share this Campaign</h3><br>
-            <p>Copy and paste your share link:</p>
-            <code><?php print $custom_social_share_link ?></code>
             <?php print $social_share_bar ?>
+            <p>Copy and paste your share link:</p>
+            <div class="padded-gray-box">
+              <?php print $custom_social_share_link ?>
+            </div>
           </div>
         </div>
        <?php endif; ?>
@@ -506,7 +512,9 @@
                   <h3>Share with your friends!</h3>
                   <p><?php print $social_share_bar ?></p>
                   <p>Copy and paste your share link:</p>
-                  <code><?php print $custom_social_share_link ?></code>
+                  <div class="padded-gray-box">
+                    <?php print $custom_social_share_link ?>
+                  </div>
                   <div class="form-item -padded submit-done-container">
                     <input type="submit" class="button js-close-modal" value="Done" />
                   </div>


### PR DESCRIPTION
#### What's this PR do?

Adds a new variable for our favorite lightest gray! Adds a new pattern for the padded gray box! Puts the custom share link in the padded gray box wherever it appears! Puts the social share buttons above the link!
#### How should this be reviewed?

tell us, how can we review, to test that this works

share modal:

![image](https://cloud.githubusercontent.com/assets/4240292/17935856/cc435464-69ea-11e6-878a-6993b3ef32db.png)

voter reg modal:

![image](https://cloud.githubusercontent.com/assets/4240292/17935868/d7d1bc76-69ea-11e6-898c-ef0983569d39.png)

competition modal:

![image](https://cloud.githubusercontent.com/assets/4240292/17935883/edee7c38-69ea-11e6-9038-cf30553ed415.png)
#### Relevant tickets

Fixes #6923
Fixes #6919 
#### Checklist
- [ ] Tested on staging.

cc: @lkpttn @ngjo 
