### PR TITLE
Extend quicksilver user registration payload with Northstar id.

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -112,6 +112,7 @@ function dosomething_mbp_get_transactional_payload($origin, $params = NULL) {
     'user_language',
     'campaign_language',
     'campaign_country',
+    'northstar_id',
   ];
   foreach ($optional_params as $op) {
     if (isset($params[$op])) {

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -598,12 +598,14 @@ function dosomething_user_new_user($form, &$form_state)
   // since registered users are subsequently logged in to their new accounts.
   dosomething_helpers_add_analytics_event('Authentication', 'Register');
 
-  // Sign the user up for transactional messaging
-  _dosomething_user_send_to_message_broker();
-
   if (module_exists('dosomething_northstar')) {
     dosomething_northstar_create_user($user, $form_state['values']['pass']);
   };
+
+  // Sign the user up for transactional messaging.
+  // Must be after dosomething_northstar_create_user()
+  // because it needs to access Northstar ID.
+  _dosomething_user_send_to_message_broker();
 }
 
 /**
@@ -638,6 +640,19 @@ function _dosomething_user_send_to_message_broker() {
     'user_language'     => isset($user_language) ? $user_language : 'en',
     'user_country'      => isset($user_country_code) ? $user_country_code : 'US',
   );
+
+  // Northstar id.
+  if (module_exists('dosomething_northstar')) {
+    try {
+      $northstar_id = dosomething_user_get_field('field_northstar_id', $account);
+      if (!empty($northstar_id)) {
+        $params['northstar_id'] = $northstar_id;
+      }
+    } catch (EntityMetadataWrapperException $e) {
+      // Don't fall into error 500 when the field is not accessible.
+      watchdog('dosomething_user', 'Northsar user doesn\'t exist for: ' . $account->mail, NULL, WATCHDOG_ERROR);
+    }
+  }
 
   // Subscribe new members to Do Something Master Campaign.
   $mobile = dosomething_user_get_field('field_mobile', $account);

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -645,7 +645,9 @@ function _dosomething_user_send_to_message_broker() {
   if (module_exists('dosomething_northstar')) {
     try {
       $northstar_id = dosomething_user_get_field('field_northstar_id', $account);
-      if (!empty($northstar_id)) {
+      // NONE is a special value representing that Northstar id is not present.
+      // @see dosomething_northstar_save_id_field();
+      if (!empty($northstar_id) && $northstar_id !== 'NONE') {
         $params['northstar_id'] = $northstar_id;
       }
     } catch (EntityMetadataWrapperException $e) {


### PR DESCRIPTION
#### What's this PR do?

This PR extends `user_register` Quicksilver payload issued for new users with optional `northstar_id` field.
#### How should this be reviewed?
- Register on the site with new mobile phone.
- Check the corresponding message in RabbitMQ, queue `mobileCommonsQueue`. It should contain `northstar_id` field.

Example:

```
a:16:{s:8:"activity";s:13:"user_register";s:5:"email";s:35:"***CENSORED***";s:3:"uid";s:7:"1708309";s:10:"merge_vars";a:2:{s:12:"MEMBER_COUNT";s:11:"3.5 million";s:5:"FNAME";s:6:"Sergii";}s:13:"user_language";s:2:"en";s:12:"northstar_id";s:24:""***CENSORED***";s:12:"user_country";s:2:"US";s:14:"email_template";s:19:"mb-user-register-US";s:17:"mailchimp_list_id";s:10:""***CENSORED***";s:9:"birthdate";s:9:"852163200";s:10:"subscribed";i:1;s:6:"mobile";s:10:"3478227222";s:17:"mc_opt_in_path_id";s:6:"164905";s:10:"email_tags";a:1:{i:0;s:20:"drupal_user_register";}s:18:"activity_timestamp";i:1473185803;s:14:"application_id";s:2:"US";}
```
#### Relevant tickets

A part of Lose your v-card messaging campaign tasks.
https://trello.com/c/tZMqE6kc/110-lose-your-v-card-signup-email-sms-data-import
