### PR TITLE
Wait for DOM to be ready before binding form event.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -45,9 +45,11 @@ function init() {
     Analytics.analyze('Modal', 'Close', label);
   });
 
-  // Custom Events
-  $('#user-login-form').on('submit', () => {
-    Analytics.analyze('Form', 'Submitted', 'user-login-form');
+  // Attach any custom events.
+  $(document).ready(() => {
+    $('#user-login-form').on('submit', function() {
+      Analytics.analyze('Form', 'Submitted', 'user-login-form')
+    });
   });
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -47,7 +47,7 @@ function init() {
 
   // Attach any custom events.
   $(document).ready(() => {
-    $('#user-login-form').on('submit', function() {
+    $('#user-login-form').on('submit', () => {
       Analytics.analyze('Form', 'Submitted', 'user-login-form')
     });
   });


### PR DESCRIPTION
#### What's this PR do?
Since we run all of our analytics code instantly now (it has its own `DOMContentLoaded` check), we need to wait to bind _this_ event inside a `$(document).ready` check (so the form is actually there to be bound)! With this fix, login events are now submitting correctly:

<img width="363" alt="screen shot 2016-11-03 at 3 48 55 pm" src="https://cloud.githubusercontent.com/assets/583202/19982597/11b120e2-a1dd-11e6-9190-413984abde18.png">


#### How should this be reviewed?
CAREFULLY. 💣

#### Any background context you want to provide?
🌵

#### Relevant tickets
Fixes 🐛. References #7170.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
