### PR TITLE
Extract analytics to helper module, fix lost events on page redirects, and add a few new events.

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -562,6 +562,7 @@ function dosomething_helpers_floor_decimal($value, $decimals = 1) {
 
 /**
  * Adds custom analytics (Google Analytics & Optimizely) event to page.
+ * @see preprocess_html.inc
  *
  * @param string $category - The category of the event.
  * @param string $action - The action being performed.

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -561,23 +561,14 @@ function dosomething_helpers_floor_decimal($value, $decimals = 1) {
 
 
 /**
- * Adds custom GA event to page
+ * Adds custom analytics (Google Analytics & Optimizely) event to page.
  *
- * @param String category The category of the event
- * @param String action The action being performed
- * @param (optional) String label The event label
- * @param (optional) String value The value to be sent
+ * @param string $category - The category of the event.
+ * @param string $action - The action being performed.
+ * @param string $label - (Optional) The event label.
  */
-function dosomething_helpers_add_analytics_event($category, $action, $label = NULL, $value = NULL) {
-  $event_string = '"' . $category . '"' . ', ' . '"' . $action . '"';
-  if ($label) {
-    $event_string = $event_string . ', ' . $label;
-  }
-  if ($value) {
-    $event_string = $event_string  . ',' . $value;
-  }
-  $google_analytics_js = 'if(typeof(ga) !== "undefined" && ga !== null) { ga("send", "event", ' . $event_string . '); }';
-  drupal_add_js($google_analytics_js, 'inline');
+function dosomething_helpers_add_analytics_event($category, $action, $label = NULL) {
+  $_SESSION['dosomething_analytics_events'][] = [$category, $action, $label];
 }
 
 /**
@@ -585,6 +576,7 @@ function dosomething_helpers_add_analytics_event($category, $action, $label = NU
  * that can be added to any url.
  * @param  $nid
  * @param  array $options - custom utm values to use.
+ * @return string
  */
 function dosomething_helpers_utm_parameters($nid, $options = NULL) {
   // Use the node id for 'utm_campaign', if it is given, otherwise use the custom value in $options

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -158,7 +158,7 @@ function dosomething_helpers_share_bar($path, $share_types, $share_description, 
     }
 
     if ($share_intents[$type]) {
-      $share_bar .= '<li><a class="social-icon -' . $type . ' js-share-link ga-click" href="' . $share_intents[$type] . '" data-ga-category="Share" data-ga-label="' . $type .'" data-ga-action="' . $share_description .'"><span>'. $type . '</span></a></li>';
+      $share_bar .= '<li><a class="social-icon -' . $type . ' js-share-link ga-click" href="' . $share_intents[$type] . '" data-track-category="Share" data-track-label="' . $type .'" data-track-action="' . $share_description .'"><span>'. $type . '</span></a></li>';
     }
   }
 

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -97,9 +97,13 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
     dosomething_user_set_fields($edit, ['created_by_openid_connect' => 1]);
   }
 
-  // HACK: Was this account registered just now (last 15s)? If so, send email.
+  // HACK: Was this account registered just now (last 15s)? If so, send transactional
+  // and fire a Registration analytics event. Otherwise, fire Login event.
   if ($userinfo['created_at'] > time() - 15) {
+    dosomething_helpers_add_analytics_event('Authentication', 'Register');
     _dosomething_user_send_to_message_broker();
+  } else {
+    dosomething_helpers_add_analytics_event('Authentication', 'Login');
   }
 
   // Make sure the user's Northstar ID is set in the field_data_field_northstar_id table.

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -110,9 +110,6 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
   // If we saved a "post-authorization" action, do it now.
   dosomething_northstar_perform_authorization_actions();
 
-  // Let's remember that this is a OpenID Connect session.
-  $_SESSION['DOSOMETHING_NORTHSTAR_OPENID_CONNECT'] = true;
-
   if (empty($account->language)) {
     // Determine the user's language code if possible.
     $language_code = dosomething_global_get_language($account);

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -53,6 +53,9 @@ function dosomething_signup_form($form, &$form_state, $nid, $label = "Sign Up") 
     '#value' => t($label),
     '#attributes' => [
       'class' => ['button'],
+      'data-track-category' => 'Link',
+      'data-track-action' => 'Click',
+      'data-track-label' => 'Signup (Authenticated)',
     ],
   ];
   return $form;

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -35,28 +35,26 @@ function dosomething_signup_forms($form_id, $args) {
  *   The label to display on the form submit button.
  */
 function dosomething_signup_form($form, &$form_state, $nid, $label = "Sign Up") {
-  $form['nid'] = array(
+  $form['nid'] = [
     '#type' => 'hidden',
     '#value' => $nid,
     '#access' => FALSE,
-  );
+  ];
   // Check query string for signup source value.
   if ($source = dosomething_signup_get_query_source()) {
-    $form['source'] = array(
+    $form['source'] = [
       '#type' => 'hidden',
       '#value' => $source,
       '#access' => FALSE,
-    );
+    ];
   }
-  $form['submit'] = array(
+  $form['submit'] = [
     '#type' => 'submit',
     '#value' => t($label),
-    '#attributes' => array(
-      'class' => array(
-        'button',
-      ),
-    ),
-  );
+    '#attributes' => [
+      'class' => ['button'],
+    ],
+  ];
   return $form;
 }
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
@@ -78,10 +78,25 @@ function dosomething_user_get_login_link($label, array $class = []) {
 function dosomething_user_get_register_link($label, array $class = []) {
   if (module_exists('dosomething_northstar') && variable_get('dosomething_user_openid_oauth_login_enabled')) {
     // @TODO: We need to implement this `?register` query string in authorize route here, and on Northstar.
-    return l(t($label), 'user/authorize?register', ['attributes' => ['class' => $class]]);
+    return l(t($label), 'user/authorize?register', [
+      'attributes' => [
+        'data-track-category' => 'Link',
+        'data-track-action' => 'Click',
+        'data-track-label' => 'Register',
+        'class' => $class
+      ]
+    ]);
   }
 
-  return l(t($label), 'user/register', ['attributes' => ['data-modal-href' => '#modal--register', 'class' => $class]]);
+  return l(t($label), 'user/register', [
+    'attributes' => [
+      'data-modal-href' => '#modal--register',
+      'data-track-category' => 'Link',
+      'data-track-action' => 'Click',
+      'data-track-label' => 'Register',
+      'class' => $class
+    ]
+  ]);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
@@ -18,11 +18,23 @@ function dosomething_user_get_sign_up_link_markup($label, $nid) {
       'query' => ['action' => 'signup', 'node' => $nid],
       'attributes' => [
         'class' => ['button'],
+        'data-track-category' => 'Link',
+        'data-track-action' => 'Click',
+        'data-track-label' => 'Signup (Unauthenticated)',
         'id' => 'link--campaign-signup-login'
       ]]);
   }
 
-  return '<a id="link--campaign-signup-login" href="#" data-modal-href="#modal--login" class="button">' . $label . '</a>';
+  return l(t($label), '#', [
+     'attributes' => [
+       'id' => 'link--campaign-signup-login',
+       'data-modal-href' => 'modal--login',
+       'data-track-category' => 'Link',
+       'data-track-action' => 'Click',
+       'data-track-label' => 'Signup (Unauthenticated)',
+       'class' => ['button'],
+     ]
+  ]);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
@@ -46,10 +46,26 @@ function dosomething_user_get_sign_up_link_markup($label, $nid) {
  */
 function dosomething_user_get_login_link($label, array $class = []) {
   if (module_exists('dosomething_northstar') && variable_get('dosomething_user_openid_oauth_login_enabled')) {
-    return l(t($label), 'user/authorize', ['attributes' => ['class' => $class]]);
+    return l(t($label), 'user/authorize', [
+      'attributes' => [
+        'data-track-category' => 'Link',
+        'data-track-action' => 'Click',
+        'data-track-label' => 'Login',
+        'class' => $class
+      ]
+    ]);
   }
 
-  return l(t($label), 'user/login', ['attributes' => ['data-modal-href' => '#modal--login', 'class' => $class, 'id' => 'link--login']]);
+  return l(t($label), 'user/login', [
+    'attributes' => [
+      'data-modal-href' => '#modal--login',
+      'data-track-category' => 'Link',
+      'data-track-action' => 'Click',
+      'data-track-label' => 'Login',
+      'class' => $class,
+      'id' => 'link--login'
+    ]
+  ]);
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_html.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_html.inc
@@ -8,7 +8,7 @@ function paraneue_dosomething_preprocess_html(&$vars) {
 
   // Output any queued analytics events:
   foreach ($_SESSION['dosomething_analytics_events'] as $index => $event) {
-    $analytics_js = 'analyze("' . implode('", "', $event) . '");';
+    $analytics_js = 'analyze("' . implode('", "', array_filter($event)) . '");';
     drupal_add_js($analytics_js, 'inline');
 
     unset($_SESSION['dosomething_analytics_events'][$index]);

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_html.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_html.inc
@@ -6,6 +6,14 @@
 function paraneue_dosomething_preprocess_html(&$vars) {
   global $user;
 
+  // Output any queued analytics events:
+  foreach ($_SESSION['dosomething_analytics_events'] as $index => $event) {
+    $analytics_js = 'analyze("' . implode('", "', $event) . '");';
+    drupal_add_js($analytics_js, 'inline');
+
+    unset($_SESSION['dosomething_analytics_events'][$index]);
+  }
+
   // Add theme stylesheet
   drupal_add_css(PARANEUE_PATH . '/dist/app.css', [
     'group' => CSS_THEME,

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_html.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_html.inc
@@ -6,7 +6,7 @@
 function paraneue_dosomething_preprocess_html(&$vars) {
   global $user;
 
-  // Output any queued analytics events:
+  // Output any queued analytics events from `dosomething_helpers_add_analytics_event`:
   foreach ($_SESSION['dosomething_analytics_events'] as $index => $event) {
     $analytics_js = 'analyze("' . implode('", "', array_filter($event)) . '");';
     drupal_add_js($analytics_js, 'inline');

--- a/lib/themes/dosomething/paraneue_dosomething/js/app.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/app.js
@@ -45,6 +45,9 @@ import 'validators/organDonation';
 
 import 'campaign/prototype';
 
+// Initialize analytics.
+Analytics.init();
+
 /**
  * Let's go!
  */
@@ -56,9 +59,6 @@ $(document).ready(function() {
 
   // Ping the dashboard with my location
   Globe.init();
-
-  // Initialize analytics.
-  Analytics.init();
 
   // Initialize the donation form on the donate page.
   Donate.init();

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -162,7 +162,7 @@ const Reportback = {
     const buttonText = Drupal.t('View more');
 
     this.$viewMoreContainer = $(`<div class="reportback__view-more"></div>`);
-    this.$viewMoreButton = $(`<button id="view-more-button" class="button button--view-more -tertiary inline-alt-text-color ga-click" data-ga-category="Gallery" data-ga-action="click" data-ga-label="View More Clicks">${buttonText}</button>`);
+    this.$viewMoreButton = $(`<button id="view-more-button" class="button button--view-more -tertiary inline-alt-text-color ga-click" data-track-category="Gallery" data-track-action="click" data-track-label="View More Clicks">${buttonText}</button>`);
 
     this.$viewMoreContainer.append(this.$viewMoreButton);
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -4,6 +4,7 @@
  * or form validation events.
  */
 
+const $ = require('jquery');
 const Analytics = require('@dosomething/analytics');
 const Validation = require('dosomething-validation');
 const Modal = require('dosomething-modal');
@@ -43,6 +44,11 @@ function init() {
   Modal.Events.subscribe('Modal:Close', (topic, args) => {
     const label = args !== null ? '#' + args.attr('id') : '';
     Analytics.analyze('Modal', 'Close', label);
+  });
+
+  // Custom Events
+  $('#user-login-form').on('submit', () => {
+    Analytics.analyze('Form', 'Submitted', 'user-login-form');
   });
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -4,97 +4,46 @@
  * or form validation events.
  */
 
-import $ from 'jquery';
-import Validation from 'dosomething-validation';
-import Modal from 'dosomething-modal';
+const Analytics = require('@dosomething/analytics');
+const Validation = require('dosomething-validation');
+const Modal = require('dosomething-modal');
 
-function subscribeEvents() {
+function init() {
+  // Configure `data-ga-*` and `data-track-*` links.
+  Analytics.init('ga');
+  Analytics.init('track');
+
   // Validation
-  Validation.Events.subscribe('Validation:InlineError', function(topic, args) {
-    ga('send', 'event', 'Form', 'Inline Validation Error', args);
+  Validation.Events.subscribe('Validation:InlineError', function (topic, args) {
+    Analytics.analyze('Form', 'Inline Validation Error', args);
   });
 
-  Validation.Events.subscribe('Validation:Suggestion', function(topic, args) {
-    ga('send', 'event', 'Form', 'Suggestion', args);
+  Validation.Events.subscribe('Validation:Suggestion', function (topic, args) {
+    Analytics.analyze('Form', 'Suggestion', args);
   });
 
-  Validation.Events.subscribe('Validation:SuggestionUsed', function(topic, args) {
-    ga('send', 'event', 'Form', 'Suggestion Used', args);
+  Validation.Events.subscribe('Validation:SuggestionUsed', function (topic, args) {
+    Analytics.analyze('Form', 'Suggestion Used', args);
   });
 
-  Validation.Events.subscribe('Validation:Submitted', function(topic, args) {
-    ga('send', 'event', 'Form', 'Submitted', args);
+  Validation.Events.subscribe('Validation:Submitted', function (topic, args) {
+    Analytics.analyze('Form', 'Submitted', args);
   });
 
-  Validation.Events.subscribe('Validation:SubmitError', function(topic, args) {
-    ga('send', 'event', 'Form', 'Validation Error on submit', args);
+  Validation.Events.subscribe('Validation:SubmitError', function (topic, args) {
+    Analytics.analyze('Form', 'Validation Error on submit', args);
   });
 
   // Modals
-  Modal.Events.subscribe('Modal:Open', function(topic, args) {
+  Modal.Events.subscribe('Modal:Open', function (topic, args) {
     const label = args !== null ? '#' + args.attr('id') : '';
-    ga('send', 'event', 'Modal', 'Open', label);
+    Analytics.analyze('Modal', 'Open', label);
   });
 
-  Modal.Events.subscribe('Modal:Close', function(topic, args) {
+  Modal.Events.subscribe('Modal:Close', function (topic, args) {
     const label = args !== null ? '#' + args.attr('id') : '';
-    ga('send', 'event', 'Modal', 'Close', label);
+    Analytics.analyze('Modal', 'Close', label);
   });
-
-  // Signup button on pitch page
-  const isPitchPage = $('.pitch').length > 0;
-  if (isPitchPage) {
-    $('#link--campaign-signup-login').on('click', () => {
-      ga('send', 'event', 'Signup button', 'Pitch page', 'Start');
-    });
-
-    // This applies to both authenticated & anonymous users. It also covers both modal register & login.
-    $('#user-login-form').on('submit', () => {
-      ga('send', 'event', 'Signup button', 'Pitch page', 'Finish');
-    });
-
-    Validation.Events.subscribe('Validation:Submitted', (topic, args) => {
-      if (args === 'user-register-form') {
-        ga('send', 'event', 'Signup button', 'Pitch page', 'Finish');
-      }
-    });
-  }
-}
-
-function exists() {
-  return typeof ga !== 'undefined' && ga !== null;
-}
-
-export function sendEvent(category, action, label) {
-  if (exists()) {
-    ga('send', 'event', category, action, label);
-  }
-}
-
-function init() {
-  // Only fire GA Custom Events if the GA object exists.
-  if (exists()) {
-    subscribeEvents();
-
-    /**
-     * Google Analytics Event Tracking
-     * Optional data attributes:
-     *   data-ga-category
-     *   data-ga-action
-     *   data-ga-label
-     *
-     * @param {jQuery} $el - The element being tracked.
-     **/
-    $('body').on('click', '.ga-click', e => {
-      const $el = $(e.target);
-
-      const category = (typeof ($el.data('ga-category')) !== 'undefined') ? $el.data('ga-category') : null;
-      const action = (typeof ($el.data('ga-action')) !== 'undefined') ? $el.data('ga-action') : null;
-      const label = (typeof ($el.data('ga-label')) !== 'undefined') ? $el.data('ga-label') : null;
-
-      sendEvent(category, action, label);
-    });
-  }
 }
 
 export default { init };

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -14,33 +14,33 @@ function init() {
   Analytics.init('track');
 
   // Validation
-  Validation.Events.subscribe('Validation:InlineError', function (topic, args) {
+  Validation.Events.subscribe('Validation:InlineError', (topic, args) => {
     Analytics.analyze('Form', 'Inline Validation Error', args);
   });
 
-  Validation.Events.subscribe('Validation:Suggestion', function (topic, args) {
+  Validation.Events.subscribe('Validation:Suggestion', (topic, args) => {
     Analytics.analyze('Form', 'Suggestion', args);
   });
 
-  Validation.Events.subscribe('Validation:SuggestionUsed', function (topic, args) {
+  Validation.Events.subscribe('Validation:SuggestionUsed', (topic, args) => {
     Analytics.analyze('Form', 'Suggestion Used', args);
   });
 
-  Validation.Events.subscribe('Validation:Submitted', function (topic, args) {
+  Validation.Events.subscribe('Validation:Submitted', (topic, args) => {
     Analytics.analyze('Form', 'Submitted', args);
   });
 
-  Validation.Events.subscribe('Validation:SubmitError', function (topic, args) {
+  Validation.Events.subscribe('Validation:SubmitError', (topic, args) => {
     Analytics.analyze('Form', 'Validation Error on submit', args);
   });
 
   // Modals
-  Modal.Events.subscribe('Modal:Open', function (topic, args) {
+  Modal.Events.subscribe('Modal:Open', (topic, args) => {
     const label = args !== null ? '#' + args.attr('id') : '';
     Analytics.analyze('Modal', 'Open', label);
   });
 
-  Modal.Events.subscribe('Modal:Close', function (topic, args) {
+  Modal.Events.subscribe('Modal:Close', (topic, args) => {
     const label = args !== null ? '#' + args.attr('id') : '';
     Analytics.analyze('Modal', 'Close', label);
   });

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -10,9 +10,8 @@ const Validation = require('dosomething-validation');
 const Modal = require('dosomething-modal');
 
 function init() {
-  // Configure `data-ga-*` and `data-track-*` links.
-  Analytics.init('ga');
-  Analytics.init('track');
+  // Configure `data-track-*` links & `analytics()` helper.
+  Analytics.init();
 
   // Validation
   Validation.Events.subscribe('Validation:InlineError', (topic, args) => {

--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -18,6 +18,7 @@
     "extends": "@dosomething/eslint-config"
   },
   "dependencies": {
+    "@dosomething/analytics": "^1.0.0",
     "@dosomething/forge": "~6.7.7",
     "dosomething-modal": "0.3.3",
     "dosomething-validation": "~0.2.4",


### PR DESCRIPTION
#### What's this PR do?
This PR extracts our little Google Analytics helper code into a [standalone npm package](https://github.com/DoSomething/analytics).

It also updates `dosomething_helpers_add_analytics_event` to flash analytics events to the session, and inject the analytics script itself when rendering a page, which fixes an issue where any events that were followed by `drupal_goto`s would be lost. (This will fix the `Authentication:Login` and `Authentication:Register` events that weren't firing.)

Finally, it removes some confusing events and adds a couple of new ones for tracking events that happen in the authentication flow: `Link:Click:Login`, `Link:Click:Register`, `Link:Click:Signup (Authenticated)`, and `Link:Click:Signup (Unauthenticated)`.

#### How should this be reviewed?
The interesting stuff happens in `dosomething_helpers_add_analytics_event` and `preprocess_html.inc`. Most of the rest is just plopping attributes into arrays.

Definitely check out [the source](https://github.com/DoSomething/analytics/blob/56a0e52a32cec86a001ac172f2f6d721000ad13c/analytics.js) for the extracted Analytics package and let me know how it looks!

#### Any background context you want to provide?
💃

#### Relevant tickets
🍃

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  