### PR TITLE
Users who registered via Northstar should edit profile there.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -203,6 +203,11 @@ function paraneue_dosomething_form_dosomething_payment_form_alter(&$form, &$form
  * Preprocesses the User Profile Form.
  */
 function paraneue_dosomething_form_user_profile_form_alter(&$form, &$form_state, $form_id) {
+  // If user was created by Northstar, redirect them to edit profile there.
+  if (module_exists('dosomething_northstar') && dosomething_user_get_field('field_created_by_openid_connect')) {
+    drupal_goto(NORTHSTAR_URL . '/users/' . dosomething_user_get_northstar_id($form['account']['uid']) . '/edit', ['absolute' => TRUE]);
+  }
+
   unset($form['timezone']);
   $form['account']['mail']['#weight'] = -100;
   $form['account']['mail']['#title'] = t("Email");
@@ -223,15 +228,6 @@ function paraneue_dosomething_form_user_profile_form_alter(&$form, &$form_state,
   // Add our process function to the array:
   $process[] = 'paraneue_dosomething_process_password_confirm';
   $form['account']['pass']['#process'] = $process;
-
-  // Remove the password fields if user has OpenID Connect profile.
-  // @TODO: Once Northstar profile page is shipped, send these users there.
-  if (dosomething_user_get_field('field_created_by_openid_connect')) {
-    $account_form = &$form['account'];
-    $account_form['current_pass']['#access'] = FALSE;
-    $account_form['current_pass_required_values']['#value'] = array();
-    $account_form['pass']['#access'] = FALSE;
-  }
 }
 
 function paraneue_dosomething_form_user_profile_after_build($form, &$form_state) {


### PR DESCRIPTION
#### What's this PR do?
If a user was _registered_ via Northstar, they should be redirected to Northstar to edit their profile. This will allow them to change their password (since Northstar knows and can check against these users' hashed passwords, and Drupal cannot). This also allows us to start testing the new profile form with a small percentage of users before we launch it as the real (and only) deal.

#### How should this be reviewed?
With 'yer eyes. 👀 

#### Any background context you want to provide?
We currently don't redirect the user back to Phoenix after completing their profile form. That's a change we'll have to make on the ✨ Northstar side ✨.

#### Relevant tickets
Fixes 🔄.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
