### PR TITLE
Sends most recently created reportback item and caption if RB exists in Phoenix but not Rogue and quantity/why is updated

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -922,7 +922,6 @@ function dosomething_helpers_get_current_campaign_run_for_user($nid, $user = NUL
   // Load the run and return it.
   // For some reason this also loads the proper translation, for both anonymous users and authed. I can't explain it.
   // @TODO: may want to investigate how it loads the proper translation...
-
   return node_load($run['id']);
 }
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -922,6 +922,7 @@ function dosomething_helpers_get_current_campaign_run_for_user($nid, $user = NUL
   // Load the run and return it.
   // For some reason this also loads the proper translation, for both anonymous users and authed. I can't explain it.
   // @TODO: may want to investigate how it loads the proper translation...
+
   return node_load($run['id']);
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -379,23 +379,38 @@ function dosomething_reportback_form_submit($form, &$form_state) {
 
   // Collect reportbacks in Rogue if rogue collection is turned on for this campaign.
   if (variable_get('rogue_collection', FALSE)) {
+    $rbid = dosomething_reportback_exists($form_state['build_info']['args'][0]->nid, $form_state['build_info']['args'][0]->run_nid, $form_state['build_info']['args'][0]->uid);
+    $reportback = reportback_load($rbid);
+    $fid = array_pop($reportback->fids);
+
     // Store the base64 encoded data uri of the file in the values array to send to rogue.
     if (array_key_exists('storage', $form_state)) {
       $file = $form_state['storage']['file'];
       $image = image_load($file->uri);
 
       $values['file'] = dosomething_helpers_get_data_uri_from_image($image);
+    } else {
+      // If there is no file and there is a RB in Phoenix, check the dosomething_rogue_reportback table to see if the RB already exists in Rogue.
+      if ($rbid) {
+        $exists_in_rogue = dosomething_rogue_rb_exists_in_rogue($rbid);
+
+        // If the RB does not yet exist in Rogue, send along the most recently created reportback_item so the RB can be created in Rogue.
+        if (! $exists_in_rogue) {
+          // $reportback = reportback_load($rbid);
+          // $most_recent_rb_item_id = array_pop($reportback->fids);
+          $reportback_file = entity_load('reportback_item', array($fid));
+          $image = file_load($fid);
+          $values['file'] = 'data: ' . mime_content_type($image->filemime) . ';base64,' . base64_encode(file_get_contents($image->uri));
+          $values['caption'] = $reportback_file[$fid]->caption;
+        }
+      }
     }
+
     // Send the reportback to rogue.
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values);
 
-    // Get the reportback stored in phoenix, store reference to the rb in rogue, redirect user to permalink page.
-    $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
-
+    // Store reference to the rb in rogue, redirect user to permalink page.
     if ($rbid) {
-      // Store references to rogue IDs for the most recent uploaded reportback item.
-      $reportback = entity_load_unchanged('reportback', [$rbid]);
-      $fid = array_pop($reportback->fids);
       dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
 
       // Redirect to permalink page.

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -193,6 +193,13 @@ function dosomething_rogue_handle_failure($user, $values, $response = NULL, $e =
       watchdog('dosomething_rogue', 'reportback not migrated to Rogue', ['user' => $user->uid, 'campaign_id' => $values['nid'], 'campaign_run_id' => $run->nid], WATCHDOG_ERROR);
 }
 
+/**
+ * Query to see if a reportback exists in Rogue by Phoenix $rbid.
+ *
+ * @param string $rbid
+ * Phoenix $rbid of reportback.
+ *
+ */
 function dosomething_rogue_rb_exists_in_rogue($rbid)
 {
   return db_query("SELECT * FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rbid = :rbid", array(':rbid' => $rbid))->fetchAll();

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -65,7 +65,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     $rbid = dosomething_reportback_exists($values['nid'], $run->nid, $user->uid);
     // If there is a RB in Phoenix, check the dosomething_rogue_reportback table to see if the RB already exists in Rogue.
     if ($rbid) {
-      $exists_in_rogue = db_query("SELECT * FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rbid = :rbid", array(':rbid' => $rbid))->fetchAll();
+      $exists_in_rogue = dosomething_rogue_rb_exists_in_rogue($rbid);
       // If the RB does not yet exist in Rogue, send along the most recently created reportback_item so the RB can be created in Rogue.
       if (! $exists_in_rogue) {
         $reportback = reportback_load($rbid);
@@ -209,4 +209,9 @@ function dosomething_rogue_handle_failure($user, $values, $response = NULL, $e =
       ->execute();
 
       watchdog('dosomething_rogue', 'reportback not migrated to Rogue', ['user' => $user->uid, 'campaign_id' => $values['nid'], 'campaign_run_id' => $run->nid], WATCHDOG_ERROR);
+}
+
+function dosomething_rogue_rb_exists_in_rogue($rbid)
+{
+  return db_query("SELECT * FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rbid = :rbid", array(':rbid' => $rbid))->fetchAll();
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -60,6 +60,20 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
 
   $client = dosomething_rogue_client();
 
+  // If there is no file, check to see if the user has already reported back for this campaign in Phoenix.
+  if (! isset($values['file'])) {
+    // $rbid = '2351';
+    $rbid = dosomething_reportback_exists($values['nid'], $run->nid, $user->uid);
+    // If there is a RB in Phoenix, check the dosomething_rogue_reportback table to see if the RB already exists in Rogue.
+    if ($rbid) {
+      $exists_in_rogue = db_query("SELECT * FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rbid = :rbid", array(':rbid' => $rbid))->fetchAll();
+      // If the RB does not yet exist in Rogue, send along the most recently created reportback_item so the RB can be created in Rogue.
+      if (! $exists_in_rogue) {
+        //
+      }
+    }
+  }
+
   $data = [
         'northstar_id' => $northstar_id ? $northstar_id : NULL,
         'drupal_id' => $user->uid,
@@ -120,7 +134,7 @@ function dosomething_rogue_update_rogue_reportback_items($data)
 }
 
 /**
- * Query to find Rogue reportbak item id by Phoenix fid.
+ * Query to find Rogue reportback item id by Phoenix fid.
  *
  * @param string $fid
  * Phoenix fid of reportback item.

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -60,24 +60,6 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
 
   $client = dosomething_rogue_client();
 
-  // If there is no file, check to see if the user has already reported back for this campaign in Phoenix.
-  if (! isset($values['file'])) {
-    $rbid = dosomething_reportback_exists($values['nid'], $run->nid, $user->uid);
-    // If there is a RB in Phoenix, check the dosomething_rogue_reportback table to see if the RB already exists in Rogue.
-    if ($rbid) {
-      $exists_in_rogue = dosomething_rogue_rb_exists_in_rogue($rbid);
-      // If the RB does not yet exist in Rogue, send along the most recently created reportback_item so the RB can be created in Rogue.
-      if (! $exists_in_rogue) {
-        $reportback = reportback_load($rbid);
-        $most_recent_rb_item_id = array_pop($reportback->fids);
-        $reportback_file = entity_load('reportback_item', array($most_recent_rb_item_id));
-        $image = file_load($most_recent_rb_item_id);
-        $values['file'] = 'data: ' . mime_content_type($image->filemime) . ';base64,' . base64_encode(file_get_contents($image->uri));
-        $values['caption'] = $reportback_file[$most_recent_rb_item_id]->caption;
-      }
-    }
-  }
-
   $data = [
     'northstar_id' => $northstar_id ? $northstar_id : NULL,
     'drupal_id' => $user->uid,

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -62,33 +62,36 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
 
   // If there is no file, check to see if the user has already reported back for this campaign in Phoenix.
   if (! isset($values['file'])) {
-    // $rbid = '2351';
     $rbid = dosomething_reportback_exists($values['nid'], $run->nid, $user->uid);
     // If there is a RB in Phoenix, check the dosomething_rogue_reportback table to see if the RB already exists in Rogue.
     if ($rbid) {
       $exists_in_rogue = db_query("SELECT * FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rbid = :rbid", array(':rbid' => $rbid))->fetchAll();
       // If the RB does not yet exist in Rogue, send along the most recently created reportback_item so the RB can be created in Rogue.
       if (! $exists_in_rogue) {
-        //
+        $reportback = reportback_load($rbid);
+        $most_recent_rb_item_id = array_pop($reportback->fids);
+        $reportback_file = entity_load('reportback_item', array($most_recent_rb_item_id));
+        $values['file'] = $reportback_file[$most_recent_rb_item_id]->image;
+        $values['caption'] = $reportback_file[$most_recent_rb_item_id]->caption;
       }
     }
   }
 
   $data = [
-        'northstar_id' => $northstar_id ? $northstar_id : NULL,
-        'drupal_id' => $user->uid,
-        'campaign_id' => $values['nid'],
-        'campaign_run_id' => $run->nid,
-        'quantity' => $values['quantity'],
-        'why_participated' => $values['why_participated'],
-        'file' => isset($values['file']) ? $values['file'] : NULL,
-        'caption' => isset($values['caption']) ? $values['caption'] : NULL,
-        'status' => isset($values['status']) ? $values['status'] : 'pending',
-        'crop_x' => $values['crop_x'],
-        'crop_y' => $values['crop_y'],
-        'crop_width' => $values['crop_width'],
-        'crop_height' => $values['crop_height'],
-        'crop_rotate' => $values['crop_rotate'],
+    'northstar_id' => $northstar_id ? $northstar_id : NULL,
+    'drupal_id' => $user->uid,
+    'campaign_id' => $values['nid'],
+    'campaign_run_id' => $run->nid,
+    'quantity' => $values['quantity'],
+    'why_participated' => $values['why_participated'],
+    'file' => isset($values['file']) ? $values['file'] : NULL,
+    'caption' => isset($values['caption']) ? $values['caption'] : NULL,
+    'status' => isset($values['status']) ? $values['status'] : 'pending',
+    'crop_x' => $values['crop_x'],
+    'crop_y' => $values['crop_y'],
+    'crop_width' => $values['crop_width'],
+    'crop_height' => $values['crop_height'],
+    'crop_rotate' => $values['crop_rotate'],
   ];
 
   try {
@@ -110,7 +113,6 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
 
     dosomething_rogue_handle_failure($user, $values, $response, $e);
   }
-
 
   return $response;
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -71,7 +71,8 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
         $reportback = reportback_load($rbid);
         $most_recent_rb_item_id = array_pop($reportback->fids);
         $reportback_file = entity_load('reportback_item', array($most_recent_rb_item_id));
-        $values['file'] = $reportback_file[$most_recent_rb_item_id]->image;
+        $image = file_load($most_recent_rb_item_id);
+        $values['file'] = 'data: ' . mime_content_type($image->filemime) . ';base64,' . base64_encode(file_get_contents($image->uri));
         $values['caption'] = $reportback_file[$most_recent_rb_item_id]->caption;
       }
     }


### PR DESCRIPTION
#### What's this PR do?

If a reportback item does not yet exist in Rogue but exists in Phoenix and a user updates the quantity/why or the reportback, instead of breaking, it just sends Rogue the most recently created reportback item and caption. 
#### How should this be reviewed?
- In Sequel Pro, go to the `dosomething_rogue_reportbacks` table in the Phoenix database and find a reportback that exists both in Phoenix and Rogue. 
- Note the `rogue_reportback_id`. 
- Go to the `reportbacks` table in the Rogue database and find this reportback by `rogue_reportback_id`. Delete this (it will also delete associated reportback items). 
- In your local Phoenix browser, go to the campaign that the reportback belongs to and update the why participated or the quantity. 
- The next page should be the permalink page. 
- Check the database - the record should show up in the `dosomething_rogue_reportbacks` table. Additionally, you should see this new record in both Rogue's `reportbacks` and `reportback_items` tables. 
#### Relevant tickets

Fixes #7153
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
