### PR TITLE
Create dosomething_rogue_reportbacks table

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @file
+ * Installation and schema hooks for dosomething_rogue.module
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function dosomething_rogue_schema() {
+  $schema = array();
+
+  $schema['dosomething_rogue_reportbacks'] = array(
+    'description' => 'Table for tracking phoenix rbid and fids and their corresponding rogue reportback and item ids',
+    'fields' => array(
+      'rbid' => array(
+        'description' => 'The rbid as it is stored in phoenix.',
+        'type' => 'int',
+        'not null' => TRUE,
+      ),
+      'rogue_reportback_id' => array(
+        'description' => 'The id of the same reportback in rogue.',
+        'type' => 'int',
+        'not null' => TRUE,
+      ),
+      'fid' => array(
+        'description' => 'The fid of the reportback item as it is stored in phoenix.',
+        'type' => 'int',
+        'not null' => TRUE,
+      ),
+      'rogue_item_id' => array(
+        'description' => 'The fid of the reportback item as it is stored in phoenix.',
+        'type' => 'int',
+        'not null' => TRUE,
+      ),
+      'created_at' => array(
+        'description' => 'The Unix timestamp of when the reportback item was stored',
+        'type' => 'int',
+        'not null' => FALSE,
+      ),
+    ),
+    'primary key' => array('rbid'),
+  );
+
+  return $schema;
+}

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -8,39 +8,44 @@
  * Implements hook_schema().
  */
 function dosomething_rogue_schema() {
-  $schema = array();
+  $schema = [];
 
-  $schema['dosomething_rogue_reportbacks'] = array(
+  $schema['dosomething_rogue_reportbacks'] = [
     'description' => 'Table for tracking phoenix rbid and fids and their corresponding rogue reportback and item ids',
-    'fields' => array(
-      'rbid' => array(
+    'fields' => [
+      'fid' => [
+        'description' => 'The fid of the reportback item as it is stored in phoenix.',
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'rogue_item_id' => [
+        'description' => 'The fid of the reportback item as it is stored in phoenix.',
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'rbid' => [
         'description' => 'The rbid as it is stored in phoenix.',
         'type' => 'int',
         'not null' => TRUE,
-      ),
-      'rogue_reportback_id' => array(
+      ],
+      'rogue_reportback_id' => [
         'description' => 'The id of the same reportback in rogue.',
         'type' => 'int',
         'not null' => TRUE,
-      ),
-      'fid' => array(
-        'description' => 'The fid of the reportback item as it is stored in phoenix.',
-        'type' => 'int',
-        'not null' => TRUE,
-      ),
-      'rogue_item_id' => array(
-        'description' => 'The fid of the reportback item as it is stored in phoenix.',
-        'type' => 'int',
-        'not null' => TRUE,
-      ),
-      'created_at' => array(
-        'description' => 'The Unix timestamp of when the reportback item was stored',
+      ],
+      'created_at' => [
+        'description' => 'The Unix timestamp of when the reportback was stored',
         'type' => 'int',
         'not null' => FALSE,
-      ),
-    ),
-    'primary key' => array('rbid'),
-  );
+      ],
+    ],
+    'primary key' => ['fid'],
+    'indexes' => [
+      'rbid' => ['rbid'],
+      'rogue_reportback_id' => ['rogue_reportback_id'],
+      'rogue_item_id' => ['rogue_item_id'],
+    ],
+  ];
 
   return $schema;
 }


### PR DESCRIPTION
#### What's this PR do?

Adds an `.install` file that creates a `dosomething_rogue_reportbacks` table we can use to track phoenix reportbacks and their corresponding reportback in rogue.
#### How should this be reviewed?

install or re-install the `dosomething_rogue` module and you should see a new table `dosomething_rogue_reportbacks` in the database.
#### Any background context you want to provide?

I originally outlined in the issue that we needed two tables, one to track `rbid`'s and corresponding rogue reportback ids and one to track items. Instead, I just created one table that holds `rbid`, `rogue_reportback_id`, `fid`, and `rogue_item_id`. Even though there will be multiple entries per reportback, we know that a reportback is unique and we can just look up how `rbid` correspond to `rogue_reportback_id` in this table. Open to changing that.
#### Relevant tickets

Fixes #7016 
#### Checklist
- [ ] Tested on staging.
