### PR TITLE
Adds Twitter metatags

### DIFF
--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -63,13 +63,14 @@ function dosomething_metatag_preprocess_page(&$vars) {
   if (isset($node) && $node->type == 'campaign') {
     $langauge_code = dosomething_global_get_language($user, $node);
 
-    $facebook_data = array(
+    $social_data = array(
       'type' => 'dosomething_facebook:campaign',
       'url' => url(current_path(), array('absolute'=> TRUE)),
       'title' => $node->title,
       'description' => "Volunteer and take action! " . $node->field_call_to_action[$langauge_code][0]['value'],
     );
-    dosomething_metatag_add_facebook_tags($facebook_data);
+    dosomething_metatag_add_facebook_tags($social_data);
+    dosomething_metatag_add_twitter_tags($social_data);
   }
 
   // Add special share info to the permalink page.
@@ -235,7 +236,7 @@ function dosomething_metatag_get_permalink_vars() {
   drupal_add_html_head($element, 'twitter:url');
 
   // Facebook.
-  $facebook_data = array(
+  $social_data = array(
     'type' => 'dosomething_facebook:campaign',
     'url' => $share_url,
     'title' => $node->title,
@@ -246,7 +247,8 @@ function dosomething_metatag_get_permalink_vars() {
     'height' => 480,
   );
 
-  dosomething_metatag_add_facebook_tags($facebook_data);
+  dosomething_metatag_add_facebook_tags($social_data);
+  dosomething_metatag_add_twitter_tags($social_data);
 }
 
 /*

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -62,12 +62,12 @@ function dosomething_metatag_preprocess_page(&$vars) {
   // Add explicit facebook og meta tags to campaign pages.
   if (isset($node) && $node->type == 'campaign') {
     $langauge_code = dosomething_global_get_language($user, $node);
-
     $social_data = array(
       'type' => 'dosomething_facebook:campaign',
       'url' => url(current_path(), array('absolute'=> TRUE)),
       'title' => $node->title,
       'description' => "Volunteer and take action! " . $node->field_call_to_action[$langauge_code][0]['value'],
+      'image' => dosomething_image_get_themed_image_url($node->nid, 'landscape', '1440x810'),
     );
     dosomething_metatag_add_facebook_tags($social_data);
     dosomething_metatag_add_twitter_tags($social_data);
@@ -403,12 +403,14 @@ function dosomething_metatag_add_twitter_tags($data) {
   ];
   drupal_add_html_head($description, 'twitter:description');
 
-  $description = [
-    '#tag' => 'meta',
-    '#attributes' => [
-      'property' => 'twitter:image',
-      'content' => $data['image'],
-    ],
-  ];
-  drupal_add_html_head($image, 'twitter:image');
+  if (array_key_exists('image', $data)) {
+    $description = [
+      '#tag' => 'meta',
+      '#attributes' => [
+        'property' => 'twitter:image',
+        'content' => $data['image'],
+      ],
+    ];
+    drupal_add_html_head($image, 'twitter:image');
+  }
 }

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -67,8 +67,9 @@ function dosomething_metatag_preprocess_page(&$vars) {
       'url' => url(current_path(), array('absolute'=> TRUE)),
       'title' => $node->title,
       'description' => "Volunteer and take action! " . $node->field_call_to_action[$langauge_code][0]['value'],
-      'image' => dosomething_image_get_themed_image_url($node->nid, 'landscape', '1440x810'),
+      'image' => dosomething_image_get_themed_image_url($node->field_image_campaign_cover[$langauge_code][0]['entity']->nid, 'landscape', '1440x810'),
     );
+
     dosomething_metatag_add_facebook_tags($social_data);
     dosomething_metatag_add_twitter_tags($social_data);
   }
@@ -188,52 +189,6 @@ function dosomething_metatag_get_permalink_vars() {
   $node = dosomething_campaign_load(node_load($rb_entity->nid));
   $share_copy = $node->call_to_action;
   $share_url = url(current_path(), array('absolute' => TRUE, 'query' => array('fid' => $fid)));
-
-  // Twitter.
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "twitter:card",
-      "content" => 'photo',
-    ),
-  );
-  drupal_add_html_head($element, 'twitter:card');
-
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "twitter:site",
-      "content" => '@dosomething',
-    ),
-  );
-  drupal_add_html_head($element, 'twitter:site');
-
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "twitter:image:src",
-      "content" => $image,
-    ),
-  );
-  drupal_add_html_head($element, 'twitter:image:src');
-
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "twitter:title",
-      "content" => $node->title,
-    ),
-  );
-  drupal_add_html_head($element, 'twitter:title');
-
-  $element = array(
-    '#tag' => 'meta',
-    '#attributes' => array(
-      "property" => "twitter:url",
-      "content" => $share_url,
-    ),
-  );
-  drupal_add_html_head($element, 'twitter:url');
 
   // Facebook.
   $social_data = array(
@@ -404,7 +359,7 @@ function dosomething_metatag_add_twitter_tags($data) {
   drupal_add_html_head($description, 'twitter:description');
 
   if (array_key_exists('image', $data)) {
-    $description = [
+    $image = [
       '#tag' => 'meta',
       '#attributes' => [
         'property' => 'twitter:image',

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -348,3 +348,65 @@ function dosomething_metatag_add_facebook_tags($data) {
     drupal_add_html_head($element, 'og:image:height');
   }
 }
+
+/*
+ * Add twitter meta tags to the page.
+ *
+ * @param array $data
+ *   Array of the content to use for each property.
+ */
+function dosomething_metatag_add_twitter_tags($data) {
+  $card = [
+    '#tag' => 'meta',
+    '#attributes' => [
+      'property' => 'twitter:card',
+      'content' => 'summary_large_image',
+    ],
+  ];
+  drupal_add_html_head($card, 'twitter:card');
+
+  $site = [
+    '#tag' => 'meta',
+    '#attributes' => [
+      'property' => 'twitter:site',
+      'content' => '@dosomething',
+    ],
+  ];
+  drupal_add_html_head($site, 'twitter:site');
+
+  $creator = [
+    '#tag' => 'meta',
+    '#attributes' => [
+      'property' => 'twitter:creator',
+      'content' => '@dosomething',
+    ],
+  ];
+  drupal_add_html_head($creator, 'twitter:creator');
+
+  $title = [
+    '#tag' => 'meta',
+    '#attributes' => [
+      'property' => 'twitter:title',
+      'content' => $data['title'],
+    ],
+  ];
+  drupal_add_html_head($title, 'twitter:title');
+
+  $description = [
+    '#tag' => 'meta',
+    '#attributes' => [
+      'property' => 'twitter:description',
+      'content' => $data['description'],
+    ],
+  ];
+  drupal_add_html_head($description, 'twitter:description');
+
+  $description = [
+    '#tag' => 'meta',
+    '#attributes' => [
+      'property' => 'twitter:image',
+      'content' => $data['image'],
+    ],
+  ];
+  drupal_add_html_head($image, 'twitter:image');
+}


### PR DESCRIPTION
#### What's this PR do?

Adds Twitter Meta tags on campaign + RB perma link page to create the [large summary card](https://dev.twitter.com/cards/types/summary-large-image)
#### How should this be reviewed?

I gave a temp port / url to my local using ngrok & used the [Twitter validator](https://cards-dev.twitter.com/validator)
<img width="598" alt="screen shot 2016-10-17 at 2 44 39 pm" src="https://cloud.githubusercontent.com/assets/897368/19450863/1933b454-9479-11e6-871b-8c8cbef6dc60.png">

<img width="606" alt="screen shot 2016-10-17 at 2 45 37 pm" src="https://cloud.githubusercontent.com/assets/897368/19450821/f808c238-9478-11e6-9a3d-1cb2a4dbe551.png">
#### Any background context you want to provide?

The metatag module could probably use a cleanup, so not the prettiest code in the world but it works for now.
#### Relevant tickets

Fixes #hmmm, I think i need to make one
here is the trello card https://trello.com/c/4ryiAJ15/99-1-as-an-admin-i-want-to-implement-twitter-cards-to-the-main-site-so-that-diane-can-push-campaigns-on-twitter-more-successfully
#### Checklist
- [ ] Tested on staging.
