### PR TITLE
Updating features to enable the new /magicks endpoint.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -105,6 +105,13 @@ function dosomething_api_default_services_endpoint() {
         ),
       ),
     ),
+    'magicks' => array(
+      'operations' => array(
+        'index' => array(
+          'enabled' => '1',
+        ),
+      ),
+    ),
     'reportback-items' => array(
       'operations' => array(
         'retrieve' => array(


### PR DESCRIPTION
#### What's this PR do?

This PR updates the Services feature in `dosomething_api` module to enable the `/magicks` endpoint! Totally forgot to do this in the prior PR @_@

![giphy-1](https://cloud.githubusercontent.com/assets/105849/18365386/79703336-75e0-11e6-875e-dd58288b947c.gif)
#### How should this be reviewed?

👓 
#### Any background context you want to provide?

This enables the `/magicks` endpoint so #7018 actually works.
#### Relevant tickets

Fixes 💅 

---

@angaither @DFurnes 

cc: @ngjo 
