### PR TITLE
Saves northstar_id in dosomething_rogue_failed_task_log table

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -216,3 +216,19 @@ function dosomething_rogue_update_7004(&$sandbox) {
     db_add_field($table_name, $field, $spec);
   }
 }
+
+/**
+ * Renames drupal_id column to northstar_id in dosomething_rogue_failed_task_log.
+ */
+function dosomething_rogue_update_7005(&$sandbox) {
+  $table_name = 'dosomething_rogue_failed_task_log';
+  if (db_table_exists($table_name)) {
+    $spec = [
+      'description' => 'The northstar_id of the user.',
+      'type' => 'int',
+      'not null' => FALSE,
+    ];
+
+    db_change_field($table_name, 'drupal_id', 'northstar_id', $spec);
+  }
+}

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -218,7 +218,7 @@ function dosomething_rogue_update_7004(&$sandbox) {
 }
 
 /**
- * Renames drupal_id column to northstar_id in dosomething_rogue_failed_task_log.
+ * Adds northstar_id in dosomething_rogue_failed_task_log.
  */
 function dosomething_rogue_update_7005(&$sandbox) {
   $table_name = 'dosomething_rogue_failed_task_log';
@@ -229,6 +229,6 @@ function dosomething_rogue_update_7005(&$sandbox) {
       'not null' => FALSE,
     ];
 
-    db_change_field($table_name, 'drupal_id', 'northstar_id', $spec);
+    db_add_field($table_name, 'northstar_id', $spec);
   }
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -225,7 +225,8 @@ function dosomething_rogue_update_7005(&$sandbox) {
   if (db_table_exists($table_name)) {
     $spec = [
       'description' => 'The northstar_id of the user.',
-      'type' => 'int',
+      'type' => 'varchar',
+      'length' => '255',
       'not null' => FALSE,
     ];
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -78,6 +78,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
   ];
 
   $values['type'] = 'reportback';
+  $values['northstar_id'] = $northstar_id;
 
   try {
     $response = $client->postReportback($data);
@@ -183,10 +184,10 @@ function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback
  * Insert record that stores reference to the most recent uploaded reportback item in
  * phoenix and it's corresponding id's in Rogue
  *
- * @param object $user
  * @param array  $values
  * @param array  $response
  * @param object $e
+ * @param object $user
  *
  */
 function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, $user = NULL)
@@ -204,7 +205,8 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
     $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([
-        'drupal_id' => $user->uid,
+        'drupal_id' => $user->id,
+        'northstar_id' => $values['northstar_id'],
         'campaign_id' => $values['nid'],
         'campaign_run_id' => $run->nid,
         'quantity' => $values['quantity'],
@@ -223,7 +225,7 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
       ])
       ->execute();
 
-    watchdog('dosomething_rogue', 'Reportback not migrated to Rogue: user: !user, campaign_id: !campaign_id, campaign run_nid: !campaign_run_id.', ['!user' => $user->uid, '!campaign_id' => $values['nid'], '!campaign_run_id' => $run->nid], WATCHDOG_ERROR);
+    watchdog('dosomething_rogue', 'Reportback not migrated to Rogue: northstar_id: !northstar_id, campaign_id: !campaign_id, campaign run_nid: !campaign_run_id.', ['!northstar_id' => $values['northstar_id'], '!campaign_id' => $values['nid'], '!campaign_run_id' => $run->nid], WATCHDOG_ERROR);
   } else {
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -205,8 +205,7 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
     $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([
-        'drupal_id' => $user->id,
-        'northstar_id' => $values['northstar_id'],
+        'drupal_id' => $user->uid,
         'campaign_id' => $values['nid'],
         'campaign_run_id' => $run->nid,
         'quantity' => $values['quantity'],
@@ -222,6 +221,7 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
         'crop_width' => $values['crop_width'],
         'crop_height' => $values['crop_height'],
         'crop_rotate' => $values['crop_rotate'],
+        'northstar_id' => $values['northstar_id'],
       ])
       ->execute();
 


### PR DESCRIPTION
#### What's this PR do?
- Adds `northstar_id` column and saves this info. to `dosomething_rogue_failed_task_log` table.

#### How should this be reviewed?
- Change Rogue API settings to rogue.com 
- Reportback for a campaign.
- Make sure the reportback is in the `dosomething_rogue_failed_task_log` table with the `northstar_id` also logged. 
- Change Rogue API settings URL to correct URL. 
- Run `drush cron` and make sure that the `dosomething_rogue_failed_task_log` table is cleared and the reportback is in the Rogue database. 

#### Any background context you want to provide?
I didn't delete the `drupal_id` in the `dosomething_rogue_failed_task_log` table because if the user doesn't have `northstar_id`, a `drupal_id` is required when hitting the `/reportbacks` Rogue endpoint. 

Q - do all users have `northstar_id`s now? If so, I can get rid of the `drupal_id` column all together and update the functions. LMK!

#### Relevant tickets
Fixes #7181 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
