### PR TITLE
send reviewer ns id to rogue

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -299,6 +299,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
         $data = [
           'rogue_reportback_item_id' => $rogue_item_id[0]->rogue_item_id,
           'status' => $rogue_status,
+          'reviewer' => dosomething_user_get_field('field_northstar_id'),
         ];
 
         $updates_to_send_to_rogue[] = $data;


### PR DESCRIPTION
#### What's this PR do?
Sends the reviewer's northstar id to Rogue with a reportback item status update.

#### How should this be reviewed?
Make sure the `reviewer` gets included in the request with the other data.

#### Any background context you want to provide?
This will be used to created the log of changes to the reportback item.

#### Relevant tickets
Fixes #7191

#### Checklist
- [x] Tested on staging.

