### PR TITLE
Restore ID used in test suite.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
@@ -37,7 +37,7 @@ function dosomething_user_get_login_link($label, $class) {
     return l(t($label), 'user/authorize', ['attributes' => ['class' => $class]]);
   }
 
-  return l(t($label), 'user/login', ['attributes' => ['data-modal-href' => '#modal--login', 'class' => $class]]);
+  return l(t($label), 'user/login', ['attributes' => ['data-modal-href' => '#modal--login', 'class' => $class, 'id' => 'link--login']]);
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?

I accidentally removed the `#link--login` ID from the login button, which the Ghost Inspector test relies on to find the right link to click.
#### How should this be reviewed?

 🆔 👀
#### Any background context you want to provide?

🔨 ⚡️
#### Relevant tickets

Fixes 👻.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
