### PR TITLE
OpenID Connect: Implements custom authorize button.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -295,9 +295,6 @@ function dosomething_northstar_log_request($op, $user, $request_body, $response)
  * @return array
  */
 function dosomething_northstar_openid_login_view() {
-  // Save our intended destination so we'll be redirected afterwards.
-  openid_connect_save_destination();
-
   /** @var $client OpenIDConnectClientNorthstar */
   $client = openid_connect_get_client('northstar');
   $scopes = openid_connect_get_scopes();

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -29,7 +29,7 @@ function dosomething_northstar_menu() {
       'file' => 'dosomething_northstar.admin.inc',
     ],
     'user/openid' => [
-      'title' => 'OpenID Login',
+      'title' => 'OpenID Connect',
       'page callback' => 'dosomething_northstar_openid_login_view',
       'access arguments' => ['access content'],
       'type' => MENU_CALLBACK,
@@ -289,14 +289,21 @@ function dosomething_northstar_log_request($op, $user, $request_body, $response)
 }
 
 /**
- * Generate templated view for openid login at /user/openid.
+ * Render the view for OpenID Connect login. Displayed standalone
+ * at `/user/openid` and (with feature flag enabled) in the modal.
  *
  * @return array
  */
 function dosomething_northstar_openid_login_view() {
-  $form = module_invoke('openid_connect', 'block_view', 'openid_connect_login');
+  // Save our intended destination so we'll be redirected afterwards.
+  openid_connect_save_destination();
 
-  return theme('openid_login', ['form' => $form]);
+  /** @var $client OpenIDConnectClientNorthstar */
+  $client = openid_connect_get_client('northstar');
+  $scopes = openid_connect_get_scopes();
+  $authorize_url = $client->getAuthorizeUrl($scopes);
+
+  return theme('openid_login', ['url' => $authorize_url]);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
+++ b/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
@@ -32,6 +32,21 @@ class OpenIDConnectClientNorthstar extends OpenIDConnectClientBase {
   }
 
   /**
+   * Creates a state token and stores it in the session for later validation.
+   *
+   * @return string
+   *   A state token that later can be validated to prevent request forgery.
+   */
+  public function createStateToken() {
+    // If we already have a state token, don't overwrite it.
+    if (empty($_SESSION['openid_connect_state'])) {
+      $_SESSION['openid_connect_state'] = openid_connect_create_state_token();
+    }
+
+    return $_SESSION['openid_connect_state'];
+  }
+
+  /**
    * Get the URL for the authorization page.
    *
    * @param string $scope
@@ -46,7 +61,7 @@ class OpenIDConnectClientNorthstar extends OpenIDConnectClientBase {
         'client_id' => $this->getSetting('client_id'),
         'redirect_uri' => url($redirect_uri, ['absolute' => TRUE]),
         'scope' => $scope,
-        'state' => openid_connect_create_state_token(),
+        'state' => $this->createStateToken(),
       ],
     ];
     $endpoints = $this->getEndpoints();

--- a/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
+++ b/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
@@ -32,6 +32,44 @@ class OpenIDConnectClientNorthstar extends OpenIDConnectClientBase {
   }
 
   /**
+   * Get the URL for the authorization page.
+   *
+   * @param string $scope
+   * @return string
+   */
+  public function getAuthorizeUrl($scope = 'openid email')
+  {
+    $redirect_uri = OPENID_CONNECT_REDIRECT_PATH_BASE . '/' . $this->name;
+    $url_options = [
+      'query' => [
+        'response_type' => 'code',
+        'client_id' => $this->getSetting('client_id'),
+        'redirect_uri' => url($redirect_uri, ['absolute' => TRUE]),
+        'scope' => $scope,
+        'state' => openid_connect_create_state_token(),
+      ],
+    ];
+    $endpoints = $this->getEndpoints();
+
+    return url($endpoints['authorization'], $url_options);
+  }
+
+  /**
+   * Redirect to the authorization page.
+   * Overrides OpenIDConnectClientBase::authorize().
+   *
+   * @param string $scope
+   */
+  public function authorize($scope = 'openid email') {
+    $authorize_url = $this->getAuthorizeUrl($scope);
+
+    // Clear $_GET['destination'] because we need to override it.
+    unset($_GET['destination']);
+
+    drupal_goto($authorize_url);
+  }
+
+  /**
    * Overrides OpenIDConnectClientBase::retrieveIDToken().
    */
   public function retrieveTokens($authorization_code) {

--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/login.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/login.inc
@@ -7,13 +7,12 @@
  */
 function paraneue_dosomething_page_alter_login(&$page) {
   if (!user_is_logged_in()){
-    if (variable_get('dosomething_user_openid_oauth_login_enabled')) {
-      $block = module_invoke('openid_connect', 'block_view', 'openid_connect_login');
+    if (module_exists('dosomething_northstar') && variable_get('dosomething_user_openid_oauth_login_enabled')) {
       $page['page_bottom']['login'] = [
         '#type' => 'item',
         '#prefix' => '<div data-modal id="modal--login" role="dialog" hidden><div class="modal__block">',
         '#suffix' => '</div></div>',
-        '#markup' => render($block),
+        '#markup' => dosomething_northstar_openid_login_view(),
       ];
     }
     else {

--- a/lib/themes/dosomething/paraneue_dosomething/templates/user/openid-login.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/user/openid-login.tpl.php
@@ -1,9 +1,6 @@
-<h3>Welcome to the OpenID Login brought to you by Northstar™.</h3>
+<h3>Log in using Northstar (beta)</h3>
+<p>Click the button below to log in using Northstar, the DoSomething.org user & identity API. Be warned, this is still an
+  experimental feature and could have bugs!</p>
 
-<?php print render($form); ?>
+<p><a href="<?php print $url; ?>" class="button">Log In</a></p>
 
-<div class="message-callout -below">
-  <div class="message-callout__copy">
-    <p>Click the button!</p>
-  </div>
-</div>


### PR DESCRIPTION
#### What's this PR do?

After merging this, we'll have a nice and stable prototype of OpenID Connect authentication on staging that we can demo & anyone can play around with! This PR implements our own custom markup for the "authorize" button, for two reasons:
1. The included Form API array in the `openid_connect` module had PHP warnings.
2. We want to eventually try showing this form inside an `<iframe>`.
#### How should this be reviewed?

👀
#### Any background context you want to provide?

It's a bummer that we have to re-implement all the logic for building the authorization link, but unfortunately the `openid_connect` module doesn't give a handy way to _only_ override that one part of the parent method without also setting it as a `drupal_goto` redirect. Oh well.
#### Relevant tickets

Closes #426. 🎉
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
