### PR TITLE
Fix issues with export scripts.

### DIFF
--- a/scripts/delete-bad-users-in-northstar.php
+++ b/scripts/delete-bad-users-in-northstar.php
@@ -38,14 +38,15 @@ foreach ($records as $record) {
     'data' => json_encode($ns_user),
   ]);
 
+  $response_data = json_decode($response->data, TRUE);
+
   // Output progress to stdout & log request details for later review.
-  dosomething_northstar_log_request('migrate', $user, $ns_user, $response);
   echo 'Migrated user ' . $user->uid . ' to Northstar [' . $response->code . ']' . PHP_EOL;
-  $response_data = json_decode($response->data);
+  dosomething_northstar_log_request('migrate', $user, $ns_user, $response_data);
 
   // If a user cannot be re-migrated due to a Drupal ID index conflict, we should add an entry for that Northstar ID.
-  if ($response->code == 400 && !empty($response_data->error->context->id)) {
-    db_insert('dosomething_northstar_delete_queue')->fields(['uid' => $user->uid, 'northstar_id' => $response_data->error->context->id])->execute();
+  if ($response->code == 400 && !empty($response_data['error']['context']['id'])) {
+    db_insert('dosomething_northstar_delete_queue')->fields(['uid' => $user->uid, 'northstar_id' => $response_data['error']['context']['id']])->execute();
   }
 
   // Store the returned Northstar ID on the user's Drupal profile.

--- a/scripts/export-users-to-northstar.php
+++ b/scripts/export-users-to-northstar.php
@@ -42,16 +42,16 @@ foreach ($users as $user) {
 
   // Output progress to stdout so we can see our good work.
   echo 'Migrated user ' . $user->uid . ' to Northstar [' . $response->code . ']' . PHP_EOL;
-  $response_data = json_decode($response->data);
+  $response_data = json_decode($response->data, TRUE);
 
   // Save any failed requests to the request log for debugging.
   if(! in_array($response->code, [200, 201])) {
-    dosomething_northstar_log_request('migrate', $user, $northstar_user, $response);
+    dosomething_northstar_log_request('migrate', $user, $northstar_user, $response_data);
   }
 
   // If a user cannot be migrated due to a Drupal ID index conflict, we should delete the conflicting Northstar record.
   if ($response->code == 400 && !empty($response_data->error->context->id)) {
-    db_insert('dosomething_northstar_delete_queue')->fields(['uid' => $user->uid, 'northstar_id' => $response_data->error->context->id])->execute();
+    db_insert('dosomething_northstar_delete_queue')->fields(['uid' => $user->uid, 'northstar_id' => $response_data['error']['context']['id']])->execute();
   }
 
   // Store the returned Northstar ID on the user's Drupal profile.


### PR DESCRIPTION
#### What's this PR do?

This fixes a bug with the export script that I noticed when restarting it.

The Northstar module now expects responses to be associate arrays (which is what we return from Gateway clients, rather than `stdClass` objects) so the "save ID field" was erring out when it got a stdClass instead.

This just updates those scripts to follow the rules (while still using old HTTP client since they're not going to be around that much longer).
#### How should this be reviewed?

👀
#### Any background context you want to provide?

I tested that these fixes work correctly when running this script on `drupal.admin`.
#### Relevant tickets

Fixes 🐛.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
