### PR TITLE
Adding custom route and template file for experimenting with openid login

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -283,8 +283,12 @@ function dosomething_northstar_log_request($op, $user, $request_body, $response)
     ->execute();
 }
 
+/**
+ * Generate templated view for openid login at /user/openid.
+ *
+ * @return array
+ */
 function dosomething_northstar_openid_login_view() {
-  // return ['#markup' => 'Poopie doopie doo!'];
   return theme('openid_login');
 }
 
@@ -292,7 +296,6 @@ function dosomething_northstar_openid_login_view() {
  * Implements hook_theme().
  */
 function dosomething_northstar_theme() {
-  //
   return [
     'openid_login' => [
       'template' => 'openid-login',

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -26,7 +26,13 @@ function dosomething_northstar_menu() {
       'page arguments' => ['dosomething_northstar_config_form'],
       'access arguments' => ['administer modules'],
       'file' => 'dosomething_northstar.admin.inc',
-    ]
+    ],
+    'user/openid' => [
+      'title' => 'OpenID Login',
+      'page callback' => 'dosomething_northstar_openid_login_view',
+      'access arguments' => ['access content'],
+      'type' => MENU_CALLBACK,
+    ],
   ];
 }
 
@@ -275,6 +281,24 @@ function dosomething_northstar_log_request($op, $user, $request_body, $response)
       'response_values' => $response->data,
     ])
     ->execute();
+}
+
+function dosomething_northstar_openid_login_view() {
+  // return ['#markup' => 'Poopie doopie doo!'];
+  return theme('openid_login');
+}
+
+/**
+ * Implements hook_theme().
+ */
+function dosomething_northstar_theme() {
+  //
+  return [
+    'openid_login' => [
+      'template' => 'openid-login',
+      'path' => drupal_get_path('module', 'dosomething_northstar') . '/theme',
+    ]
+  ];
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/theme/openid-login.tpl.php
+++ b/lib/modules/dosomething/dosomething_northstar/theme/openid-login.tpl.php
@@ -1,0 +1,3 @@
+<h3>Welcome to the OpenID Login brought to you by Northstar™.</h3>
+
+<p>It is recommended that you use a custom template file provided by your theme.</p>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/user/openid-login.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/user/openid-login.tpl.php
@@ -1,0 +1,3 @@
+<h3>Welcome to the OpenID Login brought to you by Northstar™.</h3>
+
+<p>Login form goes here</p>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/user/openid-login.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/user/openid-login.tpl.php
@@ -1,3 +1,3 @@
 <h3>Welcome to the OpenID Login brought to you by Northstar™.</h3>
 
-<p>Login form goes here</p>
+<p>Login form goes here!</p>


### PR DESCRIPTION
#### What's this PR do?

This PR adds a new `/user/openid` route to Phoenix to allow us to experiment with adding OpenID login that connects to Northstar for our members.

The **dosomething_northstar** module sets up the route since it's related to this functionality. There is a new template file in the `/theme` directory in the module, but it is recommended to use a template file in the activated theme to override it (and says so in the message if the northstar template loads 😉 ). I've provided a template in the **Paraneue** theme to override it and get the ball rolling.
#### How should this be reviewed?

Make sure the **dosomething_northstar** module is enabled, then do a good ole `drush cc all` and head to `/user/openid` and see if you get the correct page loading.
#### Relevant tickets

Refs #7046
#### Checklist
- [ ] Tested on staging.

---

@DFurnes 

cc: @jessleenyc 
