### PR TITLE
Use standard OpenID Connect flow.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -289,16 +289,26 @@ function dosomething_northstar_log_request($op, $user, $request_body, $response)
 }
 
 /**
+ * Create an OpenID Connect authorization URL.
+ *
+ * @return array
+ */
+function dosomething_northstar_openid_authorize_url() {
+  /** @var $client OpenIDConnectClientNorthstar */
+  $client = openid_connect_get_client('northstar');
+  $scopes = openid_connect_get_scopes();
+
+  return $client->getAuthorizeUrl($scopes);
+}
+
+/**
  * Render the view for OpenID Connect login. Displayed standalone
  * at `/user/openid` and (with feature flag enabled) in the modal.
  *
  * @return array
  */
 function dosomething_northstar_openid_login_view() {
-  /** @var $client OpenIDConnectClientNorthstar */
-  $client = openid_connect_get_client('northstar');
-  $scopes = openid_connect_get_scopes();
-  $authorize_url = $client->getAuthorizeUrl($scopes);
+  $authorize_url = dosomething_northstar_openid_authorize_url();
 
   return theme('openid_login', ['url' => $authorize_url]);
 }

--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/login.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/login.inc
@@ -8,12 +8,8 @@
 function paraneue_dosomething_page_alter_login(&$page) {
   if (!user_is_logged_in()){
     if (module_exists('dosomething_northstar') && variable_get('dosomething_user_openid_oauth_login_enabled')) {
-      $page['page_bottom']['login'] = [
-        '#type' => 'item',
-        '#prefix' => '<div data-modal id="modal--login" role="dialog" hidden><div class="modal__block">',
-        '#suffix' => '</div></div>',
-        '#markup' => dosomething_northstar_openid_login_view(),
-      ];
+      // See preprocess_page.inc.
+      // @TODO: Remove old login modal once OpenID Connect is fully shipped.
     }
     else {
       $page['page_bottom']['login'] = array(

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
@@ -42,11 +42,19 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     $vars['logo'] = '/' . PARANEUE_PATH . '/images/logo-dev.png';
   }
 
+  // If the OpenID Connect feature flag is enabled, link to login page rather than showing classic modal.
+  if (module_exists('dosomething_northstar') && variable_get('dosomething_user_openid_oauth_login_enabled')) {
+    $vars['log_in_link'] = l(t('Log In'), dosomething_northstar_openid_authorize_url(), ['absolute' => TRUE, 'attributes' => ['class' => ['secondary-nav-item'], 'id' => 'link--login']]);
+  } else {
+    $vars['log_in_link'] = l(t('Log In'), 'user/login', ['attributes' => ['class' => ['secondary-nav-item'], 'data-modal-href' => '#modal--login', 'id' => 'link--login']]);
+  }
+
   $navigation_vars = [
     'base_path'        => $vars['base_path'],
     'modifier_classes' => $modifier_classes,
     'logo'             => $vars['logo'],
     'front_page'       => $vars['front_page'],
+    'log_in_link'      => $vars['log_in_link'],
     'logged_in'        => $vars['logged_in'],
     'search_box'       => $vars['search_box'],
     'user_identifier'  => $vars['user_identifier'],

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/navigation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/partials/navigation.tpl.php
@@ -39,7 +39,7 @@
           </ul>
         </li>
       <?php else: ?>
-        <li class="login"><?php print l(t('Log In'), 'user/login', ['attributes' => ['class' => ['secondary-nav-item'], 'data-modal-href' => '#modal--login', 'id' => 'link--login']]) ?></li>
+        <li class="login"><?php print $log_in_link ?></li>
       <?php endif; ?>
     </ul>
   </div>


### PR DESCRIPTION
#### What's this experiment do?

This is a counter-experiment 😏 for using the standard OpenID Connect flow in place of the login modal (where the user's browser is redirected to Northstar and then returned to Phoenix afterwards).

![screen recording 2016-09-27 at 03 01 pm](https://cloud.githubusercontent.com/assets/583202/18887730/4deab140-84c3-11e6-8d5c-3f7dda1ce830.gif)
#### How should this be reviewed?

👀
#### Any background context you want to provide?

This is obviously a much less complicated implementation, and has the side benefit of allowing us to have a consistent login experience everywhere a user needs to authenticate. Paired with DoSomething/northstar#442, I think this also is a nice UX/security improvement.
#### Relevant tickets

References DoSomething/TeamRocket#13.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
