### PR TITLE
Add a script to fix users with empty email.

### DIFF
--- a/scripts/fix-empty-mail.php
+++ b/scripts/fix-empty-mail.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Script to set a placeholder email for users with blank mail field.
+ *
+ * to run:
+ * drush --script-path=../scripts/ php-script fix-empty-mail.php
+ */
+
+$troublemakers = db_query('SELECT uid FROM users LEFT JOIN field_data_field_mobile ON uid = entity_id WHERE mail = \'\' AND uid != 0');
+$fixed = 0;
+
+foreach ($troublemakers as $user) {
+  $user = user_load($user->uid);
+
+  // Set the new email for the deactivated user.
+  $mobile = dosomething_user_get_field('field_mobile', $user);
+  $fresh_and_clean_digits = dosomething_user_clean_mobile_number(preg_replace('[^0-9]', '', $mobile));
+  if (! $fresh_and_clean_digits) {
+    print 'Could not fix ' . $user->uid . ' (' . $mobile . ', ' . $user->mail . ')' . PHP_EOL;
+    continue;
+  }
+
+  $new_email = $fresh_and_clean_digits . '@mobile.import';
+  print 'Updated user ' . $user->uid . '(' . $user->mail . ' --> ' . $new_email . ')' . PHP_EOL;
+  $user = user_save($user, ['mail' => $new_email]);
+
+  $fixed++;
+}
+
+print '[✔] Fixed mobile placeholder email for ' . $fixed . ' users.' . PHP_EOL;


### PR DESCRIPTION
#### What's this PR do?

Next of the gotchas: there were 413 users with an empty-string `mail` field. All those users had a `field_mobile` so perhaps there was just a brief moment where we didn't require emails for API users? Anyways, this fixes that so we don't accidentally deactivate them all.
#### How should this be reviewed?

Is the script okay?
#### Any background context you want to provide?

👊
#### Relevant tickets

References #6409.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
