### PR TITLE
Adding logic to avoid global redirect logic craziness for API requests.

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -25,6 +25,11 @@ function dosomething_global_init() {
     return;
   }
 
+  // We don't need to redirect api requests.
+  if (dosomething_helpers_is_api_request()) {
+    return;
+  }
+
   $languages = language_list();
 
   $global_lang_code = DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
@@ -520,7 +525,7 @@ function dosomething_global_get_language($account, stdClass $node = NULL, $respe
     // Respect the URL first.
     $request_path = explode('/', request_path());
     if (!empty($request_path[0])) {
-      
+
       // Otherwise try & match it against configured languages
       $languages = language_list();
       foreach ($languages as $langcode => $lang_data) {

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -355,7 +355,7 @@ function dosomething_helpers_ip_address() {
 function dosomething_helpers_is_api_request() {
   $path = explode('/', request_path());
 
-  return in_array('api', $path);
+  return $path[0] === 'api';
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -348,6 +348,17 @@ function dosomething_helpers_ip_address() {
 }
 
 /**
+ * Utility function to check if current request is an api request.
+ *
+ * @return boolean
+ */
+function dosomething_helpers_is_api_request() {
+  $path = explode('/', request_path());
+
+  return in_array('api', $path);
+}
+
+/**
  * Implements hook_form_alter().
  */
 function dosomething_helpers_form_alter(&$form, &$form_state, $form_id) {


### PR DESCRIPTION
#### What's this PR do?

This PR just adds a tiny bit of logic to help avoid running through all the crazy **dosomething_global.module** `init()` function logic for API requests where we don't need to figure out any country prefixes to add to the request path! 
#### How should this be reviewed?

👓 
#### Any background context you want to provide?

💅 
#### Relevant tickets

Fixes 🍰 
#### Checklist
- [ ] Tested on staging.

---

@DFurnes @angaither 
