### PR TITLE
Fixes issues with SSO logout.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -180,10 +180,6 @@ function dosomething_northstar_user_logout($account) {
 
   $is_openid_login = ! empty($user->field_refresh_token[LANGUAGE_NONE][0]['value']);
   if ($is_openid_login) {
-    $northstar_logout_url = url(NORTHSTAR_URL . '/logout', [
-      'query' => ['redirect' => url('/', ['absolute' => TRUE])],
-    ]);
-
     // Clear out token information to track that SSO session will be revoked.
     // @TODO: Actually revoke the refresh token in Northstar on logout.
     $edit = [];
@@ -192,9 +188,13 @@ function dosomething_northstar_user_logout($account) {
       'access_token_expiration' => NULL,
       'refresh_token' => NULL,
     ]);
-
     user_save($user, $edit);
 
+    // And redirect to SSO logout to prevent users from automatically
+    // logging in to the same account again.
+    $northstar_logout_url = url(NORTHSTAR_URL . '/logout', [
+      'query' => ['redirect' => url('/', ['absolute' => TRUE])],
+    ]);
     drupal_goto($northstar_logout_url);
   }
 

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -173,11 +173,12 @@ function dosomething_northstar_perform_authorization_actions() {
  * @param $account
  */
 function dosomething_northstar_user_logout($account) {
-  $is_openid_login = ! empty($account->field_refresh_token[LANGUAGE_NONE][0]['value']);
+  $user = user_load($account->uid);
 
   // Destroy the current session, and reset $user to the anonymous user.
   session_destroy();
 
+  $is_openid_login = ! empty($user->field_refresh_token[LANGUAGE_NONE][0]['value']);
   if ($is_openid_login) {
     $northstar_logout_url = url(NORTHSTAR_URL . '/logout', [
       'query' => ['redirect' => url('/', ['absolute' => TRUE])],

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -173,15 +173,20 @@ function dosomething_northstar_perform_authorization_actions() {
  * @param $account
  */
 function dosomething_northstar_user_logout($account) {
-  $is_openid_login = ! empty($_SESSION['DOSOMETHING_NORTHSTAR_OPENID_CONNECT']);
-  $northstar_logout_url = url(NORTHSTAR_URL . '/logout', [
-    'query' => ['redirect' => url('/', ['absolute' => TRUE])],
-  ]);
+  $is_openid_login = ! empty($account->field_refresh_token[LANGUAGE_NONE][0]['value']);
 
   // Destroy the current session, and reset $user to the anonymous user.
   session_destroy();
 
-  drupal_goto($is_openid_login ? $northstar_logout_url : '/');
+  if ($is_openid_login) {
+    $northstar_logout_url = url(NORTHSTAR_URL . '/logout', [
+      'query' => ['redirect' => url('/', ['absolute' => TRUE])],
+    ]);
+
+    drupal_goto($northstar_logout_url);
+  }
+
+  drupal_goto('/');
 }
 
 /**
@@ -190,6 +195,7 @@ function dosomething_northstar_user_logout($account) {
  *
  * @param $form
  * @param $form_state
+ * @return bool
  */
 function dosomething_northstar_fallback_classic_login(&$form, &$form_state) {
   // If the account does not have a local password, verify using Northstar
@@ -199,17 +205,21 @@ function dosomething_northstar_fallback_classic_login(&$form, &$form_state) {
   ]);
 
   // If successful response & ID field is given, the credentials worked.
-  if (! empty($northstar_user['data']['id'])) {
-    $sub = $northstar_user['data']['id'];
-    $account = openid_connect_user_load_by_sub($sub, 'northstar');
-
-    if (! $account) {
-      return FALSE;
-    }
-
-    // Since we've validated these credentials in Northstar, force login this user.
-    $form_state['uid'] = $account->uid;
-    unset($form_state['values']['name']);
-    unset($form_state['values']['pass']);
+  if (empty($northstar_user['data']['id'])) {
+    return FALSE;
   }
+
+  $sub = $northstar_user['data']['id'];
+  $account = openid_connect_user_load_by_sub($sub, 'northstar');
+
+  if (! $account) {
+    return FALSE;
+  }
+
+  // Since we've validated these credentials in Northstar, force login this user.
+  $form_state['uid'] = $account->uid;
+  unset($form_state['values']['name']);
+  unset($form_state['values']['pass']);
+
+  return TRUE;
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -184,6 +184,17 @@ function dosomething_northstar_user_logout($account) {
       'query' => ['redirect' => url('/', ['absolute' => TRUE])],
     ]);
 
+    // Clear out token information to track that SSO session will be revoked.
+    // @TODO: Actually revoke the refresh token in Northstar on logout.
+    $edit = [];
+    dosomething_user_set_fields($edit, [
+      'access_token' => NULL,
+      'access_token_expiration' => NULL,
+      'refresh_token' => NULL,
+    ]);
+
+    user_save($user, $edit);
+
     drupal_goto($northstar_logout_url);
   }
 


### PR DESCRIPTION
#### What's this PR do?
Fixing more issues with the OpenID Connect flow!

🚪 Fixes an issue where we were losing the session "marker" that was determining whether to use SSO logout, by instead making that decision based on whether the user has a refresh token.

🏗 Clears out the token fields when a user logs out, so we can track whether to use SSO logout for them or not. In the future, we should also revoke the refresh token when doing this but I ran into some Gateway issues so putting a hold on that.

🍃 Cleans up conditionals to make `dosomething_northstar_fallback_classic_login` easier to follow. The diff looks kinda messy but the end result looks nicer!

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
🇱🇦

#### Relevant tickets
Fixes DoSomething/northstar#457.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  