### PR TITLE
pass reportback file source to rogue

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -392,6 +392,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
       $image = image_load($file->uri);
 
       $values['file'] = dosomething_helpers_get_data_uri_from_image($image);
+      $values['source'] = 'phoenix-web';
     } else {
       // If there is no file and there is a RB in Phoenix, check the dosomething_rogue_reportback table to see if the RB already exists in Rogue.
       if ($rbid) {
@@ -405,7 +406,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
           $image = file_load($fid);
           $values['file'] = dosomething_helpers_get_data_uri_from_image($image);
           $values['caption'] = $reportback_file[$fid]->caption;
-          $values['source'] = $reportback_file[$fid]->source;
+          $values['source'] = isset($reportback_file[$fid]->source) ? $reportback_file[$fid]->source : 'phoenix-web';
         }
       }
     }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -405,6 +405,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
           $image = file_load($fid);
           $values['file'] = dosomething_helpers_get_data_uri_from_image($image);
           $values['caption'] = $reportback_file[$fid]->caption;
+          $values['source'] = $reportback_file[$fid]->source;
         }
       }
     }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -75,6 +75,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     'crop_width' => $values['crop_width'],
     'crop_height' => $values['crop_height'],
     'crop_rotate' => $values['crop_rotate'],
+    'source' => isset($values['source']) ? $values['source'] : NULL,
   ];
 
   $values['type'] = 'reportback';


### PR DESCRIPTION
#### What's this PR do?
Include the item source when sending a file to Rogue. As far as I know this value is only set when a reportback is created via a call to the Phoenix api, which means that it will only ever be sent to Rogue if it is sending a previously uploaded file, so that is the only place where it tries to pull the file.

No work on the Rogue side because it already has this column and tries to pull this value.

#### How should this be reviewed?
Does it grab it okay? Does it need to try anywhere else?

#### Relevant tickets
Fixes #7189

#### Checklist
- [x] Tested on staging.
