### PR TITLE
Update to rogue

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -57,16 +57,16 @@
         },
         {
             "name": "tightenco/collect",
-            "version": "v5.2.38",
+            "version": "v5.3.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tightenco/collect.git",
-                "reference": "fded841989fcbad4532173d32e7dfaceed99f98c"
+                "reference": "321ff9a1de1466aa8546928c223cdee5b7f762cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tightenco/collect/zipball/fded841989fcbad4532173d32e7dfaceed99f98c",
-                "reference": "fded841989fcbad4532173d32e7dfaceed99f98c",
+                "url": "https://api.github.com/repos/tightenco/collect/zipball/321ff9a1de1466aa8546928c223cdee5b7f762cf",
+                "reference": "321ff9a1de1466aa8546928c223cdee5b7f762cf",
                 "shasum": ""
             },
             "require": {
@@ -100,7 +100,7 @@
                 "collection",
                 "laravel"
             ],
-            "time": "2016-06-09 21:53:44"
+            "time": "2016-09-12 17:54:06"
         },
         {
             "name": "zendesk/zendesk_api_client_php",
@@ -199,16 +199,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v3.1.2",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "39492b8b8fe514163e677bf154fd80f6cc995759"
+                "reference": "62ee73706c421654a4c840028954510277f7dfc8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/39492b8b8fe514163e677bf154fd80f6cc995759",
-                "reference": "39492b8b8fe514163e677bf154fd80f6cc995759",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/62ee73706c421654a4c840028954510277f7dfc8",
+                "reference": "62ee73706c421654a4c840028954510277f7dfc8",
                 "shasum": ""
             },
             "require": {
@@ -258,7 +258,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-08-31 09:05:42"
         }
     ],
     "aliases": [],

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -232,12 +232,15 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
  * Form submit callback for dosomething_reportback_files_form_submit.
  */
 function dosomething_reportback_files_form_submit($form, &$form_state) {
+  $node = menu_get_object();
   $user = dosomething_helpers_get_current_user();
 
   $rb_files = $form_state['values']['rb_files'];
   if (empty($rb_files) || !is_array($rb_files)) {
     return;
   }
+
+  $updates_to_send_to_rogue = [];
 
   foreach ($rb_files as $fid => $values) {
     $kudos = [
@@ -282,7 +285,20 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
       // Flush the image style cache for this image so they update with the new image.
       image_path_flush($image->source);
     }
+
+    // If Rogue feature flag is enabled, push into array to send update to Rogue.
+    if (module_exists('dosomething_rogue')) {
+      $data = [
+        'nid' => $node->nid,
+        'status' => $values['status'],
+      ];
+
+      array_push(updates_to_send_to_rogue, $data);
+    }
   }
+
+  // Send updates to Rogue.
+  dosomething_rogue_send_reportback_to_rogue($updates_to_send_to_rogue);
 
   drupal_set_message(t("Updated."));
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -288,9 +288,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
 
     // Check to see if Rogue feature flag is enabled.
     if (module_exists('dosomething_rogue')) {
-      $rogue_item_id = db_query('SELECT rogue_rbs.rogue_item_id FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rogue_rbs.fid = :fid', array(':fid' => $fid));
-
-      $rogue_item_id = $rogue_item_id->fetchAll();
+      $rogue_item_id = db_query("SELECT rogue_rbs.rogue_item_id FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE fid = :fid", array(':fid' => $fid))->fetchAll();
 
       // If there is a rogue_item_id in the dosomething_rogue_reportbacks table, send update to Rogue.
       if (!is_null($rogue_item_id[0]->rogue_item_id)) {
@@ -305,9 +303,13 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
   }
 
   // Send updates to Rogue.
-  dosomething_rogue_update_rogue_reportback_items($updates_to_send_to_rogue);
+  $response = dosomething_rogue_update_rogue_reportback_items($updates_to_send_to_rogue);
 
-  drupal_set_message(t("Updated."));
+  if ($response->code != 201) {
+    drupal_set_message($reponse->error, 'warning');
+  } else {
+    drupal_set_message(t("Updated."));
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -303,9 +303,8 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
 
   // Send updates to Rogue.
   $response = dosomething_rogue_update_rogue_reportback_items($updates_to_send_to_rogue);
-  $response->code = 404;
   if ($response->code != 201) {
-    drupal_set_message($reponse->error, 'warning');
+    drupal_set_message(print_r($response->code, TRUE) . ' ' . print_r($response->status_message, TRUE), 'warning');
   } else {
     drupal_set_message(t("Updated."));
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -232,7 +232,6 @@ function dosomething_reportback_files_form($form, &$form_state, $status = NULL, 
  * Form submit callback for dosomething_reportback_files_form_submit.
  */
 function dosomething_reportback_files_form_submit($form, &$form_state) {
-  $node = menu_get_object();
   $user = dosomething_helpers_get_current_user();
 
   $rb_files = $form_state['values']['rb_files'];

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -288,15 +288,16 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
 
     // If Rogue feature flag is enabled, push into array to send update to Rogue.
     if (module_exists('dosomething_rogue')) {
+      //TODO: find the rogue reportback item id that is associated with this rb item.
+      //TODO: update the below sending rogue reportback item id.
       $data = [
         'nid' => $node->nid,
         'status' => $values['status'],
       ];
 
-      array_push(updates_to_send_to_rogue, $data);
+      array_push($updates_to_send_to_rogue, $data);
     }
   }
-
   // Send updates to Rogue.
   dosomething_rogue_send_reportback_to_rogue($updates_to_send_to_rogue);
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -287,7 +287,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
 
     // Check to see if Rogue feature flag is enabled.
     if (module_exists('dosomething_rogue')) {
-      $rogue_item_id = db_query("SELECT rogue_rbs.rogue_item_id FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE fid = :fid", array(':fid' => $fid))->fetchAll();
+      $rogue_item_id = dosomething_rogue_get_by_file_id($fid);
 
       // If there is a rogue_item_id in the dosomething_rogue_reportbacks table, send update to Rogue.
       if (!is_null($rogue_item_id[0]->rogue_item_id)) {
@@ -303,7 +303,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
 
   // Send updates to Rogue.
   $response = dosomething_rogue_update_rogue_reportback_items($updates_to_send_to_rogue);
-
+  $response->code = 404;
   if ($response->code != 201) {
     drupal_set_message($reponse->error, 'warning');
   } else {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -286,20 +286,26 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
       image_path_flush($image->source);
     }
 
-    // If Rogue feature flag is enabled, push into array to send update to Rogue.
+    // Check to see if Rogue feature flag is enabled.
     if (module_exists('dosomething_rogue')) {
-      //TODO: find the rogue reportback item id that is associated with this rb item.
-      //TODO: update the below sending rogue reportback item id.
-      $data = [
-        'nid' => $node->nid,
-        'status' => $values['status'],
-      ];
+      $rogue_item_id = db_query('SELECT rogue_rbs.rogue_item_id FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rogue_rbs.fid = :fid', array(':fid' => $fid));
 
-      array_push($updates_to_send_to_rogue, $data);
+      $rogue_item_id = $rogue_item_id->fetchAll();
+
+      // If there is a rogue_item_id in the dosomething_rogue_reportbacks table, send update to Rogue.
+      if (!is_null($rogue_item_id[0]->rogue_item_id)) {
+        $data = [
+          'rogue_reportback_item_id' => $rogue_item_id[0]->rogue_item_id,
+          'status' => $values['status'],
+        ];
+
+        array_push($updates_to_send_to_rogue, $data);
+      }
     }
   }
+
   // Send updates to Rogue.
-  dosomething_rogue_send_reportback_to_rogue($updates_to_send_to_rogue);
+  dosomething_rogue_update_rogue_reportback_items($updates_to_send_to_rogue);
 
   drupal_set_message(t("Updated."));
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -75,6 +75,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
           'why_participated' => $values['why_participated'],
           'file' => $values['file'],
           'caption' => $values['caption'],
+          'status' => $values['status'],
           //@TODO - review status stuff can be passed here also
         ]),
   ];

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -111,3 +111,15 @@ function dosomething_rogue_update_rogue_reportback_items($data)
 
   return $response;
 }
+
+/**
+ * Query to find Rogue reportbak item id by Phoenix fid.
+ *
+ * @param string $fid
+ * Phoenix fid of reportback item.
+ *
+ */
+function dosomething_rogue_get_by_file_id($fid)
+{
+  return db_query("SELECT rogue_rbs.rogue_item_id FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE fid = :fid", array(':fid' => $fid))->fetchAll();
+}

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -86,3 +86,26 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
 
   return $response;
 }
+
+/**
+ * Sends updated reportback item(s) to Rogue.
+ *
+ * @param array $data
+ * Values to send to Rogue.
+ *
+ */
+function dosomething_rogue_update_rogue_reportback_items($data)
+{
+  $client = _dosomething_rogue_build_http_client();
+
+  $options = [
+    'method' => 'PUT',
+    'headers' => $client['headers'],
+    'data' =>
+      json_encode($data),
+  ];
+
+  $response = drupal_http_request($client['base_url'] . '/items', $options);
+
+  return $response;
+}

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -107,5 +107,7 @@ function dosomething_rogue_update_rogue_reportback_items($data)
 
   $response = drupal_http_request($client['base_url'] . '/items', $options);
 
+  //@TODO - Add error handling.
+
   return $response;
 }


### PR DESCRIPTION
#### What's this PR do?
- If Rogue feature flag is enabled, send reportback item's updated `status` to Rogue when reviewed. 
#### How should this be reviewed?
- Choose a campaign to review reportbacks.
- In Sequel Pro in the `dosomething_rogue_reportbacks` table, add the `fid` (or more if you want!) to the table and a `rogue_reportback_id` that exists as the `id` in Rogue's `reportback_items` table (make sure the status of this reportback item is `pending`).  
- Approve all reportbacks.
- In Rogue database, the reportback item's status should be changed to `approved`. 
#### Relevant tickets

Fixes #6972 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
