### PR TITLE
Pass campaign title to Northstar on login-signup.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -46,12 +46,15 @@ function dosomething_northstar_openid_authorize() {
   }
 
   $authorize_url = dosomething_northstar_openid_authorize_url();
+  $url_options = ['absolute' => TRUE];
 
   if(isset($_GET['action']) && isset($_GET['node'])) {
     dosomething_northstar_set_authorization_action($_GET['action'], $_GET['node']);
+    // @TODO: Rename parameter on the Northstar side to 'title'.
+    $url_options['query'] = ['destination' => $_GET['title']];
   }
 
-  drupal_goto($authorize_url, ['absolute' => TRUE]);
+  drupal_goto($authorize_url, $url_options);
 }
 
 /**
@@ -140,8 +143,8 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
  * Save a post-authorization destination in the session (e.g. for signing
  * up for a campaign).
  *
- * @param $node
- * @return void
+ * @param $action
+ * @param $nid
  */
 function dosomething_northstar_set_authorization_action($action, $nid) {
   if ($action !== 'signup') {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
@@ -59,8 +59,9 @@ function dosomething_signup_get_signup_button($label, $nid, $form_id) {
     // Return signup form array to be rendered.
     return drupal_get_form($form_id, $nid, $label);
   }
+
   // Otherwise, for anonymous user, return a #markup array to be rendered.
-  return array(
-    '#markup' => dosomething_user_get_sign_up_link_markup($label, $nid),
-  );
+  $node = node_load($nid);
+
+  return ['#markup' => dosomething_user_get_sign_up_link_markup($label, $nid, $node->title)];
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
@@ -7,15 +7,16 @@
 /**
  * Returns markup for link to sign up for a campaign.
  *
- * @param string $label
- *   The text to display on the button.
+ * @param string $label - The text to display on the button.
+ * @param string $nid - The campaign node ID
+ * @param string $title - The campaign title
  * @return string
  */
-function dosomething_user_get_sign_up_link_markup($label, $nid) {
+function dosomething_user_get_sign_up_link_markup($label, $nid, $title) {
   // If the OpenID Connect feature flag is enabled, link to login page rather than showing classic modal.
   if (module_exists('dosomething_northstar') && variable_get('dosomething_user_openid_oauth_login_enabled')) {
     return l(t($label), 'user/authorize', [
-      'query' => ['action' => 'signup', 'node' => $nid],
+      'query' => ['action' => 'signup', 'node' => $nid, 'title' => $title],
       'attributes' => [
         'class' => ['button'],
         'data-track-category' => 'Link',


### PR DESCRIPTION
#### What's this PR do?
Pass campaign title to Northstar when making a authorization link for the campaign signup flow.

![screen recording 2016-11-04 at 11 18 am](https://cloud.githubusercontent.com/assets/583202/20010966/6f7254be-a280-11e6-87f7-2e7fb04b7dda.gif)

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Here's the documentation for [Northstar authorization endpoint](https://github.com/DoSomething/northstar/blob/dev/documentation/endpoints/auth.md#create-token-authorization-code-grant).

I'd like to rename the `destination` query parameter to `title`, because Drupal has some crazy overrides if you have a `?destination` on a URL (since it thinks it's a URL and _runs with it_). `?title=` makes more sense anyways!

#### Relevant tickets
Fixes 🚯.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  