### PR TITLE
Adds most of the Facebook login functionality

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -158,12 +158,12 @@ function dosomething_northstar_get_northstar_user($drupal_id) {
 }
 
 /**
- * Checks if a Northstar user exists for a given index & type.
+ * Get a Northstar user for a given index & type. Useful for non Drupal ID lookups.
  * @param  string $index_type The type of index to query for (Email, Facebook, Mobile, _id)
  * @param  string $index The index to query for
- * @return bool|object
+ * @return object|null
  */
-function dosomething_northstar_user_exists_by_index($index_type, $index) {
+function dosomething_northstar_get_user_by_custom_index($index_type, $index) {
   $client = _dosomething_northstar_build_http_client();
   $response = drupal_http_request($client['base_url'] . '/users/' . $index_type . '/' . $index, [
     'headers' => $client['headers'],
@@ -174,7 +174,7 @@ function dosomething_northstar_user_exists_by_index($index_type, $index) {
     return json_decode($response->data);
   }
 
-  return FALSE;
+  return null;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -125,49 +125,39 @@ function dosomething_northstar_update_user($user, $password = null) {
 }
 
 /**
- * Get user profile data from Northstar for the given Drupal ID.
+ * Get user profile data from Northstar for the given ID.
  *
- * @param int $drupal_id Drupal user id.
+ * @param int $id Drupal user id.
+ * @param string $type The index type of the ID
  * @return object
  */
-function dosomething_northstar_get_northstar_user($drupal_id) {
-  $northstar_user_info = cache_get('northstar_user_info_' . $drupal_id, 'cache_dosomething_northstar');
+function dosomething_northstar_get_northstar_user($id, $type = 'drupal_id') {
+  $northstar_user_info = NULL;
+
+  if ($type === 'drupal_id') {
+    $northstar_user_info = cache_get('northstar_user_info_' . $id, 'cache_dosomething_northstar');
+  }
 
   if ($northstar_user_info) {
     $northstar_user_info = $northstar_user_info->data;
   }
   else {
-    $northstar_user_info = dosomething_northstar_get_user_by_custom_index('drupal_id', $drupal_id);
+    $client = _dosomething_northstar_build_http_client();
+    $response = drupal_http_request($client['base_url'] . '/users/' . $type . '/' . $id, [
+      'headers' => $client['headers'],
+      'method' => 'GET',
+    ]);
+    $northstar_user_info = $response->data;
 
     if (!empty($northstar_user_info->error)) {
-      $error = sprintf("Error fetching Northstar user data, uid=%d: '%s'", $drupal_id, $northstar_user_info->error);
+      $error = sprintf("Error fetching Northstar user data, uid=%d: '%s'", $id, $northstar_user_info->error);
       watchdog_exception('northstar', new Exception($error));
     } else {
-      cache_set('northstar_user_info_' . $drupal_id, $northstar_user_info, 'cache_dosomething_northstar', REQUEST_TIME + 60*60*24);
+      cache_set('northstar_user_info_' . json_decode($northstar_user_info)->data->drupal_id, $northstar_user_info, 'cache_dosomething_northstar', REQUEST_TIME + 60*60*24);
     }
   }
 
   return $northstar_user_info;
-}
-
-/**
- * Get a Northstar user for a given index & type. Useful for non Drupal ID lookups.
- * @param  string $index_type The type of index to query for (Email, Facebook, Mobile, _id)
- * @param  string $index The index to query for
- * @return object|null
- */
-function dosomething_northstar_get_user_by_custom_index($index_type, $index) {
-  $client = _dosomething_northstar_build_http_client();
-  $response = drupal_http_request($client['base_url'] . '/users/' . $index_type . '/' . $index, [
-    'headers' => $client['headers'],
-    'method' => 'GET',
-  ]);
-
-  if ($response->code === "200") {
-    return $response->data;
-  }
-
-  return NULL;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -174,7 +174,7 @@ function dosomething_northstar_get_user_by_custom_index($index_type, $index) {
     return json_decode($response->data);
   }
 
-  return null;
+  return NULL;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -157,9 +157,15 @@ function dosomething_northstar_get_northstar_user($drupal_id) {
   return $northstar_user_info;
 }
 
-function dosomething_northstar_get_user_by_term($term, $id) {
+/**
+ * Checks if a Northstar user exists for a given index & type.
+ * @param  string $index_type The type of index to query for (Email, Facebook, Mobile, _id)
+ * @param  string $index The index to query for
+ * @return bool Whether the user exists
+ */
+function dosomething_northstar_user_exists_by_index($index_type, $index) {
   $client = _dosomething_northstar_build_http_client();
-  $response = drupal_http_request($client['base_url'] . '\/users/' . $term . '/' . $id, [
+  $response = drupal_http_request($client['base_url'] . '\/users/' . $index_type . '/' . $index, [
     'headers' => $client['headers'],
     'method' => 'GET',
   ]);
@@ -179,6 +185,7 @@ function dosomething_northstar_transform_user($user, $password = null) {
     'birthdate' => 'field_birthdate',
     'first_name' => 'field_first_name',
     'last_name' => 'field_last_name',
+    'facebook_id' => 'field_facebook_id',
   ];
 
   // Address fields
@@ -237,7 +244,7 @@ function dosomething_northstar_transform_user($user, $password = null) {
   if(empty($northstar_user['source'])) {
     $northstar_user['source'] = 'phoenix';
   }
-
+  print_r($northstar_user);die();
   return $northstar_user;
 }
 

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -157,6 +157,15 @@ function dosomething_northstar_get_northstar_user($drupal_id) {
   return $northstar_user_info;
 }
 
+function dosomething_northstar_get_user_by_term($term, $id) {
+  $client = _dosomething_northstar_build_http_client();
+  $response = drupal_http_request($client['base_url'] . '\/users/' . $term . '/' . $id, [
+    'headers' => $client['headers'],
+    'method' => 'GET',
+  ]);
+  return $response->code !== "404";
+}
+
 /**
  * Transform Drupal user fields into the appropriate schema for Northstar.
  *

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -161,7 +161,7 @@ function dosomething_northstar_get_northstar_user($drupal_id) {
  * Checks if a Northstar user exists for a given index & type.
  * @param  string $index_type The type of index to query for (Email, Facebook, Mobile, _id)
  * @param  string $index The index to query for
- * @return bool Whether the user exists
+ * @return bool|object
  */
 function dosomething_northstar_user_exists_by_index($index_type, $index) {
   $client = _dosomething_northstar_build_http_client();
@@ -169,7 +169,12 @@ function dosomething_northstar_user_exists_by_index($index_type, $index) {
     'headers' => $client['headers'],
     'method' => 'GET',
   ]);
-  return $response->code !== "404";
+
+  if ($response->code === "200") {
+    return json_decode($response->body);
+  }
+
+  return FALSE;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -137,21 +137,14 @@ function dosomething_northstar_get_northstar_user($drupal_id) {
     $northstar_user_info = $northstar_user_info->data;
   }
   else {
-    $client = _dosomething_northstar_build_http_client();
+    $northstar_user_info = dosomething_northstar_get_user_by_custom_index('drupal_id', $drupal_id);
 
-    $northstar_user_info = drupal_http_request($client['base_url'] . '/users/drupal_id/' . $drupal_id, array(
-      'headers' => $client['headers'],
-      'method' => 'GET',
-      ));
-
-      $northstar_user_info = $northstar_user_info->data;
-
-      if (!empty($northstar_user_info->error)) {
-        $error = sprintf("Error fetching Northstar user data, uid=%d: '%s'", $drupal_id, $northstar_user_info->error);
-        watchdog_exception('northstar', new Exception($error));
-      } else {
-        cache_set('northstar_user_info_' . $drupal_id, $northstar_user_info, 'cache_dosomething_northstar', REQUEST_TIME + 60*60*24);
-      }
+    if (!empty($northstar_user_info->error)) {
+      $error = sprintf("Error fetching Northstar user data, uid=%d: '%s'", $drupal_id, $northstar_user_info->error);
+      watchdog_exception('northstar', new Exception($error));
+    } else {
+      cache_set('northstar_user_info_' . $drupal_id, $northstar_user_info, 'cache_dosomething_northstar', REQUEST_TIME + 60*60*24);
+    }
   }
 
   return $northstar_user_info;

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -216,9 +216,8 @@ function dosomething_northstar_transform_user($user, $password = null) {
       continue;
     }
 
-    $field = $user->$drupal_key;
-    if (isset($field[LANGUAGE_NONE][0]['value'])) {
-      $northstar_user[$ns_key] = $field[LANGUAGE_NONE][0]['value'];
+    if (isset($user->$drupal_key[LANGUAGE_NONE][0]['value'])) {
+      $northstar_user[$ns_key] = $user->$drupal_key[LANGUAGE_NONE][0]['value'];
     }
   }
   foreach ($address as $ns_key => $drupal_key) {

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -205,11 +205,7 @@ function dosomething_northstar_transform_user($user, $password = null) {
 
   // Set values in ns_user if they are set.
   foreach ($optional as $ns_key => $drupal_key) {
-    if (! isset($user->$drupal_key)) {
-      continue;
-    }
-
-    if (isset($user->$drupal_key[LANGUAGE_NONE][0]['value'])) {
+    if (isset($user->{$drupal_key}[LANGUAGE_NONE][0]['value'])) {
       $northstar_user[$ns_key] = $user->$drupal_key[LANGUAGE_NONE][0]['value'];
     }
   }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -164,7 +164,7 @@ function dosomething_northstar_get_user_by_custom_index($index_type, $index) {
   ]);
 
   if ($response->code === "200") {
-    return json_decode($response->data);
+    return $response->data;
   }
 
   return NULL;
@@ -206,7 +206,7 @@ function dosomething_northstar_transform_user($user, $password = null) {
   // Set values in ns_user if they are set.
   foreach ($optional as $ns_key => $drupal_key) {
     if (isset($user->{$drupal_key}[LANGUAGE_NONE][0]['value'])) {
-      $northstar_user[$ns_key] = $user->$drupal_key[LANGUAGE_NONE][0]['value'];
+      $northstar_user[$ns_key] = $user->{$drupal_key}[LANGUAGE_NONE][0]['value'];
     }
   }
   foreach ($address as $ns_key => $drupal_key) {

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -165,13 +165,13 @@ function dosomething_northstar_get_northstar_user($drupal_id) {
  */
 function dosomething_northstar_user_exists_by_index($index_type, $index) {
   $client = _dosomething_northstar_build_http_client();
-  $response = drupal_http_request($client['base_url'] . '\/users/' . $index_type . '/' . $index, [
+  $response = drupal_http_request($client['base_url'] . '/users/' . $index_type . '/' . $index, [
     'headers' => $client['headers'],
     'method' => 'GET',
   ]);
 
   if ($response->code === "200") {
-    return json_decode($response->body);
+    return json_decode($response->data);
   }
 
   return FALSE;
@@ -190,7 +190,6 @@ function dosomething_northstar_transform_user($user, $password = null) {
     'birthdate' => 'field_birthdate',
     'first_name' => 'field_first_name',
     'last_name' => 'field_last_name',
-    'facebook_id' => 'field_facebook_id',
   ];
 
   // Address fields
@@ -213,6 +212,10 @@ function dosomething_northstar_transform_user($user, $password = null) {
 
   // Set values in ns_user if they are set.
   foreach ($optional as $ns_key => $drupal_key) {
+    if (! isset($user->$drupal_key)) {
+      continue;
+    }
+
     $field = $user->$drupal_key;
     if (isset($field[LANGUAGE_NONE][0]['value'])) {
       $northstar_user[$ns_key] = $field[LANGUAGE_NONE][0]['value'];
@@ -249,7 +252,12 @@ function dosomething_northstar_transform_user($user, $password = null) {
   if(empty($northstar_user['source'])) {
     $northstar_user['source'] = 'phoenix';
   }
-  print_r($northstar_user);die();
+
+  // Facebook ID is not in the field_ format
+  if (isset($user->facebook_id)) {
+    $northstar_user['facebook_id'] = $user->facebook_id;
+  }
+
   return $northstar_user;
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -114,7 +114,17 @@ function dosomething_user_menu() {
     'page arguments' => array(2, 3, 4),
     'access callback' => TRUE,
   );
+  $items['user/social/facebook'] = [
+    'title' => 'Facebook Login',
+    'page callback' => 'dosomething_user_facebook_login',
+    'access callback' => 'dosomething_user_facebook_login_enabled',
+    'file' => 'dosomething_user_social_auth.inc',
+  ];
   return $items;
+}
+
+function dosomething_user_facebook_login_enabled() {
+  return variable_get('dosomething_user_social_auth_enabled', FALSE) && module_exists('dosomething_northstar');
 }
 
 function dosomething_user_get_view($id) {
@@ -1345,7 +1355,6 @@ function dosomething_user_set_fields(&$edit, $fields) {
     }
 
     switch ($key) {
-      case 'country':
       case 'postal_code':
         $edit['field_address'][LANGUAGE_NONE][0][$key] = $value;
         break;

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -123,6 +123,10 @@ function dosomething_user_menu() {
   return $items;
 }
 
+/**
+ * Is the Facebook login functionality enabled
+ * @return bool
+ */
 function dosomething_user_facebook_login_enabled() {
   return variable_get('dosomething_user_social_auth_enabled', FALSE) && module_exists('dosomething_northstar');
 }
@@ -1355,6 +1359,7 @@ function dosomething_user_set_fields(&$edit, $fields) {
     }
 
     switch ($key) {
+      case 'country':
       case 'postal_code':
         $edit['field_address'][LANGUAGE_NONE][0][$key] = $value;
         break;

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -598,6 +598,23 @@ function dosomething_user_update_user($form, &$form_state) {
 }
 
 /**
+ * Takes care of misc. tasks required for a new user.
+ *
+ * @param user $user The new user to perform tasks on
+ */
+function dosomething_user_new_user_tasks($user) {
+  // Trigger an analytics event on registration
+  // @NOTE: The 'Authentication - Login' event will *also* be triggered here,
+  // since registered users are subsequently logged in to their new accounts.
+  dosomething_helpers_add_analytics_event('Authentication', 'Register');
+
+  // Sign the user up for transactional messaging.
+  // Must be after dosomething_northstar_create_user()
+  // because it needs to access Northstar ID.
+  _dosomething_user_send_to_message_broker();
+}
+
+/**
  * Custom new user login submission handler.
  *
  * Does actions after a new user has registered via the web.
@@ -606,19 +623,11 @@ function dosomething_user_update_user($form, &$form_state) {
 function dosomething_user_new_user($form, &$form_state) {
   global $user;
 
-  // Trigger an analytics event on registration
-  // @NOTE: The 'Authentication - Login' event will *also* be triggered here,
-  // since registered users are subsequently logged in to their new accounts.
-  dosomething_helpers_add_analytics_event('Authentication', 'Register');
-
   if (module_exists('dosomething_northstar')) {
     dosomething_northstar_create_user($user, $form_state['values']['pass']);
-  };
+  }
 
-  // Sign the user up for transactional messaging.
-  // Must be after dosomething_northstar_create_user()
-  // because it needs to access Northstar ID.
-  _dosomething_user_send_to_message_broker();
+  dosomething_user_new_user_tasks($user);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -603,8 +603,7 @@ function dosomething_user_update_user($form, &$form_state) {
  * Does actions after a new user has registered via the web.
  * Sign user up for emails/texts.
  */
-function dosomething_user_new_user($form, &$form_state)
-{
+function dosomething_user_new_user($form, &$form_state) {
   global $user;
 
   // Trigger an analytics event on registration

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * Constructs a new Drupal user for the given account details to represent a Facebook user.
+ * @param  array $account_details  All of the properties to instantiate
+ * @return $user
+ */
 function dosomething_user_make_facebook_user($account_details) {
   $edit = [
     'mail' => $account_details['email'],
@@ -14,9 +19,71 @@ function dosomething_user_make_facebook_user($account_details) {
   $user = user_save(null, $edit);
   user_save($user, ['name' => $user->uid]);
 
+  // For simplicity we don't need to attach this before the save / save it to a table,
+  // it just needs to be here for object transformations
+  $user->facebook_id = $account_details['facebook_id'];
+  
   return $user;
 }
 
+/**
+ * Registers a new user with Northstar (or upserts with existing) & returns a Drupal account
+ * @param  array $account_details Account details for the user to register
+ * @return $user Created (or retrieved) Drupal user
+ */
+function dosomething_user_register_facebook_user($account_details) {
+  // Otherwise check if we need to make a new account or upsert with an existing.
+  $create_new_account = TRUE;
+
+  // Checks if there is an existing account for the given email
+  if (isset($account_details['email'])) {
+    $email = $account_details['email'];
+    $create_new_account = !dosomething_northstar_user_exists_by_index('email', $email);
+  }
+
+  if ($create_new_account) {
+    // Create the Drupal user.
+    // Unfortunately there doesn't seem to be anyway around this because of how Drupal is architected.
+    $user = dosomething_user_make_facebook_user($account_details);
+    dosomething_northstar_create_user($user);
+  }
+  else {
+    // Update existing Northstar user to link Facebook ID
+    $user->facebook_id = $account_details['facebook_id'];
+    $response = drupal_http_request($client['base_url'] . '/users/email/' . $email, [
+      'headers' => $client['headers'],
+      'method' => 'PUT',
+      'data' => json_encode(['facebook_id' => $facebook_id]),
+    ]);
+    $user = user_load(json_decode($response->body)->data->drupal_id);
+  }
+}
+
+/**
+ * Verify the given access token & Facebook ID are correct with Northstar
+ * @param  string $facebook_id  Facebook ID
+ * @param  String $access_token Access token to validate
+ * @return bool
+ */
+function dosomething_user_verify_facebook_user($facebook_id, $access_token) {
+  // TODO
+  return true;
+}
+
+/**
+ * Creates a Drupal session for a given Facebook user
+ * @param  $user User to create session for
+ */
+function dosomething_user_create_facebook_session($user) {
+  $form_state['uid'] = $user->uid;
+  user_login_submit([], $form_state);
+  user_login_finalize($form_state);
+}
+
+/**
+ * Handles POST request for /user/social/facebook
+ * Which can register or login a Facebook user
+ */
 function dosomething_user_facebook_login() {
   global $user;
 
@@ -27,7 +94,7 @@ function dosomething_user_facebook_login() {
   $facebook_id = $_POST['facebook_id'];
   $access_token = $_POST['access_token'];
   $verify_token = TRUE;
-  $logged_in = FALSE;
+  $token_verified = FALSE;
 
   $account_details = [
     'email' => data_get($_POST, 'email'),
@@ -37,60 +104,25 @@ function dosomething_user_facebook_login() {
     'user_registration_source' => 'facebook_auth',
   ];
 
-  if (dosomething_northstar_get_user_by_term('facebook_id', $facebook_id)) {
+  if (dosomething_northstar_user_exists_by_index('facebook_id', $facebook_id)) {
     // If the user is already registered with us, start to load them into Drupal
     $user = user_load(json_decode($response->data)->data->drupal_id);
   }
   else {
-    // Otherwise check if we need to make a new account or upsert with an existing.
-    $create_new_account = TRUE;
-    $client = _dosomething_northstar_build_http_client();
-
-    // Checks if there is an existing account for the given email
-    if (isset($account_details['email'])) {
-      $email = $account_details['email'];
-      $create_new_account = !dosomething_northstar_get_user_by_term('email', $email);
-    }
-
-    if ($create_new_account) {
-      // Create the Drupal user.
-      // Unfortunately there doesn't seem to be anyway around this because of how Drupal is architected.
-      $user = dosomething_user_make_facebook_user($account_details);
-      $account_details['drupal_id'] = $user->uid;
-
-      // Create Northstar user w/ Facebook ID
-      $response = drupal_http_request($client['base_url'] . '/users', [
-        'headers' => $client['headers'],
-        'method' => 'POST',
-        'data' => json_encode($account_details),
-      ]);
-
-      // No need to run a verify on the initial signup.
-      $verify_token = FALSE;
-      $logged_in = TRUE;
-    }
-    else {
-      // Update existing Northstar user to link Facebook ID
-      $response = drupal_http_request($client['base_url'] . '/users/email/' . $email, [
-        'headers' => $client['headers'],
-        'method' => 'PUT',
-        'data' => json_encode(['facebook_id' => $facebook_id]),
-      ]);
-      $user = user_load(json_decode($response->body)->data->drupal_id);
-    }
+    $user = dosomething_user_make_facebook_user($account_details);
+    // No need to run a verify on the initial signup.
+    $verify_token = FALSE;
+    $token_verified = TRUE;
   }
 
   // We now have Northstar verify the given oAuth token is actually for this person
   if ($verify_token) {
-    // TODO: implement verify response, if they verify...
-    $logged_in = TRUE;
+    $token_verified = dosomething_user_verify_facebook_user($facebook_id, $access_token);
   }
 
   // If they passed the login verification, create a session
-  if ($logged_in) {
-    $form_state['uid'] = $user->uid;
-    user_login_submit([], $form_state);
-    user_login_finalize($form_state);
+  if ($token_verified) {
+    dosomething_user_create_facebook_session($user);
   }
 
   // Always return them to the previous page

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
@@ -33,10 +33,10 @@ function dosomething_user_register_facebook_user($account_details) {
   // Checks if there is an existing account for the given email
   if (isset($account_details['email'])) {
     $email = $account_details['email'];
-    $northstar_account = dosomething_northstar_user_exists_by_index('email', $email);
+    $northstar_account = dosomething_northstar_get_user_by_custom_index('email', $email);
   }
 
-  if ($northstar_account === FALSE) {
+  if ($northstar_account === null) {
     $user = dosomething_user_make_facebook_user($account_details);
   }
   else {
@@ -94,9 +94,9 @@ function dosomething_user_facebook_login() {
     'user_registration_source' => 'facebook_auth',
   ];
 
-  $northstar_account = dosomething_northstar_user_exists_by_index('facebook_id', $facebook_id);
+  $northstar_account = dosomething_northstar_get_user_by_custom_index('facebook_id', $facebook_id);
 
-  if ($northstar_account != FALSE) {
+  if ($northstar_account != null) {
     // If the user is already registered with us, start to load them into Drupal
     $user = user_load($northstar_account->data->drupal_id);
   }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
@@ -33,7 +33,7 @@ function dosomething_user_register_facebook_user($account_details) {
   // Checks if there is an existing account for the given email
   if (isset($account_details['email'])) {
     $email = $account_details['email'];
-    $northstar_account = dosomething_northstar_get_user_by_custom_index('email', $email);
+    $northstar_account = json_decode(dosomething_northstar_get_user_by_custom_index('email', $email));
   }
 
   // If we can't find a NS account...
@@ -106,7 +106,7 @@ function dosomething_user_facebook_login() {
     'user_registration_source' => 'facebook_auth',
   ];
 
-  $northstar_account = dosomething_northstar_get_user_by_custom_index('facebook_id', $facebook_id);
+  $northstar_account = json_decode(dosomething_northstar_get_user_by_custom_index('facebook_id', $facebook_id));
 
   if ($northstar_account != NULL) {
     // If the user is already registered with us, start to load them into Drupal

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
@@ -44,8 +44,6 @@ function dosomething_user_register_facebook_user($account_details) {
   }
 
   $user->facebook_id = $account_details['facebook_id'];
-  dosomething_northstar_create_user($user);
-
   return $user;
 }
 
@@ -64,8 +62,13 @@ function dosomething_user_verify_facebook_user($facebook_id, $access_token) {
  * Creates a Drupal session for a given Facebook user
  * @param $user User to create session for
  */
-function dosomething_user_create_facebook_session($user) {
+function dosomething_user_create_facebook_session($user, $new_user) {
   $form_state['uid'] = $user->uid;
+
+  if ($new_user) {
+    dosomething_user_new_user(NULL, $form_state);
+  }
+
   user_login_submit([], $form_state);
   user_login_finalize($form_state);
 }
@@ -85,6 +88,7 @@ function dosomething_user_facebook_login() {
   $access_token = $_POST['access_token'];
   $verify_token = TRUE;
   $token_verified = FALSE;
+  $new_user = FALSE;
 
   $account_details = [
     'email' => data_get($_POST, 'email'),
@@ -101,7 +105,9 @@ function dosomething_user_facebook_login() {
     $user = user_load($northstar_account->data->drupal_id);
   }
   else {
+    $new_user = TRUE;
     $user = dosomething_user_register_facebook_user($account_details);
+
     // No need to run a verify on the initial signup.
     $verify_token = FALSE;
     $token_verified = TRUE;
@@ -114,7 +120,7 @@ function dosomething_user_facebook_login() {
 
   // If they passed the login verification, create a session
   if ($token_verified) {
-    dosomething_user_create_facebook_session($user);
+    dosomething_user_create_facebook_session($user, $new_user);
   }
 
   // Always return them to the previous page

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
@@ -28,8 +28,7 @@ function dosomething_user_make_facebook_user($account_details) {
  * @return $user Created (or retrieved) Drupal user
  */
 function dosomething_user_register_facebook_user($account_details) {
-  // Otherwise check if we need to make a new account or upsert with an existing.
-  $create_new_account = TRUE;
+  $user = null;
 
   // Checks if there is an existing account for the given email
   if (isset($account_details['email'])) {
@@ -37,15 +36,17 @@ function dosomething_user_register_facebook_user($account_details) {
     $northstar_account = dosomething_northstar_user_exists_by_index('email', $email);
   }
 
-  if (isset($northstar_account)) {
-    $user = $user_load($northstar_account->data->drupal_id);
+  if ($northstar_account === FALSE) {
+    $user = dosomething_user_make_facebook_user($account_details);
   }
   else {
-    $user = dosomething_user_make_facebook_user($account_details);
+    $user = user_load($northstar_account->data->drupal_id);
   }
 
   $user->facebook_id = $account_details['facebook_id'];
   dosomething_northstar_create_user($user);
+
+  return $user;
 }
 
 /**
@@ -93,12 +94,14 @@ function dosomething_user_facebook_login() {
     'user_registration_source' => 'facebook_auth',
   ];
 
-  if (dosomething_northstar_user_exists_by_index('facebook_id', $facebook_id)) {
+  $northstar_account = dosomething_northstar_user_exists_by_index('facebook_id', $facebook_id);
+
+  if ($northstar_account != FALSE) {
     // If the user is already registered with us, start to load them into Drupal
-    $user = user_load(json_decode($response->data)->data->drupal_id);
+    $user = user_load($northstar_account->data->drupal_id);
   }
   else {
-    $user = dosomething_user_make_facebook_user($account_details);
+    $user = dosomething_user_register_facebook_user($account_details);
     // No need to run a verify on the initial signup.
     $verify_token = FALSE;
     $token_verified = TRUE;

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
@@ -25,7 +25,7 @@ function dosomething_user_make_facebook_user($account_details) {
 /**
  * Registers a new user with Northstar (or upserts with existing) & returns a Drupal account
  * @param  array $account_details Account details for the user to register
- * @return $user Created (or retrieved) Drupal user
+ * @return $user
  */
 function dosomething_user_register_facebook_user($account_details) {
   $user = null;

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
@@ -19,6 +19,8 @@ function dosomething_user_make_facebook_user($account_details) {
   $user = user_save('', $edit);
   user_save($user, ['name' => $user->uid]);
 
+  dosomething_user_new_user_tasks($user);
+
   return $user;
 }
 
@@ -36,14 +38,25 @@ function dosomething_user_register_facebook_user($account_details) {
     $northstar_account = dosomething_northstar_get_user_by_custom_index('email', $email);
   }
 
+  // If we can't find a NS account...
   if ($northstar_account === NULL) {
-    $user = dosomething_user_make_facebook_user($account_details);
+    // First make sure we don't duplicate a Drupal account by checking email
+    $user = dosomething_user_get_user_by_email($email);
+
+    // If we can't find the account by email, make a new one
+    if ($user === FALSE) {
+      $user = dosomething_user_make_facebook_user($account_details);
+    }
   }
+  // Otherwise load the existing Drupal account
   else {
     $user = user_load($northstar_account->data->drupal_id);
   }
 
+  // Attack Facebook ID & update Northstar
   $user->facebook_id = $account_details['facebook_id'];
+  dosomething_northstar_create_user($user);
+
   return $user;
 }
 
@@ -62,13 +75,8 @@ function dosomething_user_verify_facebook_user($facebook_id, $access_token) {
  * Creates a Drupal session for a given Facebook user
  * @param $user User to create session for
  */
-function dosomething_user_create_facebook_session($user, $new_user) {
+function dosomething_user_create_facebook_session($user) {
   $form_state['uid'] = $user->uid;
-
-  if ($new_user) {
-    dosomething_user_new_user(NULL, $form_state);
-  }
-
   user_login_submit([], $form_state);
   user_login_finalize($form_state);
 }
@@ -88,7 +96,6 @@ function dosomething_user_facebook_login() {
   $access_token = $_POST['access_token'];
   $verify_token = TRUE;
   $token_verified = FALSE;
-  $new_user = FALSE;
 
   $account_details = [
     'email' => data_get($_POST, 'email'),
@@ -105,9 +112,7 @@ function dosomething_user_facebook_login() {
     $user = user_load($northstar_account->data->drupal_id);
   }
   else {
-    $new_user = TRUE;
     $user = dosomething_user_register_facebook_user($account_details);
-
     // No need to run a verify on the initial signup.
     $verify_token = FALSE;
     $token_verified = TRUE;
@@ -120,7 +125,7 @@ function dosomething_user_facebook_login() {
 
   // If they passed the login verification, create a session
   if ($token_verified) {
-    dosomething_user_create_facebook_session($user, $new_user);
+    dosomething_user_create_facebook_session($user);
   }
 
   // Always return them to the previous page

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
@@ -28,7 +28,7 @@ function dosomething_user_make_facebook_user($account_details) {
  * @return user
  */
 function dosomething_user_register_facebook_user($account_details) {
-  $user = null;
+  $user = NULL;
 
   // Checks if there is an existing account for the given email
   if (isset($account_details['email'])) {
@@ -36,7 +36,7 @@ function dosomething_user_register_facebook_user($account_details) {
     $northstar_account = dosomething_northstar_get_user_by_custom_index('email', $email);
   }
 
-  if ($northstar_account === null) {
+  if ($northstar_account === NULL) {
     $user = dosomething_user_make_facebook_user($account_details);
   }
   else {
@@ -96,7 +96,7 @@ function dosomething_user_facebook_login() {
 
   $northstar_account = dosomething_northstar_get_user_by_custom_index('facebook_id', $facebook_id);
 
-  if ($northstar_account != null) {
+  if ($northstar_account != NULL) {
     // If the user is already registered with us, start to load them into Drupal
     $user = user_load($northstar_account->data->drupal_id);
   }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
@@ -19,8 +19,6 @@ function dosomething_user_make_facebook_user($account_details) {
   $user = user_save('', $edit);
   user_save($user, ['name' => $user->uid]);
 
-  dosomething_user_new_user_tasks($user);
-
   return $user;
 }
 
@@ -56,6 +54,9 @@ function dosomething_user_register_facebook_user($account_details) {
   // Attack Facebook ID & update Northstar
   $user->facebook_id = $account_details['facebook_id'];
   dosomething_northstar_create_user($user);
+
+  // Tasks must be run after Northstar creation
+  dosomething_user_new_user_tasks($user);
 
   return $user;
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
@@ -1,0 +1,97 @@
+<?php
+
+function dosomething_user_make_facebook_user($account_details) {
+  $edit = [
+    'mail' => $account_details['email'],
+    'name' => $account_details['email'],
+    'pass' => user_password(),
+    'status' => 1,
+    'created' => REQUEST_TIME,
+  ];
+
+  $account_details['user_registration_source'] = 'facebook_auth';
+  dosomething_user_set_fields($edit, $account_details);
+
+  $user = user_save(null, $edit);
+  user_save($user, ['name' => $user->uid]);
+  $account_details['drupal_id'] = $user->uid;
+
+  return $user;
+}
+
+function dosomething_user_facebook_login() {
+  global $user;
+
+  if (!isset($_POST['facebook_id']) || !isset($_POST['access_token']) || !isset($_POST['email'])) {
+    return services_error("Email, Facebook ID & access token is required.");
+  }
+
+  $facebook_id = $_POST['facebook_id'];
+  $access_token = $_POST['access_token'];
+  $verify_token = TRUE;
+  $logged_in = FALSE;
+
+  $account_details = [
+    'email' => data_get($_POST, 'email'),
+    'first_name' => data_get($_POST, 'first_name'),
+    'last_name' => data_get($_POST, 'last_name'),
+    'facebook_id' => $facebook_id,
+  ];
+
+  if (dosomething_northstar_get_user_by_term('facebook_id', $facebook_id)) {
+    // If the user is already registered with us, start to load them into Drupal
+    $user = user_load(json_decode($response->data)->data->drupal_id);
+  }
+  else {
+    // Otherwise check if we need to make a new account or upsert with an existing.
+    $create_new_account = TRUE;
+    $client = _dosomething_northstar_build_http_client();
+
+    if (isset($account_details['email'])) {
+      $email = $account_details['email'];
+      $create_new_account = !dosomething_northstar_get_user_by_term('email', $email);
+    }
+
+    if ($create_new_account) {
+      // Create the Drupal user.
+      // Unfortunately there doesn't seem to be anyway around this because of how Drupal is architected.
+      $user = dosomething_user_make_facebook_user($account_details);
+
+      // Create Northstar user w/ Facebook ID
+      $response = drupal_http_request($client['base_url'] . '/users', [
+        'headers' => $client['headers'],
+        'method' => 'POST',
+        'data' => json_encode($account_details),
+      ]);
+
+      // No need to run a verify on the initial signup.
+      $verify_token = FALSE;
+      $logged_in = TRUE;
+    }
+    else {
+      // Update existing Northstar user to link Facebook ID
+      $response = drupal_http_request($client['base_url'] . '/users/email/' . $email, [
+        'headers' => $client['headers'],
+        'method' => 'PUT',
+        'data' => json_encode(['facebook_id' => $facebook_id]),
+      ]);
+      $user = user_load(json_decode($response->body)->data->drupal_id);
+    }
+  }
+
+  // We now have Northstar verify the given oAuth token is actually for this person
+  if ($verify_token) {
+    // TODO: implement verify response, if they verify...
+    $logged_in = TRUE;
+  }
+
+  // If they passed the login verification, create a session
+  if ($logged_in) {
+    $form_state['uid'] = $user->uid;
+    user_login_submit([], $form_state);
+    user_login_finalize($form_state);
+  }
+
+  // Always return them to the previous page
+  drupal_goto($_SERVER['HTTP_REFERER']);
+}

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
@@ -9,12 +9,10 @@ function dosomething_user_make_facebook_user($account_details) {
     'created' => REQUEST_TIME,
   ];
 
-  $account_details['user_registration_source'] = 'facebook_auth';
   dosomething_user_set_fields($edit, $account_details);
 
   $user = user_save(null, $edit);
   user_save($user, ['name' => $user->uid]);
-  $account_details['drupal_id'] = $user->uid;
 
   return $user;
 }
@@ -36,6 +34,7 @@ function dosomething_user_facebook_login() {
     'first_name' => data_get($_POST, 'first_name'),
     'last_name' => data_get($_POST, 'last_name'),
     'facebook_id' => $facebook_id,
+    'user_registration_source' => 'facebook_auth',
   ];
 
   if (dosomething_northstar_get_user_by_term('facebook_id', $facebook_id)) {
@@ -47,6 +46,7 @@ function dosomething_user_facebook_login() {
     $create_new_account = TRUE;
     $client = _dosomething_northstar_build_http_client();
 
+    // Checks if there is an existing account for the given email
     if (isset($account_details['email'])) {
       $email = $account_details['email'];
       $create_new_account = !dosomething_northstar_get_user_by_term('email', $email);
@@ -56,6 +56,7 @@ function dosomething_user_facebook_login() {
       // Create the Drupal user.
       // Unfortunately there doesn't seem to be anyway around this because of how Drupal is architected.
       $user = dosomething_user_make_facebook_user($account_details);
+      $account_details['drupal_id'] = $user->uid;
 
       // Create Northstar user w/ Facebook ID
       $response = drupal_http_request($client['base_url'] . '/users', [

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
@@ -3,7 +3,7 @@
 /**
  * Constructs a new Drupal user for the given account details to represent a Facebook user.
  * @param  array $account_details  All of the properties to instantiate
- * @return $user
+ * @return user
  */
 function dosomething_user_make_facebook_user($account_details) {
   $edit = [
@@ -25,7 +25,7 @@ function dosomething_user_make_facebook_user($account_details) {
 /**
  * Registers a new user with Northstar (or upserts with existing) & returns a Drupal account
  * @param  array $account_details Account details for the user to register
- * @return $user
+ * @return user
  */
 function dosomething_user_register_facebook_user($account_details) {
   $user = null;
@@ -62,7 +62,7 @@ function dosomething_user_verify_facebook_user($facebook_id, $access_token) {
 
 /**
  * Creates a Drupal session for a given Facebook user
- * @param  $user User to create session for
+ * @param $user User to create session for
  */
 function dosomething_user_create_facebook_session($user) {
   $form_state['uid'] = $user->uid;

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
@@ -19,10 +19,6 @@ function dosomething_user_make_facebook_user($account_details) {
   $user = user_save(null, $edit);
   user_save($user, ['name' => $user->uid]);
 
-  // For simplicity we don't need to attach this before the save / save it to a table,
-  // it just needs to be here for object transformations
-  $user->facebook_id = $account_details['facebook_id'];
-  
   return $user;
 }
 
@@ -38,25 +34,18 @@ function dosomething_user_register_facebook_user($account_details) {
   // Checks if there is an existing account for the given email
   if (isset($account_details['email'])) {
     $email = $account_details['email'];
-    $create_new_account = !dosomething_northstar_user_exists_by_index('email', $email);
+    $northstar_account = dosomething_northstar_user_exists_by_index('email', $email);
   }
 
-  if ($create_new_account) {
-    // Create the Drupal user.
-    // Unfortunately there doesn't seem to be anyway around this because of how Drupal is architected.
-    $user = dosomething_user_make_facebook_user($account_details);
-    dosomething_northstar_create_user($user);
+  if (isset($northstar_account)) {
+    $user = $user_load($northstar_account->data->drupal_id);
   }
   else {
-    // Update existing Northstar user to link Facebook ID
-    $user->facebook_id = $account_details['facebook_id'];
-    $response = drupal_http_request($client['base_url'] . '/users/email/' . $email, [
-      'headers' => $client['headers'],
-      'method' => 'PUT',
-      'data' => json_encode(['facebook_id' => $facebook_id]),
-    ]);
-    $user = user_load(json_decode($response->body)->data->drupal_id);
+    $user = dosomething_user_make_facebook_user($account_details);
   }
+
+  $user->facebook_id = $account_details['facebook_id'];
+  dosomething_northstar_create_user($user);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
@@ -33,7 +33,7 @@ function dosomething_user_register_facebook_user($account_details) {
   // Checks if there is an existing account for the given email
   if (isset($account_details['email'])) {
     $email = $account_details['email'];
-    $northstar_account = json_decode(dosomething_northstar_get_user_by_custom_index('email', $email));
+    $northstar_account = json_decode(dosomething_northstar_get_northstar_user($email, 'email'));
   }
 
   // If we can't find a NS account...
@@ -106,7 +106,7 @@ function dosomething_user_facebook_login() {
     'user_registration_source' => 'facebook_auth',
   ];
 
-  $northstar_account = json_decode(dosomething_northstar_get_user_by_custom_index('facebook_id', $facebook_id));
+  $northstar_account = json_decode(dosomething_northstar_get_northstar_user($facebook_id, 'facebook_id'));
 
   if ($northstar_account != NULL) {
     // If the user is already registered with us, start to load them into Drupal

--- a/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user_social_auth.inc
@@ -16,7 +16,7 @@ function dosomething_user_make_facebook_user($account_details) {
 
   dosomething_user_set_fields($edit, $account_details);
 
-  $user = user_save(null, $edit);
+  $user = user_save('', $edit);
   user_save($user, ['name' => $user->uid]);
 
   return $user;

--- a/lib/themes/dosomething/paraneue_dosomething/js/social-auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/social-auth.js
@@ -1,11 +1,24 @@
 const $ = require('jquery');
 
+function loginToPhoenix(profileData) {
+  console.log(profileData);
+}
+
+function getFacebookProfile(callback) {
+  // Birthday doesn't actually return anything cause we don't have reviewed status yet
+  FB.api('/me', {fields: 'last_name,name,email,birthday'}, function(profile) {
+    callback(profile);
+  });
+}
+
 function checkFacebookLoginState() {
   FB.getLoginStatus((response) => {
-    switch (response.status) {
-      case 'connected': console.log('Logged in'); break;
-      case 'not_authorized': console.log('App needs authorization'); break;
-      default: console.log("not logged into facebook");
+    if (response.status === 'connected') {
+      const authData = response.authResponse;
+      const userData = getFacebookProfile(function(profile) {
+        profile.authData = authData;
+        loginToPhoenix(profile);
+      });
     }
   });
 }

--- a/lib/themes/dosomething/paraneue_dosomething/js/social-auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/social-auth.js
@@ -3,28 +3,8 @@ import ApiClient from './utilities/ApiClient';
 const $ = require('jquery');
 const apiClient = new ApiClient('v1');
 
-let facebookProfile = {};
-
-// function loginToPhoenix(profileData) {
-//   apiClient.post('users/facebook_auth', profileData).then((response) => {
-//     console.log(response);
-//     if (Array.isArray(response) && response[0] === true) {
-//       // Logged in, refresh page to reflect the new user state.
-//       // location.reload();
-//     }
-//     else {
-//       console.log("Womp womp.");
-//     }
-//   });
-// }
-
 function addHiddenLoginInput(key, value) {
   $('<input>').attr('type', 'hidden').attr('name', key).attr('value', value).appendTo('#facebook_login');
-}
-
-function loginToPhoenix(e) {
-  e.preventDefault();
-
 }
 
 function getFacebookProfile(callback) {
@@ -48,12 +28,8 @@ function getFacebookProfile(callback) {
 function checkFacebookLoginState() {
   FB.getLoginStatus((response) => {
     if (response.status === 'connected') {
-      const authData = response.authResponse;
       const userData = getFacebookProfile(function(profile) {
-        profile.access_token = authData.accessToken;
-        // loginToPhoenix(profile);
-        facebookProfile = profile;
-        // $('#facebook_login').on('submit', loginToPhoenix);
+        profile.access_token = response.authResponse.accessToken;
         Object.keys(facebookProfile).forEach(key => {
           addHiddenLoginInput(key, facebookProfile[key]);
         });

--- a/lib/themes/dosomething/paraneue_dosomething/js/social-auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/social-auth.js
@@ -30,8 +30,8 @@ function checkFacebookLoginState() {
     if (response.status === 'connected') {
       const userData = getFacebookProfile(function(profile) {
         profile.access_token = response.authResponse.accessToken;
-        Object.keys(facebookProfile).forEach(key => {
-          addHiddenLoginInput(key, facebookProfile[key]);
+        Object.keys(profile).forEach(key => {
+          addHiddenLoginInput(key, profile[key]);
         });
         $('#facebook_login').trigger('submit');
       });

--- a/lib/themes/dosomething/paraneue_dosomething/js/social-auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/social-auth.js
@@ -1,12 +1,46 @@
-const $ = require('jquery');
+import ApiClient from './utilities/ApiClient';
 
-function loginToPhoenix(profileData) {
-  console.log(profileData);
+const $ = require('jquery');
+const apiClient = new ApiClient('v1');
+
+let facebookProfile = {};
+
+// function loginToPhoenix(profileData) {
+//   apiClient.post('users/facebook_auth', profileData).then((response) => {
+//     console.log(response);
+//     if (Array.isArray(response) && response[0] === true) {
+//       // Logged in, refresh page to reflect the new user state.
+//       // location.reload();
+//     }
+//     else {
+//       console.log("Womp womp.");
+//     }
+//   });
+// }
+
+function addHiddenLoginInput(key, value) {
+  $('<input>').attr('type', 'hidden').attr('name', key).attr('value', value).appendTo('#facebook_login');
+}
+
+function loginToPhoenix(e) {
+  e.preventDefault();
+
 }
 
 function getFacebookProfile(callback) {
-  // Birthday doesn't actually return anything cause we don't have reviewed status yet
+  // Birthday doesn't actually return anything cause we don't have reviewed status yet. Just an example of what we *could* do.
   FB.api('/me', {fields: 'last_name,name,email,birthday'}, function(profile) {
+    // Rename properties to match our spec.
+    if (profile.name) {
+      profile.first_name = profile.name;
+      delete profile.name;
+    }
+
+    if (profile.id) {
+      profile.facebook_id = profile.id;
+      delete profile.id;
+    }
+
     callback(profile);
   });
 }
@@ -16,8 +50,14 @@ function checkFacebookLoginState() {
     if (response.status === 'connected') {
       const authData = response.authResponse;
       const userData = getFacebookProfile(function(profile) {
-        profile.authData = authData;
-        loginToPhoenix(profile);
+        profile.access_token = authData.accessToken;
+        // loginToPhoenix(profile);
+        facebookProfile = profile;
+        // $('#facebook_login').on('submit', loginToPhoenix);
+        Object.keys(facebookProfile).forEach(key => {
+          addHiddenLoginInput(key, facebookProfile[key]);
+        });
+        $('#facebook_login').trigger('submit');
       });
     }
   });
@@ -34,6 +74,6 @@ $(document).ready(function() {
     });
   };
 
-  const $facebookLoginButton = $('<fb:login-button scope="public_profile,email" onlogin="window.checkFacebookLoginState();"></fb:login-button>');
-  $facebookLoginButton.insertBefore('#edit-create-account-link');
+  const $facebookLoginButton = $(`<form id="facebook_login" action=${apiClient.hostname + '/user/social/facebook'} method="post"><fb:login-button scope="public_profile,email" onlogin="window.checkFacebookLoginState();"></fb:login-button></form>`);
+  $('#modal--login').append($facebookLoginButton);
 });

--- a/lib/themes/dosomething/paraneue_dosomething/js/social-auth.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/social-auth.js
@@ -50,6 +50,6 @@ $(document).ready(function() {
     });
   };
 
-  const $facebookLoginButton = $(`<form id="facebook_login" action=${apiClient.hostname + '/user/social/facebook'} method="post"><fb:login-button scope="public_profile,email" onlogin="window.checkFacebookLoginState();"></fb:login-button></form>`);
+  const $facebookLoginButton = $(`<form id="facebook_login" action=${apiClient.domain + '/user/social/facebook'} method="post"><fb:login-button scope="public_profile,email" onlogin="window.checkFacebookLoginState();"></fb:login-button></form>`);
   $('#modal--login').append($facebookLoginButton);
 });

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/ApiClient.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/ApiClient.js
@@ -18,8 +18,8 @@ class ApiClient {
     this.host = host;
     this.port = port === '' ? null : port;
     this.version = `/api/${version}/`;
-    this.hostname = `//${this.host}${this.port ? ':' + this.port : ''}`;
-    this.url = `${this.hostname}${this.version}`;
+    this.domain = `//${this.host}${this.port ? ':' + this.port : ''}`;
+    this.url = `${this.domain}${this.version}`;
   }
 
   /**

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/ApiClient.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/ApiClient.js
@@ -18,7 +18,8 @@ class ApiClient {
     this.host = host;
     this.port = port === '' ? null : port;
     this.version = `/api/${version}/`;
-    this.url = `//${this.host}${this.port ? ':' + this.port : ''}${this.version}`;
+    this.hostname = `//${this.host}${this.port ? ':' + this.port : ''}`;
+    this.url = `${this.hostname}${this.version}`;
   }
 
   /**


### PR DESCRIPTION
#### What's this PR do?
- NS Helper to get user by different terms
- Updates API client to be a bit more helpful for my login form
- Adds a new endpoint under /users/ for people to login via Facebook
- Does a bunch of communication with NS to get Facebook auth working
- Puts the Facebook button inside a form which the Javascript can fake trigger / append user details too
#### How should this be reviewed?

Main test scenarios I've been running through
- Fresh new account
- Facebook email matches existing Northstar account
- Matching Facebook ID

For debugging I highly suggest making multiple tabs in Postman (or whatever rest client you use)
My first tab is setup to grab oauth credentials (they expire often enough to warrant this)
Second tab is setup to grab my NS user based on my Facebook email 
`northstar-qa.dosomething.org/v1/users/email/thedeadlybutter@gmail.com`
Third tab is setup to delete the entire user based on user ID (Get user ID from tab 2)
Fourth tab is setup to set the facebook ID to null based on user ID (Get user id from tab 2)
#### Any background context you want to provide?
1. DO NOT MAKE THIS LIVE (duh)
   This works great for setting up users but DOES NOT AUTHENTICATE BEYOND THIS POINT. I need to add another endpoint in Northstar to quickly check your oauth token.
2. The function is pretty freaking big, I tried breaking it up where it was easy to do so. Unfortunately there is just a lot of steps involved & a specific sequence they must happen. 
#### Relevant tickets

Fixes #6995
Fixes #6996
#### Checklist
- [ ] Tested on staging.
