### PR TITLE
store references to failed Rogue rbs

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -366,15 +366,8 @@ function _campaign_resource_reportback($nid, $values) {
   if (! $transaction_id) {
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
-    // Make sure the reportback exists (meaning it got back from Rogue).
-    $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
-
-    // Store reference to the rb in rogue.
-    if ($rbid && $file) {
-      $reportback = entity_load_unchanged('reportback', [$rbid]);
-      $fid = array_pop($reportback->fids);
-      dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
-    }
+    // Make sure reportback made it back to Phoenix and store reference to the Rogue item if one was added
+    $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
   }
   else {
     dosomething_reportback_save($values, $user);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -409,21 +409,16 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     // Send the reportback to rogue.
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
-    // Make sure the reportback exists (meaning it got back from Rogue)
-    $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
+    // Make sure reportback made it back to Phoenix and store reference to the Rogue item
+    $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
 
-    // Store reference to the rb in rogue, redirect user to permalink page.
-    if ($rbid) {
-      $reportback = entity_load_unchanged('reportback', [$rbid]);
-      $fid = array_pop($reportback->fids);
-      dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
-
+    if ($rb_info) {
       // Redirect to permalink page.
       $form_state['redirect'] = array(
-        'reportback/' . $rbid,
+        'reportback/' . $rb_info['rbid'],
         array(
           'query' => array(
-            'fid' => $fid,
+            'fid' => $rb_info['fid'],
           ),
         ),
       );

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -409,10 +409,8 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     // Send the reportback to rogue.
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
-    // Make sure reportback made it back to Phoenix and store reference to the Rogue item
-    if (array_key_exists('file', $values)) {
-      $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
-    }
+    // Make sure reportback made it back to Phoenix and store reference to the Rogue item if one was added
+    $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
 
     if ($rb_info) {
       // Redirect to permalink page.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -410,7 +410,9 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
     // Make sure reportback made it back to Phoenix and store reference to the Rogue item
-    $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
+    if (array_key_exists('file', $values)) {
+      $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
+    }
 
     if ($rb_info) {
       // Redirect to permalink page.

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -46,7 +46,9 @@
 
         $user = user_load($task->drupal_id);
 
-        dosomething_rogue_send_reportback_to_rogue($values, $user);
+        $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
+
+        dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
       } else {
         $values = [
           [

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -267,17 +267,17 @@ function dosomething_rogue_rb_exists_in_rogue($rbid) {
  *
  */
 function dosomething_rogue_check_rbid_and_store_ref($rogue_reportback) {
+  // @TODO: this check is really only good for a reportback that has just been created, it doesn't tell us much regarding updates
   $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
 
   // Make sure the reportback exists (meaning it got back from Rogue)
   if ($rbid) {
     // Store reference to the rb in rogue
    $reportback = entity_load_unchanged('reportback', [$rbid]);
-    // If a file was added, store references to the relevant Rogue data
-    if (isset($file)) {
-      $fid = array_pop($reportback->fids);
-      dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
-    }
+
+    // Store references to the relevant Rogue data
+    $fid = array_pop($reportback->fids);
+    dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
 
     $data = [
       'rbid' => $rbid,

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -263,3 +263,32 @@ function dosomething_rogue_rb_exists_in_rogue($rbid)
 {
   return db_query("SELECT * FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rbid = :rbid", array(':rbid' => $rbid))->fetchAll();
 }
+
+/**
+ * Checks to see if the given RB data exists in Phoenix and if so stores in Rogue reference table.
+ *
+ * @param array $rogue_reportback
+ * The response from dosomething_rogue_send_reportback_to_rogue().
+ *
+ */
+function dosomething_rogue_check_rbid_and_store_ref($rogue_reportback)
+{
+  $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
+
+  // Make sure the reportback exists (meaning it got back from Rogue)
+  if ($rbid) {
+    // Store reference to the rb in rogue
+    $reportback = entity_load_unchanged('reportback', [$rbid]);
+    $fid = array_pop($reportback->fids);
+    dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
+
+    $data = [
+      'rbid' => $rbid,
+      'fid'  => $fid,
+    ];
+
+    return $data;
+  }
+
+  return false;
+}

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -267,18 +267,23 @@ function dosomething_rogue_rb_exists_in_rogue($rbid) {
  *
  */
 function dosomething_rogue_check_rbid_and_store_ref($rogue_reportback) {
-  // @TODO: this check is really only good for a reportback that has just been created, it doesn't tell us much regarding updates
   $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
 
-  // Make sure the reportback exists (meaning it got back from Rogue)
+  // Make sure the reportback exists before we try to use it
   if ($rbid) {
-    // Store reference to the rb in rogue
-   $reportback = entity_load_unchanged('reportback', [$rbid]);
+    // Load the reportback
+    $reportback = entity_load_unchanged('reportback', [$rbid]);
 
-    // Store references to the relevant Rogue data
+    // Get the most recently added file
     $fid = array_pop($reportback->fids);
-    dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
 
+    // Make sure that file is not in the Rogue reference table yet
+    if (!dosomething_rogue_get_by_file_id($fid)) {
+      // Store reference to the rb in rogue
+      dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
+    }
+
+    // The data needed to pass to the permalink page
     $data = [
       'rbid' => $rbid,
       'fid'  => $fid,

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -119,8 +119,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
  * Values to send to Rogue.
  *
  */
-function dosomething_rogue_update_rogue_reportback_items($data)
-{
+function dosomething_rogue_update_rogue_reportback_items($data) {
   $client = dosomething_rogue_client();
   try {
     $response = $client->updateReportback($data);
@@ -159,8 +158,7 @@ function dosomething_rogue_update_rogue_reportback_items($data)
  * Phoenix fid of reportback item.
  *
  */
-function dosomething_rogue_get_by_file_id($fid)
-{
+function dosomething_rogue_get_by_file_id($fid) {
   return db_query("SELECT rogue_rbs.rogue_item_id FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE fid = :fid", array(':fid' => $fid))->fetchAll();
 }
 
@@ -174,8 +172,7 @@ function dosomething_rogue_get_by_file_id($fid)
  *
  * @return InsertQuery object
  */
-function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback)
-{
+function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback) {
   $most_recent_rogue_item = array_pop($rogue_reportback['data']['reportback_items']['data']);
 
   // Store references to rogue IDs.
@@ -200,8 +197,7 @@ function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback
  * @param object $user
  *
  */
-function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, $user = NULL)
-{
+function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, $user = NULL) {
   if (module_exists('stathat')) {
       if ($values['type'] === 'reportback') {
         stathat_send_ez_count('drupal - Rogue - reportback failed - count', 1);
@@ -259,8 +255,7 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
  * Phoenix $rbid of reportback.
  *
  */
-function dosomething_rogue_rb_exists_in_rogue($rbid)
-{
+function dosomething_rogue_rb_exists_in_rogue($rbid) {
   return db_query("SELECT * FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rbid = :rbid", array(':rbid' => $rbid))->fetchAll();
 }
 
@@ -271,8 +266,7 @@ function dosomething_rogue_rb_exists_in_rogue($rbid)
  * The response from dosomething_rogue_send_reportback_to_rogue().
  *
  */
-function dosomething_rogue_check_rbid_and_store_ref($rogue_reportback)
-{
+function dosomething_rogue_check_rbid_and_store_ref($rogue_reportback) {
   $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
 
   // Make sure the reportback exists (meaning it got back from Rogue)


### PR DESCRIPTION
#### What's this PR do?
Adds reportbacks that were successfully send to Rogue via cron to the `dosomething_rogue_reportbacks` table. Includes some helper methods to expedite that both in cron and when we send reportbacks to Rogue via the web form.

#### How should this be reviewed?
Make sure you can submit reportbacks normally. 
Submit a reportback that ends up in the failed table. Run cron. Make sure that reportback ends up both in Rogue and in the `dosomething_rogue_reportbacks` table.

#### Any background context you want to provide?
We need all these little dudes to live in this table so they know that they made it! 

#### Relevant tickets
Fixes #7223

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
