### PR TITLE
Use patched version of modal package.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@dosomething/forge": "~6.7.5",
-    "dosomething-modal": "~0.3.2",
+    "dosomething-modal": "0.3.3",
     "dosomething-validation": "~0.2.4",
     "es5-shim": "^4.1.1",
     "fixed-sticky": "DFurnes/fixed-sticky#umd",


### PR DESCRIPTION
#### What's this PR do?

This fixes [an error that @deadlybutter had flagged on Thor](https://dosomething.slack.com/archives/deploys/p1472067346002203) (based on updating the build system for that package earlier today), and plugs up that intermittent "can't call `.css` on null" error as well.
#### How should this be reviewed?

Try buildin' and it should work. 🔨 
#### Any background context you want to provide?

The relevant commit in the modal package: [`8984c6a`](https://github.com/DoSomething/modal/commit/8984c6afae39601a952a9e0ca41898cf0cdabcc0)
#### Relevant tickets

Fixes 🍃.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
