### PR TITLE
Only pull in campaigns from taxonomy get function

### DIFF
--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -119,7 +119,7 @@ function dosomething_taxonomy_preprocess_taxonomy_term(&$vars) {
 function dosomething_taxonomy_get_campaigns($tid) {
   $nids = taxonomy_select_nodes($tid, FALSE);
   $campaigns = [];
-  foreach ($nids as $delta => $nid) {
+  foreach ($nids as $nid) {
     if (node_load($nid)->type === 'campaign') {
       $campaigns[] = $nid;
     }

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -117,13 +117,9 @@ function dosomething_taxonomy_preprocess_taxonomy_term(&$vars) {
  * @return array
  */
 function dosomething_taxonomy_get_campaigns($tid) {
-  $nodes = node_load_multiple(taxonomy_select_nodes($tid, FALSE));
-  $campaigns = [];
-  foreach ($nodes as $node) {
-    if ($node->type === 'campaign') {
-      $campaigns[] = $node->nid;
-    }
-  }
+  $nodes = node_load_multiple(taxonomy_select_nodes($tid, FALSE), ['type' => 'campaign']);
+  $campaigns = array_map(function($node) { return $node->nid; }, $nodes);
+
   return $campaigns;
 }
 

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -110,7 +110,6 @@ function dosomething_taxonomy_preprocess_taxonomy_term(&$vars) {
 
 /**
  * Returns array of node nid's with the given Term $tid.
- * @deprecated Use taxonomy_select_nodes instead.
  *
  * @param int $tid
  *   A taxonomy term tid.
@@ -118,7 +117,14 @@ function dosomething_taxonomy_preprocess_taxonomy_term(&$vars) {
  * @return array
  */
 function dosomething_taxonomy_get_campaigns($tid) {
-  return taxonomy_select_nodes($tid, FALSE);
+  $nids = taxonomy_select_nodes($tid, FALSE);
+  $campaigns = [];
+  foreach ($nids as $delta => $nid) {
+    if (node_load($nid)->type === 'campaign') {
+      $campaigns[] = $nid;
+    }
+  }
+  return $campaigns;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -117,10 +117,10 @@ function dosomething_taxonomy_preprocess_taxonomy_term(&$vars) {
  * @return array
  */
 function dosomething_taxonomy_get_campaigns($tid) {
-  $nodes = node_load_multiple(taxonomy_select_nodes($tid, FALSE), ['type' => 'campaign']);
-  $campaigns = array_map(function($node) { return $node->nid; }, $nodes);
+  $campaigns = node_load_multiple(taxonomy_select_nodes($tid, FALSE), ['type' => 'campaign']);
+  $nodes = array_map(function($node) { return $node->nid; }, $nodes);
 
-  return $campaigns;
+  return $nodes;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -118,9 +118,9 @@ function dosomething_taxonomy_preprocess_taxonomy_term(&$vars) {
  */
 function dosomething_taxonomy_get_campaigns($tid) {
   $campaigns = node_load_multiple(taxonomy_select_nodes($tid, FALSE), ['type' => 'campaign']);
-  $nodes = array_map(function($node) { return $node->nid; }, $nodes);
+  $nids = array_map(function($node) { return $node->nid; }, $nodes);
 
-  return $nodes;
+  return $nids;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -118,7 +118,7 @@ function dosomething_taxonomy_preprocess_taxonomy_term(&$vars) {
  */
 function dosomething_taxonomy_get_campaigns($tid) {
   $campaigns = node_load_multiple(taxonomy_select_nodes($tid, FALSE), ['type' => 'campaign']);
-  $nids = array_map(function($node) { return $node->nid; }, $nodes);
+  $nids = array_map(function($node) { return $node->nid; }, $campaigns);
 
   return $nids;
 }

--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -117,11 +117,11 @@ function dosomething_taxonomy_preprocess_taxonomy_term(&$vars) {
  * @return array
  */
 function dosomething_taxonomy_get_campaigns($tid) {
-  $nids = taxonomy_select_nodes($tid, FALSE);
+  $nodes = node_load_multiple(taxonomy_select_nodes($tid, FALSE));
   $campaigns = [];
-  foreach ($nids as $nid) {
-    if (node_load($nid)->type === 'campaign') {
-      $campaigns[] = $nid;
+  foreach ($nodes as $node) {
+    if ($node->type === 'campaign') {
+      $campaigns[] = $node->nid;
     }
   }
   return $campaigns;


### PR DESCRIPTION
#### What's this PR do?

Only pull campaigns in the taxonomy get function, not all content types
#### How should this be reviewed?

Visit a taxonomy page, check the only content is campaigns
#### Any background context you want to provide?

Wasnt happening locally, Jen saw it happening on thor (so blocking deploy now). Wasnt able to reproduce locally until i saved an image, very strange...
#### Relevant tickets

Fixes #no
