### PR TITLE
Update to redirect user after magic signup action.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/magick_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/magick_resource.inc
@@ -127,5 +127,29 @@ function magick_signup($parameters) {
     }
   }
 
-  return (new SignupTransformer)->create($parameters);
+  $response = (new SignupTransformer)->create($parameters);
+
+  if (array_key_exists('error', $response)) {
+    return magick_redirect('node/' . $parameters['campaign'], [], 'modal--login');
+  }
+
+  // @TODO: would ideally like to redirect to the action page...
+  return magick_redirect('node/' . $parameters['campaign']);
+}
+
+/**
+ * Redirect to a specified page.
+ *
+ * @param  string $path
+ * @param  array  $query
+ * @param  string $fragment
+ * @return void
+ */
+function magick_redirect($path, array $query = [], $fragment = '') {
+  $url_options = [
+    'query' => $query,
+    'fragment' => $fragment,
+  ];
+
+  drupal_goto($path, $url_options);
 }


### PR DESCRIPTION
# Work In Progress
#### What's this PR do?

This PR adds a redirect after the automagic signup action takes place. Depending on whether the action created a new signup _or_ determined the user is already signed up for the specified campaign, the redirect can be handled differently.
#### How should this be reviewed?

...
#### Any background context you want to provide?

...
#### Relevant tickets

Fixes #7027
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.

---

@angaither @DFurnes 

cc: @ngjo 
