### PR TITLE
Fix typo when unsetting the app key variable.

### DIFF
--- a/bin/ds
+++ b/bin/ds
@@ -468,7 +468,7 @@ function pull_db {
       drush variable-delete dosomething_northstar_url -y
       drush variable-delete dosomething_northstar_port -y
       drush variable-delete dosomething_northstar_app_id -y
-      drush variable-delete dosomething_northstar_api_key -y
+      drush variable-delete dosomething_northstar_app_key -y
 
       echo "Clearing cache..."
       drush cc all


### PR DESCRIPTION
#### What's this PR do?

When users run `ds pull stage --db`, we remove the Staging server's Northstar credentials so we don't accidentally pollute data when re-enabling that module on local. It turns out I made a typo when adding this `drush variable-delete` call, so it wasn't removing the "app key".
#### How should this be reviewed?

If you pull staging, you should see `secret1` for the "Northstar App Key". This is the default value for that field, and also what Northstar seeds for the `trusted-test-client` in development.
#### Any background context you want to provide?

We should update these to be `dosomething_northstar_client_id` and `dosomething_northstar_client_secret` when we start using Northstar-PHP because the current naming is rather confusing.
#### Relevant tickets

Fixes `¯\_(ツ)_/¯`.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
