### PR TITLE
Extend quicksilver payload with optional Northstar ID.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -248,6 +248,35 @@ function dosomething_northstar_save_id_field($uid, $northstar_response) {
 }
 
 /**
+ * Save the user's Northstar ID to their local profile.
+ *
+ * @param object $account
+ *   Fully loaded user object.
+ *
+ * @return string
+ *   The Northstar id or empty string on error.
+ */
+function dosomething_northstar_get_id($account = NULL) {
+  if (!$account) {
+    global $user;
+    $account = $user;
+  }
+
+  try {
+    $northstar_id = dosomething_user_get_field('field_northstar_id', $account);
+    // NONE is a special value representing that Northstar id is not present.
+    // @see dosomething_northstar_save_id_field();
+    if (!empty($northstar_id) && $northstar_id !== 'NONE') {
+      return $northstar_id;
+    }
+  } catch (EntityMetadataWrapperException $e) {
+    // Don't fall into error 500 when the field is not accessible.
+    watchdog('dosomething_northstar', 'Northsar user doesn\'t exist for: ' . $account->mail, NULL, WATCHDOG_NOTICE);
+  }
+  return '';
+}
+
+/**
  * If the log is enabled, log this request to the database.
  *
  * @param string $op - label for the operation being performed

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -248,35 +248,6 @@ function dosomething_northstar_save_id_field($uid, $northstar_response) {
 }
 
 /**
- * Save the user's Northstar ID to their local profile.
- *
- * @param object $account
- *   Fully loaded user object.
- *
- * @return string
- *   The Northstar id or empty string on error.
- */
-function dosomething_northstar_get_id($account = NULL) {
-  if (!$account) {
-    global $user;
-    $account = $user;
-  }
-
-  try {
-    $northstar_id = dosomething_user_get_field('field_northstar_id', $account);
-    // NONE is a special value representing that Northstar id is not present.
-    // @see dosomething_northstar_save_id_field();
-    if (!empty($northstar_id) && $northstar_id !== 'NONE') {
-      return $northstar_id;
-    }
-  } catch (EntityMetadataWrapperException $e) {
-    // Don't fall into error 500 when the field is not accessible.
-    watchdog('dosomething_northstar', 'Northsar user doesn\'t exist for: ' . $account->mail, NULL, WATCHDOG_NOTICE);
-  }
-  return '';
-}
-
-/**
  * If the log is enabled, log this request to the database.
  *
  * @param string $op - label for the operation being performed

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -695,9 +695,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in, $options = 
   ];
 
   // Northstar id.
-  if (module_exists('dosomething_northstar')) {
-    $params['northstar_id'] = dosomething_northstar_get_id($account);
-  }
+  $params['northstar_id'] = dosomething_user_get_field('field_northstar_id', $account);
 
   if (isset($options['transactionals'])) {
     $params['transactionals'] = $options['transactionals'];

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -696,17 +696,7 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in, $options = 
 
   // Northstar id.
   if (module_exists('dosomething_northstar')) {
-    try {
-      $northstar_id = dosomething_user_get_field('field_northstar_id', $account);
-      // NONE is a special value representing that Northstar id is not present.
-      // @see dosomething_northstar_save_id_field();
-      if (!empty($northstar_id) && $northstar_id !== 'NONE') {
-        $params['northstar_id'] = $northstar_id;
-      }
-    } catch (EntityMetadataWrapperException $e) {
-      // Don't fall into error 500 when the field is not accessible.
-      watchdog('dosomething_user', 'Northsar user doesn\'t exist for: ' . $account->mail, NULL, WATCHDOG_NOTICE);
-    }
+    $params['northstar_id'] = dosomething_northstar_get_id($account);
   }
 
   if (isset($options['transactionals'])) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -694,6 +694,21 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in, $options = 
     'campaign_country' => $campaign_country_code,
   ];
 
+  // Northstar id.
+  if (module_exists('dosomething_northstar')) {
+    try {
+      $northstar_id = dosomething_user_get_field('field_northstar_id', $account);
+      // NONE is a special value representing that Northstar id is not present.
+      // @see dosomething_northstar_save_id_field();
+      if (!empty($northstar_id) && $northstar_id !== 'NONE') {
+        $params['northstar_id'] = $northstar_id;
+      }
+    } catch (EntityMetadataWrapperException $e) {
+      // Don't fall into error 500 when the field is not accessible.
+      watchdog('dosomething_user', 'Northsar user doesn\'t exist for: ' . $account->mail, NULL, WATCHDOG_NOTICE);
+    }
+  }
+
   if (isset($options['transactionals'])) {
     $params['transactionals'] = $options['transactionals'];
   }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -643,17 +643,7 @@ function _dosomething_user_send_to_message_broker() {
 
   // Northstar id.
   if (module_exists('dosomething_northstar')) {
-    try {
-      $northstar_id = dosomething_user_get_field('field_northstar_id', $account);
-      // NONE is a special value representing that Northstar id is not present.
-      // @see dosomething_northstar_save_id_field();
-      if (!empty($northstar_id) && $northstar_id !== 'NONE') {
-        $params['northstar_id'] = $northstar_id;
-      }
-    } catch (EntityMetadataWrapperException $e) {
-      // Don't fall into error 500 when the field is not accessible.
-      watchdog('dosomething_user', 'Northsar user doesn\'t exist for: ' . $account->mail, NULL, WATCHDOG_ERROR);
-    }
+    $params['northstar_id'] = dosomething_northstar_get_id($account);
   }
 
   // Subscribe new members to Do Something Master Campaign.

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -642,9 +642,7 @@ function _dosomething_user_send_to_message_broker() {
   );
 
   // Northstar id.
-  if (module_exists('dosomething_northstar')) {
-    $params['northstar_id'] = dosomething_northstar_get_id($account);
-  }
+  $params['northstar_id'] = dosomething_user_get_field('field_northstar_id', $account);
 
   // Subscribe new members to Do Something Master Campaign.
   $mobile = dosomething_user_get_field('field_mobile', $account);
@@ -1248,7 +1246,18 @@ function dosomething_user_get_field($field_name, $account = NULL, $format = NULL
   }
 
   $wrapper = entity_metadata_wrapper('user', $account);
-  $field_value =  $wrapper->{$field_name}->value();
+  try {
+    $field_value =  $wrapper->{$field_name}->value();
+  } catch (EntityMetadataWrapperException $e) {
+    // Don't fall into error 500 when the field is not accessible.
+    watchdog(
+      'dosomething_user',
+      'Can\'t load field `!field_name` for user `!email`.',
+      ['!field_name' => $field_name, '!email' => $account->mail],
+      WATCHDOG_NOTICE
+    );
+    return NULL;
+  }
 
   // Check if there is a specifc function handler for that field, use that first.
   $handler = 'dosomething_user_get_' . $field_name;
@@ -1289,6 +1298,30 @@ function dosomething_user_get_field_first_name($field_value, $format = 'ucwords'
  */
 function dosomething_user_get_field_last_name($field_value, $format = 'ucwords') {
   return dosomething_user_format_string($field_value, $format);
+}
+
+/**
+ * Returns user's Northstar ID.
+ *
+ * @param object $field_value
+ *   Clean field value loaded using metadata wrapper.
+ *
+ * @return string|null
+ *   Returns NULL if not set, otherwise string Northstar ID.
+ */
+function dosomething_user_get_field_northstar_id($field_value) {
+  // Return NULL if the module is not enavbled.
+  if (!module_exists('dosomething_northstar')) {
+    return NULL;
+  }
+
+  // NONE is a special value representing that Northstar id is not present.
+  // @see dosomething_northstar_save_id_field();
+  if (empty($field_value) || $field_value === 'NONE') {
+    return NULL;
+  }
+
+  return $field_value;
 }
 
 


### PR DESCRIPTION
#### What's this PR do?

This PR extends `dosomething_signup` Quicksilver payload issued for campaign subscriptions with optional `northstar_id` field.
#### How should this be reviewed?
- Sign up for a campaign.
- Check the corresponding message in RabbitMQ, queue `mobileCommonsQueue`. It should contain `northstar_id` field.

Example:

```
a:18:{s:8:"activity";s:15:"campaign_signup";s:5:"email";s:35:"sergii+test-09316-4@dosomething.org";s:3:"uid";s:7:"1708317";s:10:"merge_vars";a:8:{s:12:"MEMBER_COUNT";s:11:"3.5 million";s:5:"FNAME";s:6:"Sergii";s:14:"CAMPAIGN_TITLE";s:33:"Hunt Day 2: Trash Scavenger Hunt!";s:13:"CAMPAIGN_LINK";s:93:"http://dev.dosomething.org:8888/us/campaigns/hunt-day-2-trash-scavenger-hunt?source=node/1286";s:14:"CALL_TO_ACTION";s:49:"Show your friends that trash cleanups can be fun.";s:8:"STEP_ONE";s:16:"Start Your Hunt!";s:8:"STEP_TWO";s:10:"Snap a Pic";s:10:"STEP_THREE";s:7:"Toss It";}s:14:"transactionals";b:1;s:13:"user_language";s:2:"en";s:17:"campaign_language";s:2:"en";s:16:"campaign_country";s:2:"US";s:12:"northstar_id";s:24:"57cf0eb4a59dbf593d8b4808";s:12:"user_country";s:2:"US";s:14:"email_template";s:21:"mb-campaign-signup-US";s:10:"subscribed";i:1;s:8:"event_id";s:4:"1286";s:10:"email_tags";a:2:{i:0;s:4:"1286";i:1;s:22:"drupal_campaign_signup";}s:6:"mobile";s:10:"3478227222";s:17:"mc_opt_in_path_id";s:6:"167401";s:18:"activity_timestamp";i:1473274141;s:14:"application_id";s:2:"US";}
```
#### Relevant tickets

A part of Lose your v-card messaging campaign tasks.
https://trello.com/c/tZMqE6kc/110-lose-your-v-card-signup-email-sms-data-import
