### PR TITLE
Add custom settings flag

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -336,6 +336,10 @@ function dosomething_campaign_admin_custom_settings_page($node) {
     $reportback_field_form = drupal_get_form($form_id, $node);
     $output .= render($reportback_field_form);
   }
+  if (module_exists('dosomething_rogue')) {
+    $rogue_config_form = drupal_get_form('dosomething_rogue_campaign_config_form', $node);
+    $output .= render($rogue_config_form);
+  }
 
   return $output;
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.admin.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.admin.inc
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Rogue admin settings.
+ * Rogue admin functionality.
  */
 
 /**
@@ -38,4 +38,55 @@ function dosomething_rogue_config_form($form, &$form_state) {
   ];
 
   return system_settings_form($form);
+}
+
+/**
+ * Adds helper flag to turn on rogue collection on the custom settings page on campaign nodes.
+ */
+function dosomething_rogue_campaign_config_form($form, &$form_state, $node) {
+  // Load the node's helpers variables.
+  $vars = dosomething_helpers_get_variables('node', $node->nid);
+
+  $form['nid'] = [
+    '#type' => 'hidden',
+    '#value' => $node->nid,
+  ];
+
+  $form['rogue'] = [
+    '#type' => 'fieldset',
+    '#title' => t("Rogue"),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  ];
+
+  $form['rogue']['rogue_collection'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Send reportbacks to rogue'),
+    '#description' => t('If set, when a user submits a reportback it will be sent to our reportback service.'),
+    '#default_value' => $vars['rogue_collection'],
+    '#size' => 20,
+  ];
+
+  $form['rogue']['actions'] = [
+    '#type' => 'actions',
+    'submit' => [
+      '#type' => 'submit',
+      '#value' => 'Save',
+    ],
+  ];
+  return $form;
+}
+
+/**
+ * Submit callback for dosomething_rogue_campaign_config_form().
+ */
+function dosomething_rogue_campaign_config_form_submit(&$form, &$form_state) {
+  $var_names = ['rogue_collection'];
+
+  foreach($var_names as $var_name) {
+    $values = $form_state['values'];
+    dosomething_helpers_set_variable('node', $values['nid'], $var_name, $values[$var_name]);
+  }
+
+  drupal_set_message("Updated.");
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -4,6 +4,8 @@
  * Code for the dosomething_rogue feature.
  */
 
+include_once('dosomething_rogue.admin.inc');
+
 define('ROGUE_API_URL', variable_get('dosomething_rogue_url', 'http://rogue.app/'));
 define('ROGUE_API_VERSION', variable_get('dosomething_rogue_api_version', 'v1'));
 define('ROGUE_API_KEY', variable_get('dosomething_rogue_api_key', ''));


### PR DESCRIPTION
#### What's this PR do?

Adds a flag that can be set on a campaign node to turn on/off rogue collection.

![screen shot 2016-09-07 at 10 57 56 am](https://cloud.githubusercontent.com/assets/1700409/18316810/07a66c58-74ea-11e6-876b-0ffbd30755d4.png)
#### How should this be reviewed?

Go to the custom settings on a campaign node, turn the flag on and off.
#### Relevant tickets

Fixes #6957 
#### Checklist
- [ ] Tested on staging.
