### PR TITLE
Enable transactionalDigestQueue.

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -136,6 +136,14 @@ function dosomething_mbp_update_7007() {
 }
 
 /**
+ * Updates mbp productions to include transactionalDigestQueue.
+ */
+function dosomething_mbp_update_7008() {
+  db_drop_table('message_broker_producer_productions');
+  dosomething_mbp_install_productions();
+}
+
+/**
  * Common function for install and update of related DoSomething specific
  * message_broker_producer produciton settings.
  */
@@ -177,6 +185,7 @@ function dosomething_mbp_install_productions() {
   $productions[2]['machine_name'] = 'transactional_campaign_signup';
   $productions[2]['exchange'] = 'transactionalExchange';
   $productions[2]['queues'][] = 'transactionalQueue';
+  $productions[2]['queues'][] = 'transactionalDigestQueue';
   $productions[2]['queues'][] = 'loggingQueue';
   $productions[2]['queues'][] = 'activityStatsQueue';
   $productions[2]['queues'][] = 'mailchimpCampaignSignupQueue';
@@ -189,6 +198,7 @@ function dosomething_mbp_install_productions() {
   $productions[3]['machine_name'] = 'transactional_campaign_group_signup';
   $productions[3]['exchange'] = 'transactionalExchange';
   $productions[3]['queues'][] = 'transactionalQueue';
+  $productions[3]['queues'][] = 'transactionalDigestQueue';
   $productions[3]['queues'][] = 'loggingQueue';
   $productions[3]['queues'][] = 'activityStatsQueue';
   $productions[3]['queues'][] = 'mailchimpCampaignSignupQueue';


### PR DESCRIPTION
#### What's this PR do?

Instructs Dosomething Message Broker Producer to automatically create `transactionalDigestQueue` from the [`mb_config.json`](https://github.com/DoSomething/messagebroker-config/blob/master/mb_config.json#L32).
#### How should this be reviewed?
- Run the update
- Login as an admin
- Check `transactionalDigestQueue` to be a part of `transactional_campaign_signup`  and `transactional_campaign_group_signup`
  Message Broker [productions](http://dev.dosomething.org:8888/admin/config/services/message-broker-producer/list-productions).
#### Any background context you want to provide?

A part of transactional email digest task:
- KPI: https://trello.com/c/1dZXj81U/60-multiple-campaign-sign-ups
- Description: https://trello.com/c/pBSG3Bto/96-multiple-campaign-sign-up-email and 
- Dee's notes https://docs.google.com/document/d/1GwCXGElv19-THfklAFiWh9VoMT0tAFMDJ0cWtjLg3Sg/edit
#### Relevant tickets

Ref DoSomething/Quicksilver-PHP#62
#### Checklist
- [x] Tested on staging
