### PR TITLE
Merge multiple Signup classes into single ones.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.info
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.info
@@ -16,4 +16,3 @@ features[user_permission][] = administer third party communication
 features[user_permission][] = edit any signup
 features[user_permission][] = view any signup
 features[views_view][] = node_signups
-files[] = includes/dosomething_signup.inc

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -18,8 +18,9 @@ include_once 'includes/dosomething_signup.cron.inc';
 include_once 'dosomething_signup.query.inc';
 
 include_once 'includes/Signup.php';
-include_once 'includes/SignupController.php';
+include_once 'includes/SignupsController.php';
 include_once 'includes/SignupTransformer.php';
+
 /**
  * Implements hook_menu().
  */
@@ -78,21 +79,25 @@ function dosomething_signup_libraries_info() {
 
 /**
  * Implements hook_entity_info().
+ *
+ * @return  array
  */
 function dosomething_signup_entity_info() {
-  $info = array();
-  $info['signup'] = array(
+  $info = [];
+
+  $info['signup'] = [
     'label' => t('Signup'),
     'base table' => 'dosomething_signup',
-    'entity keys' => array(
+    'entity keys' => [
       'id' => 'sid',
       'label' => 'sid',
-    ),
-    'entity class' => 'SignupEntity',
+    ],
+    'entity class' => 'Signup',
     'uri callback' => 'entity_class_uri',
-    'controller class' => 'SignupEntityController',
+    'controller class' => 'SignupsController',
     'module' => 'dosomething_signup',
-  );
+  ];
+
   return $info;
 }
 

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupController.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupController.php
@@ -1,7 +1,0 @@
-<?php
-
-class SignupController extends EntityAPIController {
-
-  // CRUD stuff here.
-
-}

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupsController.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupsController.php
@@ -13,47 +13,47 @@ class SignupsController extends EntityAPIController {
    *
    * Adds Signup properties into Signup entity's render.
    */
-  public function buildContent($entity, $view_mode = 'full', $langcode = NULL, $content = array()) {
+  public function buildContent($entity, $view_mode = 'full', $langcode = NULL, $content = []) {
     // Load user to get username.
     $account = user_load($entity->uid);
     $build = parent::buildContent($entity, $view_mode, $langcode, $content);
-    $build['nid'] = array(
+    $build['nid'] = [
       '#type' => 'markup',
       '#markup' => '<p>Nid: ' . l($entity->nid, 'node/' . $entity->nid . '/signups') . '</p>',
-    );
-    $build['username'] = array(
+    ];
+    $build['username'] = [
       '#type' => 'markup',
       '#markup' => '<p>User: ' . l($account->name, 'user/' . $account->uid) . '</p>',
-    );
-    $build['timestamp'] = array(
+    ];
+    $build['timestamp'] = [
       '#type' => 'markup',
       '#markup' => '<p>Signed up: ' . format_date($entity->timestamp, 'short') . '</p>',
-    );
+    ];
     if ($entity->signup_data_form_timestamp) {
-      $build['signup_data_form_submitted'] = array(
+      $build['signup_data_form_submitted'] = [
         '#type' => 'markup',
         '#markup' => '<p>Signup Data Form Submitted: ' . format_date($entity->signup_data_form_timestamp, 'short') . '</p>',
-      );
+      ];
       if ($entity->signup_data_form_response != NULL) {
-        $build['signup_data_form_response'] = array(
+        $build['signup_data_form_response'] = [
           '#type' => 'markup',
           '#markup' => '<p>Signup Data Form Response: ' . $entity->signup_data_form_response . '</p>',
-        );
+        ];
       }
       $reset_form = drupal_get_form('dosomething_signup_reset_signup_data_form', $entity->sid);
       $build['reset_form'] = $reset_form;
     }
     if ($entity->why_signedup) {
-      $build['why_signedup'] = array(
+      $build['why_signedup'] = [
         '#type' => 'markup',
         '#markup' => '<p>Signup Reason: ' . check_plain($entity->why_signedup) . '</p>',
-      );
+      ];
     }
     if ($entity->source) {
-      $build['source'] = array(
+      $build['source'] = [
         '#type' => 'markup',
         '#markup' => '<p>Source: ' . check_plain($entity->source) . '</p>',
-      );
+      ];
     }
     return $build;
   }
@@ -86,10 +86,10 @@ class SignupsController extends EntityAPIController {
       // And current user can't edit any reportback:
       if (!user_access('edit any signup') && !drupal_is_cli()) {
         watchdog('dosomething_signup', "Attempted uid override for @entity by User @uid",
-          array(
+          [
             '@entity' => json_encode($entity),
             '@uid' => $user->uid,
-          ), WATCHDOG_WARNING);
+          ], WATCHDOG_WARNING);
         return FALSE;
       }
     }

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupsController.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupsController.php
@@ -85,7 +85,7 @@ class SignupsController extends EntityAPIController {
     if ($entity->uid != $user->uid) {
       // And current user can't edit any reportback:
       if (!user_access('edit any signup') && !drupal_is_cli()) {
-        watchdog('dosomething_signup', "Attempted uid override for @entity by User @uid",
+        watchdog('dosomething_signup', 'Attempted uid override for @entity by User @uid',
           [
             '@entity' => json_encode($entity),
             '@uid' => $user->uid,

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupsController.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupsController.php
@@ -1,27 +1,13 @@
 <?php
 
-/**
- * @file
- * Provides classes for the Signup Entity.
- */
+class SignupsController extends EntityAPIController {
 
-/**
- * Our Signup entity class.
- */
-class SignupEntity extends Entity {
-
-  /**
-   * Override this in order to implement a custom default URI.
-   */
-  protected function defaultUri() {
-    return array('path' => 'signup/' . $this->identifier());
+  // @TODO: dosomething_signup.inc didn't have this call to the parent construct
+  // and not sure if it's an issue if added.
+  public function __construct() {
+    parent::__construct('signup');
   }
-}
 
-/**
- * Our custom controller for the dosomething_signup type.
- */
-class SignupEntityController extends EntityAPIController {
   /**
    * Overrides buildContent() method.
    *
@@ -79,6 +65,7 @@ class SignupEntityController extends EntityAPIController {
    */
   public function save($entity, DatabaseTransaction $transaction = NULL) {
     global $user;
+
     if (isset($entity->is_new)) {
       if (!isset($entity->timestamp)) {
         $entity->timestamp = REQUEST_TIME;
@@ -88,10 +75,12 @@ class SignupEntityController extends EntityAPIController {
         $entity->uid = $user->uid;
       }
     }
+
     // Make sure a uid exists.
     if (!isset($entity->uid)) {
       return FALSE;
     }
+
     // If the entity uid doesnt belong to current user:
     if ($entity->uid != $user->uid) {
       // And current user can't edit any reportback:
@@ -104,9 +93,12 @@ class SignupEntityController extends EntityAPIController {
         return FALSE;
       }
     }
+
     parent::save($entity, $transaction);
+
     if (DOSOMETHING_SIGNUP_LOG_SIGNUPS) {
       watchdog('dosomething_signup', json_encode($entity));
     }
   }
+
 }


### PR DESCRIPTION
#### What's this PR do?

This PR does a bunch of cleanup for the **dosomething_signup** module, which contained duplicate entity classes and entity controller classes. When the signups endpoint was added, additional classes were added without cleaning up/consolidating the existing classes.
#### How should this be reviewed?

👀 
#### Any background context you want to provide?

Also running some tests to check and see if Phoenix builds properly with these changes. I was having a few issues with my local, and needed to try a full `destroy` of the vagrant box and rebuild.

After the `destroy` and rebuild with these changes, site seemed to build fine and was able to signup to a few campaigns.
#### Relevant tickets

Refs
- #6990
#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
