### PR TITLE
Send to rogue

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -932,11 +932,11 @@ function dosomething_helpers_get_current_campaign_run_for_user($nid, $user = NUL
  * @return string
 */
 function dosomething_helpers_get_data_uri_from_image($image) {
-  $imagePath = drupal_realpath($image->source);
+  $image_path = drupal_realpath($image->source);
 
   // Read image path, convert to base64 encoding
-  $imageData = base64_encode(file_get_contents($imagePath));
+  $image_data = base64_encode(file_get_contents($image_path));
 
   // Return the formated data uri: data:{mime};base64,{data};
-  return 'data: ' . mime_content_type($imagePath) . ';base64,' . $imageData;
+  return 'data: ' . mime_content_type($image_path) . ';base64,' . $image_data;
 }

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -925,6 +925,12 @@ function dosomething_helpers_get_current_campaign_run_for_user($nid, $user = NUL
   return node_load($run['id']);
 }
 
+/**
+ * Returns a base64 encoded data uri for an Image object
+ *
+ * @param  Image object $image
+ * @return string
+*/
 function dosomething_helpers_get_data_uri_from_image($image) {
   $imagePath = drupal_realpath($image->source);
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -924,3 +924,13 @@ function dosomething_helpers_get_current_campaign_run_for_user($nid, $user = NUL
   // @TODO: may want to investigate how it loads the proper translation...
   return node_load($run['id']);
 }
+
+function dosomething_helpers_get_data_uri_from_image($image) {
+  $imagePath = drupal_realpath($image->source);
+
+  // Read image path, convert to base64 encoding
+  $imageData = base64_encode(file_get_contents($imagePath));
+
+  // Return the formated data uri: data:{mime};base64,{data};
+  return 'data: ' . mime_content_type($imagePath) . ';base64,' . $imageData;
+}

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -371,7 +371,8 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     $values['uid'] = $user->uid;
   }
 
-  if (module_exists('dosomething_rogue')) {
+  // Collect reportbacks in Rogue if rogue collection is turned on for this campaign.
+  if (module_exists('dosomething_rogue') && dosomething_helpers_get_variable('node', $values['nid'], 'rogue_collection')) {
     // Store the base64 encoded data uri of the file in the values array to send to rogue.
     $file = $form_state['storage']['file'];
     $image = image_load($file->uri);
@@ -384,10 +385,9 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
 
     if ($rbid) {
+      // Store references to rogue IDs for the most recent uploaded reportback item.
       $reportback = entity_load_unchanged('reportback', [$rbid]);
       $fid = array_pop($reportback->fids);
-
-      // Store references to rogue IDs.
       dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
 
       // Redirect to permalink page.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -372,45 +372,36 @@ function dosomething_reportback_form_submit($form, &$form_state) {
   }
 
   if (module_exists('dosomething_rogue')) {
+    // Store the base64 encoded data uri of the file in the values array to send to rogue.
     $file = $form_state['storage']['file'];
-
     $image = image_load($file->uri);
-
-    $imageUrl = file_create_url($image->source);
-
-    $imagePath = drupal_realpath($image->source);
-
-    // Read image path, convert to base64 encoding
-    $imageData = base64_encode(file_get_contents($imagePath));
-
-    // Format the image SRC:  data:{mime};base64,{data};
-    $src = 'data: '.mime_content_type($imagePath).';base64,'.$imageData;
-
-    $values['file'] = $src;
+    $values['file'] = dosomething_helpers_get_data_uri_from_image($image);
 
     $reportback = dosomething_rogue_send_reportback_to_rogue($values);
 
+    // @TODO - store reference to rogue ids.
+
     $form_state['redirect'] = 'node/' . $values['nid'];
+  } else {
+    // Save uploaded file.
+    if ($file = dosomething_reportback_form_save_file($form_state)) {
+      // Store new file's fid into values.
+      $values['fid'] = $file->fid;
+    }
+
+    // Save values into reportback.
+    $rid = dosomething_reportback_save($values, $user);
+
+    // Redirect to permalink page.
+    $form_state['redirect'] = array(
+      'reportback/' . $rid,
+      array(
+        'query' => array(
+          'fid' => $values['fid'],
+        ),
+      ),
+    );
   }
-
-  // // Save uploaded file.
-  // if ($file = dosomething_reportback_form_save_file($form_state)) {
-  //   // Store new file's fid into values.
-  //   $values['fid'] = $file->fid;
-  // }
-
-  // // Save values into reportback.
-  // $rid = dosomething_reportback_save($values, $user);
-
-  // // Redirect to permalink page.
-  // $form_state['redirect'] = array(
-  //   'reportback/' . $rid,
-  //   array(
-  //     'query' => array(
-  //       'fid' => $values['fid'],
-  //     ),
-  //   ),
-  // );
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -384,7 +384,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
 
     if ($rbid) {
-      $reportback = reportback_load($rbid);
+      $reportback = entity_load_unchanged('reportback', [$rbid]);
       $fid = array_pop($reportback->fids);
 
       // Store references to rogue IDs.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -349,7 +349,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
   // If username field is set, this is an admin form.
   $is_admin_form = isset($form_state['values']['username']);
 
-  // Load uid by selected username.
+  // Load uid by selected userngit came.
   if ($is_admin_form) {
     $user = user_load_by_name($form_state['values']['username']);
     $values['uid'] = $user->uid;
@@ -371,24 +371,46 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     $values['uid'] = $user->uid;
   }
 
-  // Save uploaded file.
-  if ($file = dosomething_reportback_form_save_file($form_state)) {
-    // Store new file's fid into values.
-    $values['fid'] = $file->fid;
+  if (module_exists('dosomething_rogue')) {
+    $file = $form_state['storage']['file'];
+
+    $image = image_load($file->uri);
+
+    $imageUrl = file_create_url($image->source);
+
+    $imagePath = drupal_realpath($image->source);
+
+    // Read image path, convert to base64 encoding
+    $imageData = base64_encode(file_get_contents($imagePath));
+
+    // Format the image SRC:  data:{mime};base64,{data};
+    $src = 'data: '.mime_content_type($imagePath).';base64,'.$imageData;
+
+    $values['file'] = $src;
+
+    $reportback = dosomething_rogue_send_reportback_to_rogue($values);
+
+    $form_state['redirect'] = 'node/' . $values['nid'];
   }
 
-  // Save values into reportback.
-  $rid = dosomething_reportback_save($values, $user);
+  // // Save uploaded file.
+  // if ($file = dosomething_reportback_form_save_file($form_state)) {
+  //   // Store new file's fid into values.
+  //   $values['fid'] = $file->fid;
+  // }
 
-  // Redirect to permalink page.
-  $form_state['redirect'] = array(
-    'reportback/' . $rid,
-    array(
-      'query' => array(
-        'fid' => $values['fid'],
-      ),
-    ),
-  );
+  // // Save values into reportback.
+  // $rid = dosomething_reportback_save($values, $user);
+
+  // // Redirect to permalink page.
+  // $form_state['redirect'] = array(
+  //   'reportback/' . $rid,
+  //   array(
+  //     'query' => array(
+  //       'fid' => $values['fid'],
+  //     ),
+  //   ),
+  // );
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -377,11 +377,33 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     $image = image_load($file->uri);
     $values['file'] = dosomething_helpers_get_data_uri_from_image($image);
 
-    $reportback = dosomething_rogue_send_reportback_to_rogue($values);
+    // Send the reportback to rogue.
+    $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values);
 
-    // @TODO - store reference to rogue ids.
+    // Get the reportback stored in phoenix, store reference to the rb in rogue, redirect user to permalink page.
+    $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
 
-    $form_state['redirect'] = 'node/' . $values['nid'];
+    if ($rbid) {
+      $reportback = reportback_load($rbid);
+      $fid = array_pop($reportback->fids);
+
+      // Store references to rogue IDs.
+      dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
+
+      // Redirect to permalink page.
+      $form_state['redirect'] = array(
+        'reportback/' . $rbid,
+        array(
+          'query' => array(
+            'fid' => $fid,
+          ),
+        ),
+      );
+    } else {
+      // @TODO - if the reportback doesn't successfully get sent back to phoenix, how should
+      // this be handled for the user?
+      $form_state['redirect'] = 'node/' . $values['nid'];
+    }
   } else {
     // Save uploaded file.
     if ($file = dosomething_reportback_form_save_file($form_state)) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -349,7 +349,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
   // If username field is set, this is an admin form.
   $is_admin_form = isset($form_state['values']['username']);
 
-  // Load uid by selected userngit came.
+  // Load uid by selected username.
   if ($is_admin_form) {
     $user = user_load_by_name($form_state['values']['username']);
     $values['uid'] = $user->uid;

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -77,6 +77,11 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
           'file_id' => '', // @TODO - currently require by rogue, should not be.
           'caption' => $values['caption'],
           'status' => isset($values['status']) ? $values['status'] : 'pending',
+          'crop_x' => $values['crop_x'],
+          'crop_y' => $values['crop_y'],
+          'crop_width' => $values['crop_width'],
+          'crop_height' => $values['crop_height'],
+          'crop_rotate' => $values['crop_rotate'],
         ]),
   ];
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -126,11 +126,13 @@ function dosomething_rogue_get_by_file_id($fid)
 
 function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback)
 {
+  $most_recent_rogue_item = array_pop($rogue_reportback['data']['reportback_items']['data']);
+
   // Store references to rogue IDs.
   return db_insert('dosomething_rogue_reportbacks')
     ->fields(array(
       'fid' => $fid,
-      'rogue_item_id' => $rogue_reportback['data']['reportback_items']['data'][0]['id'],
+      'rogue_item_id' => $most_recent_rogue_item['id'],
       'rbid' => $rbid,
       'rogue_reportback_id' => $rogue_reportback['data']['id'],
       'created_at' => REQUEST_TIME,

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -74,17 +74,17 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
           'quantity' => $values['quantity'],
           'why_participated' => $values['why_participated'],
           'file' => $values['file'],
+          'file_id' => '', // @TODO - currently require by rogue, should not be.
           'caption' => $values['caption'],
           'status' => $values['status'],
-          //@TODO - review status stuff can be passed here also
         ]),
   ];
 
   $response = drupal_http_request($client['base_url'] . '/reportbacks', $options);
 
-  //@TODO - Add error handling.
+  // @TODO - handle failures.
 
-  return $response;
+  return drupal_json_decode($response->data);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -76,7 +76,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
           'file' => $values['file'],
           'file_id' => '', // @TODO - currently require by rogue, should not be.
           'caption' => $values['caption'],
-          'status' => $values['status'],
+          'status' => isset($values['status']) ? $values['status'] : 'pending',
         ]),
   ];
 
@@ -122,4 +122,18 @@ function dosomething_rogue_update_rogue_reportback_items($data)
 function dosomething_rogue_get_by_file_id($fid)
 {
   return db_query("SELECT rogue_rbs.rogue_item_id FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE fid = :fid", array(':fid' => $fid))->fetchAll();
+}
+
+function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback)
+{
+  // Store references to rogue IDs.
+  return db_insert('dosomething_rogue_reportbacks')
+    ->fields(array(
+      'fid' => $fid,
+      'rogue_item_id' => $rogue_reportback['data']['reportback_items']['data'][0]['id'],
+      'rbid' => $rbid,
+      'rogue_reportback_id' => $rogue_reportback['data']['id'],
+      'created_at' => REQUEST_TIME,
+      ))
+    ->execute();
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -129,6 +129,16 @@ function dosomething_rogue_get_by_file_id($fid)
   return db_query("SELECT rogue_rbs.rogue_item_id FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE fid = :fid", array(':fid' => $fid))->fetchAll();
 }
 
+/**
+ * Insert record that stores reference to the most recent uploaded reportback item in
+ * phoenix and it's corresponding id's in Rogue
+ *
+ * @param string $rbid
+ * @param string $fid
+ * @param object $rogue_reportback
+ *
+ * @return InsertQuery object
+ */
 function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback)
 {
   $most_recent_rogue_item = array_pop($rogue_reportback['data']['reportback_items']['data']);


### PR DESCRIPTION
#### What's this PR do?
- Sends Reportbacks to rogue before saving them in the DB. 
  - Gets the base64 encoded url of the uploaded image and sends that to rogue to be stored in s3
- Rogue then sends back the reportback to phoenix, then. 
- We store references to where the RB and RB item is stored in Rogue so we can send rogue any updates to a reportback or item.
- Send the user to the permalink page for the recently uploaded RB item.
- Also started sending over the cropping information as we will need to handle this in rogue 
#### How should this be reviewed?

Pull down this branch and the most recent rogue master. 

Submit a reportback and confirm that: 
- You are brought to the permalink page and the correct image/caption shows.
- That the reportback and reportback item are stored in the Rogue DB in the `reportback` and `reportback_item` tables.
- That the reportback and reportback item are stored in the Phoenix DB in the `dosomething_reportback` and `dosomething_reportback_file` tables.
- That the `dosomething_rogue_reportback` table has a record for the recently uploaded reportback item that stores the drupal `fid` and `rbid` and the corresponding Rogue `reportback.id` and `reportback_item.id`
#### Relevant tickets

Fixes #6960 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
