### PR TITLE
Adding referrer uri to url params sent to Northstar.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
+++ b/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
@@ -60,6 +60,7 @@ class OpenIDConnectClientNorthstar extends OpenIDConnectClientBase {
         'response_type' => 'code',
         'client_id' => $this->getSetting('client_id'),
         'redirect_uri' => url($redirect_uri, ['absolute' => TRUE]),
+        'referrer_uri' => $_SERVER['HTTP_REFERER'],
         'scope' => $scope,
         'state' => $this->createStateToken(),
       ],


### PR DESCRIPTION
#### What's this PR do?
This PR adds an additional url param which passes the referring uri (basically the last page which had a link that was clicked on) before it gets sent over to Northstar, so that Norhtstar can know which campaign or other page on Phoenix to go back to after authentication.

#### How should this be reviewed?
👁 

#### Any background context you want to provide?
💅 

#### Relevant tickets
Refs https://github.com/DoSomething/northstar/issues/495

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.

@angaither @sbsmith86 
