### PR TITLE
Remove flag module from make file.

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -95,10 +95,6 @@ projects[field_group][subdir] = "contrib"
 projects[file_entity][version] = "2.0-alpha3"
 projects[file_entity][subdir] = "contrib"
 
-; Flag
-projects[flag][version] = "3.5"
-projects[flag][subdir] = "contrib"
-
 ; Google Analytics
 projects[google_analytics][version] = "2.3"
 projects[google_analytics][subdir] = "contrib"


### PR DESCRIPTION
#### What's this PR do?

the thing it says in the title
#### How should this be reviewed?

see that `flag` is no longer in the make file. 
I also already disabled this in stage/thor/prod
#### Any background context you want to provide?

we don't use this 
#### Relevant tickets

Fixes #6988
Refs #3677
