### PR TITLE
Prefer Northstar ID whenever possible and cover some bases, huzzah!

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -718,7 +718,7 @@ function dosomething_helpers_get_current_user($user = NULL, $asArray = FALSE) {
   }
 
   // Authenticated User
-  $northstar_user = dosomething_northstar_get_user($user->uid);
+  $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
 
   if ($northstar_user && $asArray) {
     return dosomething_helpers_get_user_as_array($northstar_user);

--- a/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
@@ -115,7 +115,7 @@ class Kudos extends Entity {
     $this->term = $this->getTaxonomyTerm($data->tid);
 
     if ($full && module_exists('dosomething_northstar')) {
-      $northstar_user = dosomething_northstar_get_user($data->uid);
+      $northstar_user = dosomething_northstar_get_user($data->uid, 'drupal_id');
     }
 
     $this->user = [

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -84,6 +84,7 @@ function dosomething_northstar_openid_connect_claims_alter(&$claims) {
  */
 function dosomething_northstar_openid_connect_post_authorize($tokens, $account, $userinfo, $provider) {
   $edit = [];
+
   dosomething_user_set_fields($edit, [
     'access_token' => $tokens['access_token'],
     'refresh_token' => $tokens['access_token'],
@@ -95,11 +96,22 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
     _dosomething_user_send_to_message_broker();
   }
 
+  // Make sure the user's Northstar ID is set in the field_data_field_northstar_id table.
+  if (!dosomething_user_get_northstar_id($account->uid)) {
+    dosomething_northstar_save_id_field($account->uid, ['data' => $userinfo]);
+  }
+
   // If we saved a "post-authorization" action, do it now.
   dosomething_northstar_perform_authorization_actions();
 
   // Let's remember that this is a OpenID Connect session.
   $_SESSION['DOSOMETHING_NORTHSTAR_OPENID_CONNECT'] = true;
+
+  // Determine the user's language code if possible.
+  $language_code = dosomething_settings_get_geo_country_code();
+
+  $edit['language'] = $language_code ? $language_code : 'en-global';
+  $edit['timezone'] = 'UTC';
 
   user_save($account, $edit);
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -109,7 +109,7 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
 
   if (empty($account->language)) {
     // Determine the user's language code if possible.
-    $language_code = dosomething_settings_get_geo_country_code();
+    $language_code = dosomething_global_get_language($account);
 
     $edit['language'] = $language_code ? $language_code : 'en-global';
   }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -107,11 +107,16 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
   // Let's remember that this is a OpenID Connect session.
   $_SESSION['DOSOMETHING_NORTHSTAR_OPENID_CONNECT'] = true;
 
-  // Determine the user's language code if possible.
-  $language_code = dosomething_settings_get_geo_country_code();
+  if (empty($account->language)) {
+    // Determine the user's language code if possible.
+    $language_code = dosomething_settings_get_geo_country_code();
 
-  $edit['language'] = $language_code ? $language_code : 'en-global';
-  $edit['timezone'] = 'UTC';
+    $edit['language'] = $language_code ? $language_code : 'en-global';
+  }
+
+  if (empty($account->timezone)) {
+    $edit['timezone'] = 'UTC';
+  }
 
   user_save($account, $edit);
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -180,12 +180,23 @@ function dosomething_northstar_get_error_code($errorMessage) {
  * @param  string $type
  * @return DoSomething\Gateway\Resources\NorthstarUser|null
  */
-function dosomething_northstar_get_user($id, $type = 'drupal_id') {
+function dosomething_northstar_get_user($id, $type = 'id') {
+  // Prefer using user's Northstar ID.
+  if ($type === 'drupal_id') {
+    $northstar_id = dosomething_user_get_northstar_id($id);
+
+    if ($northstar_id) {
+      $type = 'id';
+      $id = $northstar_id;
+    }
+  }
+
   $cache_bin = 'cache_dosomething_northstar';
   $cache_key = 'northstar_user_'.$type.'='.$id;
 
   $northstar_user = cache_get($cache_key, $cache_bin);
 
+  // Return cached northstar user data.
   if ($northstar_user) {
     return $northstar_user->data;
   }

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -169,7 +169,7 @@ class Reportback extends Entity {
     $this->campaign = Campaign::get($data->nid);
 
     if ($full && module_exists('dosomething_northstar')) {
-      $northstar_user = dosomething_northstar_get_user($data->uid);
+      $northstar_user = dosomething_northstar_get_user($data->uid, 'drupal_id');
     }
 
     $this->user = [

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -110,7 +110,7 @@ class ReportbackItem extends Entity {
     $this->campaign = Campaign::get($data->nid);
 
     if ($full && module_exists('dosomething_northstar')) {
-      $northstar_user = dosomething_northstar_get_user($data->uid);
+      $northstar_user = dosomething_northstar_get_user($data->uid, 'drupal_id');
     }
 
     $this->user = [

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1323,7 +1323,7 @@ function dosomething_user_get_field_last_name($field_value, $format = 'ucwords')
  *   Returns NULL if not set, otherwise string Northstar ID.
  */
 function dosomething_user_get_field_northstar_id($field_value) {
-  // Return NULL if the module is not enavbled.
+  // Return NULL if the module is not enabled.
   if (!module_exists('dosomething_northstar')) {
     return NULL;
   }
@@ -1337,13 +1337,28 @@ function dosomething_user_get_field_northstar_id($field_value) {
   return $field_value;
 }
 
+/**
+ * Return the specified Drupal user/global user's Northstar ID.
+ *
+ * @param  string $drupal_id
+ * @return mixed
+ */
+function dosomething_user_get_northstar_id($drupal_id = NULL) {
+  $user = NULL;
+
+  if ($drupal_id) {
+    $user = user_load($drupal_id);
+  }
+
+  return dosomething_user_get_field('field_northstar_id', $user);
+}
 
 /**
  * Helper function to prepare an array of user fields.
  *
  * Extends existing array of user form values with Entity API's fields.
  * The fields will be added to &$edit array prefixed with `field_`.
- * All from this flow exceprions will be processed so &$edit is ready for
+ * All from this flow exceptions will be processed so &$edit is ready for
  * user_save() execution.
  *
  * @param  array $edit


### PR DESCRIPTION
#### What's this PR do?

This PR does a few updates to fix up an issue occurring on Staging. It defaults to referring to the Northstar ID for a user when working with their record in Phoenix and when querying Northstar for more information on them. (see background context below!)
#### How should this be reviewed?

tell us, how can we review, to test that this works
#### Any background context you want to provide?

When using OpenID to register as a new user via Northstar, Northstar creates a new record in its system and then passes the information over to Phoenix to then create a new Drupal user in its system and associating the NS ID created on the Northstar side. However, we don't then go back and tell Northstar what the `drupal_id` for this new user is, which means that all the functions that later go grab Northstar info for this user, and ask to find the user using their `drupal_id` will return `null` because that id was never passed into the NS system.
#### Relevant tickets

Fixes # https://github.com/DoSomething/northstar/issues/458
#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love

---

@DFurnes @angaither 

cc: @jessleenyc 
