### PR TITLE
add narrow to container block under prove it

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -343,7 +343,7 @@
       </div>
 
       <div class="container__row">
-          <div class="container__block">
+          <div class="container__block -narrow">
             <h3 class="inline-alt-text-color"><?php print t('Pics or It Didn&rsquo;t Happen'); ?></h3>
             <?php if (isset($reportback_copy)): ?>
               <p class="copy inline-alt-text-color"><?php print $reportback_copy; ?></p>


### PR DESCRIPTION
#### What's this PR do?

Added the `-narrow` modifier to the `container__block` that holds the text under "Prove It" in order to make the text take up 3/4 of the width.
#### How should this be reviewed?

Does this look right?

![image](https://cloud.githubusercontent.com/assets/4240292/18446863/1c568b22-78f2-11e6-80e7-9741ce1d184e.png)
#### Relevant tickets

Fixes #6987
#### Checklist
- [x] Tested on staging.

cc: @ngjo 
