### PR TITLE
Save NULL rather than empty string when unsetting mobiles.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1105,7 +1105,10 @@ function dosomething_user_register_validate($form, &$form_state) {
       form_set_error('dosomething_user_already_registered', t('The phone number '. $mobile . ' is already registered. Have you ' . l('forgotten your password?', 'user/password')));
     }
     else {
-      // Store only the numbers.
+      // If `dosomething_user_clean_mobile_number` returned false, discard this field.
+      if ($mobile_clean === FALSE) {
+        $mobile_clean = NULL;
+      }
       form_set_value($form['field_mobile'], array(LANGUAGE_NONE => array(0 => array('value' => $mobile_clean))), $form_state);
     }
   }


### PR DESCRIPTION
#### What's this PR do?

One last gotcha! When a user sets the mobile number on their profile, we run it through `dosomething_user_clean_mobile_number`, which returns false if it's not valid. That ends up storing a empty string though, which would fail our new uniqueness constraint. This adds a quick fix to provide null in that case instead, which unsets the field.
#### How should this be reviewed?

👀
#### Any background context you want to provide?

It might make sense to refactor `dosomething_user_clean_mobile_number` to always return `string|null` instead of `string|false` so things work more intuitively?
#### Relevant tickets

Fixes 🔥.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
