### PR TITLE
Updating onboarding member count

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ContextSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ContextSlide.js
@@ -30,7 +30,7 @@ class ContextSlide extends React.Component {
               <div className="container__block -primary">
                 <h2 className="heading -gamma">Woohoo! You're signed up.</h2>
                 {displayCompetitionMessage ? <p>{competition.messages.confirmation}</p> : ''}
-                <p>By joining the {this.props.campaign.title} campaign, you've teamed up with 5.3 million other members who are making an impact on the causes affecting your world.</p>
+                <p>By joining the {this.props.campaign.title} campaign, you've teamed up with 5.4 million other members who are making an impact on the causes affecting your world.</p>
                 <p>As a DoSomething.org member, you're part of something bigger. You're part of a global movement for good.</p>
 
                 <h2 className="heading -gamma">Campaigns are a way to make impact.</h2>

--- a/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemsSlide.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/components/ReportbackItemsSlide.js
@@ -5,7 +5,7 @@ import ReportbackItem from './ReportbackItem';
 
 const title = "Welcome to our global movement for good!";
 const content = [
-  "By signing up for the [CAMPAIGN NAME] campaign, you’ve teamed up with 5.3 million other DoSomething.org members who are making positive change right now.",
+  "By signing up for the [CAMPAIGN NAME] campaign, you’ve teamed up with 5.4 million other DoSomething.org members who are making positive change right now.",
   "These members (and thousands of others!) are already taking action on [CAMPAIGN NAME], so tap the heart to show them some love. Then get started! Do the campaign, take photos of yourself in action, and upload them to the site. LET’S DO THIS."
 ];
 


### PR DESCRIPTION
#### What's this PR do?

Updates the member count in the onboarding copy
~(We should probably pull this from the API like everything else, @jessleenyc should we make a card for this? Should be a quick one)~
#### How should this be reviewed?

Does it display, get ready for it. FIVE POINT FOUR MILLION?
![image](https://cloud.githubusercontent.com/assets/897368/19730213/75db23fa-9b67-11e6-8154-4a7fa4b067b0.png)
#### Any background context you want to provide?

Also searched here to make sure we had nothing else to update https://github.com/DoSomething/phoenix/search?utf8=%E2%9C%93&q=5.3+million&type=Code
#### Relevant tickets

Fixes https://trello.com/c/orhCm3ka/154-as-an-admin-i-want-onboarding-to-show-that-we-have-5-4-million-members-so-that-users-see-how-big-our-community-is
#### Checklist
- [ ] Tested on staging.
