### PR TITLE
Restrict Phoenix registration endpoint & save Northstar ID for API users.

### DIFF
--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -2,11 +2,10 @@
 
 ## Create a user
 
-Create a new Phoenix user with the given profile information. Consider using Northstar's [Create User](https://github.com/DoSomething/northstar/blob/dev/documentation/endpoints/users.md#create-a-user)
-or [Register](https://github.com/DoSomething/northstar/blob/dev/documentation/endpoints/auth.md#register-user) endpoints
-instead, as this endpoint will likely be removed in the future. 
+Create a new Phoenix user with the given profile information.
 
-This endpoint is currently available to anonymous users.
+:warning: __To create new DoSomething.org users, use Northstar's [Create User](https://github.com/DoSomething/northstar/blob/dev/documentation/endpoints/users.md#create-a-user)
+endpoint.__
 
 ```
 POST https://www.dosomething.org/api/v1/users
@@ -18,6 +17,7 @@ POST https://www.dosomething.org/api/v1/users
 // Content-Type: application/json
 
 {
+  _id: String // required.
   email: String // required.
   mobile: String
   password: String // This is the raw password that the user will use to login.
@@ -29,15 +29,11 @@ POST https://www.dosomething.org/api/v1/users
 }
 ```
 
-**Additional Query Parameters:**
-
- - `forward`: Whether to forward this user to Northstar. This option defaults to `true`.
-
 **Example request:**
 
 ```sh
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
-  -d '{"email":"aschachter+nyc@dosomething.org", "password":"password", "birthdate":"1995-12-31", \
+  -d '{"_id": "58333fbc9a892003da782d0d", "email":"aschachter+nyc@dosomething.org", "password":"password", "birthdate":"1995-12-31", \
        "first_name":"Aaroni","last_name":"Schachterelli","user_registration_source":"services"}' \
   http://dev.dosomething.org:8888/api/v1/users
 ```

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -164,10 +164,12 @@ function _member_resource_access($op) {
  *   Object of the newly created user if successful. String if errors.
  */
 function _member_resource_create($request) {
-  $query = drupal_get_query_parameters();
-
   if (!isset($request['email'])) {
     return services_error("Email is required.");
+  }
+
+  if (!isset($request['_id'])) {
+    return services_error("New Drupal accounts must be registered via Northstar.");
   }
 
   // Check if email is formatted correctly and not already in use.
@@ -221,11 +223,6 @@ function _member_resource_create($request) {
     // @see: dosomething_user_user_insert
     user_save($user, ['name' => $user->uid]);
 
-    // Forward users to Northstar, unless `?forward=false` is explicitly set.
-    $should_forward = isset($query['forward']) ? filter_var($query['forward'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) : true;
-    if ($should_forward && module_exists('dosomething_northstar')) {
-      dosomething_northstar_create_user($user, $edit['pass']);
-    }
 
     // Don't return the hashed password in the response!
     unset($user->pass);

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -139,7 +139,7 @@ function _member_resource_definition() {
  * Access callback for User resources.
  */
 function _member_resource_access($op) {
-  if ($op == 'create' || $op == 'get_member_count') {
+  if ($op == 'get_member_count') {
     return TRUE;
   }
   global $user;

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -206,6 +206,7 @@ function _member_resource_create($request) {
     'last_name' => !empty($request['last_name']) ? $request['last_name'] : NULL,
     'mobile' => !empty($request['mobile']) ? dosomething_user_clean_mobile_number($request['mobile']) : NULL,
     'user_registration_source' => !empty($request['user_registration_source']) ? $request['user_registration_source'] : NULL,
+    'northstar_id' => $request['_id'],
   ];
 
   dosomething_user_set_fields($edit, $fields);
@@ -219,10 +220,10 @@ function _member_resource_create($request) {
   try {
     $user = user_save('', $edit);
 
-    // Ensure user has UID set for name, since insert hooks don't fire on API.
-    // @see: dosomething_user_user_insert
+    // Ensure user has UID for name & an authmap record. We need to do this because insert hooks
+    // don't fire on API. (See `dosomething_user_user_insert` & `dosomething_northstar_create_user`.)
     user_save($user, ['name' => $user->uid]);
-
+    user_set_authmaps($user, ['authname_openid_connect_northstar' => $request['_id']]);
 
     // Don't return the hashed password in the response!
     unset($user->pass);


### PR DESCRIPTION
#### What's this PR do?
This PR makes some updates to fix issues with users created via the API:

🔒 It locks down the `POST /api/users` to only allow admin accounts to create users. This shouldn't be a problem because all user registrations _shoooould_ be happening via Northstar by now.

➡️ It requires the `_id` parameter to be included, and saves it in `field_northstar_id` and the `authmap` table so the Drupal account can be linked to it's corresponding Northstar user.

🚳 Removes code to forward users created via Drupal endpoint to Northstar, because we only want this endpoint to be used _by Northstar_ from now on. This will help simplify things and make it easier to think about what's going on.

#### How should this be reviewed?
👀 and 🤔. I've tested this on my local, but would appreciate an extra sanity check. I'll also post in #phoenix to make sure that nobody else can think of anything that is relying on this endpoint.

#### Any background context you want to provide?
There's a corresponding [Northstar pull request](https://github.com/DoSomething/northstar/pull/499) that needs to be deployed before this can safely be merged.

#### Relevant tickets
See attached Trello card.

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  