### PR TITLE
allow reportback updates with no file via Phoenix api

### DIFF
--- a/documentation/endpoints/campaigns.md
+++ b/documentation/endpoints/campaigns.md
@@ -312,9 +312,9 @@ Must be authenticated to post.
     The number of reportback nouns verbed.
   - **why_participated**: (string) required.
     The reason why the user participated.
-  - **file_url**: (string) required if `file` is not provided.
+  - **file_url**: (string) required if `file` is not provided and a new reportback is being created.
     An image URL for the reportback.
-  - **file**: (string) required if `file_url` is not provided.
+  - **file**: (string) required if `file_url` is not provided and a new reportback is being created.
     Base64 encoded file string to save.
   - **filename**: (string) required if `file` is provided.
     Necessary for Drupal File API save (see `dosomething_reportback_get_file_dest`).

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -332,7 +332,7 @@ function _campaign_resource_reportback($nid, $values) {
 
   if (!$file) {
     // If this is to create a new reportback, there must be an image
-    if (empty($values['file_url']) && !$rbid) {
+    if (!array_key_exists('file_url', $values) && !$rbid) {
       return services_error(t("Reportback file_url not found."), 500);
     }
     // Create a file from the $file_url.

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -318,6 +318,10 @@ function _campaign_resource_reportback($nid, $values) {
 
   $file = NULL;
 
+  // @todo: Move this logic into dosomething_reportback_save().
+  $rbid = dosomething_reportback_exists($nid, NULL, $uid);
+
+  // If this is creating a new reportback, there must be a file
   if (!empty($values['file']) && !empty($values['filename'])) {
     $values['filepath'] = dosomething_reportback_get_file_dest($values['filename'], $nid, $uid);
     // Use Services module's File Create resource to save the file.
@@ -327,20 +331,23 @@ function _campaign_resource_reportback($nid, $values) {
   }
 
   if (!$file) {
-    if (empty($values['file_url'])) {
+    // If this is to create a new reportback, there must be an image
+    if (empty($values['file_url']) && !$rbid) {
       return services_error(t("Reportback file_url not found."), 500);
     }
     // Create a file from the $file_url.
-    $file = dosomething_reportback_save_file_from_url($nid, $uid, $values['file_url']);
-    if (!$file) {
-      return services_error(t("Could not write file to destination"), 500);
+    if (!empty($values['file_url'])) {
+      $file = dosomething_reportback_save_file_from_url($nid, $uid, $values['file_url']);
+      if (!$file) {
+        return services_error(t("Could not write file to destination"), 500);
+      }
     }
   }
 
-  $values['fid'] = $file->fid;
-
   // @todo: Move this logic into dosomething_reportback_save().
-  $rbid = dosomething_reportback_exists($nid, NULL, $uid);
+  if ($file) {
+    $values['fid'] = $file->fid;
+  }
 
   if (!$rbid) {
     $rbid = 0;

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -335,7 +335,7 @@ function _campaign_resource_reportback($nid, $values) {
     if (!array_key_exists('file_url', $values) && !$rbid) {
       return services_error(t("Reportback file_url not found."), 500);
     }
-    // Create a file from the $file_url.
+    // Create a file from the $file_url if there is one.
     if (!empty($values['file_url'])) {
       $file = dosomething_reportback_save_file_from_url($nid, $uid, $values['file_url']);
       if (!$file) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -387,7 +387,6 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     }
 
     // Store the base64 encoded data uri of the file in the values array to send to rogue.
-    // @TODO: This is still set if it is a duplicate so don't bother with this
     if (array_key_exists('storage', $form_state)) {
       $file = $form_state['storage']['file'];
       $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -388,23 +388,21 @@ function dosomething_reportback_form_submit($form, &$form_state) {
 
     // Store the base64 encoded data uri of the file in the values array to send to rogue.
     // @TODO: This is still set if it is a duplicate so don't bother with this
-    if ($form_state['values']['caption']) {
-      if (array_key_exists('storage', $form_state)) {
-        $file = $form_state['storage']['file'];
-        $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
-        $values['source'] = 'phoenix-web';
-      } else {
-        // If there is no file and there is a RB in Phoenix, check the dosomething_rogue_reportback table to see if the RB already exists in Rogue.
-        if ($rbid) {
-          $exists_in_rogue = dosomething_rogue_rb_exists_in_rogue($rbid);
+    if (array_key_exists('storage', $form_state)) {
+      $file = $form_state['storage']['file'];
+      $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
+      $values['source'] = 'phoenix-web';
+    } else {
+      // If there is no file and there is a RB in Phoenix, check the dosomething_rogue_reportback table to see if the RB already exists in Rogue.
+      if ($rbid) {
+        $exists_in_rogue = dosomething_rogue_rb_exists_in_rogue($rbid);
 
-          // If the RB does not yet exist in Rogue, send along the most recently created reportback_item so the RB can be created in Rogue.
-          if (! $exists_in_rogue) {
-            $reportback_file = entity_load('reportback_item', array($fid));
-            $values['file'] = dosomething_helpers_get_data_uri_from_fid($fid);
-            $values['caption'] = $reportback_file[$fid]->caption;
-            $values['source'] = isset($reportback_file[$fid]->source) ? $reportback_file[$fid]->source : 'phoenix-web';
-          }
+        // If the RB does not yet exist in Rogue, send along the most recently created reportback_item so the RB can be created in Rogue.
+        if (! $exists_in_rogue) {
+          $reportback_file = entity_load('reportback_item', array($fid));
+          $values['file'] = dosomething_helpers_get_data_uri_from_fid($fid);
+          $values['caption'] = $reportback_file[$fid]->caption;
+          $values['source'] = isset($reportback_file[$fid]->source) ? $reportback_file[$fid]->source : 'phoenix-web';
         }
       }
     }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -387,21 +387,24 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     }
 
     // Store the base64 encoded data uri of the file in the values array to send to rogue.
-    if (array_key_exists('storage', $form_state)) {
-      $file = $form_state['storage']['file'];
-      $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
-      $values['source'] = 'phoenix-web';
-    } else {
-      // If there is no file and there is a RB in Phoenix, check the dosomething_rogue_reportback table to see if the RB already exists in Rogue.
-      if ($rbid) {
-        $exists_in_rogue = dosomething_rogue_rb_exists_in_rogue($rbid);
+    // @TODO: This is still set if it is a duplicate so don't bother with this
+    if ($form_state['values']['caption']) {
+      if (array_key_exists('storage', $form_state)) {
+        $file = $form_state['storage']['file'];
+        $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
+        $values['source'] = 'phoenix-web';
+      } else {
+        // If there is no file and there is a RB in Phoenix, check the dosomething_rogue_reportback table to see if the RB already exists in Rogue.
+        if ($rbid) {
+          $exists_in_rogue = dosomething_rogue_rb_exists_in_rogue($rbid);
 
-        // If the RB does not yet exist in Rogue, send along the most recently created reportback_item so the RB can be created in Rogue.
-        if (! $exists_in_rogue) {
-          $reportback_file = entity_load('reportback_item', array($fid));
-          $values['file'] = dosomething_helpers_get_data_uri_from_fid($fid);
-          $values['caption'] = $reportback_file[$fid]->caption;
-          $values['source'] = isset($reportback_file[$fid]->source) ? $reportback_file[$fid]->source : 'phoenix-web';
+          // If the RB does not yet exist in Rogue, send along the most recently created reportback_item so the RB can be created in Rogue.
+          if (! $exists_in_rogue) {
+            $reportback_file = entity_load('reportback_item', array($fid));
+            $values['file'] = dosomething_helpers_get_data_uri_from_fid($fid);
+            $values['caption'] = $reportback_file[$fid]->caption;
+            $values['source'] = isset($reportback_file[$fid]->source) ? $reportback_file[$fid]->source : 'phoenix-web';
+          }
         }
       }
     }
@@ -410,13 +413,17 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
     // Make sure the reportback exists (meaning it got back from Rogue)
+    // @TODO: If an update fails, this will still come back true I think
     $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
 
     // Store reference to the rb in rogue, redirect user to permalink page.
     if ($rbid) {
       $reportback = entity_load_unchanged('reportback', [$rbid]);
-      $fid = array_pop($reportback->fids);
-      dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
+      // If a file was added, store references to the relevant Rogue data
+      if (isset($file)) {
+        $fid = array_pop($reportback->fids);
+        dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
+      }
 
       // Redirect to permalink page.
       $form_state['redirect'] = array(


### PR DESCRIPTION
#### What's this PR do?
Allows reportbacks to update just their `quantity` or `why participated` via the API. It still checks if a reportback already exists and does still require an image on a new reportback. Otherwise, it just checks to see if there is a file it needs to include.

#### How should this be reviewed?
Make sure the following tasks work as expected via phoenix web and the API:
1. Attempting to submit a new reportback without an image (API should return a `500` with `Reportback file_url not found.`)
2. Submitting a valid new reportback
3. Submitting an update to just the `quantity` or `why participated` of an existing reportback
4. Submitting an update to a reportback that includes a new image

I want to make extra sure this doesn't break anything else using the API. I thiiiink in theory it should all be okay because it relaxes the requirements.

#### Any background context you want to provide?
This will allow https://github.com/DoSomething/rogue/issues/76 to be fixed since Rogue currently is sending the most recent image because it has to send something.

#### Relevant tickets
Fixes #7218

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
