### PR TITLE
Check installed NPM dependencies for local task.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "start": "npm run clean && npm run modernizr && webpack",
+    "start": "check-dependencies & npm run clean && npm run modernizr && webpack",
     "build": "npm run clean && npm run modernizr && NODE_ENV=production webpack",
     "clean": "rm -rf dist",
     "modernizr": "modernizr -c modernizr.json -d dist/modernizr.js",
@@ -43,6 +43,7 @@
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "check-dependencies": "^0.12.3",
     "eslint": "^2.4.0",
     "eslint-plugin-react": "^4.2.3",
     "modernizr": "^3.3.1",


### PR DESCRIPTION
#### What's this PR do?

This PR adds `check-dependencies` to the "start" task used when doing local front-end development. This will check that the locally installed dependencies match what is listed in the project's `package.json`, like so:

![screen shot 2016-08-24 at 2 28 28 pm](https://cloud.githubusercontent.com/assets/583202/17942885/3caa7e6e-6a07-11e6-884c-d1aecbaead97.png)
#### How should this be reviewed?

Check that you can still build. It should holler if you have any out-of-date dependencies.
#### Any background context you want to provide?

🔍 
#### Relevant tickets

Fixes #6499.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
