### PR TITLE
only pull mime from path

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -949,12 +949,12 @@ function dosomething_helpers_get_data_uri_from_image($image) {
     $mime = $image->filemime;
     $data = base64_encode(file_get_contents($image->uri));
   } else {
-    $mime = drupal_realpath($image->source);
+    $mime = mime_content_type(drupal_realpath($image->source));
     $data = base64_encode(file_get_contents($mime));
   }
 
   // Return the formated data uri: data:{mime};base64,{data};
-  return 'data:' . mime_content_type($mime) . ';base64,' . $data;
+  return 'data:' . $mime . ';base64,' . $data;
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?
There are times when the mimetype ends up being `null` which shouldn't happen. It seems like that was happening because we were calling `mime_content_type($mime)` when `$mime` may already be set as the type if the `if` statement is true. `mime_content_type` accepts a path.

Now that is just called in the `else` statement where it gives `mime_content_type` a path.

#### How should this be reviewed?
Is this going to break anything else that you know of?

#### Checklist
- [x] Tested on staging.

cc: @chloealee you wanted to know about this one!
