### PR TITLE
If user is left with no mobile or email, set a 'bad mobile' placeholder.

### DIFF
--- a/scripts/unset-duplicate-mobiles.php
+++ b/scripts/unset-duplicate-mobiles.php
@@ -36,8 +36,14 @@ foreach ($dupes as $mobile) {
 
     // Remove the mobile field for that user.
     print ' - Removing mobile from ' . $user->uid . ' (' . $mobile . ')' . PHP_EOL;
-    $user = user_save($user, ['field_mobile' => [ LANGUAGE_NONE => [] ] ]);
+    $edit = ['field_mobile' => [ LANGUAGE_NONE => [] ]];
 
+    // If the user doesn't have a real email, set them a "invalid" placeholder.
+    if (preg_match('/^[0-9]+@mobile(\.import)?$/', $user->mail)) {
+      $edit['mail'] = 'bad-mobile-' . $user->uid . '@dosomething.invalid';
+    }
+
+    $user = user_save($user, $edit);
     $removed++;
 
     // Now, update the corresponding profile in Northstar by Drupal ID.


### PR DESCRIPTION
#### What's this PR do?

When we sanitize or unset mobile numbers in our data cleanup scripts, sometimes we might end up with a user who has neither a real email or a mobile number. This happened to ~4000 users when testing on Thor. Of those users, only 255 had ever logged in.
#### How should this be reviewed?

These scripts should do the same thing, but if the user end up without a "real" email or a mobile number, then it should give them a "valid" placeholder email so they can just sync and be forgotten.
#### Any background context you want to provide?

💃
#### Relevant tickets

References #6409.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
