### PR TITLE
Backfill languages for people who didn't even have one. 

### DIFF
--- a/scripts/correct-language-for-users.php
+++ b/scripts/correct-language-for-users.php
@@ -14,7 +14,7 @@ $global_peeps = db_query("SELECT u.uid, s.field_user_registration_source_value a
                           FROM users u
                           LEFT JOIN field_data_field_user_registration_source s on s.entity_id = u.uid
                           LEFT JOIN field_data_field_address a on a.entity_id = u.uid
-                          WHERE u.language = 'en-global';");
+                          WHERE u.language = 'en-global' or u.language = '';");
 
 
 $possible_sources = ['niche', 'Nice', 'niche-import-service', 'letsdothis_ios', 'mobileapp_android'];


### PR DESCRIPTION
#### What's this PR do?

So apparently a bunch of niche/pre-global users didn't have a language
in the UI they show up as `en-global` but it's not actually saved as that
SO the original script didn't handle those people.

This does!
#### How should this be reviewed?

👀 
#### Relevant tickets

FIXES #6159
#### Checklist
- [ ] Tested on staging.
