### PR TITLE
OpenID Connect: Add ability to queue post-authorization actions.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
@@ -33,7 +33,7 @@ function dosomething_campaign_reportback_confirmation_page($node) {
   $image_size = '740x480';
 
 
-  // If SMS player is anonymous, he button should open the login/register form.
+  // If SMS player is anonymous, the button should open the login/register form.
   if (user_is_anonymous()) {
     $button_text = t(variable_get('dosomething_campaign_confirmation_page_anon_button_text'));
     $vars['call_to_action'] = t(variable_get('dosomething_campaign_confirmation_page_anon_cta_text'));

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
@@ -32,15 +32,29 @@ function dosomething_campaign_reportback_confirmation_page($node) {
   // Image size to pass to campaign block.
   $image_size = '740x480';
 
-  // Set button to link to /campaigns.
-  $button_text = t(variable_get('dosomething_campaign_confirmation_page_button_text'));
-  $vars['more_campaigns_link'] = l(t($button_text), 'campaigns', [
-    'attributes' => [
-      'class' => [
-        'button'
+
+  // If SMS player is anonymous, he button should open the login/register form.
+  if (user_is_anonymous()) {
+    $button_text = t(variable_get('dosomething_campaign_confirmation_page_anon_button_text'));
+    $vars['call_to_action'] = t(variable_get('dosomething_campaign_confirmation_page_anon_cta_text'));
+
+    $vars['more_campaigns_link'] = l(t($button_text), '#', [
+      'attributes' => [
+        'class' => ['button'],
+        'data-modal-href' => '#modal--register'
       ]
-    ]
-  ]);
+    ]);
+  } else {
+    // Otherwise, set button to link to /campaigns.
+    $button_text = t(variable_get('dosomething_campaign_confirmation_page_button_text'));
+    $vars['more_campaigns_link'] = l(t($button_text), 'campaigns', [
+      'attributes' => [
+        'class' => [
+          'button'
+        ]
+      ]
+    ]);
+  }
 
   // Set variables for authenticated user:
   if (module_exists('dosomething_reward')) {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
@@ -37,13 +37,7 @@ function dosomething_campaign_reportback_confirmation_page($node) {
   if (user_is_anonymous()) {
     $button_text = t(variable_get('dosomething_campaign_confirmation_page_anon_button_text'));
     $vars['call_to_action'] = t(variable_get('dosomething_campaign_confirmation_page_anon_cta_text'));
-
-    $vars['more_campaigns_link'] = l(t($button_text), '#', [
-      'attributes' => [
-        'class' => ['button'],
-        'data-modal-href' => '#modal--register'
-      ]
-    ]);
+    $vars['more_campaigns_link'] = dosomething_user_get_register_link($button_text, 'button');
   } else {
     // Otherwise, set button to link to /campaigns.
     $button_text = t(variable_get('dosomething_campaign_confirmation_page_button_text'));

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.pages.inc
@@ -31,37 +31,27 @@ function dosomething_campaign_reportback_confirmation_page($node) {
   ];
   // Image size to pass to campaign block.
   $image_size = '740x480';
-  // Signup source to pass to campaign block.
-  $source = dosomething_campaign_get_confirmation_path($node->nid);
 
-  // Set variables for anonymous user:
-  if (!user_is_logged_in()) {
-    $button_text = t(variable_get('dosomething_campaign_confirmation_page_anon_button_text'));
-    $vars['call_to_action'] = t(variable_get('dosomething_campaign_confirmation_page_anon_cta_text'));
-    // The button should open the login/register form.
-    $vars['more_campaigns_link'] = dosomething_user_get_login_modal_link_markup($button_text, 'large');
-  }
-  // Else set variables for authenticated user:
-  else {
-    $button_text = t(variable_get('dosomething_campaign_confirmation_page_button_text'));
-    // Set button to link to /campaigns.
-    $vars['more_campaigns_link'] = l(t($button_text), 'campaigns', [
-      'attributes' => [
-        'class' => [
-          'button'
-        ]
+  // Set button to link to /campaigns.
+  $button_text = t(variable_get('dosomething_campaign_confirmation_page_button_text'));
+  $vars['more_campaigns_link'] = l(t($button_text), 'campaigns', [
+    'attributes' => [
+      'class' => [
+        'button'
       ]
-    ]);
-    if (module_exists('dosomething_reward')) {
-      // If a reportback count reward exists:
-      if ($reward = dosomething_reward_exists('reportback_count')) {
-        // If Reward has not been redeemed:
-        if (!$reward->redeemed) {
-          // Get the Reward Redeem vars for this Reward.
-          $vars = dosomething_reward_get_redeem_form_vars($reward);
-          // Return the themed Reward Redeem page.
-          return theme('reward_redeem_reportback_count', $vars);
-        }
+    ]
+  ]);
+
+  // Set variables for authenticated user:
+  if (module_exists('dosomething_reward')) {
+    // If a reportback count reward exists:
+    if ($reward = dosomething_reward_exists('reportback_count')) {
+      // If Reward has not been redeemed:
+      if (!$reward->redeemed) {
+        // Get the Reward Redeem vars for this Reward.
+        $vars = dosomething_reward_get_redeem_form_vars($reward);
+        // Return the themed Reward Redeem page.
+        return theme('reward_redeem_reportback_count', $vars);
       }
     }
   }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -129,7 +129,9 @@ function dosomething_northstar_perform_authorization_actions() {
   $actions = $_SESSION['openid_connect_action'];
   foreach ($actions as $action => $target) {
     if($action === 'signup') {
-      dosomething_signup_user_signup((int) $target, $user, 'lolol'); // @TODO lololol
+      $source = dosomething_signup_get_query_source();
+      dosomething_signup_user_signup((int) $target, $user, $source);
+
       drupal_goto('node/' . $target);
     }
   }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -29,6 +29,19 @@ function dosomething_northstar_openid_login_view() {
 
   return theme('openid_login', ['url' => $authorize_url]);
 }
+
+/**
+ * Create an authorization link and redirect to it. (This way we don't
+ * have to make a state token every time we have a page with a login link).
+ *
+ * @return void
+ */
+function dosomething_northstar_openid_authorize() {
+  $authorize_url = dosomething_northstar_openid_authorize_url();
+
+  drupal_goto($authorize_url, ['absolute' => TRUE]);
+}
+
 /**
  * Register our custom OpenID Connect provider.
  *

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -6,6 +6,30 @@ module_load_include('php', 'openid_connect', 'includes/OpenIDConnectClientBase.c
 include_once('plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php');
 
 /**
+ * Create an OpenID Connect authorization URL.
+ *
+ * @return array
+ */
+function dosomething_northstar_openid_authorize_url() {
+  /** @var $client OpenIDConnectClientNorthstar */
+  $client = openid_connect_get_client('northstar');
+  $scopes = openid_connect_get_scopes();
+
+  return $client->getAuthorizeUrl($scopes);
+}
+
+/**
+ * Render the view for OpenID Connect login. Displayed standalone
+ * at `/user/openid` and (with feature flag enabled) in the modal.
+ *
+ * @return array
+ */
+function dosomething_northstar_openid_login_view() {
+  $authorize_url = dosomething_northstar_openid_authorize_url();
+
+  return theme('openid_login', ['url' => $authorize_url]);
+}
+/**
  * Register our custom OpenID Connect provider.
  *
  * Implements hook_ctools_plugin_directory().

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -39,6 +39,10 @@ function dosomething_northstar_openid_login_view() {
 function dosomething_northstar_openid_authorize() {
   $authorize_url = dosomething_northstar_openid_authorize_url();
 
+  if(isset($_GET['action']) && isset($_GET['node'])) {
+    dosomething_northstar_set_authorization_action($_GET['action'], $_GET['node']);
+  }
+
   drupal_goto($authorize_url, ['absolute' => TRUE]);
 }
 
@@ -86,10 +90,49 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
     'access_token_expiration' => $tokens['expire'],
   ]);
 
+  // If we saved a "post-authorization" action, do it now.
+  dosomething_northstar_perform_authorization_actions();
+
   // Let's remember that this is a OpenID Connect session.
   $_SESSION['DOSOMETHING_NORTHSTAR_OPENID_CONNECT'] = true;
 
   user_save($account, $edit);
+}
+
+/**
+ * Save a post-authorization destination in the session (e.g. for signing
+ * up for a campaign).
+ *
+ * @param $node
+ * @return void
+ */
+function dosomething_northstar_set_authorization_action($action, $nid) {
+  if ($action !== 'signup') {
+    return;
+  }
+
+  $_SESSION['openid_connect_action'] = ['signup' => $nid];
+}
+
+/**
+ * Perform any post-authorization actions (e.g. signups) queued in the session.
+ *
+ * @return void
+ */
+function dosomething_northstar_perform_authorization_actions() {
+  global $user;
+
+  if (! isset($_SESSION['openid_connect_action'])) {
+    return;
+  }
+
+  $actions = $_SESSION['openid_connect_action'];
+  foreach ($actions as $action => $target) {
+    if($action === 'signup') {
+      dosomething_signup_user_signup((int) $target, $user, 'lolol'); // @TODO lololol
+      drupal_goto('node/' . $target);
+    }
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -325,31 +325,6 @@ function dosomething_northstar_log_request($op, $user, $request_body, $response,
 }
 
 /**
- * Create an OpenID Connect authorization URL.
- *
- * @return array
- */
-function dosomething_northstar_openid_authorize_url() {
-  /** @var $client OpenIDConnectClientNorthstar */
-  $client = openid_connect_get_client('northstar');
-  $scopes = openid_connect_get_scopes();
-
-  return $client->getAuthorizeUrl($scopes);
-}
-
-/**
- * Render the view for OpenID Connect login. Displayed standalone
- * at `/user/openid` and (with feature flag enabled) in the modal.
- *
- * @return array
- */
-function dosomething_northstar_openid_login_view() {
-  $authorize_url = dosomething_northstar_openid_authorize_url();
-
-  return theme('openid_login', ['url' => $authorize_url]);
-}
-
-/**
  * Implements hook_theme().
  */
 function dosomething_northstar_theme() {

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -55,6 +55,12 @@ function dosomething_northstar_menu() {
       'access arguments' => ['access content'],
       'type' => MENU_CALLBACK,
     ],
+    'user/authorize' => [
+      'title' => 'openid connect authorize',
+      'page callback' => 'dosomething_northstar_openid_authorize',
+      'access arguments' => ['access content'],
+      'type' => MENU_CALLBACK,
+    ],
   ];
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
@@ -61,6 +61,6 @@ function dosomething_signup_get_signup_button($label, $nid, $form_id) {
   }
   // Otherwise, for anonymous user, return a #markup array to be rendered.
   return array(
-    '#markup' => dosomething_user_get_login_modal_link_markup($label),
+    '#markup' => dosomething_user_get_sign_up_link_markup($label, $nid),
   );
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
@@ -26,6 +26,37 @@ function dosomething_user_get_sign_up_link_markup($label, $nid) {
 }
 
 /**
+ * Returns markup for a link to login.
+ *
+ * @param $label
+ * @param $class
+ * @return string
+ */
+function dosomething_user_get_login_link($label, $class) {
+  if (module_exists('dosomething_northstar') && variable_get('dosomething_user_openid_oauth_login_enabled')) {
+    return l(t($label), 'user/authorize', ['attributes' => ['class' => $class]]);
+  }
+
+  return l(t($label), 'user/login', ['attributes' => ['data-modal-href' => '#modal--login', 'class' => $class]]);
+}
+
+/**
+ * Returns markup for a link to register.
+ *
+ * @param $label
+ * @param $class
+ * @return string
+ */
+function dosomething_user_get_register_link($label, $class = '') {
+  if (module_exists('dosomething_northstar') && variable_get('dosomething_user_openid_oauth_login_enabled')) {
+    // @TODO: We need to implement this `?register` query string in authorize route here, and on Northstar.
+    return l(t($label), 'user/authorize?register', ['attributes' => ['class' => $class]]);
+  }
+
+  return l(t($label), 'user/register', ['attributes' => ['data-modal-href' => '#modal--register', 'class' => $class]]);
+}
+
+/**
  * Implements template_preprocess_user_profile().
  */
 function dosomething_user_preprocess_user_profile(&$variables) {

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
@@ -60,7 +60,6 @@ function dosomething_user_get_register_link($label, $class = '') {
  * Implements template_preprocess_user_profile().
  */
 function dosomething_user_preprocess_user_profile(&$variables) {
-
   // Collect User Account data.
   $uid = $variables['elements']['#account']->uid;
   $user = user_load($uid);

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
@@ -5,15 +5,24 @@
  */
 
 /**
- * Returns markup for link to open the login/register modal with given $label.
+ * Returns markup for link to sign up for a campaign.
  *
  * @param string $label
  *   The text to display on the button.
- * @param string $class
- *   A class to apply to the button.
+ * @return string
  */
-function dosomething_user_get_login_modal_link_markup($label, $class = '') {
-  return '<a id="link--campaign-signup-login" href="#" data-modal-href="#modal--login" class="button ' . $class . '">' . $label . '</a>';
+function dosomething_user_get_sign_up_link_markup($label, $nid) {
+  // If the OpenID Connect feature flag is enabled, link to login page rather than showing classic modal.
+  if (module_exists('dosomething_northstar') && variable_get('dosomething_user_openid_oauth_login_enabled')) {
+    return l(t($label), 'user/authorize', [
+      'query' => ['action' => 'signup', 'node' => $nid],
+      'attributes' => [
+        'class' => ['button'],
+        'id' => 'link--campaign-signup-login'
+      ]]);
+  }
+
+  return '<a id="link--campaign-signup-login" href="#" data-modal-href="#modal--login" class="button">' . $label . '</a>';
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
@@ -42,19 +42,12 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     $vars['logo'] = '/' . PARANEUE_PATH . '/images/logo-dev.png';
   }
 
-  // If the OpenID Connect feature flag is enabled, link to login page rather than showing classic modal.
-  if (module_exists('dosomething_northstar') && variable_get('dosomething_user_openid_oauth_login_enabled')) {
-    $vars['log_in_link'] = l(t('Log In'), url('user/authorize'), ['absolute' => TRUE, 'attributes' => ['class' => ['secondary-nav-item'], 'id' => 'link--login']]);
-  } else {
-    $vars['log_in_link'] = l(t('Log In'), 'user/login', ['attributes' => ['class' => ['secondary-nav-item'], 'data-modal-href' => '#modal--login', 'id' => 'link--login']]);
-  }
-
   $navigation_vars = [
     'base_path'        => $vars['base_path'],
     'modifier_classes' => $modifier_classes,
     'logo'             => $vars['logo'],
     'front_page'       => $vars['front_page'],
-    'log_in_link'      => $vars['log_in_link'],
+    'log_in_link'      => dosomething_user_get_login_link('Log In', 'secondary-nav-item'),
     'logged_in'        => $vars['logged_in'],
     'search_box'       => $vars['search_box'],
     'user_identifier'  => $vars['user_identifier'],

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
@@ -44,7 +44,7 @@ function paraneue_dosomething_preprocess_page(&$vars) {
 
   // If the OpenID Connect feature flag is enabled, link to login page rather than showing classic modal.
   if (module_exists('dosomething_northstar') && variable_get('dosomething_user_openid_oauth_login_enabled')) {
-    $vars['log_in_link'] = l(t('Log In'), dosomething_northstar_openid_authorize_url(), ['absolute' => TRUE, 'attributes' => ['class' => ['secondary-nav-item'], 'id' => 'link--login']]);
+    $vars['log_in_link'] = l(t('Log In'), url('user/authorize'), ['absolute' => TRUE, 'attributes' => ['class' => ['secondary-nav-item'], 'id' => 'link--login']]);
   } else {
     $vars['log_in_link'] = l(t('Log In'), 'user/login', ['attributes' => ['class' => ['secondary-nav-item'], 'data-modal-href' => '#modal--login', 'id' => 'link--login']]);
   }


### PR DESCRIPTION
#### What's this PR do?

This pull request adds the ability to queue up "post-authorization" actions (like signing up for a campaign) when using the OpenID Connect auth flow. This allows us to keep the same behavior for the "Sign Up" button on the pitch page.
#### How should this be reviewed?

With yer eyes. 👀 This refactors a fair amount of login/register code so definitely worth giving a careful look to everything. I tried to test as many flows as possible, but always good to get a second set of eyes.
#### Any background context you want to provide?

I renamed the `dosomething_user_get_login_modal_link_markup` function because it's more about signup links than modal links (especially since signups don't necessarily make a modal now). ~~I also removed a bunch of code that was used for theming anonymous confirmation pages because it didn't seem necessary...?~~
#### Relevant tickets

Fixes #7122.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [x] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
