### PR TITLE
fix up the signup modal for voting

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -222,18 +222,26 @@
       <?php if (isset($signup_data_form)): ?>
         <div data-modal id="modal-signup-data-form" class="modal--signup-data" role="dialog" >
           <?php if ($register_voters && $can_vote) : ?>
-            <?php print $voter_reg_form ?>
-          <?php else: ?>
-            <div><?php print render($signup_data_form); ?></div>
-          <?php endif; ?>
-          <?php if ($register_voters && dosomething_campaign_feature_on($campaign, 'social_share_unique_link')) : ?>
             <div class="modal__block">
+              <?php print $voter_reg_form_copy ?>
               <?php print $social_share_bar ?>
               <p>Copy and paste your share link:</p>
               <div class="padded-gray-box">
                 <?php print $custom_social_share_link ?>
               </div>
             </div>
+            <?php print $voter_reg_form ?>
+          <?php else: ?>
+            <div><?php print render($signup_data_form); ?></div>
+            <?php if ($register_voters && dosomething_campaign_feature_on($campaign, 'social_share_unique_link')) : ?>
+              <div class="modal__block">
+                <p>Copy and paste your share link:</p>
+                <div class="padded-gray-box">
+                  <?php print $custom_social_share_link ?>
+                </div>
+                <?php print $social_share_bar ?>
+              </div>
+            <?php endif; ?>
           <?php endif; ?>
           <?php if (isset($skip_signup_data_form)): ?>
             <div><?php print render($skip_signup_data_form); ?></div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -225,7 +225,7 @@
             <div class="modal__block">
               <?php print $voter_reg_form_copy ?>
               <?php print $social_share_bar ?>
-              <p>Copy and paste your share link:</p>
+              <?php print t('Copy and paste your share link:') ?>
               <div class="padded-gray-box">
                 <?php print $custom_social_share_link ?>
               </div>
@@ -235,7 +235,7 @@
             <div><?php print render($signup_data_form); ?></div>
             <?php if ($register_voters && dosomething_campaign_feature_on($campaign, 'social_share_unique_link')) : ?>
               <div class="modal__block">
-                <p>Copy and paste your share link:</p>
+                <?php print t('Copy and paste your share link:') ?>
                 <div class="padded-gray-box">
                   <?php print $custom_social_share_link ?>
                 </div>
@@ -433,9 +433,9 @@
       <?php if ($custom_social_share_link) : ?>
         <div data-modal id="modal-share" role="dialog">
           <div class="modal__block">
-            <h3>Share this Campaign</h3><br>
+            <h3><?php print t('Share this Campaign') ?></h3><br>
             <?php print $social_share_bar ?>
-            <p>Copy and paste your share link:</p>
+            <?php print t('Copy and paste your share link:') ?>
             <div class="padded-gray-box">
               <?php print $custom_social_share_link ?>
             </div>


### PR DESCRIPTION
#### What's this PR do?
- Added the voter reg form copy into the signup modal when it displays the voter reg form
- Put the share info below the voter reg form copy, but above the form on this modal (just like in the regular voter reg one)
- On the competitions signup modal, put the share info at the bottom
#### How should this be reviewed?

Make sure everything is in the order listed above.
#### Relevant tickets

Fixes #6937
#### Checklist
- [ ] Tested on staging.

cc: @ngjo 
