### PR TITLE
Fixes taxonomy page showing duplicate campaigns

### DIFF
--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -110,6 +110,7 @@ function dosomething_taxonomy_preprocess_taxonomy_term(&$vars) {
 
 /**
  * Returns array of node nid's with the given Term $tid.
+ * @deprecated Use taxonomy_select_nodes instead.
  *
  * @param int $tid
  *   A taxonomy term tid.

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -117,14 +117,7 @@ function dosomething_taxonomy_preprocess_taxonomy_term(&$vars) {
  * @return array
  */
 function dosomething_taxonomy_get_campaigns($tid) {
-  $nids = array();
-  $view = views_get_view('campaigns_by_term');
-  $view->set_arguments(array($tid));
-  $view->execute();
-  foreach ($view->result as $record) {
-    $nids[] = $record->nid;
-  }
-  return $nids;
+  return taxonomy_select_nodes($tid, FALSE);
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_taxonomy.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_taxonomy.inc
@@ -22,4 +22,3 @@ function paraneue_dosomething_preprocess_taxonomy_term(&$vars) {
   }
   paraneue_dosomething_add_info_bar($vars);
 }
-


### PR DESCRIPTION
#### What's this PR do?
- Removes old method of retrieving campaigns for a given TID in favor of a single line drupal function
#### How should this be reviewed?

Do you see duplicate campaigns on the taxonomy pages?
<img width="497" alt="screen shot 2016-10-07 at 12 15 36 pm" src="https://cloud.githubusercontent.com/assets/897368/19197495/1b8fd596-8c88-11e6-8817-1c007773826d.png">

Also spot check the campaigns to make sure they have "donate something" applied (or whatever taxonomy you're testing on)
#### Any background context you want to provide?

I wrote up the debug process in detail on this trello card: https://trello.com/c/zfLHlD6F/82-research-as-a-developer-i-want-the-know-why-the-volunteer-pages-image-section-is-broken#comment-57f7c76c34aca52c139159f5
#### Relevant tickets

Fixes N/A ?
#### Checklist
- [ ] Tested on staging.
