### PR TITLE
Make sure that "fallback" register call always uses full user object.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -224,7 +224,7 @@ function _member_resource_create($request) {
     // Forward users to Northstar, unless `?forward=false` is explicitly set.
     $should_forward = isset($query['forward']) ? filter_var($query['forward'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) : true;
     if ($should_forward && module_exists('dosomething_northstar')) {
-      dosomething_northstar_register_user($user, $edit['pass']);
+      dosomething_northstar_create_user($user, $edit['pass']);
     }
 
     // Don't return the hashed password in the response!

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -224,10 +224,7 @@ function _member_resource_create($request) {
     // Forward users to Northstar, unless `?forward=false` is explicitly set.
     $should_forward = isset($query['forward']) ? filter_var($query['forward'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) : true;
     if ($should_forward && module_exists('dosomething_northstar')) {
-      $payload = dosomething_northstar_transform_user($user);
-      $payload['password'] = $edit['pass'];
-
-      dosomething_northstar_register_user($user, $payload);
+      dosomething_northstar_register_user($user, $edit['pass']);
     }
 
     // Don't return the hashed password in the response!

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -76,26 +76,17 @@ function dosomething_northstar_save_id_field($uid, $northstar_response) {
  * Send user registration events to northstar.
  *
  * @param $user - Drupal user object
- * @param $password - Un-hashed password provided during registration.
+ * @param $password - Unhashed password provided during registration.
  */
 function dosomething_northstar_register_user($user, $password = null) {
   $client = _dosomething_northstar_build_http_client();
-  $payload = dosomething_northstar_transform_user($user);
+  $payload = dosomething_northstar_transform_user($user, $password);
 
-  if (! is_null($password)) {
-    // If un-hashed password is provided (e.g. from register/profile form), send that.
-    $payload['password'] = $password;
-  } else {
-    // Otherwise we're sending an existing user, so we'll attach their hashed
-    // password (which Northstar can use thanks to its DrupalPasswordHash class).
-    $payload['drupal_password'] = $user->pass;
-  }
-
-  $response = drupal_http_request($client['base_url'] . '/users', array(
+  $response = drupal_http_request($client['base_url'] . '/users', [
     'headers' => $client['headers'],
     'method' => 'POST',
     'data' => json_encode($payload),
-  ));
+  ]);
 
   // Save the newly registered user's ID to their local profile field.
   dosomething_northstar_save_id_field($user->uid, json_decode($response->data));
@@ -141,16 +132,11 @@ function _dosomething_northstar_build_http_client() {
  * their Drupal ID.
  *
  * @param $user - Drupal user object
- * @param $form_state - The form state, for unmodified fields
+ * @param $password - Unhashed password provided during registration.
  */
-function dosomething_northstar_update_user($user, $form_state) {
+function dosomething_northstar_update_user($user, $password = null) {
   $client = _dosomething_northstar_build_http_client();
-  $payload = dosomething_northstar_transform_user($user);
-
-  // Don't send blank passwords from the user update screen.
-  if (! empty($form_state['values']['pass'])) {
-    $payload['password'] = $form_state['values']['pass'];
-  }
+  $payload = dosomething_northstar_transform_user($user, $password);
 
   $response = drupal_http_request($client['base_url'] . '/users/drupal_id/' . $user->uid, [
     'headers' => $client['headers'],
@@ -213,9 +199,10 @@ function dosomething_northstar_get_northstar_user($drupal_id) {
  * Transform Drupal user fields into the appropriate schema for Northstar.
  *
  * @param $user - Drupal user object
+ * @param $password - Unhashed password provided during registration.
  * @return array
  */
-function dosomething_northstar_transform_user($user) {
+function dosomething_northstar_transform_user($user, $password = null) {
   // Optional fields
   $optional = [
     'mobile' => 'field_mobile',
@@ -258,6 +245,15 @@ function dosomething_northstar_transform_user($user) {
     }
   }
 
+  // Provide either the hashed or unhashed password, depending on which is given.
+  // If we only have hashed password, we can send that in the 'drupal_password'
+  // field and Northstar can then verify via its DrupalPasswordHash class.
+  if (! is_null($password)) {
+    $payload['password'] = $password;
+  } else {
+    $payload['drupal_password'] = $user->pass;
+  }
+
   // If user has a "1234565555@mobile" or "1234565555@mobile.import" placeholder
   // email address, don't send that field to Northstar (since it's made-up and
   // Northstar doesn't require every account to have an email like Drupal does).
@@ -270,20 +266,6 @@ function dosomething_northstar_transform_user($user) {
   if(empty($northstar_user['source'])) {
     $northstar_user['source'] = 'phoenix';
   }
-
-  return $northstar_user;
-}
-
-/**
- * Build a Northstar user from a Drupal form submission.
- *
- * @param $user - Drupal user object
- * @param $form_state - Form fields from registration/profile form.
- * @return array
- */
-function dosomething_northstar_build_ns_user($user, $form_state) {
-  $northstar_user = dosomething_northstar_transform_user($user);
-
 
   return $northstar_user;
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -76,10 +76,21 @@ function dosomething_northstar_save_id_field($uid, $northstar_response) {
  * Send user registration events to northstar.
  *
  * @param $user - Drupal user object
- * @param $payload - Array of data to be sent to Northstar
+ * @param $password - Un-hashed password provided during registration.
  */
-function dosomething_northstar_register_user($user, $payload) {
+function dosomething_northstar_register_user($user, $password = null) {
   $client = _dosomething_northstar_build_http_client();
+  $payload = dosomething_northstar_transform_user($user);
+
+  if (! is_null($password)) {
+    // If un-hashed password is provided (e.g. from register/profile form), send that.
+    $payload['password'] = $password;
+  } else {
+    // Otherwise we're sending an existing user, so we'll attach their hashed
+    // password (which Northstar can use thanks to its DrupalPasswordHash class).
+    $payload['drupal_password'] = $user->pass;
+  }
+
   $response = drupal_http_request($client['base_url'] . '/users', array(
     'headers' => $client['headers'],
     'method' => 'POST',
@@ -130,17 +141,22 @@ function _dosomething_northstar_build_http_client() {
  * their Drupal ID.
  *
  * @param $user - Drupal user object
- * @param $payload - Array of data to be sent to Northstar
+ * @param $form_state - The form state, for unmodified fields
  */
-function dosomething_northstar_update_user($user, $payload) {
+function dosomething_northstar_update_user($user, $form_state) {
   $client = _dosomething_northstar_build_http_client();
+  $payload = dosomething_northstar_transform_user($user);
 
-  $id = $user->uid;
-  $response = drupal_http_request($client['base_url'] . '/users/drupal_id/' . $id, array(
+  // Don't send blank passwords from the user update screen.
+  if (! empty($form_state['values']['pass'])) {
+    $payload['password'] = $form_state['values']['pass'];
+  }
+
+  $response = drupal_http_request($client['base_url'] . '/users/drupal_id/' . $user->uid, [
     'headers' => $client['headers'],
     'method' => 'PUT',
     'data' => json_encode($payload),
-  ));
+  ]);
 
   // Add to request log if enabled.
   dosomething_northstar_log_request('update_user', $user, $payload, $response);
@@ -152,7 +168,8 @@ function dosomething_northstar_update_user($user, $payload) {
   }
   elseif ($response->code === '404') {
     // If the given Drupal ID 404s, try to register them.
-    dosomething_northstar_register_user($user, $payload);
+    $password_or_null = ! empty($form_state['values']['pass']) ? $form_state['values']['pass'] : null;
+    dosomething_northstar_register_user($user, $password_or_null);
   }
   else {
     watchdog('dosomething_northstar', 'User not updated : ' . $response->code, NULL, WATCHDOG_ERROR);
@@ -221,6 +238,7 @@ function dosomething_northstar_transform_user($user) {
     'email'         => $user->mail,
     'drupal_id'     => $user->uid,
     'language'      => $user->language,
+    'created_at'    => $user->created,
   ];
 
   // Set values in ns_user if they are set.
@@ -266,10 +284,6 @@ function dosomething_northstar_transform_user($user) {
 function dosomething_northstar_build_ns_user($user, $form_state) {
   $northstar_user = dosomething_northstar_transform_user($user);
 
-  // Don't send blank passwords from the user update screen.
-  if (!empty($form_state['values']['pass'])) {
-    $northstar_user['password'] = $form_state['values']['pass'];
-  }
 
   return $northstar_user;
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -18,16 +18,16 @@ define('NORTHSTAR_APP_KEY', variable_get('dosomething_northstar_app_key', 'abc43
  * Implements hook_menu().
  */
 function dosomething_northstar_menu() {
-  $items = array();
-  $items['admin/config/services/northstar'] = array(
-    'title' => 'Northstar',
-    'description' => 'Manage Northstar connection settings.',
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('dosomething_northstar_config_form'),
-    'access arguments' => array('administer modules'),
-    'file' => 'dosomething_northstar.admin.inc',
-  );
-  return $items;
+  return [
+    'admin/config/services/northstar' => [
+      'title' => 'Northstar',
+      'description' => 'Manage Northstar connection settings.',
+      'page callback' => 'drupal_get_form',
+      'page arguments' => ['dosomething_northstar_config_form'],
+      'access arguments' => ['administer modules'],
+      'file' => 'dosomething_northstar.admin.inc',
+    ]
+  ];
 }
 
 /**
@@ -58,27 +58,12 @@ function dosomething_northstar_verify_user($credentials) {
 }
 
 /**
- * Save the user's Northstar ID to their local profile.
- *
- * @param $uid - Drupal user ID
- * @param $northstar_response - Northstar user JSON response
- */
-function dosomething_northstar_save_id_field($uid, $northstar_response) {
-  $northstar_id = !empty($northstar_response->data->id) ? $northstar_response->data->id : 'NONE';
-  $user = user_load($uid);
-
-  $edit = [];
-  dosomething_user_set_fields($edit, ['northstar_id' => $northstar_id]);
-  user_save($user, $edit);
-}
-
-/**
  * Send user registration events to northstar.
  *
  * @param $user - Drupal user object
  * @param $password - Unhashed password provided during registration.
  */
-function dosomething_northstar_register_user($user, $password = null) {
+function dosomething_northstar_create_user($user, $password = null) {
   $client = _dosomething_northstar_build_http_client();
   $payload = dosomething_northstar_transform_user($user, $password);
 
@@ -102,29 +87,6 @@ function dosomething_northstar_register_user($user, $password = null) {
   if (module_exists('stathat')) {
     stathat_send_ez_count('drupal - Northstar - user migrated - count', 1);
   }
-}
-
-/**
- * Build the drupal_http_request object for Northstar calls.
- * @returns array
- */
-function _dosomething_northstar_build_http_client() {
-  $base_url = NORTHSTAR_URL;
-  if (getenv('DS_ENVIRONMENT') === 'local') {
-      $base_url .=  ":" . NORTHSTAR_PORT;
-    }
-  $base_url .= '/' . NORTHSTAR_VERSION;
-
-  $client = array(
-    'base_url' => $base_url,
-    'headers' => array(
-      'X-DS-REST-API-Key' => NORTHSTAR_APP_KEY,
-      'Content-Type' => 'application/json',
-      'Accept' => 'application/json',
-      ),
-    );
-
-  return $client;
 }
 
 /**
@@ -155,7 +117,7 @@ function dosomething_northstar_update_user($user, $password = null) {
   elseif ($response->code === '404') {
     // If the given Drupal ID 404s, try to register them.
     $password_or_null = ! empty($form_state['values']['pass']) ? $form_state['values']['pass'] : null;
-    dosomething_northstar_register_user($user, $password_or_null);
+    dosomething_northstar_create_user($user, $password_or_null);
   }
   else {
     watchdog('dosomething_northstar', 'User not updated : ' . $response->code, NULL, WATCHDOG_ERROR);
@@ -271,15 +233,18 @@ function dosomething_northstar_transform_user($user, $password = null) {
 }
 
 /**
- * Return whether the response has a "successful" status code or not.
+ * Save the user's Northstar ID to their local profile.
  *
- * @param $response
- * @return bool
+ * @param $uid - Drupal user ID
+ * @param $northstar_response - Northstar user JSON response
  */
-function _dosomething_northstar_is_successful_response($response) {
-  $code = (int) $response->code;
+function dosomething_northstar_save_id_field($uid, $northstar_response) {
+  $northstar_id = !empty($northstar_response->data->id) ? $northstar_response->data->id : 'NONE';
+  $user = user_load($uid);
 
-  return $code >= 200 && $code <= 299;
+  $edit = [];
+  dosomething_user_set_fields($edit, ['northstar_id' => $northstar_id]);
+  user_save($user, $edit);
 }
 
 /**
@@ -312,3 +277,37 @@ function dosomething_northstar_log_request($op, $user, $request_body, $response)
     ->execute();
 }
 
+/**
+ * Return whether the response has a "successful" status code or not.
+ *
+ * @param $response
+ * @return bool
+ */
+function _dosomething_northstar_is_successful_response($response) {
+  $code = (int) $response->code;
+
+  return $code >= 200 && $code <= 299;
+}
+
+/**
+ * Build the drupal_http_request object for Northstar calls.
+ * @returns array
+ */
+function _dosomething_northstar_build_http_client() {
+  $base_url = NORTHSTAR_URL;
+  if (getenv('DS_ENVIRONMENT') === 'local') {
+    $base_url .=  ":" . NORTHSTAR_PORT;
+  }
+  $base_url .= '/' . NORTHSTAR_VERSION;
+
+  $client = [
+    'base_url' => $base_url,
+    'headers' => [
+      'X-DS-REST-API-Key' => NORTHSTAR_APP_KEY,
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json',
+    ],
+  ];
+
+  return $client;
+}

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -211,9 +211,9 @@ function dosomething_northstar_transform_user($user, $password = null) {
   // If we only have hashed password, we can send that in the 'drupal_password'
   // field and Northstar can then verify via its DrupalPasswordHash class.
   if (! is_null($password)) {
-    $payload['password'] = $password;
+    $northstar_user['password'] = $password;
   } else {
-    $payload['drupal_password'] = $user->pass;
+    $northstar_user['drupal_password'] = $user->pass;
   }
 
   // If user has a "1234565555@mobile" or "1234565555@mobile.import" placeholder

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -577,7 +577,10 @@ function dosomething_user_update_user($form, &$form_state) {
   // Forward user updates into Northstar.
   $user = $form_state['user'];
 
-  dosomething_northstar_update_user($user, $form_state);
+  // Don't send blank passwords from the user update screen.
+  $password = ! empty($form_state['values']['pass']) ? $form_state['values']['pass'] : null;
+
+  dosomething_northstar_update_user($user, $password);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -576,8 +576,8 @@ function dosomething_user_update_user($form, &$form_state) {
 
   // Forward user updates into Northstar.
   $user = $form_state['user'];
-  $northstar_user = dosomething_northstar_build_ns_user($user, $form_state);
-  dosomething_northstar_update_user($user, $northstar_user);
+
+  dosomething_northstar_update_user($user, $form_state);
 }
 
 /**
@@ -599,10 +599,7 @@ function dosomething_user_new_user($form, &$form_state)
   _dosomething_user_send_to_message_broker();
 
   if (module_exists('dosomething_northstar')) {
-    $northstar_user = dosomething_northstar_build_ns_user($user, $form_state);
-
-    // Send the prepared user to Northstar.
-    dosomething_northstar_register_user($user, $northstar_user);
+    dosomething_northstar_register_user($user, $form_state['values']['pass']);
   };
 }
 
@@ -672,13 +669,12 @@ function _dosomething_user_send_to_message_broker() {
 }
 
 function dosomething_user_new_user_attributes($form, &$form_state) {
+  global $user;
+
   dosomething_user_set_global_attributes();
 
   if (module_exists('dosomething_northstar')){
-    $user = $form_state['user'];
-    $northstar_user = dosomething_northstar_build_ns_user($user, $form_state);
-
-    dosomething_northstar_update_user($user, $northstar_user);
+    dosomething_northstar_register_user($user, $form_state['values']['pass']);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -602,7 +602,7 @@ function dosomething_user_new_user($form, &$form_state)
   _dosomething_user_send_to_message_broker();
 
   if (module_exists('dosomething_northstar')) {
-    dosomething_northstar_register_user($user, $form_state['values']['pass']);
+    dosomething_northstar_create_user($user, $form_state['values']['pass']);
   };
 }
 
@@ -677,7 +677,7 @@ function dosomething_user_new_user_attributes($form, &$form_state) {
   dosomething_user_set_global_attributes();
 
   if (module_exists('dosomething_northstar')){
-    dosomething_northstar_register_user($user, $form_state['values']['pass']);
+    dosomething_northstar_create_user($user, $form_state['values']['pass']);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1808,7 +1808,7 @@ function dosomething_user_mail($key, &$message, $params) {
  */
 function dosomething_user_magic_session($uid, $timestamp, $login_token) {
   global $user;
-  
+
   $query = drupal_get_query_parameters();
   $redirect = ! empty($query['redirect']) ? $query['redirect'] : '/';
 
@@ -1839,7 +1839,7 @@ function dosomething_user_magic_session($uid, $timestamp, $login_token) {
 /**
  * Check that a magic login link is valid: it hasn't expired, the referred account exists and
  * hasn't logged in since generating the link, and the hash of those parameters is correct.
- * 
+ *
  * @param $account
  * @param $timestamp
  * @param $login_token
@@ -1849,13 +1849,13 @@ function dosomething_user_check_magic_login_validity($account, $timestamp, $logi
   if(! $account) {
     return false;
   }
-  
+
   $timeout = variable_get('user_password_reset_timeout', 86400);
   $has_expired = REQUEST_TIME - $timestamp > $timeout;
-  
+
   $valid_parameters = $account->uid && $timestamp >= $account->login && $timestamp <= REQUEST_TIME;
   $valid_hash = $login_token == user_pass_rehash($account->pass, $timestamp, $account->login, $account->uid);
-  
+
   return ! $has_expired && $valid_parameters && $valid_hash;
 }
 

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -25,7 +25,7 @@ else {
 foreach ($users as $user) {
   // Create json object
   $user = user_load($user->uid);
-  $ns_user = build_northstar_user($user);
+  $northstar_user = dosomething_northstar_transform_user($user);
 
   // Don't "forward" the anonymous user.
   if($user->uid == 0) {
@@ -37,7 +37,7 @@ foreach ($users as $user) {
   $response = drupal_http_request($client['base_url'] . '/users', [
     'headers' => $client['headers'],
     'method' => 'POST',
-    'data' => json_encode($ns_user),
+    'data' => json_encode($northstar_user),
   ]);
 
   // Output progress to stdout so we can see our good work.
@@ -46,7 +46,7 @@ foreach ($users as $user) {
 
   // Save any failed requests to the request log for debugging.
   if(! in_array($response->code, [200, 201])) {
-    dosomething_northstar_log_request('migrate', $user, $ns_user, $response);
+    dosomething_northstar_log_request('migrate', $user, $northstar_user, $response);
   }
 
   // If a user cannot be migrated due to a Drupal ID index conflict, we should delete the conflicting Northstar record.
@@ -59,19 +59,4 @@ foreach ($users as $user) {
 
   // If the script fails, we can use this to start the script from a previous person.
   variable_set('dosomething_northstar_last_user_migrated', $user->uid);
-}
-
-/**
- * Build a Northstar request from the $user global variable.
- */
-function build_northstar_user($user) {
-  $northstar_user = dosomething_northstar_transform_user($user);
-
-  // Since we're sending an existing user, we'll also attach their hashed password
-  // (which Northstar can understand thanks to it's DrupalPasswordHash class), and
-  // the created_at timestamp on the original account.
-  $northstar_user['drupal_password'] = $user->pass;
-  $northstar_user['created_at'] = $user->created;
-
-  return $northstar_user;
 }

--- a/scripts/remove-duplicate-emails.php
+++ b/scripts/remove-duplicate-emails.php
@@ -36,11 +36,11 @@ foreach ($dupes as $mail) {
     // Set the new email for the deactivated user.
     $new_email = 'duplicate-' . $canonical_uid . '-' . $index . '@dosomething.invalid';
     print ' - Removing ' . $user->uid . ' (' . $user->mail . ' --> ' . $new_email . ')' . PHP_EOL;
-    user_save($user, ['mail' => $new_email, 'status' => 0]);
+    $user = user_save($user, ['mail' => $new_email, 'status' => 0]);
     $removed++;
 
     // Finally, try to push the updated profile to this Drupal ID in Northstar
-    dosomething_northstar_update_user($user, ['drupal_id' => $user->uid, 'email' => $new_email]);
+    dosomething_northstar_update_user($user);
   }
 
   print PHP_EOL;

--- a/scripts/remove-duplicate-emails.php
+++ b/scripts/remove-duplicate-emails.php
@@ -43,6 +43,10 @@ foreach ($dupes as $mail) {
     dosomething_northstar_update_user($user);
   }
 
+  // And push the canonical profile once we've fixed all the dupes.
+  $canonical_user = user_load($canonical_uid);
+  dosomething_northstar_update_user($canonical_user);
+
   print PHP_EOL;
 }
 

--- a/scripts/sanitize-mobile-numbers.php
+++ b/scripts/sanitize-mobile-numbers.php
@@ -30,10 +30,10 @@ foreach($wild_typers as $wilder) {
 
     // Update the `field_mobile` for that user (to either sanitize or remove it).
     $user = user_load($wilder->uid);
-    user_save($user, $edit);
+    $user = user_save($user, $edit);
 
     // Now, update (or create) the corresponding profile in Northstar by Drupal ID.
-    dosomething_northstar_update_user($user, ['mobile' => $fresh_and_clean_digits, 'drupal_id' => $user->uid]);
+    dosomething_northstar_update_user($user);
   }
 }
 

--- a/scripts/unset-duplicate-mobiles.php
+++ b/scripts/unset-duplicate-mobiles.php
@@ -36,12 +36,12 @@ foreach ($dupes as $mobile) {
 
     // Remove the mobile field for that user.
     print ' - Removing mobile from ' . $user->uid . ' (' . $mobile . ')' . PHP_EOL;
-    user_save($user, ['field_mobile' => [ LANGUAGE_NONE => [] ] ]);
+    $user = user_save($user, ['field_mobile' => [ LANGUAGE_NONE => [] ] ]);
 
     $removed++;
 
     // Now, update the corresponding profile in Northstar by Drupal ID.
-    dosomething_northstar_update_user($user, ['mobile' => null, 'drupal_id' => $user->uid]);
+    dosomething_northstar_update_user($user);
   }
 
   print PHP_EOL;


### PR DESCRIPTION
#### What's this PR do?

When our data cleanup scripts get a 404 on updating a user profile by Drupal ID, they'll try to register that user via the `POST users/` endpoint. Unfortunately, sending the same payload along would attempt to make a "partial" user (just the changed fields)...

This PR refactors those Northstar sync methods to always operate on a full `$user` object rather than being passed a custom payload. This way, if the `dosomething_northstar_update_user` fails, it'll try to run `dosomething_northstar_register_user` based on the full user object.
#### How should this be reviewed?

I tried to do a little tidying up while I was working on this PR, so I'd recommend taking a look commit-by-commit so it doesn't just look like a bunch of noise:

👾 Just whitespace: 5c02291

🏭 Use the `$user` object in the register method rather than a `$payload` array: b47c4b1

🔒 Handle the `password` vs `drupal_password` hash business in the transform too: e4740cd

🍃 Shuffle things around (short array syntax, move private methods to bottom of file, rename "register" method to "create" so it's same terminology as we use in Northstar): 17ac4e1
#### Any background context you want to provide?

Hopefully this is the last PR for this? 😁 
#### Relevant tickets

References #6409.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
