### PR TITLE
Sends Reportback from Phoenix API -> Rogue 

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -387,7 +387,7 @@ function _campaign_resource_reportback($nid, $values) {
     // Make sure the reportback exists (meaning it got back from Rogue).
     $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
 
-    // Store reference to the rb in rogue, redirect user to permalink page.
+    // Store reference to the rb in rogue.
     if ($rbid) {
       $reportback = entity_load_unchanged('reportback', [$rbid]);
       $fid = array_pop($reportback->fids);

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -343,11 +343,12 @@ function _campaign_resource_reportback($nid, $values) {
     }
   }
 
-  $values['fid'] = $file->fid;
   $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
 
   // @todo: Move this logic into dosomething_reportback_save().
-  $rbid = dosomething_reportback_exists($nid, NULL, $uid);
+  if ($file) {
+    $values['fid'] = $file->fid;
+  }
 
   if (!$rbid) {
     $rbid = 0;

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -364,7 +364,7 @@ function _campaign_resource_reportback($nid, $values) {
   $values['fid'] = $file->fid;
   $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
 
-  // // @todo: Move this logic into dosomething_reportback_save().
+  // @todo: Move this logic into dosomething_reportback_save().
   $rbid = dosomething_reportback_exists($nid, NULL, $uid);
 
   if (!$rbid) {

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -344,6 +344,7 @@ function _campaign_resource_reportback($nid, $values) {
       }
     }
   }
+
   $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
 
   if (!$rbid) {
@@ -368,9 +369,7 @@ function _campaign_resource_reportback($nid, $values) {
 
     // Store reference to the rb in rogue.
     if ($rbid) {
-      $reportback = entity_load_unchanged('reportback', [$rbid]);
-      $fid = array_pop($reportback->fids);
-      dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
+      dosomething_rogue_store_rogue_references($rbid, $rogue_reportback);
     }
   }
   else {

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -346,9 +346,7 @@ function _campaign_resource_reportback($nid, $values) {
   $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
 
   // @todo: Move this logic into dosomething_reportback_save().
-  if ($file) {
-    $values['fid'] = $file->fid;
-  }
+  $rbid = dosomething_reportback_exists($nid, NULL, $uid);
 
   if (!$rbid) {
     $rbid = 0;

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -380,7 +380,17 @@ function _campaign_resource_reportback($nid, $values) {
   $transaction_id = $_SERVER['HTTP_X_REQUEST_ID'];
 
   if (! $transaction_id) {
-    dosomething_rogue_send_reportback_to_rogue($values, $user);
+    $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
+
+    // Make sure the reportback exists (meaning it got back from Rogue).
+    $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
+
+    // Store reference to the rb in rogue, redirect user to permalink page.
+    if ($rbid) {
+      $reportback = entity_load_unchanged('reportback', [$rbid]);
+      $fid = array_pop($reportback->fids);
+      dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
+    }
   }
   else {
     dosomething_reportback_save($values, $user);

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -318,6 +318,7 @@ function _campaign_resource_reportback($nid, $values) {
 
   $file = NULL;
 
+
   // @todo: Move this logic into dosomething_reportback_save().
   $rbid = dosomething_reportback_exists($nid, NULL, $uid);
 
@@ -343,11 +344,7 @@ function _campaign_resource_reportback($nid, $values) {
       }
     }
   }
-
   $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
-
-  // @todo: Move this logic into dosomething_reportback_save().
-  $rbid = dosomething_reportback_exists($nid, NULL, $uid);
 
   if (!$rbid) {
     $rbid = 0;
@@ -371,7 +368,9 @@ function _campaign_resource_reportback($nid, $values) {
 
     // Store reference to the rb in rogue.
     if ($rbid) {
-      dosomething_rogue_store_rogue_references($rbid, $rogue_reportback);
+      $reportback = entity_load_unchanged('reportback', [$rbid]);
+      $fid = array_pop($reportback->fids);
+      dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
     }
   }
   else {

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -353,11 +353,9 @@ function _campaign_resource_reportback($nid, $values) {
     $rbid = 0;
   }
 
-  $values['rbid'] = $rbid;
-
-  if (DOSOMETHING_REPORTBACK_LOG) {
-    watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
-  }
+  // if (DOSOMETHING_REPORTBACK_LOG) {
+  //   watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
+  // }
   return dosomething_rogue_send_reportback_to_rogue($values, $user);
   // return dosomething_reportback_save($values, $user);
 }

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -303,6 +303,7 @@ function _campaign_resource_signup($nid, $values) {
  */
 function _campaign_resource_reportback($nid, $values) {
   // @todo: Return error if signup doesn't exist.
+
   $values['nid'] = $nid;
 
   if (!isset($values['uid'])) {

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -358,7 +358,7 @@ function _campaign_resource_reportback($nid, $values) {
   if (DOSOMETHING_REPORTBACK_LOG) {
     watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
   }
-
-  return dosomething_reportback_save($values, $user);
+  return dosomething_rogue_send_reportback_to_rogue($values);
+  // return dosomething_reportback_save($values, $user);
 }
 

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -358,7 +358,7 @@ function _campaign_resource_reportback($nid, $values) {
   if (DOSOMETHING_REPORTBACK_LOG) {
     watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
   }
-  return dosomething_rogue_send_reportback_to_rogue($values);
+  return dosomething_rogue_send_reportback_to_rogue($values, $user);
   // return dosomething_reportback_save($values, $user);
 }
 

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -361,24 +361,6 @@ function _campaign_resource_reportback($nid, $values) {
 
   $transaction_id = $_SERVER['HTTP_X_REQUEST_ID'];
 
-  $values['fid'] = $file->fid;
-  $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
-
-  // @todo: Move this logic into dosomething_reportback_save().
-  $rbid = dosomething_reportback_exists($nid, NULL, $uid);
-
-  if (!$rbid) {
-    $rbid = 0;
-  }
-
-  $values['rbid'] = $rbid;
-
-  if (DOSOMETHING_REPORTBACK_LOG) {
-    watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
-  }
-
-  $transaction_id = $_SERVER['HTTP_X_REQUEST_ID'];
-
   // If there is no transaction id, the request is coming from the mobile app or SMS reportbacks.
   // Only send to Rogue if there is no transaction id to avoid infinite loop.
   if (! $transaction_id) {

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -303,7 +303,6 @@ function _campaign_resource_signup($nid, $values) {
  */
 function _campaign_resource_reportback($nid, $values) {
   // @todo: Return error if signup doesn't exist.
-
   $values['nid'] = $nid;
 
   if (!isset($values['uid'])) {
@@ -345,7 +344,7 @@ function _campaign_resource_reportback($nid, $values) {
   }
 
   $values['fid'] = $file->fid;
-  $values['file'] = dosomething_helpers_get_data_uri_from_image(image_load($file->uri));
+  $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
 
   // @todo: Move this logic into dosomething_reportback_save().
   $rbid = dosomething_reportback_exists($nid, NULL, $uid);
@@ -360,12 +359,15 @@ function _campaign_resource_reportback($nid, $values) {
     watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
   }
 
-  $transaction_id = drupal_get_http_header('X-Request-ID');
-  print_r($transaction_id);
-  die();
-  // if the flag is less than 2, send to rogue
-  // dosomething_rogue_send_reportback_to_rogue($values, $user);
+  $transaction_id = $_SERVER['HTTP_X_REQUEST_ID'];
+
+  if (! $transaction_id) {
+    dosomething_rogue_send_reportback_to_rogue($values, $user);
+  }
+  else {
+    dosomething_reportback_save($values, $user);
+  }
+
   return $rbid;
-  // return dosomething_reportback_save($values, $user);
 }
 

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -379,7 +379,7 @@ function _campaign_resource_reportback($nid, $values) {
 
   $transaction_id = $_SERVER['HTTP_X_REQUEST_ID'];
 
-  // If there is no transaction id, the request is coming from an app other than Rogue.
+  // If there is no transaction id, the request is coming from the mobile app or SMS reportbacks.
   // Only send to Rogue if there is no transaction id to avoid infinite loop.
   if (! $transaction_id) {
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -344,19 +344,24 @@ function _campaign_resource_reportback($nid, $values) {
     }
   }
 
+  $values['fid'] = $file->fid;
+  $values['file'] = dosomething_helpers_get_data_uri_from_image(image_load($file->uri));
+
   // @todo: Move this logic into dosomething_reportback_save().
-  if ($file) {
-    $values['fid'] = $file->fid;
-  }
+  $rbid = dosomething_reportback_exists($nid, NULL, $uid);
 
   if (!$rbid) {
     $rbid = 0;
   }
 
-  // if (DOSOMETHING_REPORTBACK_LOG) {
-  //   watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
-  // }
-  return dosomething_rogue_send_reportback_to_rogue($values, $user);
+  $values['rbid'] = $rbid;
+
+  if (DOSOMETHING_REPORTBACK_LOG) {
+    watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
+  }
+
+  dosomething_rogue_send_reportback_to_rogue($values, $user);
+  return $rbid;
   // return dosomething_reportback_save($values, $user);
 }
 

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -361,6 +361,24 @@ function _campaign_resource_reportback($nid, $values) {
 
   $transaction_id = $_SERVER['HTTP_X_REQUEST_ID'];
 
+  $values['fid'] = $file->fid;
+  $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
+
+  // // @todo: Move this logic into dosomething_reportback_save().
+  $rbid = dosomething_reportback_exists($nid, NULL, $uid);
+
+  if (!$rbid) {
+    $rbid = 0;
+  }
+
+  $values['rbid'] = $rbid;
+
+  if (DOSOMETHING_REPORTBACK_LOG) {
+    watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
+  }
+
+  $transaction_id = $_SERVER['HTTP_X_REQUEST_ID'];
+
   if (! $transaction_id) {
     dosomething_rogue_send_reportback_to_rogue($values, $user);
   }

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -303,7 +303,6 @@ function _campaign_resource_signup($nid, $values) {
  */
 function _campaign_resource_reportback($nid, $values) {
   // @todo: Return error if signup doesn't exist.
-
   $values['nid'] = $nid;
 
   if (!isset($values['uid'])) {
@@ -317,8 +316,6 @@ function _campaign_resource_reportback($nid, $values) {
   $uid = $values['uid'];
 
   $file = NULL;
-
-
   // @todo: Move this logic into dosomething_reportback_save().
   $rbid = dosomething_reportback_exists($nid, NULL, $uid);
 

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -371,9 +371,7 @@ function _campaign_resource_reportback($nid, $values) {
 
     // Store reference to the rb in rogue.
     if ($rbid) {
-      $reportback = entity_load_unchanged('reportback', [$rbid]);
-      $fid = array_pop($reportback->fids);
-      dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
+      dosomething_rogue_store_rogue_references($rbid, $rogue_reportback);
     }
   }
   else {

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -360,7 +360,11 @@ function _campaign_resource_reportback($nid, $values) {
     watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
   }
 
-  dosomething_rogue_send_reportback_to_rogue($values, $user);
+  $transaction_id = drupal_get_http_header('X-Request-ID');
+  print_r($transaction_id);
+  die();
+  // if the flag is less than 2, send to rogue
+  // dosomething_rogue_send_reportback_to_rogue($values, $user);
   return $rbid;
   // return dosomething_reportback_save($values, $user);
 }

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -379,6 +379,8 @@ function _campaign_resource_reportback($nid, $values) {
 
   $transaction_id = $_SERVER['HTTP_X_REQUEST_ID'];
 
+  // If there is no transaction id, the request is coming from an app other than Rogue.
+  // Only send to Rogue if there is no transaction id to avoid infinite loop.
   if (! $transaction_id) {
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -387,6 +387,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     }
 
     // Store the base64 encoded data uri of the file in the values array to send to rogue.
+    // @TODO: This is still set if it is a duplicate so don't bother with this
     if (array_key_exists('storage', $form_state)) {
       $file = $form_state['storage']['file'];
       $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -419,8 +419,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
       $reportback = entity_load_unchanged('reportback', [$rbid]);
       // If a file was added, store references to the relevant Rogue data
       if (isset($file)) {
-        $fid = array_pop($reportback->fids);
-        dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
+        dosomething_rogue_store_rogue_references($rbid, $rogue_reportback);
       }
 
       // Redirect to permalink page.

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -30,25 +30,8 @@
           $task->file = $mime_split[0] . ':' . $mimetype . $mime_split[1];
         }
 
-        $data = [
-          'nid' => $task->campaign_id,
-          'campaign_run_id' => $task->campaign_run_id,
-          'quantity' => $task->quantity,
-          'why_participated' => $task->why_participated,
-          'file' => $task->file,
-          'caption' => $task->caption,
-          'type' => $task->type,
-        ];
-
-        if ($task->crop_x) {
-          $cropped_values = dosomething_rogue_format_crop_values($task);
-
-          foreach ($cropped_values as $key => $value) {
-            $data[$key] = $value;
-          }
-        }
-
         $user = user_load($task->drupal_id);
+        $data = (array)$task;
 
         dosomething_rogue_send_reportback_to_rogue($data, $user);
       } else {

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -37,12 +37,15 @@
           'file' => $task->file,
           'caption' => $task->caption,
           'type' => $task->type,
-          'crop_x' => $task->crop_x,
-          'crop_y' => $task->crop_y,
-          'crop_width' => $task->crop_width,
-          'crop_height' => $task->crop_height,
-          'crop_rotate' => $task->crop_rotate,
         ];
+
+        if ($task->crop_x) {
+          $values['crop_x'] = $task->crop_x;
+          $values['crop_y'] = $task->crop_y;
+          $values['crop_width'] = $task->crop_width;
+          $values['crop_height'] = $task->crop_height;
+          $values['crop_rotate'] = $task->crop_rotate;
+        }
 
         $user = user_load($task->drupal_id);
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -29,7 +29,8 @@
           $mime_split = explode(':', $task->file);
           $task->file = $mime_split[0] . ':' . $mimetype . $mime_split[1];
         }
-        $values = [
+
+        $data = [
           'nid' => $task->campaign_id,
           'campaign_run_id' => $task->campaign_run_id,
           'quantity' => $task->quantity,
@@ -40,25 +41,25 @@
         ];
 
         if ($task->crop_x) {
-          $values['crop_x'] = $task->crop_x;
-          $values['crop_y'] = $task->crop_y;
-          $values['crop_width'] = $task->crop_width;
-          $values['crop_height'] = $task->crop_height;
-          $values['crop_rotate'] = $task->crop_rotate;
+          $cropped_values = dosomething_rogue_send_crop_values($task);
+
+          foreach ($cropped_values as $key => $value) {
+            $data[$key] = $value;
+          }
         }
 
         $user = user_load($task->drupal_id);
 
-        dosomething_rogue_send_reportback_to_rogue($values, $user);
+        dosomething_rogue_send_reportback_to_rogue($data, $user);
       } else {
-        $values = [
+        $data = [
           [
             'rogue_reportback_item_id' => $task->rogue_item_id,
             'status' => $task->status,
           ]
         ];
 
-        dosomething_rogue_update_rogue_reportback_items($values);
+        dosomething_rogue_update_rogue_reportback_items($data);
       }
    }
  }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -33,7 +33,14 @@
         $user = user_load($task->drupal_id);
         $data = (array)$task;
 
-        dosomething_rogue_send_reportback_to_rogue($data, $user);
+        $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($data, $user);
+
+        $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
+
+        // Store reference to the rb in rogue.
+        if ($rbid) {
+          dosomething_rogue_store_rogue_references($rbid, $rogue_reportback);
+        }
       } else {
         $data = [
           [

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -41,7 +41,7 @@
         ];
 
         if ($task->crop_x) {
-          $cropped_values = dosomething_rogue_send_crop_values($task);
+          $cropped_values = dosomething_rogue_format_crop_values($task);
 
           foreach ($cropped_values as $key => $value) {
             $data[$key] = $value;

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -34,7 +34,6 @@
         $data = (array)$task;
 
         $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($data, $user);
-
         $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
 
         // Store reference to the rb in rogue.

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -54,7 +54,6 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
   if (!isset($user)) {
     global $user;
   }
-
   $northstar_id = dosomething_user_get_field('field_northstar_id', $user);
 
   // Band-aid fix for an issue we are seeing with phoenix not being
@@ -102,8 +101,6 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
-    print_r('hello');
-    die();
     // These aren't yet caught by Gateway
     dosomething_rogue_handle_failure($values, $response, $e, $user);
   }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -79,11 +79,11 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     'file' => isset($values['file']) ? $values['file'] : NULL,
     'caption' => isset($values['caption']) ? $values['caption'] : NULL,
     'status' => isset($values['status']) ? $values['status'] : 'pending',
-    'crop_x' => $values['crop_x'],
-    'crop_y' => $values['crop_y'],
-    'crop_width' => $values['crop_width'],
-    'crop_height' => $values['crop_height'],
-    'crop_rotate' => $values['crop_rotate'],
+    'crop_x' => isset($values['crop_x']) ? $values['crop_x'] : NULL,
+    'crop_y' => isset($values['crop_y']) ? $values['crop_y'] : NULL,
+    'crop_width' => isset($values['crop_width']) ? $values['crop_width'] : NULL,
+    'crop_height' => isset($values['crop_height']) ? $values['crop_height'] : NULL,
+    'crop_rotate' => isset($values['crop_rotate']) ? $values['crop_rotate'] : NULL,
     'source' => isset($values['source']) ? $values['source'] : NULL,
   ];
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -87,11 +87,11 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
   ];
 
   if ($values['crop_x']) {
-    $data['crop_x'] = $values['crop_x'];
-    $data['crop_y'] = $values['crop_y'];
-    $data['crop_width'] = $values['crop_width'];
-    $data['crop_height'] = $values['crop_height'];
-    $data['crop_rotate'] = $values['crop_rotate'];
+    $cropped_values = dosomething_rogue_send_crop_values($values);
+
+    foreach ($cropped_values as $key => $value) {
+      $data[$key] = $value;
+    }
   }
 
   $values['type'] = 'reportback';
@@ -269,4 +269,25 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
 function dosomething_rogue_rb_exists_in_rogue($rbid)
 {
   return db_query("SELECT * FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rbid = :rbid", array(':rbid' => $rbid))->fetchAll();
+}
+
+/**
+ * Format cropped values to send to Rogue.
+ * @param array $values
+ *
+ */
+function dosomething_rogue_send_crop_values($values)
+{
+  if (is_array($values)) {
+    $values = (object)$values;
+  }
+
+  $cropped_values = [];
+  $cropped_values['crop_x'] = $values->crop_x;
+  $cropped_values['crop_y'] = $values->crop_y;
+  $cropped_values['crop_width'] = $values->crop_width;
+  $cropped_values['crop_height'] = $values->crop_height;
+  $cropped_values['crop_rotate'] = $values->crop_rotate;
+
+  return $cropped_values;
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -149,13 +149,15 @@ function dosomething_rogue_get_by_file_id($fid)
  * phoenix and it's corresponding id's in Rogue
  *
  * @param string $rbid
- * @param string $fid
  * @param object $rogue_reportback
  *
  * @return InsertQuery object
  */
-function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback)
+function dosomething_rogue_store_rogue_references($rbid, $rogue_reportback)
 {
+  $reportback = entity_load_unchanged('reportback', [$rbid]);
+  $fid = array_pop($reportback->fids);
+
   $most_recent_rogue_item = array_pop($rogue_reportback['data']['reportback_items']['data']);
 
   // Store references to rogue IDs.

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -78,13 +78,16 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     'file' => isset($values['file']) ? $values['file'] : NULL,
     'caption' => isset($values['caption']) ? $values['caption'] : NULL,
     'status' => isset($values['status']) ? $values['status'] : 'pending',
-    'crop_x' => isset($values['crop_x']) ? $values['crop_x'] : NULL,
-    'crop_y' => isset($values['crop_y']) ? $values['crop_y'] : NULL,
-    'crop_width' => isset($values['crop_width']) ? $values['crop_width'] : NULL,
-    'crop_height' => isset($values['crop_height']) ? $values['crop_height'] : NULL,
-    'crop_rotate' => isset($values['crop_rotate']) ? $values['crop_rotate'] : NULL,
     'source' => isset($values['source']) ? $values['source'] : NULL,
   ];
+
+  if ($values['crop_x']) {
+    $data['crop_x'] = $values['crop_x'];
+    $data['crop_y'] = $values['crop_y'];
+    $data['crop_width'] = $values['crop_width'];
+    $data['crop_height'] = $values['crop_height'];
+    $data['crop_rotate'] = $values['crop_rotate'];
+  }
 
   $values['type'] = 'reportback';
   $values['northstar_id'] = $northstar_id;

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -54,6 +54,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
   if (!isset($user)) {
     global $user;
   }
+
   $northstar_id = dosomething_user_get_field('field_northstar_id', $user);
 
   // Band-aid fix for an issue we are seeing with phoenix not being
@@ -66,10 +67,8 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
 
   $client = dosomething_rogue_client();
 
-  $data = dosomething_rogue_transform_reportback($northstar_id, $user, $values);
-
-  $values['type'] = 'reportback';
-  $values['northstar_id'] = $northstar_id;
+  $data = dosomething_rogue_transform_reportback($values, $northstar_id);
+  $data['type'] = 'reportback';
 
   try {
     $response = $client->postReportback($data);
@@ -79,15 +78,15 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     }
     if (!$response) {
       // This is a 404
-      dosomething_rogue_handle_failure($values, $response, $e, $user);
+      dosomething_rogue_handle_failure($data, $response, $e, $user);
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
     // These aren't yet caught by Gateway
-    dosomething_rogue_handle_failure($values, $response, $e, $user);
+    dosomething_rogue_handle_failure($data, $response, $e, $user);
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
-    dosomething_rogue_handle_failure($values, $response, $e, $user);
+    dosomething_rogue_handle_failure($data, $response, $e, $user);
   }
 
   return $response;
@@ -193,12 +192,11 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
 
   // Save fail to a db log so we can easily export.
   if ($values['type'] === 'reportback') {
-    $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([
         'drupal_id' => $user->uid,
-        'campaign_id' => $values['nid'],
-        'campaign_run_id' => $run->nid,
+        'campaign_id' => $values['campaign_id'],
+        'campaign_run_id' => $values['campaign_run_id'],
         'quantity' => $values['quantity'],
         'why_participated' => $values['why_participated'],
         'file' => $values['file'],
@@ -216,7 +214,7 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
       ])
       ->execute();
 
-    watchdog('dosomething_rogue', 'Reportback not migrated to Rogue: northstar_id: !northstar_id, campaign_id: !campaign_id, campaign run_nid: !campaign_run_id.', ['!northstar_id' => $values['northstar_id'], '!campaign_id' => $values['nid'], '!campaign_run_id' => $run->nid], WATCHDOG_ERROR);
+    watchdog('dosomething_rogue', 'Reportback not migrated to Rogue: northstar_id: !northstar_id, campaign_id: !campaign_id, campaign run_nid: !campaign_run_id.', ['!northstar_id' => $values['northstar_id'], '!campaign_id' => $values['campaign_id'], '!campaign_run_id' => $values['campaign_run_id']], WATCHDOG_ERROR);
   } else {
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([
@@ -248,18 +246,23 @@ function dosomething_rogue_rb_exists_in_rogue($rbid)
 /**
  * Transform reportback into the appropriate scheme to send to Rogue.
  *
- * @param $northstar_id - User's Northstar user id.
- * @param $user - Drupal user object.
  * @param $values - Reportback values to send to Rogue.
+ * @param $northstar_id - User's Northstar user id.
  * @return array
  */
-function dosomething_rogue_transform_reportback($northstar_id, $user, $values) {
-  $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
+function dosomething_rogue_transform_reportback($values, $northstar_id) {
+  if ($values['nid']) {
+    $campaign_id = $values['nid'];
+  }
+  elseif ($values['campaign_id']) {
+    $campaign_id = $values['campaign_id'];
+  }
+
+  $run = dosomething_helpers_get_current_campaign_run_for_user($campaign_id);
 
   $data = [
     'northstar_id' => $northstar_id,
-    'drupal_id' => $user->uid,
-    'campaign_id' => $values['nid'],
+    'campaign_id' => $campaign_id,
     'campaign_run_id' => $run->nid,
     'quantity' => $values['quantity'],
     'why_participated' => $values['why_participated'],
@@ -267,6 +270,7 @@ function dosomething_rogue_transform_reportback($northstar_id, $user, $values) {
     'caption' => isset($values['caption']) ? $values['caption'] : NULL,
     'status' => isset($values['status']) ? $values['status'] : 'pending',
     'source' => isset($values['source']) ? $values['source'] : NULL,
+    'type' => isset($values['type']) ? $values['type'] : NULL,
   ];
 
   if ($values['crop_x']) {
@@ -282,14 +286,10 @@ function dosomething_rogue_transform_reportback($northstar_id, $user, $values) {
 
 /**
  * Format cropped values to send to Rogue.
- * @param array $values
+ * @param object $values
  *
  */
 function dosomething_rogue_format_crop_values($values) {
-  if (is_array($values)) {
-    $values = (object)$values;
-  }
-
   $cropped_values = [];
   $cropped_values['crop_x'] = $values->crop_x;
   $cropped_values['crop_y'] = $values->crop_y;

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -64,11 +64,9 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     $northstar_id = $northstar_user->id;
   }
 
-  $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
-
   $client = dosomething_rogue_client();
 
-  $data = dosomething_rogue_transform_reportback($northstar_id, $user, $values, $run);
+  $data = dosomething_rogue_transform_reportback($northstar_id, $user, $values);
 
   $values['type'] = 'reportback';
   $values['northstar_id'] = $northstar_id;
@@ -253,11 +251,11 @@ function dosomething_rogue_rb_exists_in_rogue($rbid)
  * @param $northstar_id - User's Northstar user id.
  * @param $user - Drupal user object.
  * @param $values - Reportback values to send to Rogue.
- * @param $run - Campaign run id.
  * @return array
  */
-function dosomething_rogue_transform_reportback($northstar_id, $user, $values, $run)
-{
+function dosomething_rogue_transform_reportback($northstar_id, $user, $values) {
+  $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
+
   $data = [
     'northstar_id' => $northstar_id,
     'drupal_id' => $user->uid,
@@ -287,8 +285,7 @@ function dosomething_rogue_transform_reportback($northstar_id, $user, $values, $
  * @param array $values
  *
  */
-function dosomething_rogue_format_crop_values($values)
-{
+function dosomething_rogue_format_crop_values($values) {
   if (is_array($values)) {
     $values = (object)$values;
   }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -78,6 +78,14 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     'file' => isset($values['file']) ? $values['file'] : NULL,
     'caption' => isset($values['caption']) ? $values['caption'] : NULL,
     'status' => isset($values['status']) ? $values['status'] : 'pending',
+<<<<<<< HEAD
+=======
+    'crop_x' => isset($values['crop_x']) ? $values['crop_x'] : NULL,
+    'crop_y' => isset($values['crop_y']) ? $values['crop_y'] : NULL,
+    'crop_width' => isset($values['crop_width']) ? $values['crop_width'] : NULL,
+    'crop_height' => isset($values['crop_height']) ? $values['crop_height'] : NULL,
+    'crop_rotate' => isset($values['crop_rotate']) ? $values['crop_rotate'] : NULL,
+>>>>>>> update docs
     'source' => isset($values['source']) ? $values['source'] : NULL,
   ];
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -92,6 +92,8 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
 
   try {
     $response = $client->postReportback($data);
+    print_r($response);
+    die();
 
     if (module_exists('stathat')) {
       stathat_send_ez_count('drupal - Rogue - reportback sent - count', 1);
@@ -102,10 +104,14 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
+  print_r('hello');
+  die();
     // These aren't yet caught by Gateway
     dosomething_rogue_handle_failure($values, $response, $e, $user);
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
+  print_r('bye');
+  die();
     dosomething_rogue_handle_failure($values, $response, $e, $user);
   }
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -78,14 +78,11 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     'file' => isset($values['file']) ? $values['file'] : NULL,
     'caption' => isset($values['caption']) ? $values['caption'] : NULL,
     'status' => isset($values['status']) ? $values['status'] : 'pending',
-<<<<<<< HEAD
-=======
     'crop_x' => isset($values['crop_x']) ? $values['crop_x'] : NULL,
     'crop_y' => isset($values['crop_y']) ? $values['crop_y'] : NULL,
     'crop_width' => isset($values['crop_width']) ? $values['crop_width'] : NULL,
     'crop_height' => isset($values['crop_height']) ? $values['crop_height'] : NULL,
     'crop_rotate' => isset($values['crop_rotate']) ? $values['crop_rotate'] : NULL,
->>>>>>> update docs
     'source' => isset($values['source']) ? $values['source'] : NULL,
   ];
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -92,8 +92,6 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
 
   try {
     $response = $client->postReportback($data);
-    print_r($response);
-    die();
 
     if (module_exists('stathat')) {
       stathat_send_ez_count('drupal - Rogue - reportback sent - count', 1);
@@ -104,14 +102,10 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
-  print_r('hello');
-  die();
     // These aren't yet caught by Gateway
     dosomething_rogue_handle_failure($values, $response, $e, $user);
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
-  print_r('bye');
-  die();
     dosomething_rogue_handle_failure($values, $response, $e, $user);
   }
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -193,8 +193,6 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
 
   // Save fail to a db log so we can easily export.
   if ($values['type'] === 'reportback') {
-
-
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([
         'drupal_id' => $user->uid,
@@ -248,7 +246,7 @@ function dosomething_rogue_rb_exists_in_rogue($rbid)
 }
 
 /**
- * Transform reportback into the appropriate scheme to send to Rogue.
+ * Transform reportback into the appropriate schema to send to Rogue.
  *
  * @param $values - Reportback values to send to Rogue.
  * @param $northstar_id - User's Northstar user id.

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -54,7 +54,6 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
   if (!isset($user)) {
     global $user;
   }
-
   $northstar_id = dosomething_user_get_field('field_northstar_id', $user);
 
   // Band-aid fix for an issue we are seeing with phoenix not being
@@ -71,6 +70,8 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
   $data['type'] = 'reportback';
 
   try {
+    print_r($data);
+    die();
     $response = $client->postReportback($data);
 
     if (module_exists('stathat')) {
@@ -293,11 +294,11 @@ function dosomething_rogue_transform_reportback($values, $northstar_id) {
  */
 function dosomething_rogue_format_crop_values($values) {
   $cropped_values = [];
-  $cropped_values['crop_x'] = $values->crop_x;
-  $cropped_values['crop_y'] = $values->crop_y;
-  $cropped_values['crop_width'] = $values->crop_width;
-  $cropped_values['crop_height'] = $values->crop_height;
-  $cropped_values['crop_rotate'] = $values->crop_rotate;
+  $cropped_values['crop_x'] = $values['crop_x'];
+  $cropped_values['crop_y'] = $values['crop_y'];
+  $cropped_values['crop_width'] = $values['crop_width'];
+  $cropped_values['crop_height'] = $values['crop_height'];
+  $cropped_values['crop_rotate'] = $values['crop_rotate'];
 
   return $cropped_values;
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -102,6 +102,8 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
+    print_r('hello');
+    die();
     // These aren't yet caught by Gateway
     dosomething_rogue_handle_failure($values, $response, $e, $user);
   }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -70,8 +70,6 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
   $data['type'] = 'reportback';
 
   try {
-    print_r($data);
-    die();
     $response = $client->postReportback($data);
 
     if (module_exists('stathat')) {

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -193,6 +193,8 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
 
   // Save fail to a db log so we can easily export.
   if ($values['type'] === 'reportback') {
+
+
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([
         'drupal_id' => $user->uid,
@@ -216,6 +218,7 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
       ->execute();
 
     watchdog('dosomething_rogue', 'Reportback not migrated to Rogue: northstar_id: !northstar_id, campaign_id: !campaign_id, campaign run_nid: !campaign_run_id.', ['!northstar_id' => $values['northstar_id'], '!campaign_id' => $values['campaign_id'], '!campaign_run_id' => $values['campaign_run_id']], WATCHDOG_ERROR);
+
   } else {
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -68,31 +68,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
 
   $client = dosomething_rogue_client();
 
-  $data = [
-    'northstar_id' => $northstar_id,
-    'drupal_id' => $user->uid,
-    'campaign_id' => $values['nid'],
-    'campaign_run_id' => $run->nid,
-    'quantity' => $values['quantity'],
-    'why_participated' => $values['why_participated'],
-    'file' => isset($values['file']) ? $values['file'] : NULL,
-    'caption' => isset($values['caption']) ? $values['caption'] : NULL,
-    'status' => isset($values['status']) ? $values['status'] : 'pending',
-    'crop_x' => isset($values['crop_x']) ? $values['crop_x'] : NULL,
-    'crop_y' => isset($values['crop_y']) ? $values['crop_y'] : NULL,
-    'crop_width' => isset($values['crop_width']) ? $values['crop_width'] : NULL,
-    'crop_height' => isset($values['crop_height']) ? $values['crop_height'] : NULL,
-    'crop_rotate' => isset($values['crop_rotate']) ? $values['crop_rotate'] : NULL,
-    'source' => isset($values['source']) ? $values['source'] : NULL,
-  ];
-
-  if ($values['crop_x']) {
-    $cropped_values = dosomething_rogue_send_crop_values($values);
-
-    foreach ($cropped_values as $key => $value) {
-      $data[$key] = $value;
-    }
-  }
+  $data = dosomething_rogue_transform_reportback($northstar_id, $user, $values, $run);
 
   $values['type'] = 'reportback';
   $values['northstar_id'] = $northstar_id;
@@ -272,11 +248,46 @@ function dosomething_rogue_rb_exists_in_rogue($rbid)
 }
 
 /**
+ * Transform reportback into the appropriate scheme to send to Rogue.
+ *
+ * @param $northstar_id - User's Northstar user id.
+ * @param $user - Drupal user object.
+ * @param $values - Reportback values to send to Rogue.
+ * @param $run - Campaign run id.
+ * @return array
+ */
+function dosomething_rogue_transform_reportback($northstar_id, $user, $values, $run)
+{
+  $data = [
+    'northstar_id' => $northstar_id,
+    'drupal_id' => $user->uid,
+    'campaign_id' => $values['nid'],
+    'campaign_run_id' => $run->nid,
+    'quantity' => $values['quantity'],
+    'why_participated' => $values['why_participated'],
+    'file' => isset($values['file']) ? $values['file'] : NULL,
+    'caption' => isset($values['caption']) ? $values['caption'] : NULL,
+    'status' => isset($values['status']) ? $values['status'] : 'pending',
+    'source' => isset($values['source']) ? $values['source'] : NULL,
+  ];
+
+  if ($values['crop_x']) {
+    $cropped_values = dosomething_rogue_format_crop_values($values);
+
+    foreach ($cropped_values as $key => $value) {
+      $data[$key] = $value;
+    }
+  }
+
+  return $data;
+}
+
+/**
  * Format cropped values to send to Rogue.
  * @param array $values
  *
  */
-function dosomething_rogue_send_crop_values($values)
+function dosomething_rogue_format_crop_values($values)
 {
   if (is_array($values)) {
     $values = (object)$values;

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -22,6 +22,7 @@ class Rogue extends RestApiClient {
    */
   public function postReportback($data) {
     $response = $this->post('reportbacks', $data);
+
     return $response;
   }
 

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -22,7 +22,6 @@ class Rogue extends RestApiClient {
    */
   public function postReportback($data) {
     $response = $this->post('reportbacks', $data);
-
     return $response;
   }
 


### PR DESCRIPTION
#### What's this PR do?
- When an app hits Phoenix's `/api/v1/campaigns/[nid]/reportback` endpoint, instead of saving directly to Phoenix, it will send along to Rogue first and then Rogue will send back to Phoenix to be saved.
- If crop values aren't set, don't send to Rogue (both on first send and on cron job).

#### How should this be reviewed?
- Hit the `/api/v1/campaigns/[nid]/reportback` endpoint.
![screen shot 2016-11-17 at 3 51 11 pm](https://cloud.githubusercontent.com/assets/9019452/20407050/b646eb72-acdd-11e6-837f-9aa246408c0b.png)
- Check the Rogue `reportback_items` table for the reportback item.
- Check the Phoenix `dosomething_reportback_file` table for the reportback item. 
- Check that Phoenix's `dosoemthing_rogue_reportbacks` table has the reportback item with all correct data.

#### Relevant tickets
Fixes #7183 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
