### PR TITLE
handle rogue failures when using gateway

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -69,7 +69,6 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
         'quantity' => $values['quantity'],
         'why_participated' => $values['why_participated'],
         'file' => $values['file'],
-        'file_id' => '', // @TODO - currently require by rogue, should not be.
         'caption' => $values['caption'],
         'status' => isset($values['status']) ? $values['status'] : 'pending',
         'crop_x' => $values['crop_x'],
@@ -79,36 +78,28 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
         'crop_rotate' => $values['crop_rotate'],
   ];
 
-  $response = $client->post($client->getBaseUri() . '/reportbacks', $data);
+  try {
+    $response = $client->post($client->getBaseUri() . '/reportback', $data);
 
-  if (in_array($response->code, [200, 201]) && module_exists('stathat')) {
-    stathat_send_ez_count('drupal - Rogue - reportback sent - count', 1);
-  }
-  else {
-    // Log as watchdog error, and stathat value.
     if (module_exists('stathat')) {
-      stathat_send_ez_count('drupal - Rogue - reportback failed - count', 1);
+      stathat_send_ez_count('drupal - Rogue - reportback sent - count', 1);
     }
-    // Save fail to a db log so we can easily export.
-    db_insert('dosomething_rogue_failed_task_log')
-      ->fields([
-        'drupal_id' => $user->uid,
-        'campaign_id' => $values['nid'],
-        'campaign_run_id' => $run->nid,
-        'quantity' => $values['quantity'],
-        'why_participated' => $values['why_participated'],
-        'file' => $values['file'],
-        'caption' => $values['caption'],
-        'timestamp' => REQUEST_TIME,
-        'response_code' => $response->code,
-        'response_values' => json_encode($response),
-      ])
-      ->execute();
+    if (!$response) {
+      // This is a 404
+      dosomething_rogue_handle_failure($user, $values, $run, $response, $e);
+    }
+  }
+  catch (GuzzleHttp\Exception\ServerException $e) {
+    // These aren't yet caught by Gateway
+    dosomething_rogue_handle_failure($user, $values, $run, $response, $e);
+  }
+  catch (Exception $e) {
 
-      watchdog('dosomething_rogue', 'reportback not migrated to Rogue', ['user' => $user->uid, 'campaign_id' => $values['nid'], 'campaign_run_id' => $run->nid], WATCHDOG_ERROR);
+    dosomething_rogue_handle_failure($user, $values, $run, $response, $e);
   }
 
-  return drupal_json_decode($response->data);
+
+  return $response;
 }
 
 /**
@@ -172,4 +163,40 @@ function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback
       'created_at' => REQUEST_TIME,
       ))
     ->execute();
+}
+
+/**
+ * Insert record that stores reference to the most recent uploaded reportback item in
+ * phoenix and it's corresponding id's in Rogue
+ *
+ * @param object $user
+ * @param array  $values
+ * @param int    $run
+ * @param array  $response
+ * @param object $e
+ *
+ */
+function dosomething_rogue_handle_failure($user, $values, $run, $response = NULL, $e = NULL)
+{
+   if (module_exists('stathat')) {
+      stathat_send_ez_count('drupal - Rogue - reportback failed - count', 1);
+    }
+
+    // Save fail to a db log so we can easily export.
+    db_insert('dosomething_rogue_failed_task_log')
+      ->fields([
+        'drupal_id' => $user->uid,
+        'campaign_id' => $values['nid'],
+        'campaign_run_id' => $run->nid,
+        'quantity' => $values['quantity'],
+        'why_participated' => $values['why_participated'],
+        'file' => $values['file'],
+        'caption' => $values['caption'],
+        'timestamp' => REQUEST_TIME,
+        'response_code' => $response->code, // @TODO: this is currently null until there a better way to get it from Gateway
+        'response_values' => (isset($e)) ? $e->getMessage() : NULL,
+      ])
+      ->execute();
+
+      watchdog('dosomething_rogue', 'reportback not migrated to Rogue', ['user' => $user->uid, 'campaign_id' => $values['nid'], 'campaign_run_id' => $run->nid], WATCHDOG_ERROR);
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -92,7 +92,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     // These aren't yet caught by Gateway
     dosomething_rogue_handle_failure($user, $values, $response, $e);
   }
-  catch (Exception $e) {
+  catch (DoSomething\Gateway\Exceptions\ApiException $e) {
 
     dosomething_rogue_handle_failure($user, $values, $response, $e);
   }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -78,24 +78,23 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
   ];
 
   try {
-    $response = $client->post($client->getBaseUri() . '/reportback', $data);
+    $response = $client->postReportback($data);
 
     if (module_exists('stathat')) {
       stathat_send_ez_count('drupal - Rogue - reportback sent - count', 1);
     }
     if (!$response) {
       // This is a 404
-      dosomething_rogue_handle_failure($user, $values, $run, $response, $e);
+      dosomething_rogue_handle_failure($user, $values, $response, $e);
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
     // These aren't yet caught by Gateway
-    dosomething_rogue_handle_failure($user, $values, $run, $response, $e);
+    dosomething_rogue_handle_failure($user, $values, $response, $e);
   }
   catch (Exception $e) {
 
-
-    dosomething_rogue_handle_failure($user, $values, $run, $response, $e);
+    dosomething_rogue_handle_failure($user, $values, $response, $e);
   }
 
 
@@ -164,16 +163,17 @@ function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback
  *
  * @param object $user
  * @param array  $values
- * @param int    $run
  * @param array  $response
  * @param object $e
  *
  */
-function dosomething_rogue_handle_failure($user, $values, $run, $response = NULL, $e = NULL)
+function dosomething_rogue_handle_failure($user, $values, $response = NULL, $e = NULL)
 {
    if (module_exists('stathat')) {
       stathat_send_ez_count('drupal - Rogue - reportback failed - count', 1);
     }
+
+    $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
 
     // Save fail to a db log so we can easily export.
     db_insert('dosomething_rogue_failed_task_log')


### PR DESCRIPTION
#### What's this PR do?

Catch all the errors that we can get back when posting to Rogue via Gateway. Gateway returns the response in a different way than we got before (already `json_decode`d). Gateway also doesn't handle exceptions of type `GuzzleHttp\Exception\ServerException` for us, so we are looking out for those.
#### How should this be reviewed?

Make sure that no matter what error you get back, the campaign page just refreshes and you see a fresh entry in the `dosomething_rogue_failed_task_log` table.
#### Any background context you want to provide?

@DFurnes I believe had reservations about using `catch (Exception $e)` but I wasn't able to catch the exceptions in any other way. Maybe I wasn't throwing them right though.
#### Relevant tickets

Fixes #7123
#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
