### PR TITLE
Always send the mobile field so its unset if removed.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -167,7 +167,6 @@ function dosomething_northstar_get_northstar_user($drupal_id) {
 function dosomething_northstar_transform_user($user, $password = null) {
   // Optional fields
   $optional = [
-    'mobile' => 'field_mobile',
     'birthdate' => 'field_birthdate',
     'first_name' => 'field_first_name',
     'last_name' => 'field_last_name',
@@ -185,6 +184,7 @@ function dosomething_northstar_transform_user($user, $password = null) {
 
   $northstar_user = [
     'email'         => $user->mail,
+    'mobile'        => dosomething_user_get_field('field_mobile', $user),
     'drupal_id'     => $user->uid,
     'language'      => $user->language,
     'created_at'    => $user->created,


### PR DESCRIPTION
#### What's this PR do?

This updates the Northstar modules "transform" method to always send the `mobile` field in the Northstar payload, so if a user ever removes their phone number from their account we send `null` and unset it on the corresponding Northstar profile.
#### How should this be reviewed?

👀
#### Any background context you want to provide?

🔥
#### Relevant tickets

References #6409.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
