### PR TITLE
Adds variables in message of watchdog errors when RB or updated RB Item status doesn't make it to Rogue

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -223,7 +223,7 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
       ])
       ->execute();
 
-    watchdog('dosomething_rogue', 'reportback not migrated to Rogue', ['user' => $user->uid, 'campaign_id' => $values['nid'], 'campaign_run_id' => $run->nid], WATCHDOG_ERROR);
+    watchdog('dosomething_rogue', 'Reportback not migrated to Rogue: user: !user, campaign_id: !campaign_id, campaign run_nid: !campaign_run_id.', ['!user' => $user->uid, '!campaign_id' => $values['nid'], '!campaign_run_id' => $run->nid], WATCHDOG_ERROR);
   } else {
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([
@@ -236,7 +236,7 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
       ])
       ->execute();
 
-    watchdog('dosomething_rogue', 'reportback item status not migrated to Rogue. (Rogue item id: !rogue_item_id status: !status', ['!rogue_item_id' => $values['rogue_item_id'], '!status' => $values['status']], WATCHDOG_ERROR);
+    watchdog('dosomething_rogue', 'Reportback item status not migrated to Rogue: Rogue item id: !rogue_item_id, status: !status.', ['!rogue_item_id' => $values['rogue_reportback_item_id'], '!status' => $values['status']], WATCHDOG_ERROR);
   }
 }
 


### PR DESCRIPTION
#### What's this PR do?
Adds variables in message of watchdog errors when RB or updated RB Item status doesn't make it to Rogue. 
#### How should this be reviewed?
- Go to Rogue API Settings and change the url to something incorrect, like rogue.com
- Submit a reportback.
--Check the watchdog errors and you'll see there are variables that tell more details about the error, similar to below: 
![screen shot 2016-11-07 at 2 06 23 pm](https://cloud.githubusercontent.com/assets/9019452/20071678/65b1c2f0-a4f3-11e6-864c-546081fe0e7d.png)

- Review a campaign with pending reportback items.
- Review the reportback items.
- Check the watch dog errors and you'll see both the rogue item id and the status have variables, similar to the screen shot below: 
![screen shot 2016-11-07 at 2 07 32 pm](https://cloud.githubusercontent.com/assets/9019452/20071731/8d9d441a-a4f3-11e6-9f58-d5d7376a24f4.png)

#### Relevant tickets
Fixes #7179 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  

