### PR TITLE
Send transactionals if user registered via OpenID Connect flow.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -90,6 +90,11 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
     'access_token_expiration' => $tokens['expire'],
   ]);
 
+  // HACK: Is this account newly created (last 15s)? If so, send email.
+  if ($userinfo['created_at'] > time() - 15) {
+    _dosomething_user_send_to_message_broker();
+  }
+
   // If we saved a "post-authorization" action, do it now.
   dosomething_northstar_perform_authorization_actions();
 


### PR DESCRIPTION
#### What's this PR do?

This PR has a wonderfully hacky solution for sending transactional emails for OpenID Connect registrations. Since we're not told whether the user is newly registered or not, comparing the `created_at` timestamp seems to work nicely.
#### How should this be reviewed?

👀
#### Any background context you want to provide?

This is a short-term fix, since we want these transactional messages to be triggered from Northstar once Quicksilver API is ready for production use.
#### Relevant tickets

Fixes ⁉️.
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
