### PR TITLE
The authorize route should always log in SSO session.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -19,8 +19,9 @@ function dosomething_northstar_openid_authorize_url() {
 }
 
 /**
- * Render the view for OpenID Connect login. Displayed standalone
- * at `/user/openid` and (with feature flag enabled) in the modal.
+ * Render the super-secret page for testing OpenID Connect login.
+ *
+ * GET /user/openid
  *
  * @return array
  */
@@ -31,8 +32,10 @@ function dosomething_northstar_openid_login_view() {
 }
 
 /**
- * Create an authorization link and redirect to it. (This way we don't
+ * Create an Northstar authorization link and redirect to it. (This way we don't
  * have to make a state token every time we have a page with a login link).
+ *
+ * GET /user/authorize
  *
  * @return void
  */

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -40,6 +40,11 @@ function dosomething_northstar_openid_login_view() {
  * @return void
  */
 function dosomething_northstar_openid_authorize() {
+  // If a Drupal session already exists, reset it from Northstar.
+  if (user_is_logged_in()) {
+    session_destroy();
+  }
+
   $authorize_url = dosomething_northstar_openid_authorize_url();
 
   if(isset($_GET['action']) && isset($_GET['node'])) {


### PR DESCRIPTION
#### What's this PR do?
This updates the Phoenix `user/authorize` route to log out an existing user if one exists, and replace it with the user account resolved through the OpenID Connect flow. This should let us easily & safely update Phoenix session to be for the same user as Northstar (e.g. after resetting a users' password).

I also updated some docblocks cuz why not. ✏️

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
See the changes in the related Northstar ticket (linked below) for context. 👇 

#### Relevant tickets
References DoSomething/northstar#472.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  