### PR TITLE
Experiment: Display authorization page in an iframe.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/login.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/login.inc
@@ -16,11 +16,11 @@ function paraneue_dosomething_page_alter_login(&$page) {
       ];
     }
     else {
-      $page['page_bottom']['login'] = array(
+      $page['page_bottom']['login'] = [
         '#prefix' => '<div data-modal id="modal--login" role="dialog" hidden><div class="modal__block">',
         '#suffix' => '</div></div>',
         'login' => drupal_get_form('user_login_block')
-      );
+      ];
     }
   }
 }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/login.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/login.inc
@@ -10,8 +10,8 @@ function paraneue_dosomething_page_alter_login(&$page) {
     if (module_exists('dosomething_northstar') && variable_get('dosomething_user_openid_oauth_login_enabled')) {
       $page['page_bottom']['login'] = [
         '#type' => 'item',
-        '#prefix' => '<div data-modal id="modal--login" role="dialog" hidden><div class="modal__block">',
-        '#suffix' => '</div></div>',
+        '#prefix' => '<div data-modal id="modal--login" role="dialog" hidden>',
+        '#suffix' => '</div>',
         '#markup' => dosomething_northstar_openid_login_view(),
       ];
     }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -59,3 +59,10 @@ $asset-path: "";
 
 // Variables
 $off-white: #f7f7f7;
+
+
+// HACK: Make the iframe look okay.
+.modal-iframe {
+  width: 100%;
+  min-height: 475px;
+}

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -64,5 +64,5 @@ $off-white: #f7f7f7;
 // HACK: Make the iframe look okay.
 .modal-iframe {
   width: 100%;
-  min-height: 475px;
+  min-height: 450px;
 }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -38,11 +38,16 @@
   <script type="text/javascript" src="<?php print '/' . PARANEUE_PATH . '/dist/modernizr.js' ?>"></script>
 
   <script type="text/javascript">
-    function resizeIframe(obj){
+    handleSizingResponse = function(e) {
+      var action = e.data.split(':')[0];
 
-      obj.style.height = 0;
-      obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px';
-    }
+      if (action == 'sizing') {
+        var height = e.data.split(':')[1];
+        document.getElementById('login-iframe').style.height = height + 'px';
+      }
+    };
+
+    window.addEventListener('message', handleSizingResponse, false);
   </script>
 </head>
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -36,6 +36,14 @@
   <?php print $head; ?>
 
   <script type="text/javascript" src="<?php print '/' . PARANEUE_PATH . '/dist/modernizr.js' ?>"></script>
+
+  <script type="text/javascript">
+    function resizeIframe(obj){
+
+      obj.style.height = 0;
+      obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px';
+    }
+  </script>
 </head>
 
 <body class="<?php print $classes; if ($variables['is_affiliate']) print ' -affiliate'; ?>" <?php print $attributes;?>>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/user/openid-login.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/user/openid-login.tpl.php
@@ -1,6 +1,5 @@
-<h3>Log in using Northstar (beta)</h3>
-<p>Click the button below to log in using Northstar, the DoSomething.org user & identity API. Be warned, this is still an
-  experimental feature and could have bugs!</p>
-
-<p><a href="<?php print $url; ?>" class="button">Log In</a></p>
+<iframe frameborder="0" class="modal-iframe" src="<?php print $url; ?>&chrome=false" onload="resizeIframe(this)">
+  <h3>Log in to get started!</h3>
+  <p><a href="<?php print $url; ?>" class="button">Log In</a></p>
+</iframe>
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/user/openid-login.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/user/openid-login.tpl.php
@@ -1,5 +1,19 @@
-<iframe frameborder="0" class="modal-iframe" src="<?php print $url; ?>&chrome=false" onload="resizeIframe(this)">
+<iframe id="login-iframe" onLoad="iframeReady();" frameborder="0" class="modal-iframe" src="<?php print $url; ?>&chrome=false">
   <h3>Log in to get started!</h3>
   <p><a href="<?php print $url; ?>" class="button">Log In</a></p>
 </iframe>
+<script>
+  // HACK: Handle resizing modal/refreshing page on successful login.
+  function iframeReady() {
+    // Ask the child page for it's sizing information (since we cannot access document cross-domain).
+    document.getElementById('login-iframe').contentWindow.postMessage('sizing?', '*');
+
+    // If we're redirected back to same-origin, then load that in the page.
+    // (If the child page is on a different domain, we cannot access the `contentWindow`
+    // object, hence why we can safely redirect anytime this is variable is truthy).
+    if (document.getElementById('login-iframe').contentWindow.location.href) {
+      window.location = document.getElementById('login-iframe').contentWindow.location.href;
+    }
+  }
+</script>
 


### PR DESCRIPTION
#### What's this experiment do?

This is a work-in-progress experiment for displaying the OpenID Connect authorization page within an `<iframe>` in a modal, so it matches our existing flow. We'll probably deploy this branch to Thor at some point so we can discuss trade-offs.

It relies on other experimental changes made in DoSomething/northstar#444.
#### How should this be reviewed?

It probably shouldn't. 🙃
#### What are the upsides/downsides to this experiment?

The upside is that we can more-or-less maintain the current user experience. While it looks like the plain old modal, it's actually loading the login page from Northstar in an `iframe` and all communications for the authentication flow happen there:

![screen recording 2016-09-27 at 02 14 pm](https://cloud.githubusercontent.com/assets/583202/18886169/d3c88906-84bc-11e6-927d-d9af46974f93.gif)

This approach also introduces some extra complexity:
- Sometimes the "message" for telling Phoenix how big to make the modal doesn't get sent correctly, and we end up with [an extra tall modal](https://cloud.githubusercontent.com/assets/583202/18886212/fe45647e-84bc-11e6-9c68-81dc9ab6a98e.png). I haven't yet tracked down why this is.
- Rather than simply redirecting back to Phoenix after completing the flow, we'd need to add a script to watch for the successful redirect in the iframe and reload the page. This is harder than you'd think because...
- We need to add client-side code to allow the iframes to communicate with each other, in order to make the iframe resize vertically to fit the content of the embedded page. This would be [relatively straightforward](http://stackoverflow.com/questions/9975810/make-iframe-automatically-adjust-height-according-to-the-contents-without-using), but becomes [more complicated](https://www.viget.com/articles/using-javascript-postmessage-to-talk-to-iframes) since both pages are not on the same domain.
- With our current modal implementation, we'd be loading a whole "subpage" on every page load  (since the iframe loads the linked page immediately whether or not the modal is opened). We'd probably want to add some custom code to only inject the iframe when the modal is opened.
#### Relevant tickets

References DoSomething/TeamRocket#13.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
