### PR TITLE
Add even more text to the rb section

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -88,22 +88,23 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     ),
     '#prefix' => 'Reportback Image',
     '#suffix' => 'The image must be at least 480 by 480 pixels. The site will crop the image on its own, so if possible submit a square image with the subject in the center of the crop.',
+    '#children' => t("Add your photo here and we’ll check it out!"),
 
   );
+
+  $form['reportback_submissions']['reportback_item']['#attributes']['is_supersized'] = TRUE;
+
   // If rbid doesn't exist, this is a create form.
   if (!isset($entity->rbid)) {
     $entity->rbid = 0;
 
-    $form['reportback_submissions']['reportback_item']['#attributes']['is_supersized'] = TRUE;
-
     $submit_label = t("Submit your pic");
+
+
   }
 
   // Else, it's an update form.
   else {
-    // Output reportback images with date last updated.
-    $form['reportback_submissions']['reportback_item']['#attributes']['is_supersized'] = TRUE;
-
     // do not require a new image to be uploaded on update
     unset($form['reportback_submissions']['reportback_item']['#attributes']['data-validate']);
 
@@ -130,8 +131,8 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     }
 
     $submit_label = t("Update submission");
+    $form['reportback_submissions']['reportback_item']['#children'] = t("Add another photo and we’ll check it out!");
   }
-
 
   $form['rbid'] = array(
     '#type' => 'hidden',

--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -165,6 +165,7 @@ function paraneue_dosomething_select($variables) {
 function paraneue_dosomething_file($variables) {
   $element = $variables['element'];
   $id = NULL;
+  $label = $element['#children'];
 
   if (isset($element['#id'])) {
     $id = $element['#id'];
@@ -174,14 +175,10 @@ function paraneue_dosomething_file($variables) {
   $element['#attributes']['aria-label'] = 'file browser';
   element_set_attributes($element, array('id', 'name', 'size'));
   _form_set_class($element, array('form-file'));
-
   // Need to include the <input> within <label> to universalize style for file input.
   if ($element['#attributes']['is_supersized']) {
-    $message = '<div class="message-callout -below"><div class="message-callout__copy"><p>' . t("Add your photo here!") . '</p></div></div>';
+    $message = '<div class="message-callout -below"><div class="message-callout__copy"><p>' . $label . '</p></div></div>';
     return '<label class="gigantor" id="' . $id . '">' . $message . '<input' . drupal_attributes($element['#attributes']) . ' /></label>';
-  }
-  else {
-    return '<label class="button button--file -tertiary"><span>' . t('Add another photo') . '</span><input' . drupal_attributes($element['#attributes']) . ' /></label>';
   }
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -13,6 +13,9 @@
 .campaign--action .container--prove {
   .message-callout__copy {
     left: 12px;
+    &:before {
+      left: 250px;
+    }
   }
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
@@ -274,10 +274,10 @@
     left: 50%;
     margin-left: -130px;
     position: absolute;
-    width: 240px;
+    width: 300px;
 
     @include media($medium) {
-      bottom: 25%;
+      bottom: 20%;
     }
   }
 


### PR DESCRIPTION
#### What's this PR do?
- Add text to the reportback image holder to say 'and we'll check it out'
- Refactor how that text is added so we know if it's a new reportback or an updated one.
#### How should this be reviewed?

Take a look at the ~new world~ 
I personally think this looks more crowded/worse than what we used to have. 😢 
_new reportback_
![image](https://cloud.githubusercontent.com/assets/645205/17940624/f3bb4926-69fd-11e6-907f-a5bc85e7cda6.png)

_updating reportback_
![image](https://cloud.githubusercontent.com/assets/645205/17940611/e8943b66-69fd-11e6-90e5-bf1a48378e3f.png)
#### Any background context you want to provide?

The scholarship block was actually quite a bit of refactoring and causing a lot of bugs, I'm wondering if there's a way we can test that in optimizely without writing code to see if it makes a difference? 
#### Relevant tickets

Fixes #6913
#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
