### PR TITLE
Set an Optimizely dimension for auth link clicks.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/utilities/Analytics.js
@@ -9,6 +9,22 @@ const Analytics = require('@dosomething/analytics');
 const Validation = require('dosomething-validation');
 const Modal = require('dosomething-modal');
 
+/**
+ * Set a custom Optimizely dimension for segmenting results.
+ * @see https://goo.gl/R9QLpS
+ *
+ * @param {String} dimension
+ * @param {String} value
+ */
+function setOptimizelyDimension(dimension, value) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.info(`Set Optimizely Dimension - ${dimension}:${value}`);
+  }
+
+  window['optimizely'] = window['optimizely'] || [];
+  optimizely.push(['setDimensionValue', dimension, value]);
+}
+
 function init() {
   // Configure `data-track-*` links & `analytics()` helper.
   Analytics.init();
@@ -44,6 +60,10 @@ function init() {
     const label = args !== null ? '#' + args.attr('id') : '';
     Analytics.analyze('Modal', 'Close', label);
   });
+
+  // Optimizely Dimensions
+  $('#link--login, #link--openid-connect-login').on('click', () => setOptimizelyDimension('link', 'auth'));
+  $('#link--campaign-signup-login, #link--openid-connect-campaign-signup-login').on('click', () => setOptimizelyDimension('link', 'signup'));
 
   // Attach any custom events.
   $(document).ready(() => {


### PR DESCRIPTION
#### What's this PR do?
This pull request adds a lil' snippet of code to set a custom [Optimizely Dimension](https://help.optimizely.com/Target_Your_Visitors/Dimensions%3A_Capture_visitor_data_through_the_API_in_Optimizely_Classic) whenever users click on either the "Log In" or "Sign Up" links on the page.

This will allow us to better track differences in the conversion rate of the new auth flow, since otherwise we can only track the overall conversion rate of _all_ users that see the modified links, rather than just those that click them.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
📊

#### Relevant tickets
Fixes 🍃.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
