### PR TITLE
Strips emoji from RB fields

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -940,3 +940,14 @@ function dosomething_helpers_get_data_uri_from_image($image) {
   // Return the formated data uri: data:{mime};base64,{data};
   return 'data: ' . mime_content_type($image_path) . ';base64,' . $image_data;
 }
+
+/**
+ * Remove all emoji and special chars from the given string.
+ * Referenced from http://stackoverflow.com/a/20208095/2129670
+ *
+ * @param  String $text
+ * @return String Returns a sanitized string.
+ */
+function dosomething_helpers_remove_emoji_from_string($text) {
+  return preg_replace('/([0-9#][\x{20E3}])|[\x{00ae}\x{00a9}\x{203C}\x{2047}\x{2048}\x{2049}\x{3030}\x{303D}\x{2139}\x{2122}\x{3297}\x{3299}][\x{FE00}-\x{FEFF}]?|[\x{2190}-\x{21FF}][\x{FE00}-\x{FEFF}]?|[\x{2300}-\x{23FF}][\x{FE00}-\x{FEFF}]?|[\x{2460}-\x{24FF}][\x{FE00}-\x{FEFF}]?|[\x{25A0}-\x{25FF}][\x{FE00}-\x{FEFF}]?|[\x{2600}-\x{27BF}][\x{FE00}-\x{FEFF}]?|[\x{2900}-\x{297F}][\x{FE00}-\x{FEFF}]?|[\x{2B00}-\x{2BF0}][\x{FE00}-\x{FEFF}]?|[\x{1F000}-\x{1F6FF}][\x{FE00}-\x{FEFF}]?/u', '', $text);
+}

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -727,6 +727,9 @@ function dosomething_reportback_save($values, $user = NULL) {
     global $user;
   }
 
+  $values['why_participated'] = dosomething_helpers_remove_emoji_from_string($values['why_participated']);
+  $values['caption'] = dosomething_helpers_remove_emoji_from_string($values['caption']);
+
   $campaign = Campaign::get($values['nid']);
   $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid'], $user, $campaign);
 


### PR DESCRIPTION
#### What's this PR do?
- Adds helper function to strip all emoji's and special chars from a string
- Calls emoji removal function on the caption & why participated fields when a RB is saved
#### How should this be reviewed?

Copy this text,
emoji 😅

And paste it inside the caption + why participated fields. It should successfully take you to the RB perma link & remove the emoji's.
#### Any background context you want to provide?

See this comment for why I had a problem with using `iconv` https://github.com/DoSomething/phoenix/issues/7014#issuecomment-252281196
#### Relevant tickets

Fixes #7014
#### Checklist
- [ ] Tested on staging.
