### PR TITLE
only create the field if the field doesn't already exist

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -234,8 +234,9 @@ function dosomething_rogue_update_7005(&$sandbox) {
       'length' => '255',
       'not null' => FALSE,
     ];
-
-    db_add_field($table_name, 'northstar_id', $spec);
+    if (! db_field_exists($table_name, 'northstar_id') {
+      db_add_field($table_name, 'northstar_id', $spec);
+    }
   }
 }
 


### PR DESCRIPTION
#### What's this PR do?
goes back to a previous update hook and only create the field if it doesn't already exist

#### How should this be reviewed?
:eye_speech_bubble: 

#### Any background context you want to provide?
noticed this in the [deploy](https://jenkins.dosomething.org/job/Deploy-Production/230/consoleFull)

#### Relevant tickets
Refs #7214
