### PR TITLE
Add dosomething_rogue module

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.admin.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.admin.inc
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * Rogue admin settings.
+ */
+
+/**
+ * System settings form for Rogue configuration.
+ */
+function dosomething_rogue_config_form($form, &$form_state) {
+  $form = array();
+
+  $form['rogue'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Rogue Settings.')
+  ];
+
+  $form['rogue']['dosomething_rogue_url'] = [
+    '#type' => 'textfield',
+    '#title' => t('Rogue URL'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_rogue_url', 'https://qa-rogue.dosomething.org'),
+  ];
+
+  $form['rogue']['dosomething_rogue_api_version'] = [
+    '#type' => 'textfield',
+    '#title' => t('Rogue API version number'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('dosomething_rogue_api_version', 'v1'),
+  ];
+
+  $form['rogue']['dosomething_rogue_api_key'] = [
+    '#type' => 'textfield',
+    '#title' => t('Rogue API Key'),
+    '#required' => FALSE,
+    '#default_value' => variable_get('dosomething_rogue_api_key', ''),
+  ];
+
+  return system_settings_form($form);
+}

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.admin.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.admin.inc
@@ -20,7 +20,7 @@ function dosomething_rogue_config_form($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Rogue URL'),
     '#required' => TRUE,
-    '#default_value' => variable_get('dosomething_rogue_url', 'https://qa-rogue.dosomething.org'),
+    '#default_value' => variable_get('dosomething_rogue_url', 'http://rogue.app/'),
   ];
 
   $form['rogue']['dosomething_rogue_api_version'] = [

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.info
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.info
@@ -1,0 +1,6 @@
+name = DoSomething Rogue
+description = Provides connection to our reportback service
+core = 7.x
+package = DoSomething
+version = 7.x-0.3
+project = dosomething_rogue

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @file
+ * Code for the dosomething_rogue feature.
+ */
+
+define('ROGUE_API_URL', variable_get('dosomething_rogue_url', 'https://qa-rogue.dosomething.org'));
+define('ROGUE_API_VERSION', variable_get('dosomething_rogue_api_version', 'v1'));
+define('ROGUE_API_KEY', variable_get('dosomething_rogue_api_key', ''));
+
+/*
+ * Implements hook_menu()
+ *
+ */
+function dosomething_rogue_menu() {
+  $items = [];
+
+  $items['admin/config/services/rogue'] = [
+    'title' => 'Rogue API Settings',
+    'description' => 'Manage Rogue connection settings.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('dosomething_rogue_config_form'),
+    'access arguments' => array('administer modules'),
+    'file' => 'dosomething_rogue.admin.inc',
+  ];
+
+  // Return the $items array to register the path
+  return $items;
+}

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -4,7 +4,7 @@
  * Code for the dosomething_rogue feature.
  */
 
-define('ROGUE_API_URL', variable_get('dosomething_rogue_url', 'https://qa-rogue.dosomething.org'));
+define('ROGUE_API_URL', variable_get('dosomething_rogue_url', 'http://rogue.app/'));
 define('ROGUE_API_VERSION', variable_get('dosomething_rogue_api_version', 'v1'));
 define('ROGUE_API_KEY', variable_get('dosomething_rogue_api_key', ''));
 

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -97,6 +97,7 @@ dependencies[] = dosomething_organ_donation
 dependencies[] = dosomething_helpers
 dependencies[] = dosomething_home
 dependencies[] = dosomething_reportback
+dependencies[] = dosomething_rogue
 dependencies[] = dosomething_search
 dependencies[] = dosomething_settings
 dependencies[] = dosomething_signup

--- a/lib/profiles/dosomething/dosomething.make
+++ b/lib/profiles/dosomething/dosomething.make
@@ -133,6 +133,12 @@ projects[dosomething_reward][download][type] = local
 projects[dosomething_reward][download][source] = './lib/modules/dosomething/dosomething_reward'
 projects[dosomething_reward][subdir] = "dosomething"
 
+; Dosomething Rogue
+projects[dosomething_rogue][type] = "module"
+projects[dosomething_rogue][download][type] = local
+projects[dosomething_rogue][download][source] = './lib/modules/dosomething/dosomething_rogue'
+projects[dosomething_rogue][subdir] = "dosomething"
+
 ; Dosomething Search
 projects[dosomething_search][type] = "module"
 projects[dosomething_search][download][type] = local


### PR DESCRIPTION
#### What's this PR do?

Adds a `dosomething_rogue` module to hold all rogue related features. 

Adds a global configuration form so we can configure api settings.

![image](https://cloud.githubusercontent.com/assets/1700409/18288162/43af1846-7448-11e6-9781-0d098cf271a4.png)
#### How should this be reviewed?

enable to the new `dosomething_rogue` module. go to `/admin/config/services/rogue` and you should be able to edit the settings there.
#### Relevant tickets

Fixes #6958
