### PR TITLE
Transaction id trait

### DIFF
--- a/lib/app/Auth/PhoenixTransactionBridge.php
+++ b/lib/app/Auth/PhoenixTransactionBridge.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Phoenix\Auth;
+
+use DoSomething\Gateway\Contracts\TransactionBridgeContract; // we import the transaction bridge contract
+use League\OAuth2\Client\Token\AccessToken;
+
+class PhoenixTransactionBridge implements TransactionBridgeContract {
+
+  /**
+   * Get the value of the given HTTP header.
+   *
+   * @return string
+   */
+  public function getHeader($name) {
+      return drupal_get_http_header($name);
+  }
+
+  /**
+   * Write a log message.
+   *
+   * @return void
+   */
+  public function log($message, array $details) {
+      watchdog('Transaction', $details, [], WATCHDOG_INFO);
+  }
+}

--- a/lib/app/Auth/PhoenixTransactionBridge.php
+++ b/lib/app/Auth/PhoenixTransactionBridge.php
@@ -2,7 +2,7 @@
 
 namespace Phoenix\Auth;
 
-use DoSomething\Gateway\Contracts\TransactionBridgeContract; // we import the transaction bridge contract
+use DoSomething\Gateway\Contracts\TransactionBridgeContract;
 use League\OAuth2\Client\Token\AccessToken;
 
 class PhoenixTransactionBridge implements TransactionBridgeContract {
@@ -22,8 +22,6 @@ class PhoenixTransactionBridge implements TransactionBridgeContract {
    * @return void
    */
   public function log($message, array $details) {
-      // Example:
-      // watchdog('dosomething_rogue', 'reportback not migrated to Rogue', ['user' => $user->uid, 'campaign_id' => $values['nid'], 'campaign_run_id' => $run->nid], WATCHDOG_ERROR);
-      watchdog('PhoenixTransactionBridge', 'Request made.', $details, WATCHDOG_INFO);
+      watchdog('PhoenixTransactionBridge', $message, $details, WATCHDOG_INFO);
   }
 }

--- a/lib/app/Auth/PhoenixTransactionBridge.php
+++ b/lib/app/Auth/PhoenixTransactionBridge.php
@@ -13,7 +13,7 @@ class PhoenixTransactionBridge implements TransactionBridgeContract {
    * @return string
    */
   public function getHeader($name) {
-      return drupal_get_http_header($name);
+    return drupal_get_http_header($name);
   }
 
   /**
@@ -22,6 +22,6 @@ class PhoenixTransactionBridge implements TransactionBridgeContract {
    * @return void
    */
   public function log($message, array $details) {
-      watchdog('PhoenixTransactionBridge', $message, $details, WATCHDOG_INFO);
+    watchdog('PhoenixTransactionBridge', $message, $details, WATCHDOG_INFO);
   }
 }

--- a/lib/app/Auth/PhoenixTransactionBridge.php
+++ b/lib/app/Auth/PhoenixTransactionBridge.php
@@ -22,6 +22,8 @@ class PhoenixTransactionBridge implements TransactionBridgeContract {
    * @return void
    */
   public function log($message, array $details) {
-      watchdog('Transaction', $details, [], WATCHDOG_INFO);
+      // Example:
+      // watchdog('dosomething_rogue', 'reportback not migrated to Rogue', ['user' => $user->uid, 'campaign_id' => $values['nid'], 'campaign_run_id' => $run->nid], WATCHDOG_ERROR);
+      watchdog('PhoenixTransactionBridge', 'Request made.', $details, WATCHDOG_INFO);
   }
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -40,7 +40,7 @@ function dosomething_rogue_menu() {
  */
 function dosomething_rogue_client() {
 
-  return new Rogue();
+  return new Rogue(ROGUE_API_URL . '/' . ROGUE_API_VERSION);
 }
 
 /**
@@ -119,16 +119,16 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
  */
 function dosomething_rogue_update_rogue_reportback_items($data)
 {
-  $client = _dosomething_rogue_build_http_client();
+  $client = dosomething_rogue_client();
 
-  $options = [
-    'method' => 'PUT',
-    'headers' => $client['headers'],
-    'data' =>
-      json_encode($data),
-  ];
+  // $options = [
+  //   'method' => 'PUT',
+  //   'headers' => $client['headers'],
+  //   'data' =>
+  //     json_encode($data),
+  // ];
 
-  $response = $client->updateReportback('items', $options);
+  $response = $client->updateReportback('items', $data);
 
   //@TODO - Add error handling.
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -1,8 +1,7 @@
 <?php
 
+use DoSomething\Gateway\ForwardsTransactionIds;
 use DoSomething\Gateway\Common\RestApiClient;
-// use DoSomething\Gateway\ForwardsTransactionIds;
-use DoSomething\Gateway\src\ForwardsTransactionIds;
 
 /**
  * @file

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -121,13 +121,6 @@ function dosomething_rogue_update_rogue_reportback_items($data)
 {
   $client = dosomething_rogue_client();
 
-  // $options = [
-  //   'method' => 'PUT',
-  //   'headers' => $client['headers'],
-  //   'data' =>
-  //     json_encode($data),
-  // ];
-
   $response = $client->updateReportback('items', $data);
 
   //@TODO - Add error handling.

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -128,7 +128,7 @@ function dosomething_rogue_update_rogue_reportback_items($data)
       json_encode($data),
   ];
 
-  $response = drupal_http_request($client['base_url'] . '/items', $options);
+  $response = $client->updateReportback($client['base_url'] . '/items', $options);
 
   //@TODO - Add error handling.
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -78,7 +78,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
         'crop_rotate' => $values['crop_rotate'],
   ];
 
-  $response = $client->postReportback('reportbacks', $data);
+  $response = $client->postReportback($data);
 
   if (in_array($response->code, [200, 201]) && module_exists('stathat')) {
     stathat_send_ez_count('drupal - Rogue - reportback sent - count', 1);
@@ -121,7 +121,7 @@ function dosomething_rogue_update_rogue_reportback_items($data)
 {
   $client = dosomething_rogue_client();
 
-  $response = $client->updateReportback('items', $data);
+  $response = $client->updateReportback($data);
 
   //@TODO - Add error handling.
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -40,7 +40,7 @@ function dosomething_rogue_menu() {
  */
 function dosomething_rogue_client() {
 
-  return new Rogue(ROGUE_API_URL . '/' . ROGUE_API_VERSION);
+  return new Rogue(ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/');
 }
 
 /**
@@ -61,21 +61,21 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
   $client = dosomething_rogue_client();
 
   $data = [
-        'northstar_id' => $northstar_id ? $northstar_id : NULL,
-        'drupal_id' => $user->uid,
-        'campaign_id' => $values['nid'],
-        'campaign_run_id' => $run->nid,
-        'quantity' => $values['quantity'],
-        'why_participated' => $values['why_participated'],
-        'file' => $values['file'],
-        'file_id' => '', // @TODO - currently require by rogue, should not be.
-        'caption' => $values['caption'],
-        'status' => isset($values['status']) ? $values['status'] : 'pending',
-        'crop_x' => $values['crop_x'],
-        'crop_y' => $values['crop_y'],
-        'crop_width' => $values['crop_width'],
-        'crop_height' => $values['crop_height'],
-        'crop_rotate' => $values['crop_rotate'],
+    'northstar_id' => $northstar_id ? $northstar_id : NULL,
+    'drupal_id' => $user->uid,
+    'campaign_id' => $values['nid'],
+    'campaign_run_id' => $run->nid,
+    'quantity' => $values['quantity'],
+    'why_participated' => $values['why_participated'],
+    'file' => $values['file'],
+    'file_id' => '', // @TODO - currently require by rogue, should not be.
+    'caption' => $values['caption'],
+    'status' => isset($values['status']) ? $values['status'] : 'pending',
+    'crop_x' => $values['crop_x'],
+    'crop_y' => $values['crop_y'],
+    'crop_width' => $values['crop_width'],
+    'crop_height' => $values['crop_height'],
+    'crop_rotate' => $values['crop_rotate'],
   ];
 
   $response = $client->postReportback($data);

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -1,6 +1,5 @@
 <?php
 
-use DoSomething\Gateway\ForwardsTransactionIds;
 use DoSomething\Gateway\Common\RestApiClient;
 
 /**
@@ -10,6 +9,8 @@ use DoSomething\Gateway\Common\RestApiClient;
 
 include_once('dosomething_rogue.admin.inc');
 include_once('dosomething_rogue.cron.inc');
+include_once('includes/Rogue.php');
+
 
 define('ROGUE_API_URL', variable_get('dosomething_rogue_url', 'http://rogue.app/api'));
 define('ROGUE_API_VERSION', variable_get('dosomething_rogue_api_version', 'v1'));

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -40,7 +40,7 @@ function dosomething_rogue_menu() {
  */
 function dosomething_rogue_client() {
 
-  return new Rogue(ROGUE_API_URL . '/' . ROGUE_API_VERSION);
+  return new Rogue();
 }
 
 /**
@@ -78,7 +78,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
         'crop_rotate' => $values['crop_rotate'],
   ];
 
-  $response = $client->postReportback($client->getBaseUri() . '/reportbacks', $data);
+  $response = $client->postReportback('reportbacks', $data);
 
   if (in_array($response->code, [200, 201]) && module_exists('stathat')) {
     stathat_send_ez_count('drupal - Rogue - reportback sent - count', 1);
@@ -128,7 +128,7 @@ function dosomething_rogue_update_rogue_reportback_items($data)
       json_encode($data),
   ];
 
-  $response = $client->updateReportback($client['base_url'] . '/items', $options);
+  $response = $client->updateReportback('items', $options);
 
   //@TODO - Add error handling.
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -1,6 +1,8 @@
 <?php
 
 use DoSomething\Gateway\Common\RestApiClient;
+// use DoSomething\Gateway\ForwardsTransactionIds;
+use DoSomething\Gateway\src\ForwardsTransactionIds;
 
 /**
  * @file

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -1,7 +1,5 @@
 <?php
 
-use DoSomething\Gateway\Common\RestApiClient;
-
 /**
  * @file
  * Code for the dosomething_rogue feature.
@@ -10,7 +8,6 @@ use DoSomething\Gateway\Common\RestApiClient;
 include_once('dosomething_rogue.admin.inc');
 include_once('dosomething_rogue.cron.inc');
 include_once('includes/Rogue.php');
-
 
 define('ROGUE_API_URL', variable_get('dosomething_rogue_url', 'http://rogue.app/api'));
 define('ROGUE_API_VERSION', variable_get('dosomething_rogue_api_version', 'v1'));
@@ -43,7 +40,7 @@ function dosomething_rogue_menu() {
  */
 function dosomething_rogue_client() {
 
-  return new RestApiClient(ROGUE_API_URL . '/' . ROGUE_API_VERSION);
+  return new Rogue(ROGUE_API_URL . '/' . ROGUE_API_VERSION);
 }
 
 /**
@@ -81,7 +78,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
         'crop_rotate' => $values['crop_rotate'],
   ];
 
-  $response = $client->post($client->getBaseUri() . '/reportbacks', $data);
+  $response = $client->postReportback($client->getBaseUri() . '/reportbacks', $data);
 
   if (in_array($response->code, [200, 201]) && module_exists('stathat')) {
     stathat_send_ez_count('drupal - Rogue - reportback sent - count', 1);

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -14,16 +14,6 @@ class Rogue extends RestApiClient {
   protected $transactionBridge = Phoenix\Auth\PhoenixTransactionBridge::class;
 
   /**
-   * Create a new Rogue API client.
-   */
-  // public function __construct() {
-  //   $url = ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/';
-
-  //   parent::__construct($url);
-  // }
-
-
-  /**
    * Send a POST request of the reportback to be saved in Rogue.
    *
    * @param string $baseurl
@@ -44,7 +34,7 @@ class Rogue extends RestApiClient {
    * @return object|false
    */
   public function updateReportback($baseurl, $data) {
-    $response = $this->put($url . $baseurl, $data);
+    $response = $this->put(ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/' . $baseurl, $data);
 
     return is_null($response) ? null : $response;
   }

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -6,5 +6,7 @@ use DoSomething\Gateway\ForwardsTransactionIds;
 class Rogue extends RestApiClient {
   use ForwardsTransactionIds;
 
-
+  public function postReportback($url, $data) {
+    return $this->post($url, $data);
+  }
 }

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -16,11 +16,11 @@ class Rogue extends RestApiClient {
   /**
    * Create a new Rogue API client.
    */
-  public function __construct() {
-    $url = ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/';
+  // public function __construct() {
+  //   $url = ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/';
 
-    parent::__construct($url);
-  }
+  //   parent::__construct($url);
+  // }
 
 
   /**
@@ -31,7 +31,8 @@ class Rogue extends RestApiClient {
    * @return object|false
    */
   public function postReportback($baseurl, $data) {
-    $response = $this->post($baseurl, $data);
+    // die(ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/' . $baseurl);
+    $response = $this->post(ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/' . $baseurl, $data);
 
     return is_null($response) ? null : $response;
   }

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -20,8 +20,8 @@ class Rogue extends RestApiClient {
    * @param array $data
    * @return object|false
    */
-  public function postReportback($baseurl, $data) {
-    $response = $this->post(ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/' . $baseurl, $data);
+  public function postReportback($data) {
+    $response = $this->post(ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/' . 'reportbacks', $data);
 
     return $response;
   }
@@ -33,8 +33,8 @@ class Rogue extends RestApiClient {
    * @param array $data
    * @return object|false
    */
-  public function updateReportback($baseurl, $data) {
-    $response = $this->put(ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/' . $baseurl, $data);
+  public function updateReportback($data) {
+    $response = $this->put(ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/' . 'items', $data);
 
     return $response;
   }

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -7,28 +7,31 @@ class Rogue extends RestApiClient {
   use ForwardsTransactionIds;
 
   /**
-   * Get the CSRF token for the authenitcated API session.
    * The class name of the transaction framework bridge.
    *
-   * @return string - token
    * @var string
    */
-  private function getAuthenticationToken()
-  {
-    return $this->authenticate()['token'];
+  protected $transactionBridge = Phoenix\Auth\PhoenixTransactionBridge::class;
+
+  /**
+   * Create a new Rogue API client.
+   */
+  public function __construct() {
+    $url = ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/';
+
+    parent::__construct($url);
   }
 
-  protected $transactionBridge = Phoenix\Auth\PhoenixTransactionBridge::class;
 
   /**
    * Send a POST request of the reportback to be saved in Rogue.
    *
-   * @param string $url
+   * @param string $baseurl
    * @param array $data
    * @return object|false
    */
-  public function postReportback($url, $data) {
-    $respons = $this->post($url, $data);
+  public function postReportback($baseurl, $data) {
+    $response = $this->post($baseurl, $data);
 
     return is_null($response) ? null : $response;
   }
@@ -36,12 +39,12 @@ class Rogue extends RestApiClient {
   /**
    * Send a PUT request of the updated reportback to be saved in Rogue.
    *
-   * @param string $url
+   * @param string $baseurl
    * @param array $data
    * @return object|false
    */
-  public function updateReportback($url, $data) {
-    $response = $this->put($url, $data);
+  public function updateReportback($baseurl, $data) {
+    $response = $this->put($url . $baseurl, $data);
 
     return is_null($response) ? null : $response;
   }

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -31,7 +31,6 @@ class Rogue extends RestApiClient {
    * @return object|false
    */
   public function postReportback($baseurl, $data) {
-    // die(ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/' . $baseurl);
     $response = $this->post(ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/' . $baseurl, $data);
 
     return is_null($response) ? null : $response;

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -1,0 +1,10 @@
+<?php
+
+use DoSomething\Gateway\Common\RestApiClient;
+use DoSomething\Gateway\ForwardsTransactionIds;
+
+class Rogue extends RestApiClient {
+  use ForwardsTransactionIds;
+
+
+}

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -23,7 +23,7 @@ class Rogue extends RestApiClient {
   public function postReportback($baseurl, $data) {
     $response = $this->post(ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/' . $baseurl, $data);
 
-    return is_null($response) ? null : $response;
+    return $response;
   }
 
   /**
@@ -36,6 +36,6 @@ class Rogue extends RestApiClient {
   public function updateReportback($baseurl, $data) {
     $response = $this->put(ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/' . $baseurl, $data);
 
-    return is_null($response) ? null : $response;
+    return $response;
   }
 }

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -6,7 +6,43 @@ use DoSomething\Gateway\ForwardsTransactionIds;
 class Rogue extends RestApiClient {
   use ForwardsTransactionIds;
 
+  /**
+   * Get the CSRF token for the authenitcated API session.
+   * The class name of the transaction framework bridge.
+   *
+   * @return string - token
+   * @var string
+   */
+  private function getAuthenticationToken()
+  {
+    return $this->authenticate()['token'];
+  }
+
+  protected $transactionBridge = Phoenix\Auth\PhoenixTransactionBridge::class;
+
+  /**
+   * Send a POST request of the reportback to be saved in Rogue.
+   *
+   * @param string $url
+   * @param array $data
+   * @return object|false
+   */
   public function postReportback($url, $data) {
-    return $this->post($url, $data);
+    $respons = $this->post($url, $data);
+
+    return is_null($response) ? null : $response;
+  }
+
+  /**
+   * Send a PUT request of the updated reportback to be saved in Rogue.
+   *
+   * @param string $url
+   * @param array $data
+   * @return object|false
+   */
+  public function updateReportback($url, $data) {
+    $response = $this->put($url, $data);
+
+    return is_null($response) ? null : $response;
   }
 }

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -21,7 +21,7 @@ class Rogue extends RestApiClient {
    * @return object|false
    */
   public function postReportback($data) {
-    $response = $this->post(ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/' . 'reportbacks', $data);
+    $response = $this->post('reportbacks', $data);
 
     return $response;
   }
@@ -34,7 +34,7 @@ class Rogue extends RestApiClient {
    * @return object|false
    */
   public function updateReportback($data) {
-    $response = $this->put(ROGUE_API_URL . '/' . ROGUE_API_VERSION . '/' . 'items', $data);
+    $response = $this->put('items', $data);
 
     return $response;
   }


### PR DESCRIPTION
#### What's this PR do?

Creates a new `Rogue` class to pull in the `ForwardsTransactionIds` trait to successfully log transaction Id requests from Phoenix -> Rogue. 
#### How should this be reviewed?
1. Clear your dblogs. 
2. Submit a reportback. 
3. Refresh your dblogs and you should see the following:
   ![screen shot 2016-10-17 at 2 24 00 pm](https://cloud.githubusercontent.com/assets/9019452/19451018/af1b97c0-9479-11e6-9300-b37142734cff.png)

Question - how can we access the `$details` array that we send to watchdog as the third param? 
#### Any background context you want to provide?

By looking in SequelPro, it is confirmed that the reportback and reportback items are successfully being sent to Rogue however I noticed the "reportback not migrated to Rogue" error in the dblogs. I believe this is something that will be fixed with @katiecrane's work with [this issue](https://github.com/DoSomething/phoenix/issues/7123) since it looks like it [logs](https://github.com/DoSomething/phoenix/blob/dev/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module#L108) it if the [status code is not `200` or `201`](https://github.com/DoSomething/phoenix/blob/dev/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module#L84).
#### Relevant tickets

Fixes #7126
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
