### PR TITLE
Northstar field authmap

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -220,7 +220,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   ];
   $utm_params = dosomething_helpers_utm_parameters(null, $utm_params);
 
-  if (dosomething_user_get_field('field_northstar_id') !== 'NONE') {
+  if (dosomething_user_get_field('field_northstar_id')) {
     $share_path = 'user/' . dosomething_user_get_field('field_northstar_id');
   }
   else {

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.install
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.install
@@ -13,7 +13,12 @@ function dosomething_northstar_schema() {
 
   $schema['dosomething_northstar_request_log'] = [
     'description' => 'Log of requests made to Northstar for debugging.',
+    'primary key' => ['id'],
     'fields' => [
+      'id' => [
+        'description' => 'The transaction ID',
+        'type' => 'serial',
+      ],
       'uid' => [
         'description' => 'The user\'s Drupal UID',
         'type' => 'int',
@@ -88,4 +93,20 @@ function dosomething_northstar_update_7002() {
     $schema = dosomething_northstar_schema();
     db_create_table($table_name, $schema[$table_name]);
   }
+}
+
+/**
+ * Add a primary key to the Northstar request log table.
+ */
+function dosomething_northstar_update_7003() {
+  db_add_field( 'dosomething_northstar_request_log', 'id', [
+    'type' => 'int',
+  ]);
+
+  db_change_field('dosomething_northstar_request_log', 'id', 'id', [
+    'type' => 'serial',
+    'not null' => 'true',
+  ], [
+    'primary key' => ['id'],
+  ]);
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -241,7 +241,7 @@ function dosomething_northstar_transform_user($user, $password = null) {
 }
 
 /**
- * Save the user's Northstar ID to their local profile.
+ * Save the user's Northstar ID to their local profile field and the authmap.
  *
  * @param $uid - Drupal user ID
  * @param $northstar_response - Northstar user JSON response
@@ -250,6 +250,15 @@ function dosomething_northstar_save_id_field($uid, $northstar_response) {
   $northstar_id = !empty($northstar_response->data->id) ? $northstar_response->data->id : null;
   $user = user_load($uid);
 
+  // Save a record to the `authmap` table if Northstar user exists:
+  if (! is_null($northstar_id)) {
+    db_merge('authmap')
+      ->key(['uid' => $user->uid])
+      ->fields(['authname' => $northstar_id, 'module' => 'openid_connect_northstar'])
+      ->execute();
+  }
+
+  // Save the `field_northstar_id`:
   $edit = [];
   dosomething_user_set_fields($edit, ['northstar_id' => $northstar_id]);
   user_save($user, $edit);

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -251,12 +251,7 @@ function dosomething_northstar_save_id_field($uid, $northstar_response) {
   $user = user_load($uid);
 
   // Save a record to the `authmap` table if Northstar user exists:
-  if (! is_null($northstar_id)) {
-    db_merge('authmap')
-      ->key(['uid' => $user->uid])
-      ->fields(['authname' => $northstar_id, 'module' => 'openid_connect_northstar'])
-      ->execute();
-  }
+  user_set_authmaps($user, ['authname_openid_connect_northstar' => $northstar_id]);
 
   // Save the `field_northstar_id`:
   $edit = [];

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -247,7 +247,7 @@ function dosomething_northstar_transform_user($user, $password = null) {
  * @param $northstar_response - Northstar user JSON response
  */
 function dosomething_northstar_save_id_field($uid, $northstar_response) {
-  $northstar_id = !empty($northstar_response->data->id) ? $northstar_response->data->id : 'NONE';
+  $northstar_id = !empty($northstar_response->data->id) ? $northstar_response->data->id : null;
   $user = user_load($uid);
 
   $edit = [];


### PR DESCRIPTION
#### What's this PR do?

This updates the `dosomething_northstar_save_id_field` function to also save the Northstar ID to the `authmap` table so it's available to the OpenID Connect module. It also adds a primary key to the `dosomething_northstar_request_log` table because that's a reasonable thing to do.
#### How should this be reviewed?

👀
#### Any background context you want to provide?

🍃 
#### Relevant tickets

References DoSomething/northstar#426.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
