### PR TITLE
Fixes security issue with Kudos creation

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -95,6 +95,7 @@ function _kudos_resource_definition() {
             ],
           ],
         ],
+        'access arguments append' => TRUE,
         'access callback' => '_kudos_resource_access',
         'access arguments' => ['create'],
       ],
@@ -135,7 +136,9 @@ function _kudos_resource_definition() {
  *
  * @return bool
  */
-function _kudos_resource_access($op) {
+function _kudos_resource_access($op, $args = []) {
+  global $user;
+
   if ($op === 'view') {
     return TRUE;
   }
@@ -145,9 +148,17 @@ function _kudos_resource_access($op) {
   }
 
   if ($op === 'create' || $op === 'delete') {
-    if (!user_is_anonymous()) {
-      return TRUE;
+    // Only auth'd users should be giving Kudos
+    if (user_is_anonymous()) {
+      return FALSE;
     }
+
+    // We need to make sure people are only creating Kudos for themselves
+    if ($op === 'create' && $user->uid !== $args[1]) {
+      return FALSE;
+    }
+
+    return TRUE;
   }
 
   return FALSE;

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -77,15 +77,6 @@ function _kudos_resource_definition() {
             ],
           ],
           [
-            'name' => 'user_id',
-            'description' => 'The ID of the user executing a kudos.',
-            'optional' => FALSE,
-            'type' => 'string',
-            'source' => [
-              'data' => 'user_id',
-            ],
-          ],
-          [
             'name' => 'term_ids',
             'description' => 'An array of kudos term IDs.',
             'optional' => FALSE,
@@ -95,7 +86,6 @@ function _kudos_resource_definition() {
             ],
           ],
         ],
-        'access arguments append' => TRUE,
         'access callback' => '_kudos_resource_access',
         'access arguments' => ['create'],
       ],
@@ -149,16 +139,9 @@ function _kudos_resource_access($op, $args = []) {
 
   if ($op === 'create' || $op === 'delete') {
     // Only auth'd users should be giving Kudos
-    if (user_is_anonymous()) {
-      return FALSE;
+    if (!user_is_anonymous()) {
+      return TRUE;
     }
-
-    // We need to make sure people are only creating Kudos for themselves
-    if ($op === 'create' && $user->uid !== $args[1]) {
-      return FALSE;
-    }
-
-    return TRUE;
   }
 
   return FALSE;
@@ -200,10 +183,9 @@ function _kudos_resource_index($reportbackitems, $count) {
  * @param $user_id
  * @param $term_ids
  */
-function _kudos_resource_create($reportback_item_id, $user_id, $term_ids) {
+function _kudos_resource_create($reportback_item_id, $term_ids) {
   $parameters = [
     'fid' => $reportback_item_id,
-    'uid' => $user_id,
     'tids' => $term_ids,
   ];
 

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -138,7 +138,6 @@ function _kudos_resource_access($op, $args = []) {
   }
 
   if ($op === 'create' || $op === 'delete') {
-    // Only auth'd users should be giving Kudos
     if (!user_is_anonymous()) {
       return TRUE;
     }

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -126,9 +126,7 @@ function _kudos_resource_definition() {
  *
  * @return bool
  */
-function _kudos_resource_access($op, $args = []) {
-  global $user;
-
+function _kudos_resource_access($op) {
   if ($op === 'view') {
     return TRUE;
   }

--- a/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/KudosTransformer.php
@@ -71,9 +71,11 @@ class KudosTransformer extends Transformer {
    * @return array
    */
   public function create($parameters) {
+    global $user;
+
     $values = [
       'fid' => $parameters['fid'],
-      'uid' => $parameters['uid'],
+      'uid' => $user->uid,
       'created' => time(),
     ];
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -19,7 +19,6 @@ function makeKudosRequest($el, id)
     },
     data: JSON.stringify({
       'reportback_item_id': $el.closest('[data-reportback-item-id]').attr('data-reportback-item-id'),
-      'user_id': $('meta[name="drupal-user-id"]').attr('content'),
       'term_ids': [$el.attr('data-kudos-term-id')]
     }),
   });

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ReactionsList.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ReactionsList.js
@@ -112,7 +112,6 @@ class ReactionsList extends React.Component {
     if (!reactionId) {
       this.apiClient.post('kudos', {
         'reportback_item_id': this.props.reportbackItemId,
-        'user_id': this.props.user.info.drupal_id,
         'term_ids':[termId]
       }).then((response) => {
         response.forEach((data) => {


### PR DESCRIPTION
#### What's this PR do?

Prevents you from creating a Kudo for someone else 
#### How should this be reviewed?
1. Can you perform kudos?
2. Edit the `<meta name="drupal-user-id"` with a different user id. Can you still perform kudos? (Look at the JS console, errors blocking auth should show up)
#### Any background context you want to provide?

Never trust the client!
#### Relevant tickets

Fixes #6933 
#### Checklist
- [ ] Tested on staging.
