### PR TITLE
Allows taxonomy pages to render with infobar

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -80,17 +80,20 @@ function paraneue_dosomething_add_info_bar(&$vars) {
       // All other countries get the zendesk form.
     }
     else {
-
-      // If the campaign is closed, link to the help center
-      // If the campaign is open, link to the FAQs if there are any
-      $node = node_load($vars['nid']);
-      if (dosomething_campaign_is_closed($node)) {
-        $info_bar_vars['help_center'] = true;
-        $info_bar_vars['faqs'] = NULL;
-      }
-      else {
-        $info_bar_vars['faqs'] = !empty($vars['field_faq']);
-        $info_bar_vars['help_center'] = NULL;
+      
+      // If being called from a taxonomy page, this won't be set.
+      if (isset($vars['nid'])) {
+        // If the campaign is closed, link to the help center
+        // If the campaign is open, link to the FAQs if there are any
+        $node = node_load($vars['nid']);
+        if (dosomething_campaign_is_closed($node)) {
+          $info_bar_vars['help_center'] = true;
+          $info_bar_vars['faqs'] = NULL;
+        }
+        else {
+          $info_bar_vars['faqs'] = !empty($vars['field_faq']);
+          $info_bar_vars['help_center'] = NULL;
+        }
       }
 
       $zendesk_form_header = t(variable_get('dosomething_zendesk_form_header'));


### PR DESCRIPTION
#### What's this PR do?

Add a null check to the add_info_bar preprocess function so taxonomy pages can safely use it 
#### How should this be reviewed?

Can you load taxonomy pages without error?
#### Any background context you want to provide?

See the comments in the issue linked below, I walked through the debug process in detail
#### Relevant tickets

Fixes #7089
