### PR TITLE
Makes RabbitMQ management on host optional.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,7 +42,9 @@ Vagrant.configure("2") do |config|
   config.vm.network :forwarded_port, guest: 6081, host: 9999
 
   # Rabbit
-  config.vm.network :forwarded_port, guest: 15672, host: 15672
+  if ENV['DS_VAGRANT_RABBITMQ_MANAGEMENT']
+    config.vm.network :forwarded_port, guest: 15672, host: 15672
+  end
 
   # Solr.
   config.vm.network :forwarded_port, guest: 8983, host: 8983


### PR DESCRIPTION
#### What's this PR do?
- Turned off port forwarding from Vagrant VM to host on port 15672 by default
- Added env variable `DS_VAGRANT_RABBITMQ_MANAGEMENT` to turn in on optionally
#### How should this be reviewed?

Go to http://localhost:15672, run `vagrant reload`, refresh the page. It shouldn't be available. Add the variable, reload, try again
#### Any background context you want to provide?

Conflicts with other RabbitMQ instances on localhost.
