### PR TITLE
Use a less strict regex to match placeholder emails.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -219,7 +219,7 @@ function dosomething_northstar_transform_user($user, $password = null) {
   // If user has a "1234565555@mobile" or "1234565555@mobile.import" placeholder
   // email address, don't send that field to Northstar (since it's made-up and
   // Northstar doesn't require every account to have an email like Drupal does).
-  if(preg_match('/^[0-9]+@mobile(\.import)?$/', $northstar_user['email'])) {
+  if(preg_match('/@mobile(\.import)?$/', $northstar_user['email'])) {
     unset($northstar_user['email']);
   }
 

--- a/scripts/sanitize-mobile-numbers.php
+++ b/scripts/sanitize-mobile-numbers.php
@@ -29,7 +29,7 @@ foreach($wild_typers as $wilder) {
       $edit = ['field_mobile' => [ LANGUAGE_NONE => [] ] ];
 
       // If the user doesn't have a real email, set them a "invalid" placeholder.
-      if (preg_match('/^[0-9]+@mobile(\.import)?$/', $user->mail)) {
+      if (preg_match('/@mobile(\.import)?$/', $user->mail)) {
         $edit['mail'] = 'bad-mobile-' . $user->uid . '@dosomething.invalid';
       }
     }

--- a/scripts/unset-duplicate-mobiles.php
+++ b/scripts/unset-duplicate-mobiles.php
@@ -39,7 +39,7 @@ foreach ($dupes as $mobile) {
     $edit = ['field_mobile' => [ LANGUAGE_NONE => [] ]];
 
     // If the user doesn't have a real email, set them a "invalid" placeholder.
-    if (preg_match('/^[0-9]+@mobile(\.import)?$/', $user->mail)) {
+    if (preg_match('/@mobile(\.import)?$/', $user->mail)) {
       $edit['mail'] = 'bad-mobile-' . $user->uid . '@dosomething.invalid';
     }
 


### PR DESCRIPTION
#### What's this PR do?

Switches out the regex for detecting placeholder "fake" mobile emails to be less strict (must end in `@mobile` or `@mobile.import`, but can have _anything_ before that). This is because we had some crazier ones before we started sanitizing mobiles properly, like `(123) 444-5555@mobile`.
#### How should this be reviewed?

👀 
#### Any background context you want to provide?

📵 
#### Relevant tickets

References #6409.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
