### PR TITLE
Prototype  automagic signup  redirects

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.info
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.info
@@ -2,6 +2,7 @@ name = DoSomething API
 core = 7.x
 package = DoSomething
 dependencies[] = ctools
+dependencies[] = dosomething_global
 dependencies[] = dosomething_image
 dependencies[] = services
 dependencies[] = taxonomy

--- a/lib/modules/dosomething/dosomething_api/resources/magick_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/magick_resource.inc
@@ -129,12 +129,21 @@ function magick_signup($parameters) {
 
   $response = (new SignupTransformer)->create($parameters);
 
+  $data = magick_get_data($parameters['user'], $parameters['campaign']);
+
+  $campaign_uri = $data['language_prefix'] . '/node/' . $parameters['campaign'];
+
   if (array_key_exists('error', $response)) {
-    return magick_redirect('node/' . $parameters['campaign'], [], 'modal--login');
+    return magick_redirect($campaign_uri, [], 'modal--login');
   }
 
-  // @TODO: would ideally like to redirect to the action page...
-  return magick_redirect('node/' . $parameters['campaign']);
+  $query = [
+    'magicks' => TRUE,
+    'user_id' => $parameters['user'],
+    'campaign_id' => $parameters['campaign'],
+  ];
+
+  return magick_redirect($campaign_uri, $query);
 }
 
 /**
@@ -152,4 +161,27 @@ function magick_redirect($path, array $query = [], $fragment = '') {
   ];
 
   drupal_goto($path, $url_options);
+}
+
+/**
+ * Get a bunch of useful ingredients we need to conjure
+ * magick spells.
+ *
+ * @param  string $user_id
+ * @param  string $campaign_id
+ * @return array
+ */
+function magick_get_data($user_id, $campaign_id) {
+  $user = user_load($user_id);
+  $campaign = node_load($campaign_id);
+
+  $language_code = dosomething_global_get_language($user, $campaign, TRUE);
+  $language_prefix = dosomething_global_get_prefix_for_language($language_code);
+
+  return [
+    'user' => $user,
+    'campaign' => $campaign,
+    'language_code' => $language_code,
+    'language_prefix' => $language_prefix,
+  ];
 }

--- a/lib/modules/dosomething/dosomething_api/resources/magick_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/magick_resource.inc
@@ -127,5 +127,29 @@ function magick_signup($parameters) {
     }
   }
 
-  return (new SignupTransformer)->create($parameters);
+  $response = (new SignupTransformer)->create($parameters);
+
+  if (array_key_exists('error', $response)) {
+    return magick_redirect('node/' . $parameters['campaign'], [], 'modal--login');
+  }
+
+  // @TODO: would ideally like to redirect to the action page...
+  return magick_redirect('node/' . $parameters['campaign']);
+}
+
+/**
+ * Redirect to a specified page.
+ *
+ * @param  string $path
+ * @param  array  $query
+ * @param  string $fragment
+ * @return void
+ */
+function magick_redirect($path, array $query = [], $fragment = '') {
+  $url_options = [
+    'query' => $query,
+    'fragment' => $fragment,
+  ];
+
+  drupal_goto($path, $url_options);
 }


### PR DESCRIPTION
#### What's this PR do?

This PR adds a redirect after the automagic signup action takes place. Depending on whether the action created a new signup or determined the user is already signed up for the specified campaign, the redirect can be handled differently.
#### How should this be reviewed?

Take a gander 👀  and see if the code make sense.
#### Any background context you want to provide?

Currently, for a user already signed up for the campaign, the redirect will send them to the campaign pitch page and prompt them to login by popping up the login modal.

For a user who is signing up for the first time, it also redirects them to the campaign pitch page but passes along some specific url parameters so that in the next step we can do some automagicks with the info and override the conditionals for showing just the pitch page to an anon user and allowing them to see the action page instead.

Sample redirection uri:

```
http://dev.dosomething.org:8888/us/node/1280?magicks=1&user_id=1700013&campaign_id=1280
```
#### Relevant tickets

Fixes #7027
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.

---

@angaither @DFurnes 

cc: @ngjo 
