### PR TITLE
Add OpenID Connect module dependency.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -1,5 +1,8 @@
 <?php
 
+module_load_include('php', 'openid_connect', 'includes/OpenIDConnectClientInterface.class');
+module_load_include('php', 'openid_connect', 'includes/OpenIDConnectClientBase.class');
+
 include_once('plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php');
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.info
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.info
@@ -6,6 +6,7 @@ version = 7.x-0.3
 project = dosomething_northstar
 dependencies[] = ctools
 dependencies[] = strongarm
+dependencies[] = openid_connect
 features[ctools][] = strongarm:strongarm:1
 features[features_api][] = api:2
 features[variable][] = openid_connect_client_generic

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -48,6 +48,7 @@ dependencies[] = metatag
 dependencies[] = metatag_views
 dependencies[] = module_filter
 dependencies[] = new_relic_rpm
+dependencies[] = openid_connect
 dependencies[] = pathauto
 dependencies[] = pathauto_i18n
 dependencies[] = pathauto_i18n_node


### PR DESCRIPTION
#### What's this PR do?

Adds the missing dependency on `openid_connect`, and ensures the module's base class and interface are loaded in the Northstar module before we make our own provider that extends/implements them.
#### How should this be reviewed?

I deployed this branch to Staging ([build](https://jenkins.dosomething.org/job/Deploy-Staging/700/console)) and it worked! ✅ 
#### Any background context you want to provide?

Here's the [broken build](https://jenkins.dosomething.org/job/Deploy-Staging/692/console) for 6dc64ce1aa48de289cb2bd8ecb856ecc9d2c8e31:

```
DEBUG [64423f2f]    Drush status:
 DEBUG [64423f2f]   PHP Fatal error:  Class 'OpenIDConnectClientBase' not found in /var/www/staging.beta.dosomething.org/releases/20160916173520/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php on line 8
 DEBUG [64423f2f]   Drush command terminated abnormally due to an unrecoverable error.   [error]
Error: Class 'OpenIDConnectClientBase' not found in
/var/www/staging.beta.dosomething.org/releases/20160916173520/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php,
```
#### Relevant tickets

🔔 
#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
