### PR TITLE
Add redirect to logout of Northstar as well.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -51,3 +51,22 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
 
   user_save($account, $edit);
 }
+
+/**
+ * Redirect to destroy a Northstar single-sign-on session if one exists.
+ *
+ * Implements hook_user_logout().
+ *
+ * @param $account
+ */
+function dosomething_northstar_user_logout($account) {
+  // @TODO: Conditionally apply this only for OpenID Connect logins...?
+  $logout_url = url(NORTHSTAR_URL . '/logout', [
+    'query' => ['redirect' => url('/', ['absolute' => TRUE])],
+  ]);
+
+  // Destroy the current session, and reset $user to the anonymous user.
+  session_destroy();
+
+  drupal_goto($logout_url);
+}

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -49,6 +49,9 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
     'access_token_expiration' => $tokens['expire'],
   ]);
 
+  // Let's remember that this is a OpenID Connect session.
+  $_SESSION['DOSOMETHING_NORTHSTAR_OPENID_CONNECT'] = true;
+
   user_save($account, $edit);
 }
 
@@ -60,13 +63,13 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
  * @param $account
  */
 function dosomething_northstar_user_logout($account) {
-  // @TODO: Conditionally apply this only for OpenID Connect logins...?
-  $logout_url = url(NORTHSTAR_URL . '/logout', [
+  $is_openid_login = ! empty($_SESSION['DOSOMETHING_NORTHSTAR_OPENID_CONNECT']);
+  $northstar_logout_url = url(NORTHSTAR_URL . '/logout', [
     'query' => ['redirect' => url('/', ['absolute' => TRUE])],
   ]);
 
   // Destroy the current session, and reset $user to the anonymous user.
   session_destroy();
 
-  drupal_goto($logout_url);
+  drupal_goto($is_openid_login ? $northstar_logout_url : '/');
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -10,8 +10,7 @@ include_once('dosomething_northstar.admin.inc');
 include_once('dosomething_northstar.auth.inc');
 
 // Config vars, if not set.
-define('NORTHSTAR_URL', variable_get('dosomething_northstar_url', 'http://northstar.dev'));
-define('NORTHSTAR_PORT', variable_get('dosomething_northstar_port', '8000'));
+define('NORTHSTAR_URL', variable_get('dosomething_northstar_url', 'http://northstar.dev:8000'));
 define('NORTHSTAR_VERSION', variable_get('dosomething_northstar_version', 'v1'));
 define('NORTHSTAR_APP_ID', variable_get('dosomething_northstar_app_id', '456'));
 define('NORTHSTAR_APP_KEY', variable_get('dosomething_northstar_app_key', 'abc4324'));
@@ -331,9 +330,6 @@ function _dosomething_northstar_is_successful_response($response) {
  */
 function _dosomething_northstar_build_http_client() {
   $base_url = NORTHSTAR_URL;
-  if (getenv('DS_ENVIRONMENT') === 'local') {
-    $base_url .=  ":" . NORTHSTAR_PORT;
-  }
   $base_url .= '/' . NORTHSTAR_VERSION;
 
   $client = [


### PR DESCRIPTION
#### What's this PR do?

This PR adds a logout hook to redirect to Northstar and kill a single sign-on as well.
#### How should this be reviewed?

~~I don't know if we can only do this for OpenID Connect sessions... any ideas?~~ We added a session variable to track whether a user's session was started via OpenID Connect, so we only redirect to Northstar to kill the single sign-on session then.

I think this seems okay, but would love to hear any thoughts/counter-arguments!
#### Any background context you want to provide?

➡️ 🚪 👋 
#### Relevant tickets

References DoSomething/northstar#434.
References DoSomething/northstar#426.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
