### PR TITLE
Failures

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,24 +1,23 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
     "hash": "03854d361fc8d4d26f3d20af648afc64",
-    "content-hash": "1c449f02e541b69ff3008088c0aee495",
     "packages": [
         {
             "name": "dosomething/gateway",
-            "version": "v1.0.0-rc12",
+            "version": "v1.0.0-rc14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DoSomething/gateway.git",
-                "reference": "fdac8a325a36414f7d3ff982d0c326222b0d9f8e"
+                "reference": "2de6ade1b724fc93353545996426ecee49b7cd7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/fdac8a325a36414f7d3ff982d0c326222b0d9f8e",
-                "reference": "fdac8a325a36414f7d3ff982d0c326222b0d9f8e",
+                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/2de6ade1b724fc93353545996426ecee49b7cd7e",
+                "reference": "2de6ade1b724fc93353545996426ecee49b7cd7e",
                 "shasum": ""
             },
             "require": {
@@ -29,6 +28,10 @@
                 "nesbot/carbon": "~1.14",
                 "symfony/psr-http-message-bridge": "^1.0",
                 "zendframework/zend-diactoros": "^1.3"
+            },
+            "require-dev": {
+                "illuminate/database": "^5.2",
+                "phpunit/phpunit": "^4.8"
             },
             "type": "library",
             "autoload": {
@@ -50,20 +53,20 @@
                 }
             ],
             "description": "Standard PHP API client for DoSomething.org services.",
-            "time": "2016-10-04 18:21:58"
+            "time": "2016-10-06 20:04:26"
         },
         {
             "name": "giggsey/libphonenumber-for-php",
-            "version": "7.7.1",
+            "version": "7.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/libphonenumber-for-php.git",
-                "reference": "da9a24a60169fedca9a0a4e07baf7e94f9c75fc4"
+                "reference": "245324b87d59fe122945f5cf4521c75af2bd472a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/da9a24a60169fedca9a0a4e07baf7e94f9c75fc4",
-                "reference": "da9a24a60169fedca9a0a4e07baf7e94f9c75fc4",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/245324b87d59fe122945f5cf4521c75af2bd472a",
+                "reference": "245324b87d59fe122945f5cf4521c75af2bd472a",
                 "shasum": ""
             },
             "require": {
@@ -112,21 +115,24 @@
                 "phonenumber",
                 "validation"
             ],
-            "time": "2016-10-01 21:48:02"
+            "time": "2016-10-06 13:02:39"
         },
         {
             "name": "giggsey/locale",
-            "version": "1.0",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/Locale.git",
-                "reference": "9087acaf8493472fcd129118017fd7e06be3d8fa"
+                "reference": "d936229da2187025f693f25724c5af2a090f5e7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/Locale/zipball/9087acaf8493472fcd129118017fd7e06be3d8fa",
-                "reference": "9087acaf8493472fcd129118017fd7e06be3d8fa",
+                "url": "https://api.github.com/repos/giggsey/Locale/zipball/d936229da2187025f693f25724c5af2a090f5e7c",
+                "reference": "d936229da2187025f693f25724c5af2a090f5e7c",
                 "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
             },
             "require-dev": {
                 "pear/pear-core-minimal": "^1.9",
@@ -158,7 +164,7 @@
                 }
             ],
             "description": "Locale functions required by libphonenumber-for-php",
-            "time": "2016-08-04 23:02:29"
+            "time": "2016-10-05 20:26:22"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/composer.lock
+++ b/composer.lock
@@ -1,23 +1,24 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
     "hash": "03854d361fc8d4d26f3d20af648afc64",
+    "content-hash": "1c449f02e541b69ff3008088c0aee495",
     "packages": [
         {
             "name": "dosomething/gateway",
-            "version": "v1.0.0-rc14",
+            "version": "v1.0.0-rc12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DoSomething/gateway.git",
-                "reference": "2de6ade1b724fc93353545996426ecee49b7cd7e"
+                "reference": "fdac8a325a36414f7d3ff982d0c326222b0d9f8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/2de6ade1b724fc93353545996426ecee49b7cd7e",
-                "reference": "2de6ade1b724fc93353545996426ecee49b7cd7e",
+                "url": "https://api.github.com/repos/DoSomething/gateway/zipball/fdac8a325a36414f7d3ff982d0c326222b0d9f8e",
+                "reference": "fdac8a325a36414f7d3ff982d0c326222b0d9f8e",
                 "shasum": ""
             },
             "require": {
@@ -28,10 +29,6 @@
                 "nesbot/carbon": "~1.14",
                 "symfony/psr-http-message-bridge": "^1.0",
                 "zendframework/zend-diactoros": "^1.3"
-            },
-            "require-dev": {
-                "illuminate/database": "^5.2",
-                "phpunit/phpunit": "^4.8"
             },
             "type": "library",
             "autoload": {
@@ -53,20 +50,20 @@
                 }
             ],
             "description": "Standard PHP API client for DoSomething.org services.",
-            "time": "2016-10-06 20:04:26"
+            "time": "2016-10-04 18:21:58"
         },
         {
             "name": "giggsey/libphonenumber-for-php",
-            "version": "7.7.2",
+            "version": "7.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/libphonenumber-for-php.git",
-                "reference": "245324b87d59fe122945f5cf4521c75af2bd472a"
+                "reference": "da9a24a60169fedca9a0a4e07baf7e94f9c75fc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/245324b87d59fe122945f5cf4521c75af2bd472a",
-                "reference": "245324b87d59fe122945f5cf4521c75af2bd472a",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/da9a24a60169fedca9a0a4e07baf7e94f9c75fc4",
+                "reference": "da9a24a60169fedca9a0a4e07baf7e94f9c75fc4",
                 "shasum": ""
             },
             "require": {
@@ -115,24 +112,21 @@
                 "phonenumber",
                 "validation"
             ],
-            "time": "2016-10-06 13:02:39"
+            "time": "2016-10-01 21:48:02"
         },
         {
             "name": "giggsey/locale",
-            "version": "1.1",
+            "version": "1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/Locale.git",
-                "reference": "d936229da2187025f693f25724c5af2a090f5e7c"
+                "reference": "9087acaf8493472fcd129118017fd7e06be3d8fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/Locale/zipball/d936229da2187025f693f25724c5af2a090f5e7c",
-                "reference": "d936229da2187025f693f25724c5af2a090f5e7c",
+                "url": "https://api.github.com/repos/giggsey/Locale/zipball/9087acaf8493472fcd129118017fd7e06be3d8fa",
+                "reference": "9087acaf8493472fcd129118017fd7e06be3d8fa",
                 "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
             },
             "require-dev": {
                 "pear/pear-core-minimal": "^1.9",
@@ -164,7 +158,7 @@
                 }
             ],
             "description": "Locale functions required by libphonenumber-for-php",
-            "time": "2016-10-05 20:26:22"
+            "time": "2016-08-04 23:02:29"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Implements hook_cron()
+ */
+ function dosomething_rogue_cron() {
+    dosomething_rogue_retry_failed_reportbacks();
+ }
+
+ function dosomething_rogue_retry_failed_reportbacks() {
+    $task_log = db_select('dosomething_rogue_failed_task_log', 't')
+      ->fields('t')
+      ->execute()
+      ->fetchAll();
+    db_truncate('dosomething_rogue_failed_task_log')->execute();
+
+    foreach ($task_log as $task) {
+      $values = [
+        'nid' => $task->campaign_id,
+        'campaign_run_id' => $task->campaign_run_id,
+        'quantity' => $task->quantity,
+        'why_participated' => $task->why_participated,
+        'file' => $task->file,
+        'caption' => $task->caption,
+      ];
+
+      $user = user_load($task->drupal_id);
+
+      dosomething_rogue_send_reportback_to_rogue($values, $user);
+   }
+ }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -88,6 +88,9 @@ function dosomething_rogue_schema() {
         'not null' => FALSE,
       ],
       'file' => [
+        'description' => 'The file string to save of the reportback image.',
+        'type' => 'text',
+        'not null' => TRUE,
       ],
       'caption' => [
         'description' => 'File caption.',

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -113,7 +113,7 @@ function dosomething_rogue_schema() {
         'length' => '500000',
         'not null' => FALSE,
       ],
-    ]
+    ],
     'primary key' => ['id'],
   ];
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -61,11 +61,6 @@ function dosomething_rogue_schema() {
         'type' => 'int',
         'not null' => TRUE,
       ],
-      'northstar_id' => [
-        'description' => 'The northstar_id of the user.',
-        'type' => 'int',
-        'not null' => TRUE,
-      ],
       'campaign_id' => [
         'description' => 'Campaign nid for the reportback.',
         'type' => 'int',
@@ -90,6 +85,7 @@ function dosomething_rogue_schema() {
       'file' => [
         'description' => 'The file string to save of the reportback image.',
         'type' => 'text',
+        'length' => '500000',
         'not null' => TRUE,
       ],
       'caption' => [

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -80,13 +80,13 @@ function dosomething_rogue_schema() {
         'description' => 'Why the user participated in the campaign.',
         'type' => 'text',
         'length' => '2048',
-        'not null' => FALSE,
+        'not null' => TRUE,
       ],
       'file' => [
         'description' => 'The file string to save of the reportback image.',
         'type' => 'text',
         'length' => '500000',
-        'not null' => TRUE,
+        'not null' => FALSE,
       ],
       'caption' => [
         'description' => 'File caption.',

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -47,6 +47,73 @@ function dosomething_rogue_schema() {
     ],
   ];
 
+  $schema['dosomething_rogue_failed_task_log'] = [
+    'description' => 'Table of failed requests sending reportbacks from Phoenix to Rogue',
+    'fields' => [
+      'id' => [
+        'description' => 'Primary key of log table.',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'drupal_id' => [
+        'description' => 'The drupal_id of the user.',
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'northstar_id' => [
+        'description' => 'The northstar_id of the user.',
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'campaign_id' => [
+        'description' => 'Campaign nid for the reportback.',
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'campaign_run_id' => [
+        'description' => 'Campaign run nid for the reportback.',
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'quantity' => [
+        'description' => 'The quantity of reportback_nouns reportback_verbed.',
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'why_participated' => [
+        'description' => 'Why the user participated in the campaign.',
+        'type' => 'text',
+        'length' => '2048',
+        'not null' => FALSE,
+      ],
+      'file' => [
+      ],
+      'caption' => [
+        'description' => 'File caption.',
+        'type' => 'varchar',
+        'length' => '255',
+        'not null' => FALSE,
+      ],
+      'timestamp' => [
+        'description' => 'The Unix timestamp of the request.',
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'response_code' => [
+        'description' => 'The HTTP response code from Rogue.',
+        'type' => 'int',
+      ],
+      'response_values' => [
+        'description' => 'The JSON response from Rogue.',
+        'type' => 'text',
+        'length' => '500000',
+        'not null' => FALSE,
+      ],
+    ]
+    'primary key' => ['id'],
+  ];
+
   return $schema;
 }
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -130,3 +130,14 @@ function dosomething_rogue_update_7001(&$sandbox) {
     db_create_table($table_name, $schema[$table_name]);
   }
 }
+
+/**
+ * Create dosomething_rogue_failed_task_log table.
+ */
+function dosomething_rogue_update_7002(&$sandbox) {
+  $table_name = 'dosomething_rogue_failed_task_log';
+  if (!db_table_exists($table_name)) {
+    $schema = dosomething_rogue_schema();
+    db_create_table($table_name, $schema[$table_name]);
+  }
+}

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -5,6 +5,7 @@
  */
 
 include_once('dosomething_rogue.admin.inc');
+include_once('dosomething_rogue.cron.inc');
 
 define('ROGUE_API_URL', variable_get('dosomething_rogue_url', 'http://rogue.app/api'));
 define('ROGUE_API_VERSION', variable_get('dosomething_rogue_api_version', 'v1'));
@@ -72,24 +73,24 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
           'northstar_id' => $northstar_id ? $northstar_id : NULL,
           'drupal_id' => $user->uid,
           'campaign_id' => $values['nid'],
-          'campaign_run_id' => $run->nid,
+          'campaign_run_id' => isset($values['campaign_run_id']) ? $values['campaign_run_id'] : $run->nid,
           'quantity' => $values['quantity'],
           'why_participated' => $values['why_participated'],
           'file' => $values['file'],
           'file_id' => '', // @TODO - currently require by rogue, should not be.
           'caption' => $values['caption'],
           'status' => isset($values['status']) ? $values['status'] : 'pending',
-          'crop_x' => $values['crop_x'],
-          'crop_y' => $values['crop_y'],
-          'crop_width' => $values['crop_width'],
-          'crop_height' => $values['crop_height'],
-          'crop_rotate' => $values['crop_rotate'],
+          'crop_x' => isset($values['crop_x']) ? $values['crop_x'] : NULL,
+          'crop_y' => isset($values['crop_y']) ? $values['crop_y'] : NULL,
+          'crop_width' => isset($values['crop_width']) ? $values['crop_width'] : NULL,
+          'crop_height' => isset($values['crop_height']) ? $values['crop_height'] : NULL,
+          'crop_rotate' => isset($values['crop_rotate']) ? $values['crop_rotate'] : NULL,
         ]),
   ];
 
   $response = drupal_http_request($client['base_url'] . '/reportbacks', $options);
 
-  if ($response->code == 200 && module_exists('stathat')) {
+  if (in_array($response->code, [200, 201]) && module_exists('stathat')) {
     stathat_send_ez_count('drupal - Rogue - reportback sent - count', 1);
   }
   else {

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -89,7 +89,32 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
 
   $response = drupal_http_request($client['base_url'] . '/reportbacks', $options);
 
-  // @TODO - handle failures.
+  if ($response->code == 200 && module_exists('stathat')) {
+    stathat_send_ez_count('drupal - Rogue - reportback sent - count', 1);
+  }
+  else {
+    // Log as watchdog error, and stathat value.
+    if (module_exists('stathat')) {
+      stathat_send_ez_count('drupal - Rogue - reportback failed - count', 1);
+    }
+    // Save fail to a db log so we can easily export.
+    db_insert('dosomething_rogue_failed_task_log')
+      ->fields([
+        'drupal_id' => $user->uid,
+        'campaign_id' => $values['nid'],
+        'campaign_run_id' => $run->nid,
+        'quantity' => $values['quantity'],
+        'why_participated' => $values['why_participated'],
+        'file' => $values['file'],
+        'caption' => $values['caption'],
+        'timestamp' => REQUEST_TIME,
+        'response_code' => $response->code,
+        'response_values' => json_encode($response),
+      ])
+      ->execute();
+
+      watchdog('dosomething_rogue', 'reportback not migrated to Rogue', ['user' => $user->uid, 'campaign_id' => $values['nid'], 'campaign_run_id' => $run->nid], WATCHDOG_ERROR);
+  }
 
   return drupal_json_decode($response->data);
 }


### PR DESCRIPTION
#### What's this PR do?

Builds on @chloealee's work on handling failures when sending reportbacks to rogue. 
- creates a `dosomething_rogue_failed_task_log` table that holds failed reportbacks
- Stores failed reportbacks in this table
- Creates a cron job that will retry sending the failed reportbacks to rogue. 
#### How should this be reviewed?

Try to send a reportback without rogue running and it should get stored in the failed table. 

Turn rogue back on and run cron, the reportback should be sent to rogue successfully (or restored in the table if it fails again.)
#### Relevant tickets

Fixes #6959 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
