### PR TITLE
Include messagingGroupsQueue.

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -144,6 +144,14 @@ function dosomething_mbp_update_7008() {
 }
 
 /**
+ * Updates mbp productions to include messagingGroupsQueue.
+ */
+function dosomething_mbp_update_7009() {
+  db_drop_table('message_broker_producer_productions');
+  dosomething_mbp_install_productions();
+}
+
+/**
  * Common function for install and update of related DoSomething specific
  * message_broker_producer produciton settings.
  */
@@ -192,6 +200,7 @@ function dosomething_mbp_install_productions() {
   $productions[2]['queues'][] = 'userCampaignActivityQueue';
   $productions[2]['queues'][] = 'userAPICampaignActivityQueue';
   $productions[2]['queues'][] = 'mobileCommonsQueue';
+  $productions[2]['queues'][] = 'messagingGroupsQueue';
   $productions[2]['routing_key'] = 'campaign.signup.transactional';
   $productions[2]['status'] = 1;
 
@@ -205,6 +214,7 @@ function dosomething_mbp_install_productions() {
   $productions[3]['queues'][] = 'userCampaignActivityQueue';
   $productions[3]['queues'][] = 'userAPICampaignActivityQueue';
   $productions[3]['queues'][] = 'mobileCommonsQueue';
+  $productions[3]['queues'][] = 'messagingGroupsQueue';
   $productions[3]['routing_key'] = 'campaign.signup.transactional';
   $productions[3]['status'] = 1;
 
@@ -215,6 +225,7 @@ function dosomething_mbp_install_productions() {
   $productions[4]['queues'][] = 'activityStatsQueue';
   $productions[4]['queues'][] = 'userAPICampaignActivityQueue';
   $productions[4]['queues'][] = 'imageProcessingQueue';
+  $productions[4]['queues'][] = 'messagingGroupsQueue';
   $productions[4]['routing_key'] = 'campaign.report_back.transactional';
   $productions[4]['status'] = 1;
 


### PR DESCRIPTION
#### What's this PR do?
Includes new `messagingGroupsQueue` into Quicksilver (ex. Message Broker) queue mapping.

#### How should this be reviewed?
Run the update.
Tested locally:
![image](https://cloud.githubusercontent.com/assets/672669/20106008/686646a8-a5dc-11e6-99f3-14faefd8839c.png)

#### Relevant tickets
A part of DoSomething/Quicksilver-PHP#64.

#### Checklist
- [x] Tested on thor
- [x] Post a message in #phoenix if this includes something that causes a rebuild!  

