### PR TITLE
Fixes syntax error from #7001.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -654,7 +654,7 @@ function _dosomething_user_send_to_message_broker() {
   // $country_code = dosomething_global_convert_language_to_country($user_language);
   // if (empty($country_code)) {
   //   $country_code = 'global';
-  }
+  // }
   // ----- End uncooment code instruction ----
 
   // Only US is supported.


### PR DESCRIPTION
Fixes syntax error introduced in #7001. Missed to comment out a bracket.
