### PR TITLE
Multiple rb items status updates

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -291,14 +291,14 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
       // If there is a rogue_item_id in the dosomething_rogue_reportbacks table, send update to Rogue.
       if ($rogue_item_id[0]->rogue_item_id) {
         if ($values['status'] === 'promoted' || $values['status'] === 'approved' || $values['status'] === 'excluded') {
-          $values['status'] = 'accepted';
+          $rogue_status = 'accepted';
         } else {
-          $values['status'] = 'rejected';
+          $rogue_status = 'rejected';
         }
 
         $data = [
           'rogue_reportback_item_id' => $rogue_item_id[0]->rogue_item_id,
-          'status' => $values['status'],
+          'status' => $rogue_status,
         ];
 
         $updates_to_send_to_rogue[] = $data;

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -240,7 +240,6 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
   }
 
   $updates_to_send_to_rogue = [];
-
   foreach ($rb_files as $fid => $values) {
     $kudos = [
       'fid' => $fid,
@@ -290,13 +289,19 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
       $rogue_item_id = dosomething_rogue_get_by_file_id($fid);
 
       // If there is a rogue_item_id in the dosomething_rogue_reportbacks table, send update to Rogue.
-      if (!is_null($rogue_item_id[0]->rogue_item_id)) {
+      if ($rogue_item_id[0]->rogue_item_id) {
+        if ($values['status'] === 'promoted' || $values['status'] === 'approved' || $values['status'] === 'excluded') {
+          $values['status'] = 'accepted';
+        } else {
+          $values['status'] = 'rejected';
+        }
+
         $data = [
           'rogue_reportback_item_id' => $rogue_item_id[0]->rogue_item_id,
           'status' => $values['status'],
         ];
 
-        array_push($updates_to_send_to_rogue, $data);
+        $updates_to_send_to_rogue[] = $data;
       }
     }
   }
@@ -310,7 +315,6 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
       drupal_set_message(t("Updated."));
     }
   }
-
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?
- Fixes bug that it only sends one rb item's updated status to Rogue. 
- Adds logic to send the new Rogue rb item `status` terms instead of `Approved`, `Promoted`, `Excluded`, and `Flagged`  
#### How should this be reviewed?
- Review a campaign's reportback items that has two or more reportback items. 
- Make sure the items `status` is updated in the Rogue database with the following: 
  - `Approved`, `Promoted`, `Excluded` should be `accepted` in the Rogue database
  - `Flagged` should be `rejected` in the Rogue database

done with @angaither !
#### Relevant tickets

Fixes #7159 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
