### PR TITLE
put the gallery heading outside the gallery ul

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/gallery.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/gallery.tpl.php
@@ -14,12 +14,12 @@
  * @see paraneue_dosomething_get_gallery()
  */
 ?>
+<?php if (!empty($title)): ?>
+  <div class="gallery__heading">
+    <h1><?php print $title; ?></h1>
+  </div>
+<?php endif; ?>
 <ul class="gallery -<?php print $layout; ?> <?php print $classes; ?>" <?php if (isset($roles)) { print $roles; } ?>>
-  <?php if (!empty($title)): ?>
-    <div class="gallery__heading">
-      <h1><?php print $title; ?></h1>
-    </div>
-  <?php endif; ?>
   <?php if (!empty($items)): ?>
     <?php foreach ($items as $item): ?>
       <li>


### PR DESCRIPTION
#### What's this PR do?

Puts the `gallery__heading` div outside of the `gallery` ul.
#### How should this be reviewed?

Make sure that this looks right and doesn't mess up all galleries everywhere.
#### Any background context you want to provide?

The problem in the issue goes away if you hide the heading altogether as well, so I think something to do with the non-li div inside the ul was funky once it got little.
#### Relevant tickets

Fixes #6945
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
