### PR TITLE
Adds advertising tracking for FB & Twitter

### DIFF
--- a/lib/modules/dosomething/dosomething_settings/dosomething_settings.admin.inc
+++ b/lib/modules/dosomething/dosomething_settings/dosomething_settings.admin.inc
@@ -48,6 +48,20 @@ function dosomething_settings_admin_config_form($form, &$form_state) {
     '#default_value' => variable_get($var_name),
   );
 
+  $form['ads'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Ad tracking'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+
+  $var_name = 'dosomething_setting_ad_tracking_enabled';
+  $form['ads'][$var_name] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable ad tracking'),
+    '#default_value' => variable_get($var_name, FALSE),
+  );
+
   $form['fun'] = array(
     '#type' => 'fieldset',
     '#title' => t('FUN!'),

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_html.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_html.inc
@@ -25,16 +25,7 @@ function paraneue_dosomething_preprocess_html(&$vars) {
   $member_count = dosomething_user_get_member_count(TRUE);
   $vars['head_title'] = token_replace($vars['head_title'], ['member-count-readable' => $member_count]);
 
-  $enable_facebook_login = variable_get('dosomething_user_social_auth_enabled', FALSE);
-  $vars['enable_facebook_login'] = $enable_facebook_login;
-  if ($enable_facebook_login) {
-    drupal_add_js(PARANEUE_PATH . '/dist/social-auth.js', [
-      'group'      => JS_THEME,
-      'weight'     => 1000,
-      'every_page' => FALSE,
-      'preprocess' => FALSE,
-    ]);
-  }
+  $vars['enable_ad_tracking'] = variable_get('dosomething_setting_ad_tracking_enabled', FALSE);
 
   $update_url = variable_get('dosomething_settings_realtimefeed_update_url');
   drupal_add_js(

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -39,18 +39,6 @@
 </head>
 
 <body class="<?php print $classes; if ($variables['is_affiliate']) print ' -affiliate'; ?>" <?php print $attributes;?>>
-  <?php if ($variables['enable_facebook_login']): ?>
-    <script>
-      (function(d, s, id){
-         var js, fjs = d.getElementsByTagName(s)[0];
-         if (d.getElementById(id)) {return;}
-         js = d.createElement(s); js.id = id;
-         js.src = "//connect.facebook.net/en_US/sdk.js";
-         fjs.parentNode.insertBefore(js, fjs);
-       }(document, 'script', 'facebook-jssdk'));
-    </script>
-  <?php endif; ?>
-
   <div class="chrome">
     <?php print $page_top; ?>
     <?php print $page; ?>
@@ -58,6 +46,30 @@
 
   <?php print $scripts; ?>
   <?php print $page_bottom; ?>
+
+  <?php if ($variables['enable_ad_tracking']): ?>
+    <!-- Twitter single-event website tag code -->
+    <script src="//platform.twitter.com/oct.js" type="text/javascript"></script>
+    <script type="text/javascript">twttr.conversion.trackPid('nvo4z', { tw_sale_amount: 0, tw_order_quantity: 0 });</script>
+    <noscript>
+    <img height="1" width="1" style="display:none;" alt="" src="https://analytics.twitter.com/i/adsct?txn_id=nvo4z&p_id=Twitter&tw_sale_amount=0&tw_order_quantity=0" />
+    <img height="1" width="1" style="display:none;" alt="" src="//t.co/i/adsct?txn_id=nvo4z&p_id=Twitter&tw_sale_amount=0&tw_order_quantity=0" />
+    </noscript>
+
+    <!-- Facebook Pixel Code -->
+    <script>
+    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+    document,'script','https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init', '883788485091123');
+    fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+    src="https://www.facebook.com/tr?id=883788485091123&ev=PageView&noscript=1"
+    /></noscript>
+  <?php endif; ?>
 </body>
 
 </html>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -65,6 +65,7 @@
     document,'script','https://connect.facebook.net/en_US/fbevents.js');
     fbq('init', '883788485091123');
     fbq('track', 'PageView');
+    fbq('track', 'CompleteRegistration');
     </script>
     <noscript><img height="1" width="1" style="display:none"
     src="https://www.facebook.com/tr?id=883788485091123&ev=PageView&noscript=1"


### PR DESCRIPTION
#### What's this PR do?
- Adds advertising tracking for FB & Twitter
- (Replaces/Removes social auth prototype code)

#### How should this be reviewed?
Does the checkbox properly enable / disable the tracking code?

#### Any background context you want to provide?
Needed for VCard ad campaign asap

#### Relevant tickets
Fixes #n/a

