### PR TITLE
#7137: Passes class parameter as array

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
@@ -29,10 +29,10 @@ function dosomething_user_get_sign_up_link_markup($label, $nid) {
  * Returns markup for a link to login.
  *
  * @param $label
- * @param $class
+ * @param array $class
  * @return string
  */
-function dosomething_user_get_login_link($label, $class) {
+function dosomething_user_get_login_link($label, array $class) {
   if (module_exists('dosomething_northstar') && variable_get('dosomething_user_openid_oauth_login_enabled')) {
     return l(t($label), 'user/authorize', ['attributes' => ['class' => $class]]);
   }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
@@ -28,7 +28,7 @@ function dosomething_user_get_sign_up_link_markup($label, $nid) {
 /**
  * Returns markup for a link to login.
  *
- * @param $label
+ * @param string $label
  * @param array $class
  * @return string
  */

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_page.inc
@@ -47,7 +47,7 @@ function paraneue_dosomething_preprocess_page(&$vars) {
     'modifier_classes' => $modifier_classes,
     'logo'             => $vars['logo'],
     'front_page'       => $vars['front_page'],
-    'log_in_link'      => dosomething_user_get_login_link('Log In', 'secondary-nav-item'),
+    'log_in_link'      => dosomething_user_get_login_link('Log In', ['secondary-nav-item']),
     'logged_in'        => $vars['logged_in'],
     'search_box'       => $vars['search_box'],
     'user_identifier'  => $vars['user_identifier'],


### PR DESCRIPTION
#### What's this PR do?

Passing `$class` as an array when invoking the [new login helper](https://github.com/DoSomething/phoenix/blob/dev/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc#L35).
#### How should this be reviewed?

Calls to the login helper should no longer spawn errors like

```
Error: Uncaught exception 'Error' with message '[] operator not supported for strings' in /var/www/www.dosomething.org/releases/20161019170210/html/includes/common.inc:2494
in l called at /var/www/www.dosomething.org/releases/20161019170210/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc (40)
[...]
```
#### Relevant tickets

Fixes #7137 
