### PR TITLE
Cropping bug

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -13,9 +13,9 @@
       ->execute()
       ->fetchAll();
     db_truncate('dosomething_rogue_failed_task_log')->execute();
+
     foreach ($task_log as $task) {
       if ($task->type === 'reportback') {
-
         $values = [
           'nid' => $task->campaign_id,
           'campaign_run_id' => $task->campaign_run_id,
@@ -30,7 +30,6 @@
 
         dosomething_rogue_send_reportback_to_rogue($values, $user);
       } else {
-
         $values = [
           [
             'rogue_reportback_item_id' => $task->rogue_item_id,

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -24,6 +24,11 @@
           'file' => $task->file,
           'caption' => $task->caption,
           'type' => $task->type,
+          'crop_x' => $task->crop_x,
+          'crop_y' => $task->crop_y,
+          'crop_width' => $task->crop_width,
+          'crop_height' => $task->crop_height,
+          'crop_rotate' => $task->crop_rotate,
         ];
 
         $user = user_load($task->drupal_id);

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -13,9 +13,9 @@
       ->execute()
       ->fetchAll();
     db_truncate('dosomething_rogue_failed_task_log')->execute();
-
     foreach ($task_log as $task) {
       if ($task->type === 'reportback') {
+
         $values = [
           'nid' => $task->campaign_id,
           'campaign_run_id' => $task->campaign_run_id,
@@ -23,12 +23,14 @@
           'why_participated' => $task->why_participated,
           'file' => $task->file,
           'caption' => $task->caption,
+          'type' => $task->type,
         ];
 
         $user = user_load($task->drupal_id);
 
         dosomething_rogue_send_reportback_to_rogue($values, $user);
       } else {
+
         $values = [
           [
             'rogue_reportback_item_id' => $task->rogue_item_id,

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -193,3 +193,26 @@ function dosomething_rogue_update_7003(&$sandbox) {
     db_change_field($table_name, 'why_participated', 'why_participated', $why_participated_spec);
   }
 }
+
+/**
+ * Adds cropping columns to dosomething_rogue_failed_task_log table.
+ */
+function dosomething_rogue_update_7004(&$sandbox) {
+  $table_name = 'dosomething_rogue_failed_task_log';
+   $new_fields = [
+    'crop_x' => 'X coordinates of cropped rb item image.',
+    'crox_y' => 'Y coordinates of cropped rb item image.',
+    'crop_width' => 'Crop width of cropped rb item image.',
+    'crop_height' => 'Crop height of cropped rb item image.',
+    'crop_rotate' => 'Rotate info of cropped rb item image.'
+  ];
+
+  foreach ($new_fields as $field => $description) {
+    $spec = [
+      'type' => 'int',
+      'description' => $description,
+    ];
+
+    db_add_field($table_name, $field, $spec);
+  }
+}

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -201,7 +201,7 @@ function dosomething_rogue_update_7004(&$sandbox) {
   $table_name = 'dosomething_rogue_failed_task_log';
    $new_fields = [
     'crop_x' => 'X coordinates of cropped rb item image.',
-    'crox_y' => 'Y coordinates of cropped rb item image.',
+    'crop_y' => 'Y coordinates of cropped rb item image.',
     'crop_width' => 'Crop width of cropped rb item image.',
     'crop_height' => 'Crop height of cropped rb item image.',
     'crop_rotate' => 'Rotate info of cropped rb item image.'

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -215,6 +215,11 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
         'timestamp' => REQUEST_TIME,
         'response_code' => (isset($response->code)) ? $response->code : NULL, // @TODO: this is currently null until there a better way to get it from Gateway
         'response_values' => (isset($e)) ? $e->getMessage() : NULL,
+        'crop_x' => $values['crop_x'],
+        'crop_y' => $values['crop_y'],
+        'crop_width' => $values['crop_width'],
+        'crop_height' => $values['crop_height'],
+        'crop_rotate' => $values['crop_rotate'],
       ])
       ->execute();
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -77,9 +77,10 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     'crop_rotate' => $values['crop_rotate'],
   ];
 
+  $values['type'] = 'reportback';
+
   try {
     $response = $client->postReportback($data);
-    $values['type'] = 'reportback';
 
     if (module_exists('stathat')) {
       stathat_send_ez_count('drupal - Rogue - reportback sent - count', 1);


### PR DESCRIPTION
#### What's this PR do?
- Adds cropping columns to `dosomething_rogue_failed_task_log`
- Adds `type` (`reportback`) to `$values` array before trying to send to failed tasks table

#### Any background context you want to provide?
Fixes bug when re-sending failed jobs to Rogue. 

Pair programmed with @sbsmith86 !
