### PR TITLE
Unhides title + subtitle for all devices

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_home.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_home.scss
@@ -9,22 +9,13 @@
   }
 
   .header__title {
-    @include visually-hidden();
     text-align: center;
-
-    @include media($tablet) {
-      @include visually-restored();
-    }
   }
 
   .header__subtitle {
     font-size: $font-medium;
     font-weight: $weight-normal;
     text-align: center;
-
-    @include media($tablet) {
-      @include visually-hidden();
-    }
   }
 }
 


### PR DESCRIPTION
#### What's this PR do?

Allows mobile & desktop users to see both the title and subtitle

<img width="318" alt="screen shot 2016-09-30 at 12 50 26 pm" src="https://cloud.githubusercontent.com/assets/897368/19001133/f3319e32-8713-11e6-80f8-491dc6eb6e19.png">
<img width="1604" alt="screen shot 2016-09-30 at 1 44 05 pm" src="https://cloud.githubusercontent.com/assets/897368/19001160/010e25d4-8714-11e6-8e03-9ec13db838d4.png">
#### How should this be reviewed?

Does the paint look good? Respond well on all sizes?
#### Any background context you want to provide?

no
#### Relevant tickets

Fixes https://github.com/DoSomething/TeamRocket/issues/1
