### PR TITLE
Update to default to PHP 7 box to make sure everyone is on the same page.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,11 +2,8 @@ Vagrant.configure("2") do |config|
 
   ## Choose your base box
   config.vm.box = "dosomething/phoenix"
-  if ENV['DS_VAGRANT_BETA']
-    config.vm.box_version = "2.0.0.beta1"
-  else
-    config.vm.box_version = "1.0.8"
-  end
+
+  config.vm.box_version = "2.0.0.beta1"
 
   config.vm.provider "virtualbox" do |v|
     v.customize ["modifyvm", :id, "--memory", 3072]


### PR DESCRIPTION
#### What's this PR do?

This PR updates the **Vagrantfile** so that we don't need to make sure we have a local ENV variable set to decide whether to build our local environment using PHP 7 or not. Since Staging/Thor/Production are all on PHP7 we should probably just default to it and make sure we're all on the same page!
#### How should this be reviewed?

👀 
#### Any background context you want to provide?

I did not know I needed to add `export DS_VAGRANT_BETA=true` to my `.bash_profile` to ensure that builds of my local environment were using PHP 7. @DFurnes kindly let me know 💃  I've been on PHP 5.5.9 this entire time @_@ The wiki didn't indicate anything either... so since all our environments (sans Northstar?) are on PHP7 why not just default to it so all devs are up to date!
#### Relevant tickets

Fixes 💅 

---

@mshmsh5000 @sheyd @blisteringherb 

cc: @angaither @DFurnes 
