### PR TITLE
Rogue fail permalink page

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -271,12 +271,12 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#required' => TRUE,
     '#default_value' => t(variable_get('dosomething_campaign_permalink_failure_copy')),
   );
-  $form['permalink']['owners']['failure']['dosomething_campaign_permalink_failure_image_fid'] = array(
+  $form['permalink']['owners']['failure']['dosomething_campaign_permalink_failure_image_nid'] = array(
     '#type' => 'textfield',
     '#title' => t('Permalink failure page image'),
-    '#description' => t('FID of the image that appears on the failure page in place of the reportback image.'),
+    '#description' => t('NID of the image that appears on the failure page in place of the reportback image.'),
     '#required' => TRUE,
-    '#default_value' => t(variable_get('dosomething_campaign_permalink_failure_image_fid')),
+    '#default_value' => t(variable_get('dosomething_campaign_permalink_failure_image_nid')),
   );
   $form['permalink']['owners']['dosomething_campaign_permalink_owners_page_title'] = array(
     '#type' => 'textfield',

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -258,6 +258,26 @@ function dosomething_campaign_admin_config_form($form, &$form_state) {
     '#required' => TRUE,
     '#default_value' => t(variable_get('dosomething_campaign_permalink_confirmation_owners_social_network_copy')),
   );
+  $form['permalink']['owners']['failure'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Owners Permalink Failure Page'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['permalink']['owners']['failure']['dosomething_campaign_permalink_failure_copy'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Permalink failure page text'),
+    '#description' => t('Appears on the failure page to the right side of the image.'),
+    '#required' => TRUE,
+    '#default_value' => t(variable_get('dosomething_campaign_permalink_failure_copy')),
+  );
+  $form['permalink']['owners']['failure']['dosomething_campaign_permalink_failure_image_fid'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Permalink failure page image'),
+    '#description' => t('FID of the image that appears on the failure page in place of the reportback image.'),
+    '#required' => TRUE,
+    '#default_value' => t(variable_get('dosomething_campaign_permalink_failure_image_fid')),
+  );
   $form['permalink']['owners']['dosomething_campaign_permalink_owners_page_title'] = array(
     '#type' => 'textfield',
     '#title' => t('Permalink owners title'),

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -75,7 +75,7 @@ function dosomething_metatag_preprocess_page(&$vars) {
   }
 
   // Add special share info to the permalink page.
-  if (in_array('page__reportback', $vars['theme_hook_suggestions'])) {
+  if (in_array('page__reportback', $vars['theme_hook_suggestions']) && !in_array('page__reportback__failure', $vars['theme_hook_suggestions'])) {
     dosomething_metatag_get_permalink_vars();
   }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -409,14 +409,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
       );
     } else {
       // Send user to the failed permalink page
-      $form_state['redirect'] = [
-        'reportback/failure',
-        [
-          'query' => [
-            'nid' => $values['nid'],
-          ],
-        ],
-      ];
+      $form_state['redirect'] = 'reportback/failure/' . $values['nid'];
     }
   } else {
     // Save uploaded file.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -410,7 +410,15 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     } else {
       // @TODO - if the reportback doesn't successfully get sent back to phoenix, how should
       // this be handled for the user?
-      $form_state['redirect'] = 'reportback/failure/' . $values['nid'];
+      // $form_state['redirect'] = 'reportback/failure/' . $values['nid'];
+      $form_state['redirect'] = [
+        'reportback/failure',
+        [
+          'query' => [
+            'nid' => $values['nid'],
+          ],
+        ],
+      ];
     }
   } else {
     // Save uploaded file.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -408,8 +408,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
         ),
       );
     } else {
-      // @TODO - if the reportback doesn't successfully get sent back to phoenix, how should
-      // this be handled for the user?
+      // Send user to the failed permalink page
       $form_state['redirect'] = [
         'reportback/failure',
         [

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -410,7 +410,6 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     } else {
       // @TODO - if the reportback doesn't successfully get sent back to phoenix, how should
       // this be handled for the user?
-      // $form_state['redirect'] = 'reportback/failure/' . $values['nid'];
       $form_state['redirect'] = [
         'reportback/failure',
         [

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -410,7 +410,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     } else {
       // @TODO - if the reportback doesn't successfully get sent back to phoenix, how should
       // this be handled for the user?
-      $form_state['redirect'] = 'node/' . $values['nid'];
+      $form_state['redirect'] = 'reportback/failure/' . $values['nid'];
     }
   } else {
     // Save uploaded file.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -245,8 +245,6 @@ function dosomething_reportback_menu() {
   $items['reportback/failure'] = array(
     'title' => 'Reportback',
     'page callback' => 'dosomething_reportback_view_failure',
-    // 'page arguments' => array(1),
-    //'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('access content'),
   );
   $items['reportback/%reportback'] = array(

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -636,7 +636,7 @@ function dosomething_reportback_view_failure() {
   $node = dosomething_campaign_load(node_load($nid));
 
   // Get all the copy and allow admins to build a link to the user's profile
-  $copy_vars = _dosomething_reportback_get_permalink_copy_vars($rb_user);
+  $copy_vars = _dosomething_reportback_get_permalink_copy_vars($user);
   $failure_copy = token_replace(t(variable_get('dosomething_campaign_permalink_failure_copy', '')), ['user' => $user]);
   $incentive = ($node->scholarship) ? $copy_vars['owners_rb_scholarship'] : "";
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -242,7 +242,7 @@ function dosomething_reportback_menu() {
       'file' => 'dosomething_reportback.admin.inc',
     );
   }
-  $items['reportback/failure/%nid'] = array(
+  $items['reportback/failure'] = array(
     'title' => 'Reportback',
     'page callback' => 'dosomething_reportback_view_failure',
     // 'page arguments' => array(1),
@@ -623,14 +623,15 @@ function dosomething_reportback_view_entity($entity) {
   return theme('reportback_permalink', $permalink_vars);
 }
 
-function dosomething_reportback_view_failure($entity) {
+function dosomething_reportback_view_failure() {
   global $user;
   // @TODO: use $rb_simple_user->uid to build link to user profile (or find function that builds the link)
   $rb_simple_user = dosomething_user_get_simple_user($rb_user = user_load($user));
 
   $copy_vars = _dosomething_reportback_get_permalink_copy_vars($rb_user);
 
-  $node = dosomething_campaign_load(node_load($entity));
+  $nid = $_GET['nid'];
+  $node = dosomething_campaign_load(node_load($nid));
 
   $profile_path = $base_url . '/user/' . $user->uid;
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -242,9 +242,10 @@ function dosomething_reportback_menu() {
       'file' => 'dosomething_reportback.admin.inc',
     );
   }
-  $items['reportback/failure'] = array(
+  $items['reportback/failure/%nid'] = array(
     'title' => 'Reportback',
     'page callback' => 'dosomething_reportback_view_failure',
+    'page arguments' => array(2),
     'access arguments' => array('access content'),
   );
   $items['reportback/%reportback'] = array(
@@ -626,13 +627,12 @@ function dosomething_reportback_view_entity($entity) {
  *
  * We hit this when a reportback sent to Rogue fails to send back to Phoenix
  */
-function dosomething_reportback_view_failure() {
+function dosomething_reportback_view_failure($nid) {
   // Get the user in all the forms that we need
   global $user;
   $rb_simple_user = dosomething_user_get_simple_user($user);
 
   // Load the campaign node so we can find out its name, if there's a scholarship, etc.
-  $nid = $_GET['nid'];
   $node = dosomething_campaign_load(node_load($nid));
 
   // Get all the copy and allow admins to build a link to the user's profile
@@ -641,8 +641,7 @@ function dosomething_reportback_view_failure() {
   $incentive = ($node->scholarship) ? $copy_vars['owners_rb_scholarship'] : "";
 
   // Get the image
-  $file = reportback_file_load(variable_get('dosomething_campaign_permalink_failure_image_fid'));
-  $fail_image = $file->getImage('480x480');
+  $fail_image = dosomething_image_get_themed_image(variable_get('dosomething_campaign_permalink_failure_image_nid'), 'square', '480x480');
 
   $permalink_fail_vars = [
     'user' => $rb_simple_user,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -623,27 +623,38 @@ function dosomething_reportback_view_entity($entity) {
   return theme('reportback_permalink', $permalink_vars);
 }
 
+/**
+ * Callback for /reportback/failure page.
+ *
+ * We hit this when a reportback sent to Rogue fails to send back to Phoenix
+ */
 function dosomething_reportback_view_failure() {
+  // Get the user in all the forms that we need
   global $user;
-  // @TODO: use $rb_simple_user->uid to build link to user profile (or find function that builds the link)
   $rb_simple_user = dosomething_user_get_simple_user($rb_user = user_load($user));
 
-  $copy_vars = _dosomething_reportback_get_permalink_copy_vars($rb_user);
 
+  // Load the campaign node so we can find out its name, if there's a scholarship, etc.
   $nid = $_GET['nid'];
   $node = dosomething_campaign_load(node_load($nid));
 
-  $profile_path = $base_url . '/user/' . $user->uid;
+  // Get all the copy and allow admins to build a link to the user's profile
+  $copy_vars = _dosomething_reportback_get_permalink_copy_vars($rb_user);
+  $failure_copy = token_replace(t(variable_get('dosomething_campaign_permalink_failure_copy', '')), ['user' => $user]);
+  $incentive = ($node->scholarship) ? $copy_vars['owners_rb_scholarship'] : "";
+
+  // Get the image
+  $file = reportback_file_load(variable_get('dosomething_campaign_permalink_failure_image_fid'));
+  $fail_image = $file->getImage('480x480');
 
   $permalink_fail_vars = [
-    'rb' => $rb,
-    'node' => $node,
     'user' => $rb_simple_user,
     'copy_vars' => $copy_vars,
     'title' => $copy_vars['owners_title'],
     'subtitle' => $copy_vars['owners_rb_subtitle'] . " " . $incentive,
     'node' => $node,
-    'profile' => $profile_path,
+    'failure_copy' => $failure_copy,
+    'fail_image' => $fail_image,
   ];
 
   return theme('reportback_rogue_fail_permalink', $permalink_fail_vars);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -629,8 +629,7 @@ function dosomething_reportback_view_entity($entity) {
 function dosomething_reportback_view_failure() {
   // Get the user in all the forms that we need
   global $user;
-  $rb_simple_user = dosomething_user_get_simple_user($rb_user = user_load($user));
-
+  $rb_simple_user = dosomething_user_get_simple_user($user);
 
   // Load the campaign node so we can find out its name, if there's a scholarship, etc.
   $nid = $_GET['nid'];

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -242,6 +242,13 @@ function dosomething_reportback_menu() {
       'file' => 'dosomething_reportback.admin.inc',
     );
   }
+  $items['reportback/failure/%nid'] = array(
+    'title' => 'Reportback',
+    'page callback' => 'dosomething_reportback_view_failure',
+    // 'page arguments' => array(1),
+    //'access callback' => 'dosomething_reportback_access',
+    'access arguments' => array('access content'),
+  );
   $items['reportback/%reportback'] = array(
     'title' => 'Reportback',
     'page callback' => 'dosomething_reportback_view_entity',
@@ -616,6 +623,30 @@ function dosomething_reportback_view_entity($entity) {
   return theme('reportback_permalink', $permalink_vars);
 }
 
+function dosomething_reportback_view_failure($entity) {
+  global $user;
+  // @TODO: use $rb_simple_user->uid to build link to user profile (or find function that builds the link)
+  $rb_simple_user = dosomething_user_get_simple_user($rb_user = user_load($user));
+
+  $copy_vars = _dosomething_reportback_get_permalink_copy_vars($rb_user);
+
+  $node = dosomething_campaign_load(node_load($entity));
+
+  $profile_path = $base_url . '/user/' . $user->uid;
+
+  $permalink_fail_vars = [
+    'rb' => $rb,
+    'node' => $node,
+    'user' => $rb_simple_user,
+    'copy_vars' => $copy_vars,
+    'title' => $copy_vars['owners_title'],
+    'subtitle' => $copy_vars['owners_rb_subtitle'] . " " . $incentive,
+    'node' => $node,
+    'profile' => $profile_path,
+  ];
+
+  return theme('reportback_rogue_fail_permalink', $permalink_fail_vars);
+}
 
 /**
  * Custom submit handler for signup form.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.theme.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.theme.inc
@@ -31,6 +31,10 @@ function dosomething_reportback_theme($existing, $type, $theme, $path) {
     'reportback_permalink' => array(
       'template' => 'reportback-permalink',
       'path' => drupal_get_path('module', 'dosomething_reportback') . '/theme',
+    ),
+    'reportback_rogue_fail_permalink' => array(
+      'template' => 'reportback-rogue-fail-permalink',
+      'path' => drupal_get_path('module', 'dosomething_reportback') . '/theme',
       )
     );
 }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-rogue-fail-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-rogue-fail-permalink.tpl.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @file
+ * Reportback confirmation/permalink page when Rogue sending fails.
+ *
+ * Available variables:
+ * - $node->title                        : Title of the campaign
+ * - $is_owner                           : Used to determine if the curernt logged in user is the user who submitted the rb.
+ * - $title                              : Title of the permalink/confirmation page.
+ * - $subtitle                           : Subtitle of the permalink/confirmation page.
+ * - $copy_vars['owners_rb_scholarship'] : Subtitle of the reportback confirmation page.
+ * - $copy_vars['owners_rb_important']   : Title of the why I participated section
+ * - $user->first_name                   : User's first name
+ * - $node->fact_problem['fact']
+ * - $node->fact_solution['fact']
+ *
+ */
+
+?>
+<article class="reportback__permalink">
+  <header role="banner" class="header ">
+    <div class="wrapper">
+      <h1 class="header__title"><?php print $title; ?></h1>
+      <p class="header__subtitle"><?php print $subtitle; ?></p>
+    </div>
+  </header>
+
+  <div class="container -padded -dark">
+    <div class="wrapper">
+      <div class="card">
+        <div class="card__column">
+          <img src="http://lorempizza.com/480/480">
+        </div>
+        <div class="card__column">
+          <div class="wrapper">
+          <!--Show user the reportback confirmation page -->
+            <div class="card__copy">
+              <h1><?php print $node->title; ?></h1>
+
+              <p>Well, this is embarrassing. We got your photo, but it's taking longer for our servers to process than we thought.</p>
+              <p>Don't worry, your photo is safe andyou're still entered into any scholarship drawings you qualified for. Check back on <a href="<?php print $profile; ?>">your profile</a> in about an hour to see your completed campaign!</p>
+
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</article>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-rogue-fail-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-rogue-fail-permalink.tpl.php
@@ -5,14 +5,10 @@
  *
  * Available variables:
  * - $node->title                        : Title of the campaign
- * - $is_owner                           : Used to determine if the curernt logged in user is the user who submitted the rb.
+ * - $fail_image                         : Image to use in place of reportback photo
  * - $title                              : Title of the permalink/confirmation page.
  * - $subtitle                           : Subtitle of the permalink/confirmation page.
- * - $copy_vars['owners_rb_scholarship'] : Subtitle of the reportback confirmation page.
- * - $copy_vars['owners_rb_important']   : Title of the why I participated section
- * - $user->first_name                   : User's first name
- * - $node->fact_problem['fact']
- * - $node->fact_solution['fact']
+ * - $failure_copy                       : Text to use next to the image (in place of the user's Why Participated)
  *
  */
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-rogue-fail-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-rogue-fail-permalink.tpl.php
@@ -29,17 +29,14 @@
     <div class="wrapper">
       <div class="card">
         <div class="card__column">
-          <img src="http://lorempizza.com/480/480">
+          <?php print $fail_image; ?>
         </div>
         <div class="card__column">
           <div class="wrapper">
           <!--Show user the reportback confirmation page -->
             <div class="card__copy">
               <h1><?php print $node->title; ?></h1>
-
-              <p>Well, this is embarrassing. We got your photo, but it's taking longer for our servers to process than we thought.</p>
-              <p>Don't worry, your photo is safe andyou're still entered into any scholarship drawings you qualified for. Check back on <a href="<?php print $profile; ?>">your profile</a> in about an hour to see your completed campaign!</p>
-
+              <?php print $failure_copy; ?>
             </div>
           </div>
         </div>


### PR DESCRIPTION
#### What's this PR do?
- if a user's reportback fails to post to Rogue, they hit this (tongue cat is not hard coded, and neither is the copy!):
  ![image](https://cloud.githubusercontent.com/assets/4240292/19774897/a0190134-9c3c-11e6-9601-8b10b290452d.png)
- the image (grabbed by image `nid`) and copy are editable by admins at `admin/config/dosomething/dosomething_campaign` under Permalink Page > Owners Permalink (this won't be shared so only an "owner" will hit it) > Owners Permalink Failure Page

![image](https://cloud.githubusercontent.com/assets/4240292/19970063/3b8c3dd8-a1b1-11e6-8a52-62700ddaa1b5.png)

- Should anything happen and we want to change the copy on this page, it is a quick change not needing any code (for example, if Rogue goes down and it will take longer than we say for the RB to show up and we want to change it). 
#### How should this be reviewed?

Make sure the page looks okay and that we have access to all the variables and info we need/want for the failure page. Also if anyone has any other thoughts on if the path should be something other than `reportback/failure` I'm very open to that but didn't know what else to make it.
#### Any background context you want to provide?

`drush cc all` often when doing stuff like this or it'll take you longer than it should to track down your mistake!
#### Relevant tickets

Fixes #7116
#### Checklist
- [x] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love (cc: @lkpttn @ngjo)
