### PR TITLE
Use the configured Northstar URL.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
+++ b/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
@@ -22,8 +22,7 @@ class OpenIDConnectClientNorthstar extends OpenIDConnectClientBase {
    * Overrides OpenIDConnectClientBase::getEndpoints().
    */
   public function getEndpoints() {
-    // @TODO: Build these from Northstar module settings.
-    $url = 'http://northstar.dev:8000';
+    $url = NORTHSTAR_URL;
 
     return [
       'authorization' => $url . '/authorize',


### PR DESCRIPTION
#### What's this PR do?

This is what I get for only testing this on local! This PR updates the Northstar OpenID Connect provider to use the actual Northstar URL.
#### How should this be reviewed?

We should be safe using this constant because the provider is provided as a plugin bundled in the Northstar module, so it'll never not be defined. Anyways, 👀.
#### Any background context you want to provide?

🍃
#### Relevant tickets

Fixes 🐛.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
