### PR TITLE
align the join others text

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -343,28 +343,35 @@
       </div>
 
       <div class="container__row">
-          <div class="container__block">
-            <h3 class="inline-alt-text-color"><?php print t('Pics or It Didn&rsquo;t Happen'); ?></h3>
-            <?php if (isset($reportback_copy)): ?>
-              <p class="copy inline-alt-text-color"><?php print $reportback_copy; ?></p>
-            <?php endif; ?>
+        <div class="container__block">
+          <h3 class="inline-alt-text-color"><?php print t('Pics or It Didn&rsquo;t Happen'); ?></h3>
+          <?php if (isset($reportback_copy)): ?>
+            <p class="copy inline-alt-text-color"><?php print $reportback_copy; ?></p>
+          <?php endif; ?>
 
-            <?php if (isset($helpful_tips)): ?>
-              <h3 class="inline-alt-text-color"><?php print t('Helpful Tips'); ?></h3>
-              <div class="with-lists copy inline-alt-text-color">
-                <?php print $helpful_tips; ?>
-              </div>
-            <?php endif; ?>
-
-            <div class="container__row">
-              <h2 class="heading -emphasized"><?php print t('Join others making a difference'); ?></h2>
+          <?php if (isset($helpful_tips)): ?>
+            <h3 class="inline-alt-text-color"><?php print t('Helpful Tips'); ?></h3>
+            <div class="with-lists copy inline-alt-text-color">
+              <?php print $helpful_tips; ?>
             </div>
-
-            <?php if(dosomething_reportback_exists($campaign->nid)): ?>
-              <a href="#" data-modal-href="#modal-missing-photos">Is your photo not showing up?</a>
-            <?php endif; ?>
-          </div>
+          <?php endif; ?>
+        </div>
       </div>
+
+      <div class="container__row">
+        <div class="container__block">
+          <h2 class="heading -emphasized"><?php print t('Join others making a difference'); ?></h2>
+        </div>
+      </div>
+
+      <?php if(dosomething_reportback_exists($campaign->nid)): ?>
+        <div class="container__row">
+          <div class="container__block">
+            <a href="#" data-modal-href="#modal-missing-photos">Is your photo not showing up?</a>
+          </div>
+        </div>
+      <?php endif; ?>
+
 
 
       <div id="reportback" class="reportback" data-nid="<?php print $campaign->nid; ?>" data-ids="<?php print implode(',', $reportbacks_gallery['item_ids']); ?>" data-remaining="<?php print $reportbacks_gallery['remaining']; ?>" data-admin="<?php print $reportbacks_gallery['admin_access']; ?>">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -357,9 +357,7 @@
             <?php endif; ?>
 
             <div class="container__row">
-              <div class="container__block">
-                <h2 class="heading -emphasized"><?php print t('Join others making a difference'); ?></h2>
-              </div>
+              <h2 class="heading -emphasized"><?php print t('Join others making a difference'); ?></h2>
             </div>
 
             <?php if(dosomething_reportback_exists($campaign->nid)): ?>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -361,17 +361,11 @@
       <div class="container__row">
         <div class="container__block">
           <h2 class="heading -emphasized"><?php print t('Join others making a difference'); ?></h2>
+          <?php if(dosomething_reportback_exists($campaign->nid)): ?>
+            <a href="#" data-modal-href="#modal-missing-photos">Is your photo not showing up?</a>
+          <?php endif; ?>
         </div>
       </div>
-
-      <?php if(dosomething_reportback_exists($campaign->nid)): ?>
-        <div class="container__row">
-          <div class="container__block">
-            <a href="#" data-modal-href="#modal-missing-photos">Is your photo not showing up?</a>
-          </div>
-        </div>
-      <?php endif; ?>
-
 
 
       <div id="reportback" class="reportback" data-nid="<?php print $campaign->nid; ?>" data-ids="<?php print implode(',', $reportbacks_gallery['item_ids']); ?>" data-remaining="<?php print $reportbacks_gallery['remaining']; ?>" data-admin="<?php print $reportbacks_gallery['admin_access']; ?>">


### PR DESCRIPTION
#### What's this PR do?

Removes the `container__block` div that was around the misaligned text so that now it is aligned.
#### How should this be reviewed?
1. Go to a campaign
2. Scroll to Prove it
3. See the alignment

![image](https://cloud.githubusercontent.com/assets/4240292/18446275/b48736ce-78ef-11e6-92d0-834525bb3be0.png)
#### Relevant tickets

Fixes #7011
#### Checklist
- [x] Tested on staging.
