### PR TITLE
hit correct permalink page on reportback creation with Rogue

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -379,9 +379,12 @@ function dosomething_reportback_form_submit($form, &$form_state) {
 
   // Collect reportbacks in Rogue if rogue collection is turned on for this campaign.
   if (variable_get('rogue_collection', FALSE)) {
+    // If this is a reportback update, grab the file most recent file in case we need it later
     $rbid = dosomething_reportback_exists($form_state['build_info']['args'][0]->nid, $form_state['build_info']['args'][0]->run_nid, $form_state['build_info']['args'][0]->uid);
-    $reportback = reportback_load($rbid);
-    $fid = array_pop($reportback->fids);
+    if ($rbid) {
+      $reportback = reportback_load($rbid);
+      $fid = array_pop($reportback->fids);
+    }
 
     // Store the base64 encoded data uri of the file in the values array to send to rogue.
     if (array_key_exists('storage', $form_state)) {
@@ -409,8 +412,13 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     // Send the reportback to rogue.
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values);
 
+    // Make sure the reportback exists (meaning it got back from Rogue)
+    $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
+
     // Store reference to the rb in rogue, redirect user to permalink page.
     if ($rbid) {
+      $reportback = entity_load_unchanged('reportback', [$rbid]);
+      $fid = array_pop($reportback->fids);
       dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
 
       // Redirect to permalink page.


### PR DESCRIPTION
#### What's this PR do?
We check if a reportback exists:
- before the update/new one is sent to Rogue (and grab the most recent file in case we need to send it to Rogue as well) <- this is what we already did
- after the reportback should have come back from Rogue so we know if it made it back successfully (if we know this we can send the user to the right permalink page)

This also fixes a bug where the permalink page is 1 image behind (meaning it shows the second most recently uploaded image).

#### How should this be reviewed?
Make sure you are hitting the right permalink page when creating a new reportback.

#### Any background context you want to provide?
I think this was working right at some point, but got muddled in another fix.

#### Relevant tickets
Fixes #7160
Fixes #7167 

#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
