### PR TITLE
Make sure to set Drupal ID field on NS profile for OpenID Connect users.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -122,6 +122,13 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
     dosomething_northstar_save_id_field($account->uid, ['data' => $userinfo]);
   }
 
+  // Make sure the user's `drupal_id` field is set in Northstar (now that they *have* a Drupal ID).
+  try {
+    dosomething_northstar_client()->put('v1/users/id/' . $userinfo['id'], ['drupal_id' => $account->uid]);
+  } catch (Exception $error) {
+    watchdog('dosomething_northstar', 'User NOT updated on Northstar: ' . $error->getMessage(), NULL, WATCHDOG_ERROR);
+  }
+
   // If we saved a "post-authorization" action, do it now.
   dosomething_northstar_perform_authorization_actions();
 


### PR DESCRIPTION
#### What's this PR do?
When users register as part of the OpenID Connect flow, their Northstar account is created via Northstar's web interface (rather than by a Phoenix API call). This means they will never get the `drupal_id` field set on their profile.

This pull request adds a step to the "post-authorize" hook which updates the given Northstar ID with the user's Drupal UID, so we can continue to rely on that being available.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
We obviously want to minimize use of the `drupal_id` field, but it's unfortunately still required for a lot of core experiences (like signing up or reporting back for a campaign via the mobile app).

#### Relevant tickets
See linked Trello card.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  