### PR TITLE
Add a unique database constraint on email and mobile fields.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.install
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.install
@@ -58,6 +58,14 @@ function dosomething_user_update_7006() {
 }
 
 /**
+ * Add a unique constraint to the `mail` field on the users table.
+ */
+function dosomething_user_update_7008() {
+  db_drop_index('users', 'mail');
+  db_add_unique_key('users', 'mail', ['mail']);
+}
+
+/**
  * Implements hook_uninstall().
  */
 function dosomething_user_uninstall() {

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.install
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.install
@@ -66,6 +66,14 @@ function dosomething_user_update_7008() {
 }
 
 /**
+ * Add a unique constraint to the `field_mobile_value` field for the
+ * mobile field (since fields don't support unique database constraints).
+ */
+function dosomething_user_update_7009() {
+  db_add_unique_key('field_data_field_mobile', 'field_mobile_value', ['field_mobile_value']);
+}
+
+/**
  * Implements hook_uninstall().
  */
 function dosomething_user_uninstall() {


### PR DESCRIPTION
#### What's this PR do?

This adds unique indexes to the user's email ~~and mobile fields~~, finally making a happy ending for the long and terrifying tale of the [duplicates](https://en.wikipedia.org/wiki/Auton). Phew.

🚧 🚧 🚧 See comment below.
#### How should this be reviewed?

👀
#### Any background context you want to provide?

We'll want to do a spot-check to make sure these fields can be safely made unique before deploying (as conflicts can still be made through a race condition). I just checked when making this PR, and there are 3 dupe emails and 3 dupe mobiles on production.
#### Relevant tickets

Fixes #6409. 😌 ‼️ 🔨
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
