### PR TITLE
Create global feature flag for rogue collection

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -286,7 +286,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
     }
 
     // Check to see if Rogue feature flag is enabled.
-    if (module_exists('dosomething_rogue')) {
+    if (variable_get('rogue_collection', FALSE)) {
       $rogue_item_id = dosomething_rogue_get_by_file_id($fid);
 
       // If there is a rogue_item_id in the dosomething_rogue_reportbacks table, send update to Rogue.
@@ -302,12 +302,16 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
   }
 
   // Send updates to Rogue.
-  $response = dosomething_rogue_update_rogue_reportback_items($updates_to_send_to_rogue);
-  if ($response->code != 201) {
-    drupal_set_message(print_r($response->code, TRUE) . ' ' . print_r($response->status_message, TRUE), 'warning');
-  } else {
-    drupal_set_message(t("Updated."));
+  if (variable_get('rogue_collection', FALSE))
+  {
+    $response = dosomething_rogue_update_rogue_reportback_items($updates_to_send_to_rogue);
+    if ($response->code != 201) {
+      drupal_set_message(print_r($response->code, TRUE) . ' ' . print_r($response->status_message, TRUE), 'warning');
+    } else {
+      drupal_set_message(t("Updated."));
+    }
   }
+
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -302,8 +302,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
   }
 
   // Send updates to Rogue.
-  if (variable_get('rogue_collection', FALSE))
-  {
+  if (variable_get('rogue_collection', FALSE)) {
     $response = dosomething_rogue_update_rogue_reportback_items($updates_to_send_to_rogue);
     if ($response->code != 201) {
       drupal_set_message(print_r($response->code, TRUE) . ' ' . print_r($response->status_message, TRUE), 'warning');

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -372,7 +372,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
   }
 
   // Collect reportbacks in Rogue if rogue collection is turned on for this campaign.
-  if (module_exists('dosomething_rogue') && dosomething_helpers_get_variable('node', $values['nid'], 'rogue_collection')) {
+  if (variable_get('rogue_collection', FALSE)) {
     // Store the base64 encoded data uri of the file in the values array to send to rogue.
     $file = $form_state['storage']['file'];
     $image = image_load($file->uri);

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.admin.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.admin.inc
@@ -37,56 +37,13 @@ function dosomething_rogue_config_form($form, &$form_state) {
     '#default_value' => variable_get('dosomething_rogue_api_key', ''),
   ];
 
-  return system_settings_form($form);
-}
-
-/**
- * Adds helper flag to turn on rogue collection on the custom settings page on campaign nodes.
- */
-function dosomething_rogue_campaign_config_form($form, &$form_state, $node) {
-  // Load the node's helpers variables.
-  $vars = dosomething_helpers_get_variables('node', $node->nid);
-
-  $form['nid'] = [
-    '#type' => 'hidden',
-    '#value' => $node->nid,
-  ];
-
-  $form['rogue'] = [
-    '#type' => 'fieldset',
-    '#title' => t("Rogue"),
-    '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
-  ];
-
   $form['rogue']['rogue_collection'] = [
     '#type' => 'checkbox',
     '#title' => t('Send reportbacks to rogue'),
     '#description' => t('If set, when a user submits a reportback it will be sent to our reportback service.'),
-    '#default_value' => $vars['rogue_collection'],
+    '#default_value' => variable_get('rogue_collection', FALSE),
     '#size' => 20,
   ];
 
-  $form['rogue']['actions'] = [
-    '#type' => 'actions',
-    'submit' => [
-      '#type' => 'submit',
-      '#value' => 'Save',
-    ],
-  ];
-  return $form;
-}
-
-/**
- * Submit callback for dosomething_rogue_campaign_config_form().
- */
-function dosomething_rogue_campaign_config_form_submit(&$form, &$form_state) {
-  $var_names = ['rogue_collection'];
-
-  foreach($var_names as $var_name) {
-    $values = $form_state['values'];
-    dosomething_helpers_set_variable('node', $values['nid'], $var_name, $values[$var_name]);
-  }
-
-  drupal_set_message("Updated.");
+  return system_settings_form($form);
 }


### PR DESCRIPTION
#### What's this PR do?
- Adds a feature flag that can be used to turn on/off rogue collection of reportbacks across all campaigns. 
- Updates previous checks for the flag that was set per node to use new global flag and updates spots where we were just checking if the module exists to use the flag.

![image](https://cloud.githubusercontent.com/assets/1700409/19127459/0d5c1e20-8b0d-11e6-82ed-653c5becb32e.png)
#### How should this be reviewed?

Go to `/admin/config/services/rogue` and turn on rogue collection. Go to submit a reportback and that reportback should be sent to rogue. Then turn off the flag and submit a reportback, it should not go to rogue.
#### Relevant tickets

Fixes #7107 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
