### PR TITLE
If phoenix does not have ns id, grab it directly from ns

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -57,12 +57,20 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
 
   $northstar_id = dosomething_user_get_field('field_northstar_id', $user);
 
+  // Band-aid fix for an issue we are seeing with phoenix not being
+  // aware of a user's northstar id. If it doesn't find one, we just grab it
+  // from northstar directly.
+  if (!$northstar_id) {
+    $northstar_user = dosomething_northstar_get_user($user->uid);
+    $northstar_id = $northstar_user->id;
+  }
+
   $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
 
   $client = dosomething_rogue_client();
 
   $data = [
-    'northstar_id' => $northstar_id ? $northstar_id : NULL,
+    'northstar_id' => $northstar_id,
     'drupal_id' => $user->uid,
     'campaign_id' => $values['nid'],
     'campaign_run_id' => $run->nid,


### PR DESCRIPTION
#### What's this PR do?

If phoenix is unaware of a user's Northstar ID, then we grab the user's NS id directly from northstar. 

#### Any background context you want to provide?

Fixes new relic errors we are seeing in Rogue. There is an API error that is causing Phoenix to not store a user's Northstar Id. When the user reports back we try to send a `null` Northstar id to rogue, the request fails, the request goes in the failed log table with a `null` NS id and we keep trying it and it keeps failing. Rogue does not accept `null `values for Northstar id.

The "Bandaid" fix to handle the rogue error alerts is to grab the northstar id directly from northstar if it doesn't exists in phoenix.

#### Relevant tickets
Fixes #7201


#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  

