### PR TITLE
Displays only 2 reportbacks in onboarding for mobile devices

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
@@ -160,6 +160,7 @@
   }
 
   @include media($mobile) {
+    // Hides last two cards on mobile
     .gallery.-quartet > li:nth-last-of-type(-n+2) {
       display: none;
     }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_onboarding.scss
@@ -158,6 +158,12 @@
   &.-active {
     display: block;
   }
+
+  @include media($mobile) {
+    .gallery.-quartet > li:nth-last-of-type(-n+2) {
+      display: none;
+    }
+  }
 }
 
 .slideshow__controller {


### PR DESCRIPTION
#### What's this PR do?

Hides last two reportbacks in onboarding for mobile devices
<img width="240" alt="screen shot 2016-09-29 at 10 59 09 am" src="https://cloud.githubusercontent.com/assets/897368/18959332/c820ec4c-8633-11e6-9454-4f1cb4b4696c.png">
#### How should this be reviewed?

View onboarding in mobile
#### Any background context you want to provide?

no
#### Relevant tickets

Fixes https://github.com/DoSomething/TeamRocket/issues/25
