### PR TITLE
Quick fix for tracking

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -45,7 +45,6 @@ function subscribeEvents() {
   const isPitchPage = $('.pitch').length > 0;
   if (isPitchPage) {
     $('#link--campaign-signup-login').on('click', () => {
-      console.log("HALLO");
       ga('send', 'event', 'Signup button', 'Pitch page', 'Start');
     });
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -44,14 +44,19 @@ function subscribeEvents() {
   // Signup button on pitch page
   const isPitchPage = $('.pitch').length > 0;
   if (isPitchPage) {
+    $('#link--campaign-signup-login').on('click', () => {
+      console.log("HALLO");
+      ga('send', 'event', 'Signup button', 'Pitch page', 'Start');
+    });
+
     // This applies to both authenticated & anonymous users. It also covers both modal register & login.
-    $('.header__signup form, #user-login-form').on('submit', () => {
-      ga('send', 'event', 'Signup button', 'Pitch page');
+    $('#user-login-form').on('submit', () => {
+      ga('send', 'event', 'Signup button', 'Pitch page', 'Finish');
     });
 
     Validation.Events.subscribe('Validation:Submitted', (topic, args) => {
       if (args === 'user-register-form') {
-        ga('send', 'event', 'Signup button', 'Pitch page');
+        ga('send', 'event', 'Signup button', 'Pitch page', 'Finish');
       }
     });
   }


### PR DESCRIPTION
#### What's this PR do?

Changes the Google Analytics tracking to include a "Start" and "Finish" event to the login/registration modal on the pitch page.
#### How should this be reviewed?

Um, not sure?
#### Any background context you want to provide?

We will use this to track how many people see the login/registration modal and successfully submit the form. This will allow us to evaluate how much value a social authentication service has for us. 

e.g. - If 56% percent of people who see the modal successfully registers or logs in, a social service could lower the barrier for people and increase that number. If 90% of people make it through the modal, the service has less to offer.  
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  

Written by Luke
