### PR TITLE
Extend campaign_signup quicksilver payload with signup_id.

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.module
@@ -223,6 +223,11 @@ function dosomething_mbp_get_common_campaign_payload(&$payload, $params) {
   $payload['subscribed'] = 1;
   $payload['event_id']   = $params['event_id'];
 
+  // Signup Id.
+  if (!empty($params['signup_id'])) {
+    $payload['signup_id'] = $params['signup_id'];
+  }
+
   if (isset($params['campaign_language'])) {
     $payload['campaign_language'] = $params['campaign_language'];
     $payload['campaign_country'] = $params['campaign_country'];

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -525,6 +525,7 @@ function dosomething_signup_entity_insert($entity, $type) {
   $account = user_load($entity->uid);
   $options['transactionals'] = $entity->transactionals;
   $options['source'] = $entity->source;
+  $options['signup_id'] = $entity->sid;
 
   // Send relevant third-party subscribe requests.
   dosomething_signup_third_party_subscribe($account, $node, $options);
@@ -701,6 +702,9 @@ function dosomething_signup_get_mbp_params($account, $node, $opt_in, $options = 
   }
   if (isset($options['source'])) {
     $params['source'] = $options['source'];
+  }
+  if (isset($options['signup_id'])) {
+    $params['signup_id'] = $options['signup_id'];
   }
 
   // Don't subscribe 26+ yo users for Mobile Commons.


### PR DESCRIPTION
#### What's this PR do?

Extends campaign_signup quicksilver payload with `signup_id`.
#### Any background context you want to provide?

Now it passes `campaign_id` as an `event_id`, so I'm just extending existing payload.
#### Relevant tickets

Ref DoSomething/mbc-registration-email#71.
