### PR TITLE
Handles failures when making PUT request to Rogue's /items endpoint 

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -267,7 +267,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
 
     // Save kudos reaction from admin on RB item.
     if ($values['status'] === 'promoted' || $values['status'] === 'approved' || $values['status'] === 'excluded') {
-      $record = (new KudosController)->create($kudos);
+      // $record = (new KudosController)->create($kudos);
     }
 
     // Rotate the original image, if a rotation option was selected.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -267,7 +267,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
 
     // Save kudos reaction from admin on RB item.
     if ($values['status'] === 'promoted' || $values['status'] === 'approved' || $values['status'] === 'excluded') {
-      // $record = (new KudosController)->create($kudos);
+      $record = (new KudosController)->create($kudos);
     }
 
     // Rotate the original image, if a rotation option was selected.

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -15,17 +15,28 @@
     db_truncate('dosomething_rogue_failed_task_log')->execute();
 
     foreach ($task_log as $task) {
-      $values = [
-        'nid' => $task->campaign_id,
-        'campaign_run_id' => $task->campaign_run_id,
-        'quantity' => $task->quantity,
-        'why_participated' => $task->why_participated,
-        'file' => $task->file,
-        'caption' => $task->caption,
-      ];
+      if ($task->type === 'reportback') {
+        $values = [
+          'nid' => $task->campaign_id,
+          'campaign_run_id' => $task->campaign_run_id,
+          'quantity' => $task->quantity,
+          'why_participated' => $task->why_participated,
+          'file' => $task->file,
+          'caption' => $task->caption,
+        ];
 
-      $user = user_load($task->drupal_id);
+        $user = user_load($task->drupal_id);
 
-      dosomething_rogue_send_reportback_to_rogue($values, $user);
+        dosomething_rogue_send_reportback_to_rogue($values, $user);
+      } else {
+        $values = [
+          [
+            'rogue_reportback_item_id' => $task->rogue_item_id,
+            'status' => $task->status,
+          ]
+        ];
+
+        dosomething_rogue_update_rogue_reportback_items($values);
+      }
    }
  }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -181,3 +181,107 @@ function dosomething_rogue_update_7005(&$sandbox) {
   }
 }
 
+/**
+ * Change schema so drupal_id is not required.
+ */
+function dosomething_rogue_update_7006(&$sandbox) {
+  $table_name = 'dosomething_rogue_failed_task_log';
+  if (db_table_exists($table_name)) {
+    $spec = [
+      'description' => 'The drupal_id of the user.',
+      'type' => 'int',
+      'not null' => FALSE,
+    ];
+    db_change_field($table_name, 'drupal_id', 'drupal_id', $spec);
+  }
+}
+
+/**
+ * Change schema so campaign_id is not required.
+ */
+function dosomething_rogue_update_7007(&$sandbox) {
+  $table_name = 'dosomething_rogue_failed_task_log';
+  if (db_table_exists($table_name)) {
+    $spec = [
+      'description' => 'Campaign nid for the reportback.',
+      'type' => 'int',
+      'not null' => FALSE,
+    ];
+    db_change_field($table_name, 'campaign_id', 'campaign_id', $spec);
+  }
+}
+
+/**
+ * Change schema so campaign_run_id is not required.
+ */
+function dosomething_rogue_update_7008(&$sandbox) {
+  $table_name = 'dosomething_rogue_failed_task_log';
+  if (db_table_exists($table_name)) {
+    $spec = [
+      'description' => 'Campaign run nid for the reportback.',
+      'type' => 'int',
+      'not null' => FALSE,
+    ];
+    db_change_field($table_name, 'campaign_run_id', 'campaign_run_id', $spec);
+  }
+}
+
+/**
+ * Change schema so quantity is not required.
+ */
+function dosomething_rogue_update_7009(&$sandbox) {
+  $table_name = 'dosomething_rogue_failed_task_log';
+  if (db_table_exists($table_name)) {
+    $spec = [
+      'description' => 'The quantity of reportback_nouns reportback_verbed.',
+      'type' => 'int',
+      'not null' => FALSE,
+    ];
+    db_change_field($table_name, 'quantity', 'quantity', $spec);
+  }
+}
+
+/**
+ * Change schema so why_participated is not required.
+ */
+function dosomething_rogue_update_7010(&$sandbox) {
+  $table_name = 'dosomething_rogue_failed_task_log';
+  if (db_table_exists($table_name)) {
+    $spec = [
+      'description' => 'Why the user participated in the campaign.',
+      'type' => 'text',
+      'length' => '2048',
+      'not null' => FALSE,
+    ];
+    db_change_field($table_name, 'why_participated', 'why_participated', $spec);
+  }
+}
+
+/**
+ * Changes the type to be text in the status column.
+ */
+function dosomething_rogue_update_7011(&$sandbox) {
+  $table_name = 'dosomething_rogue_failed_task_log';
+  if (db_table_exists($table_name)) {
+    $spec = [
+      'type' => 'text',
+      'description' => 'The updated status of the reportback item',
+    ];
+    db_change_field($table_name, 'status', 'status', $spec);
+  }
+}
+
+/**
+ * Changes the type to be text in the type column.
+ */
+function dosomething_rogue_update_7012(&$sandbox) {
+  $table_name = 'dosomething_rogue_failed_task_log';
+  if (db_table_exists($table_name)) {
+    $spec = [
+      'type' => 'text',
+      'description' => 'Either a POST to the /reportbacks Rogue endpoint or a PUT to the /items Rogue endpoint',
+    ];
+    db_change_field($table_name, 'type', 'type', $spec);
+  }
+}
+

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -139,149 +139,57 @@ function dosomething_rogue_update_7002(&$sandbox) {
 }
 
 /**
- * Add rogue_reportback_item_id column to dosomething_rogue_failed_task_log table.
+ * Adds rogue_item_id, status, and type columns to dosomething_rogue_failed_task_log table.
+ * Changes schema so drupal_id, campaign_id, campaign_run_id, quantity, why_participated are not required.
  */
 function dosomething_rogue_update_7003(&$sandbox) {
   $table_name = 'dosomething_rogue_failed_task_log';
   if (db_table_exists($table_name)) {
-    $spec = [
-      'type' => int,
+    $rogue_item_id_spec = [
+      'type' => 'int',
       'description' => 'The fid of the reportback item as it is stored in phoenix.',
     ];
-  db_add_field($table_name, 'rogue_item_id', $spec);
-  }
-}
 
-/**
- * Add the status column to dosomething_rogue_failed_task_log table.
- */
+    db_add_field($table_name, 'rogue_item_id', $rogue_item_id_spec);
 
-function dosomething_rogue_update_7004(&$sandbox) {
-  $table_name = 'dosomething_rogue_failed_task_log';
-  if (db_table_exists($table_name)) {
-    $spec = [
-      'type' => int,
-      'description' => 'The updated status of the reportback item',
+    $new_text_fields = [
+      'status' => 'The updated status of the reportback item.',
+      'type' => 'Either reportback if POST to the /reportbacks Rogue endpoint or reportback item a PUT to the /items Rogue endpoint.'
     ];
-  db_add_field($table_name, 'status', $spec);
-  }
-}
 
-/**
- * Add the type column to dosomething_rogue_failed_task_log table.
- */
-function dosomething_rogue_update_7005(&$sandbox) {
-  $table_name = 'dosomething_rogue_failed_task_log';
-  if (db_table_exists($table_name)) {
-    $spec = [
-      'type' => int,
-      'description' => 'Either a POST to the /reportbacks Rogue endpoint or a PUT to the /items Rogue endpoint',
+    foreach ($new_text_fields as $field => $description) {
+      $text_spec = [
+        'type' => 'text',
+        'description' => $description,
+      ];
+
+      db_add_field($table_name, $field, $text_spec);
+    }
+
+    $not_required_int_columns = [
+      'drupal_id' => 'The drupal_id of the user.',
+      'campaign_id' => 'Campaign nid for the reportback.',
+      'campaign_run_id' => 'Campaign run nid for the reportback.',
+      'quantity' => 'The quantity of reportback_nouns reportback_verbed.'
     ];
-  db_add_field($table_name, 'type', $spec);
-  }
-}
 
-/**
- * Change schema so drupal_id is not required.
- */
-function dosomething_rogue_update_7006(&$sandbox) {
-  $table_name = 'dosomething_rogue_failed_task_log';
-  if (db_table_exists($table_name)) {
-    $spec = [
-      'description' => 'The drupal_id of the user.',
-      'type' => 'int',
-      'not null' => FALSE,
-    ];
-    db_change_field($table_name, 'drupal_id', 'drupal_id', $spec);
-  }
-}
+    foreach ($not_required_int_columns as $field => $description) {
+      $not_required_spec = [
+        'type' => 'int',
+        'description' => $description,
+        'not null' => FALSE
+      ];
 
-/**
- * Change schema so campaign_id is not required.
- */
-function dosomething_rogue_update_7007(&$sandbox) {
-  $table_name = 'dosomething_rogue_failed_task_log';
-  if (db_table_exists($table_name)) {
-    $spec = [
-      'description' => 'Campaign nid for the reportback.',
-      'type' => 'int',
-      'not null' => FALSE,
-    ];
-    db_change_field($table_name, 'campaign_id', 'campaign_id', $spec);
-  }
-}
+      db_change_field($table_name, $field, $field, $not_required_spec);
+    }
 
-/**
- * Change schema so campaign_run_id is not required.
- */
-function dosomething_rogue_update_7008(&$sandbox) {
-  $table_name = 'dosomething_rogue_failed_task_log';
-  if (db_table_exists($table_name)) {
-    $spec = [
-      'description' => 'Campaign run nid for the reportback.',
-      'type' => 'int',
-      'not null' => FALSE,
-    ];
-    db_change_field($table_name, 'campaign_run_id', 'campaign_run_id', $spec);
-  }
-}
-
-/**
- * Change schema so quantity is not required.
- */
-function dosomething_rogue_update_7009(&$sandbox) {
-  $table_name = 'dosomething_rogue_failed_task_log';
-  if (db_table_exists($table_name)) {
-    $spec = [
-      'description' => 'The quantity of reportback_nouns reportback_verbed.',
-      'type' => 'int',
-      'not null' => FALSE,
-    ];
-    db_change_field($table_name, 'quantity', 'quantity', $spec);
-  }
-}
-
-/**
- * Change schema so why_participated is not required.
- */
-function dosomething_rogue_update_7010(&$sandbox) {
-  $table_name = 'dosomething_rogue_failed_task_log';
-  if (db_table_exists($table_name)) {
-    $spec = [
-      'description' => 'Why the user participated in the campaign.',
+    $why_participated_spec = [
       'type' => 'text',
+      'description' => 'Why the user participated in the campaign.',
       'length' => '2048',
       'not null' => FALSE,
     ];
-    db_change_field($table_name, 'why_participated', 'why_participated', $spec);
+
+    db_change_field($table_name, 'why_participated', 'why_participated', $why_participated_spec);
   }
 }
-
-/**
- * Changes the type to be text in the status column.
- */
-function dosomething_rogue_update_7011(&$sandbox) {
-  $table_name = 'dosomething_rogue_failed_task_log';
-  if (db_table_exists($table_name)) {
-    $spec = [
-      'type' => 'text',
-      'description' => 'The updated status of the reportback item',
-    ];
-    db_change_field($table_name, 'status', 'status', $spec);
-  }
-}
-
-/**
- * Changes the type to be text in the type column.
- */
-function dosomething_rogue_update_7012(&$sandbox) {
-  $table_name = 'dosomething_rogue_failed_task_log';
-  if (db_table_exists($table_name)) {
-    $spec = [
-      'type' => 'text',
-      'description' => 'Either a POST to the /reportbacks Rogue endpoint or a PUT to the /items Rogue endpoint',
-    ];
-    db_change_field($table_name, 'type', 'type', $spec);
-  }
-}
-

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -19,7 +19,7 @@ function dosomething_rogue_schema() {
         'not null' => TRUE,
       ],
       'rogue_item_id' => [
-        'description' => 'The fid of the reportback item as it is stored in phoenix.',
+        'description' => 'The fid of the reportback item as it is stored in rogue.',
         'type' => 'int',
         'not null' => TRUE,
       ],
@@ -137,3 +137,47 @@ function dosomething_rogue_update_7002(&$sandbox) {
     db_create_table($table_name, $schema[$table_name]);
   }
 }
+
+/**
+ * Add rogue_reportback_item_id column to dosomething_rogue_failed_task_log table.
+ */
+function dosomething_rogue_update_7003(&$sandbox) {
+  $table_name = 'dosomething_rogue_failed_task_log';
+  if (db_table_exists($table_name)) {
+    $spec = [
+      'type' => int,
+      'description' => 'The fid of the reportback item as it is stored in phoenix.',
+    ];
+  db_add_field($table_name, 'rogue_item_id', $spec);
+  }
+}
+
+/**
+ * Add the status column to dosomething_rogue_failed_task_log table.
+ */
+
+function dosomething_rogue_update_7004(&$sandbox) {
+  $table_name = 'dosomething_rogue_failed_task_log';
+  if (db_table_exists($table_name)) {
+    $spec = [
+      'type' => int,
+      'description' => 'The updated status of the reportback item',
+    ];
+  db_add_field($table_name, 'status', $spec);
+  }
+}
+
+/**
+ * Add the type column to dosomething_rogue_failed_task_log table.
+ */
+function dosomething_rogue_update_7005(&$sandbox) {
+  $table_name = 'dosomething_rogue_failed_task_log';
+  if (db_table_exists($table_name)) {
+    $spec = [
+      'type' => int,
+      'description' => 'Either a POST to the /reportbacks Rogue endpoint or a PUT to the /items Rogue endpoint',
+    ];
+  db_add_field($table_name, 'type', $spec);
+  }
+}
+

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -79,23 +79,21 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
 
   try {
     $response = $client->postReportback($data);
+    $values['type'] = 'reportback';
 
     if (module_exists('stathat')) {
       stathat_send_ez_count('drupal - Rogue - reportback sent - count', 1);
     }
     if (!$response) {
       // This is a 404
-      $values['type'] = 'reportback';
       dosomething_rogue_handle_failure($values, $response, $e, $user);
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
     // These aren't yet caught by Gateway
-    $values['type'] = 'reportback';
     dosomething_rogue_handle_failure($values, $response, $e, $user);
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
-    $values['type'] = 'reportback';
     dosomething_rogue_handle_failure($values, $response, $e, $user);
   }
 
@@ -114,14 +112,12 @@ function dosomething_rogue_update_rogue_reportback_items($data)
 
   $client = dosomething_rogue_client();
   try {
-    // $response = $client->updateReportback($data);
-    $response = NULL;
+    $response = $client->updateReportback($data);
 
     if (module_exists('stathat')) {
       stathat_send_ez_count('drupal - Rogue - reportback items(s) updated status sent - count', count($data));
     }
-    // if (!$response) {
-    if (is_null($response)) {
+    if (!$response) {
       foreach ($data as $values) {
         $values['type'] = 'reportback item';
         dosomething_rogue_handle_failure($values, $response);

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -109,7 +109,6 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
  */
 function dosomething_rogue_update_rogue_reportback_items($data)
 {
-
   $client = dosomething_rogue_client();
   try {
     $response = $client->updateReportback($data);

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -85,15 +85,17 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     }
     if (!$response) {
       // This is a 404
+      $values['type'] = 'reportback';
       dosomething_rogue_handle_failure($user, $values, $response, $e);
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
     // These aren't yet caught by Gateway
+    $values['type'] = 'reportback';
     dosomething_rogue_handle_failure($user, $values, $response, $e);
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
-
+    $values['type'] = 'reportback';
     dosomething_rogue_handle_failure($user, $values, $response, $e);
   }
 
@@ -109,11 +111,36 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
  */
 function dosomething_rogue_update_rogue_reportback_items($data)
 {
+
   $client = dosomething_rogue_client();
+  try {
+    // $response = $client->updateReportback($data);
+    $response = NULL;
 
-  $response = $client->updateReportback($data);
-
-  //@TODO - Add error handling.
+    if (module_exists('stathat')) {
+      stathat_send_ez_count('drupal - Rogue - reportback items(s) updated status sent - count', count($data));
+    }
+    // if (!$response) {
+    if (is_null($response)) {
+      foreach ($data as $values) {
+        $values['type'] = 'reportback item';
+        dosomething_rogue_handle_failure(NULL, $values, $response, NULL);
+      }
+    }
+  }
+  catch (GuzzleHttp\Exception\ServerException $e) {
+    // These aren't yet caught by Gateway
+    foreach ($data as $values) {
+      $values['type'] = 'reportback item';
+      dosomething_rogue_handle_failure(NULL, $values, $response, $e);
+    }
+  }
+  catch (DoSomething\Gateway\Exceptions\ApiException $e) {
+    foreach ($data as $values) {
+      $values['type'] = 'reportback item';
+      dosomething_rogue_handle_failure(NULL, $values, $response, $e);
+    }
+  }
 
   return $response;
 }
@@ -166,15 +193,24 @@ function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback
  * @param object $e
  *
  */
-function dosomething_rogue_handle_failure($user, $values, $response = NULL, $e = NULL)
+function dosomething_rogue_handle_failure($user = NULL, $values, $response = NULL, $e = NULL)
 {
-   if (module_exists('stathat')) {
-      stathat_send_ez_count('drupal - Rogue - reportback failed - count', 1);
-    }
+  if (module_exists('stathat')) {
+      if ($values['type'] === 'reportback') {
+        stathat_send_ez_count('drupal - Rogue - reportback failed - count', 1);
+      } else {
+        stathat_send_ez_count('drupal - Rogue - reportback item status failed - count', 1);
+      }
+  }
 
+  if ($values['nid']) {
     $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
+  } else {
+    $values['nid'] = NULL;
+  }
 
-    // Save fail to a db log so we can easily export.
+  // Save fail to a db log so we can easily export.
+  if ($values['type'] === 'reportback') {
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([
         'drupal_id' => $user->uid,
@@ -184,13 +220,28 @@ function dosomething_rogue_handle_failure($user, $values, $response = NULL, $e =
         'why_participated' => $values['why_participated'],
         'file' => $values['file'],
         'caption' => $values['caption'],
+        'type' => $values['type'],
+        'timestamp' => REQUEST_TIME,
+        'response_code' => $response->code, // @TODO: this is currently null until there a better way to get it from Gateway
+        'response_values' => (isset($e)) ? $e->getMessage() : NULL,
+      ])
+      ->execute();
+      watchdog('dosomething_rogue', 'reportback not migrated to Rogue', ['user' => $user->uid, 'campaign_id' => $values['nid'], 'campaign_run_id' => $run->nid], WATCHDOG_ERROR);
+
+  } else {
+    db_insert('dosomething_rogue_failed_task_log')
+      ->fields([
+        'rogue_item_id' => $values['rogue_reportback_item_id'],
+        'status' => $values['status'],
+        'type' => $values['type'],
         'timestamp' => REQUEST_TIME,
         'response_code' => $response->code, // @TODO: this is currently null until there a better way to get it from Gateway
         'response_values' => (isset($e)) ? $e->getMessage() : NULL,
       ])
       ->execute();
 
-      watchdog('dosomething_rogue', 'reportback not migrated to Rogue', ['user' => $user->uid, 'campaign_id' => $values['nid'], 'campaign_run_id' => $run->nid], WATCHDOG_ERROR);
+      watchdog('dosomething_rogue', 'reportback item status not migrated to Rogue. (Rogue item id: !rogue_item_id status: !status', ['!rogue_item_id' => $values['rogue_item_id'], '!status' => $values['status']], WATCHDOG_ERROR);
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -221,7 +221,8 @@ function dosomething_rogue_handle_failure($user = NULL, $values, $response = NUL
         'response_values' => (isset($e)) ? $e->getMessage() : NULL,
       ])
       ->execute();
-      watchdog('dosomething_rogue', 'reportback not migrated to Rogue', ['user' => $user->uid, 'campaign_id' => $values['nid'], 'campaign_run_id' => $run->nid], WATCHDOG_ERROR);
+
+    watchdog('dosomething_rogue', 'reportback not migrated to Rogue', ['user' => $user->uid, 'campaign_id' => $values['nid'], 'campaign_run_id' => $run->nid], WATCHDOG_ERROR);
   } else {
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([
@@ -229,12 +230,12 @@ function dosomething_rogue_handle_failure($user = NULL, $values, $response = NUL
         'status' => $values['status'],
         'type' => $values['type'],
         'timestamp' => REQUEST_TIME,
-        'response_code' => $response->code, // @TODO: this is currently null until there a better way to get it from Gateway
+        'response_code' => (isset($response->code)) ? $response->code : NULL, // @TODO: this is currently null until there a better way to get it from Gateway
         'response_values' => (isset($e)) ? $e->getMessage() : NULL,
       ])
       ->execute();
 
-      watchdog('dosomething_rogue', 'reportback item status not migrated to Rogue. (Rogue item id: !rogue_item_id status: !status', ['!rogue_item_id' => $values['rogue_item_id'], '!status' => $values['status']], WATCHDOG_ERROR);
+    watchdog('dosomething_rogue', 'reportback item status not migrated to Rogue. (Rogue item id: !rogue_item_id status: !status', ['!rogue_item_id' => $values['rogue_item_id'], '!status' => $values['status']], WATCHDOG_ERROR);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -86,17 +86,17 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     if (!$response) {
       // This is a 404
       $values['type'] = 'reportback';
-      dosomething_rogue_handle_failure($user, $values, $response, $e);
+      dosomething_rogue_handle_failure($values, $response, $e, $user);
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
     // These aren't yet caught by Gateway
     $values['type'] = 'reportback';
-    dosomething_rogue_handle_failure($user, $values, $response, $e);
+    dosomething_rogue_handle_failure($values, $response, $e, $user);
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
     $values['type'] = 'reportback';
-    dosomething_rogue_handle_failure($user, $values, $response, $e);
+    dosomething_rogue_handle_failure($values, $response, $e, $user);
   }
 
   return $response;
@@ -124,7 +124,7 @@ function dosomething_rogue_update_rogue_reportback_items($data)
     if (is_null($response)) {
       foreach ($data as $values) {
         $values['type'] = 'reportback item';
-        dosomething_rogue_handle_failure(NULL, $values, $response, NULL);
+        dosomething_rogue_handle_failure($values, $response);
       }
     }
   }
@@ -132,13 +132,13 @@ function dosomething_rogue_update_rogue_reportback_items($data)
     // These aren't yet caught by Gateway
     foreach ($data as $values) {
       $values['type'] = 'reportback item';
-      dosomething_rogue_handle_failure(NULL, $values, $response, $e);
+      dosomething_rogue_handle_failure($values, $response, $e);
     }
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
     foreach ($data as $values) {
       $values['type'] = 'reportback item';
-      dosomething_rogue_handle_failure(NULL, $values, $response, $e);
+      dosomething_rogue_handle_failure($values, $response, $e);
     }
   }
 
@@ -193,7 +193,7 @@ function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback
  * @param object $e
  *
  */
-function dosomething_rogue_handle_failure($user = NULL, $values, $response = NULL, $e = NULL)
+function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, $user = NULL)
 {
   if (module_exists('stathat')) {
       if ($values['type'] === 'reportback') {

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -203,14 +203,9 @@ function dosomething_rogue_handle_failure($user = NULL, $values, $response = NUL
       }
   }
 
-  if ($values['nid']) {
-    $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
-  } else {
-    $values['nid'] = NULL;
-  }
-
   // Save fail to a db log so we can easily export.
   if ($values['type'] === 'reportback') {
+    $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([
         'drupal_id' => $user->uid,
@@ -227,7 +222,6 @@ function dosomething_rogue_handle_failure($user = NULL, $values, $response = NUL
       ])
       ->execute();
       watchdog('dosomething_rogue', 'reportback not migrated to Rogue', ['user' => $user->uid, 'campaign_id' => $values['nid'], 'campaign_run_id' => $run->nid], WATCHDOG_ERROR);
-
   } else {
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -212,7 +212,7 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
         'caption' => $values['caption'],
         'type' => $values['type'],
         'timestamp' => REQUEST_TIME,
-        'response_code' => $response->code, // @TODO: this is currently null until there a better way to get it from Gateway
+        'response_code' => (isset($response->code)) ? $response->code : NULL, // @TODO: this is currently null until there a better way to get it from Gateway
         'response_values' => (isset($e)) ? $e->getMessage() : NULL,
       ])
       ->execute();


### PR DESCRIPTION
#### What's this PR do?
- Updates the  `dosomething_rogue_failed_task_log`: 
  - Adds the `rogue_item_id`, `status`, and `type` columns 
  - If a reportback fails to send to Rogue, the `type` will be `reportback`.
  - If a reportback item's status fails to send to Rogue, the `type` will be `reportback item`. 
  - `drupal_id`, `campaign_id`, `campaign_run_id`, `quantity`, and `why_participated` are now all set to `'not_null' => FALSE`.
- Enters the `rogue_item_id` and updated `status` in the `dosomething_rogue_failed_task_log` if the `PUT` request to `/items` fails and sends stathat alerts. 
- Updates the cron job to retry the `PUT` request to `/items` for everything in the `dosomething_rogue_failed_task_log`

#### How should this be reviewed?
- In `lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module`: 
  - Comment out line 81 and replace with `$response = NULL;`
  - Comment out line 87 and replace with `if(is_null($response){`
- Submit a new reportback. 
- Check the `dosomething_rogue_failed_task_log` and all expected columns should be filled out. The `type` should say `reportback`.

- Submit a new reportback item (or many!). 
- In `lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module`: 
  - Comment out line 115 and replace with `$response = NULL;`
  - Comment out line 120 and replace with `if(is_null($response){`
- Review the reportback items. 
- Check the `dosomething_rogue_failed_task_log` table and `rogue_item_id`, `status`, and `type` should be filled out. `type` should be `reportback item`. 

#### Relevant tickets
Fixes #7157 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
