### PR TITLE
Send reactions to rogue

### DIFF
--- a/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
@@ -148,17 +148,4 @@ class Kudos extends Entity {
     $data['name'] = strtolower($taxonomy->name);
     return $data;
   }
-
-  /**
-   * Query to find Kudo fid by Kudo id.
-   *
-   * @param string $kid
-   * Phoenix fid of reportback item.
-   *
-   */
-  function dosomething_kudos_get_fid($kid)
-  {
-    return db_query("SELECT kudos.fid FROM {dosomething_kudos} kudos WHERE kid = :kid", array(':kid' => $kid))->fetch();
-  }
-
 }

--- a/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
@@ -148,4 +148,5 @@ class Kudos extends Entity {
     $data['name'] = strtolower($taxonomy->name);
     return $data;
   }
+
 }

--- a/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/Kudos.php
@@ -149,4 +149,16 @@ class Kudos extends Entity {
     return $data;
   }
 
+  /**
+   * Query to find Kudo fid by Kudo id.
+   *
+   * @param string $kid
+   * Phoenix fid of reportback item.
+   *
+   */
+  function dosomething_kudos_get_fid($kid)
+  {
+    return db_query("SELECT kudos.fid FROM {dosomething_kudos} kudos WHERE kid = :kid", array(':kid' => $kid))->fetch();
+  }
+
 }

--- a/lib/modules/dosomething/dosomething_kudos/includes/KudosController.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/KudosController.php
@@ -31,7 +31,11 @@ class KudosController extends EntityAPIController {
       // For ~reasons~ the entity save doesn't return the entity
       // So we need to query for the record and return it.
       $kudo = $this->get($values);
-      dosomething_rogue_send_reaction_to_rogue($kudo['fid']);
+
+      // Send the reaction to Rogue if it is on
+      if (variable_get('rogue_collection', FALSE)) {
+        dosomething_rogue_send_reaction_to_rogue($kudo['fid']);
+      }
 
       return $kudo;
     }
@@ -83,9 +87,11 @@ class KudosController extends EntityAPIController {
     try {
       $ids = array_keys($entities);
 
-      // Send each deleted reaction to Rogue
-      foreach ($entities as $kudo) {
-        dosomething_rogue_send_reaction_to_rogue($kudo->fid);
+      // Send each deleted reaction to Rogue if it is on
+      if (variable_get('rogue_collection', FALSE)) {
+        foreach ($entities as $kudo) {
+          dosomething_rogue_send_reaction_to_rogue($kudo->fid);
+        }
       }
 
       db_delete($this->entityInfo['base table'])

--- a/lib/modules/dosomething/dosomething_kudos/includes/KudosController.php
+++ b/lib/modules/dosomething/dosomething_kudos/includes/KudosController.php
@@ -27,10 +27,12 @@ class KudosController extends EntityAPIController {
       $record = $this->save($kudos);
     }
 
-    if ($record) {
+    if (isset($record)) {
       // For ~reasons~ the entity save doesn't return the entity
       // So we need to query for the record and return it.
       $kudo = $this->get($values);
+      dosomething_rogue_send_reaction_to_rogue($kudo['fid']);
+
       return $kudo;
     }
 
@@ -80,6 +82,11 @@ class KudosController extends EntityAPIController {
 
     try {
       $ids = array_keys($entities);
+
+      // Send each deleted reaction to Rogue
+      foreach ($entities as $kudo) {
+        dosomething_rogue_send_reaction_to_rogue($kudo->fid);
+      }
 
       db_delete($this->entityInfo['base table'])
         ->condition($this->idKey, $ids, 'IN')

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -255,3 +255,58 @@ function dosomething_rogue_rb_exists_in_rogue($rbid)
 {
   return db_query("SELECT * FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rbid = :rbid", array(':rbid' => $rbid))->fetchAll();
 }
+
+/**
+ * Sends a reaction to Rogue.
+ *
+ * @param array $values
+ *   Values to send to Rogue. (just the FID)
+ */
+function dosomething_rogue_send_reaction_to_rogue($fid, $user = NULL) 
+{
+  // Get rogue item id by fid
+  $rogue_item_id = dosomething_rogue_get_by_file_id($fid)[0]->rogue_item_id;
+  
+  // Only try to send to Rogue if 
+  if (!is_null($rogue_item_id))
+  {
+    // Get the user who left the reaction
+    if (!isset($user)) {
+      global $user;
+    }
+
+    $northstar_id = dosomething_user_get_field('field_northstar_id', $user);
+
+    $client = dosomething_rogue_client();
+
+    $data = [
+      'northstar_id' => $northstar_id ? $northstar_id : NULL,
+      'reportback_item_id' => $rogue_item_id,
+    ];
+    // Send to Rogue
+    try {
+      $response = $client->postReaction($data);
+
+      if (module_exists('stathat')) {
+        stathat_send_ez_count('drupal - Rogue - reaction sent - count', 1);
+      }
+      if (!$response) {
+        // This is a 404
+        if (module_exists('stathat')) {
+          stathat_send_ez_count('drupal - Rogue - reaction failed - count', 1);
+        }
+      }
+    }
+    catch (GuzzleHttp\Exception\ServerException $e) {
+      // These aren't yet caught by Gateway
+      if (module_exists('stathat')) {
+          stathat_send_ez_count('drupal - Rogue - reaction failed - count', 1);
+        }
+    }
+    catch (DoSomething\Gateway\Exceptions\ApiException $e) {
+      if (module_exists('stathat')) {
+          stathat_send_ez_count('drupal - Rogue - reaction failed - count', 1);
+      }
+    }
+  }
+}

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -265,11 +265,13 @@ function dosomething_rogue_rb_exists_in_rogue($rbid)
 function dosomething_rogue_send_reaction_to_rogue($fid, $user = NULL) 
 {
   // Get rogue item id by fid
-  $rogue_item_id = dosomething_rogue_get_by_file_id($fid)[0]->rogue_item_id;
-  
-  // Only try to send to Rogue if 
-  if (!is_null($rogue_item_id))
-  {
+  $rogue_item_id = dosomething_rogue_get_by_file_id($fid);
+
+  // Only try to send to Rogue if the item exists there
+  if (isset($rogue_item_id[0])) {
+    // Get the actual rogue_item_id from the query result
+    $rogue_item_id = $rogue_item_id[0]->rogue_item_id;
+
     // Get the user who left the reaction
     if (!isset($user)) {
       global $user;

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -38,4 +38,16 @@ class Rogue extends RestApiClient {
 
     return $response;
   }
+
+  /**
+   * Send a POST request of the reaction to be saved or deleted in Rogue.
+   *
+   * @param array $data
+   * @return object|false
+   */
+  public function postReaction($data) {
+    $response = $this->post('reactions', $data);
+
+    return $response;
+  }
 }


### PR DESCRIPTION
#### What's this PR do?
Sends reactions to Rogue as they are created and deleted! Checks to see if Rogue is on first. This will send reactions created via the Phoenix api to Rogue as well. It only sends the reaction to Rogue if the item exists in Rogue. Logs failures in StatHat.

#### How should this be reviewed?
Give some reactions to some reportbacks. Try a mix of ones in Rogue and not in Rogue. Then check the `reactions` table in Rogue and `dosomething_kudos` in Phoenix to make sure the correct data is there.

#### Relevant tickets
Fixes #7196

#### Checklist
- [ ] Tested on staging.
