### PR TITLE
Send the user lang prefix in magic link login.

### DIFF
--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -228,7 +228,7 @@ POST /api/v1/users/{uid}/magic_login_url
 // 200 Okay
 
 {
-  "url": "http://dev.dosomething.org:8888/user/magic/1700226/1425495228/P-f-5d6kHLrOXl0VrQfXavgmMjiNz042uihpxJW4jBc",
+  "url": "http://dev.dosomething.org:8888/us/user/magic/1700226/1425495228/P-f-5d6kHLrOXl0VrQfXavgmMjiNz042uihpxJW4jBc",
   "expires": "2016-06-08T15:12:52+00:00"
 }
 ```

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -371,9 +371,10 @@ function _member_resource_magic_login_url($uid) {
   if (! $account) {
     return services_error('That user does not exist', 404);
   }
+ $prefix = dosomething_global_get_prefix_for_language($account->language);
 
   // Create a one-time login URL using the same methods as built-in Drupal password reset.
-  $magic_url = url('user/magic/' . $uid . '/' . $timestamp . '/' . user_pass_rehash($account->pass, $timestamp, $account->login, $account->uid), ['absolute' => TRUE]);
+  $magic_url = url($prefix . '/user/magic/' . $uid . '/' . $timestamp . '/' . user_pass_rehash($account->pass, $timestamp, $account->login, $account->uid), ['absolute' => TRUE]);
 
   return [
     'url' => $magic_url,


### PR DESCRIPTION
#### What's this PR do?

Adds global prefix based on the user language to the magic link. 
#### How should this be reviewed?

Make a request to `users/[uid]/magic_login_link` and see the b-e-a-utiful country code pre-appended to it! 
#### Any background context you want to provide?

This is needed to avoid redirects happening when you use the link on prod, since a global redirect will override and `redirect=campaigns/whatever` appended onto the query string of the URL. 
#### Relevant tickets

Fixes #6942
#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.

cc @aaronschachter 
