### PR TITLE
Migrate reportback data

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -189,6 +189,22 @@ function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback
       ))
     ->execute();
 }
+/**
+ * Given a phoenix status, transform that into the corresponding rogue status
+ * @param  string $status phoenix item status
+ * @return string
+ */
+function dosomething_rogue_transform_status($status) {
+  if ($status === 'promoted' || $status === 'approved' || $status === 'excluded') {
+    return 'accepted';
+  }
+  else if ($status === 'pending') {
+    return 'pending';
+  }
+  else {
+    return 'rejected';
+  }
+}
 
 /**
  * Insert record that stores reference to the most recent uploaded reportback item in

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -172,23 +172,26 @@ function dosomething_rogue_get_by_file_id($fid)
  * @param string $fid
  * @param object $rogue_reportback
  *
- * @return InsertQuery object
+ * @return
  */
 function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback)
 {
   $most_recent_rogue_item = array_pop($rogue_reportback['data']['reportback_items']['data']);
 
-  // Store references to rogue IDs.
-  return db_insert('dosomething_rogue_reportbacks')
-    ->fields(array(
+  if (! dosomething_rogue_get_by_file_id($fid)) {
+    // Store references to rogue IDs.
+    db_insert('dosomething_rogue_reportbacks')
+    ->fields([
       'fid' => $fid,
       'rogue_item_id' => $most_recent_rogue_item['id'],
       'rbid' => $rbid,
       'rogue_reportback_id' => $rogue_reportback['data']['id'],
       'created_at' => REQUEST_TIME,
-      ))
+      ])
     ->execute();
+  }
 }
+
 /**
  * Given a phoenix status, transform that into the corresponding rogue status
  * @param  string $status phoenix item status

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -12,27 +12,29 @@ include_once('../lib/modules/dosomething/dosomething_northstar/dosomething_north
 
 $last_saved = variable_get('dosomething_rogue_last_rbi_migrated', NULL);
 if ($last_saved) {
-  $rbis = db_query("SELECT *
+  $rbis = db_query("SELECT rb.uid
             FROM dosomething_reportback_file rbf
-            LEFT JOIN dosomething_reportback rb on rbf.rbid = rb.rbid
+            INNER JOIN dosomething_reportback rb on rbf.rbid = rb.rbid
             WHERE rbf.fid > $last_saved
-            ORDER BY rbf.fid");
+            ORDER BY rbf.fid
+            LIMIT 1");
 }
 else {
-  // Get all the users!
+  // Get all the things!
   $rbis = db_query('SELECT *
                    FROM dosomething_reportback_file rbf
-                   LEFT JOIN dosomething_reportback rb on rbf.rbid = rb.rbid
-                   ORDER BY rbf.fid');
+                   INNER JOIN dosomething_reportback rb on rbf.rbid = rb.rbid
+                   ORDER BY rbf.fid
+                   LIMIT 15');
 }
 
 $client = dosomething_rogue_client();
 
 
-foreach ($rbis as $rbi) {
+foreach ($rbis as $rb) {
 
   $data = [
-    'northstar_id' => dosomething_northstar_get_user($rb->uid, 'drupal_id'),
+    'northstar_id' => dosomething_northstar_get_user($rb->uid, 'drupal_id')->id,
     'campaign_id' => $rb->nid,
     'campaign_run_id' => $rb->run_nid,
     'quantity' => $rb->quantity,
@@ -41,8 +43,7 @@ foreach ($rbis as $rbi) {
     'caption' => $rb->caption,
     'source' => $rb->source,
     'remote_addr' => $rb->remote_addr,
-    // do this but first need to transform what they mean.
-    // 'status' => isset($values['status']) ? $values['status'] : 'pending',
+    'status' => dosomething_rogue_transform_status($rb->status),
   ];
 
 

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -7,11 +7,14 @@
  */
 
 include_once('../lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module');
+include_once('../lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module');
+
 
 $last_saved = variable_get('dosomething_rogue_last_rbi_migrated', NULL);
 if ($last_saved) {
   $rbis = db_query("SELECT *
             FROM dosomething_reportback_file rbf
+            LEFT JOIN dosomething_reportback rb on rbf.rbid = rb.rbid
             WHERE rbf.fid > $last_saved
             ORDER BY rbf.fid");
 }
@@ -19,22 +22,35 @@ else {
   // Get all the users!
   $rbis = db_query('SELECT *
                    FROM dosomething_reportback_file rbf
+                   LEFT JOIN dosomething_reportback rb on rbf.rbid = rb.rbid
                    ORDER BY rbf.fid');
 }
 
-  $client = dosomething_rogue_client();
-  echo 'Client ' . $client;
+$client = dosomething_rogue_client();
+
 
 foreach ($rbis as $rbi) {
-  // Get the reportback item and info
 
-  // Get the reportback continer info
+  $data = [
+    'northstar_id' => dosomething_northstar_get_user($rb->uid, 'drupal_id'),
+    'campaign_id' => $rb->nid,
+    'campaign_run_id' => $rb->run_nid,
+    'quantity' => $rb->quantity,
+    'why_participated' => $rb->why_participated,
+    'file' => dosomething_helpers_get_data_uri_from_fid($rb->fid),
+    'caption' => $rb->caption,
+    'source' => $rb->source,
+    'remote_addr' => $rb->remote_addr,
+    // do this but first need to transform what they mean.
+    // 'status' => isset($values['status']) ? $values['status'] : 'pending',
+  ];
+
 
   // Transform Reviewer to NS id
   // Transform user to NS id
   // Transform status to the rogue status
 
-  echo $rbi->fid . "\n";
+  print_r($data) . "\n";
 
   // $response = $client->postReportback($data);
 

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -12,7 +12,7 @@ include_once('../lib/modules/dosomething/dosomething_northstar/dosomething_north
 
 $last_saved = variable_get('dosomething_rogue_last_rbi_migrated', NULL);
 if ($last_saved) {
-  $rbis = db_query("SELECT rb.uid
+  $rbis = db_query("SELECT *
             FROM dosomething_reportback_file rbf
             INNER JOIN dosomething_reportback rb on rbf.rbid = rb.rbid
             WHERE rbf.fid > $last_saved
@@ -46,9 +46,9 @@ foreach ($rbis as $rb) {
     'status' => dosomething_rogue_transform_status($rb->status),
   ];
 
-  $response = $client->postReportback($data);
+  try {
+    $response = $client->postReportback($data);
 
-  if ($response) {
     // Output progress to see what's going on.
     echo 'Migrated reportback ' . $rb->fid . ' to Rogue [' . $rb->caption . ']' . PHP_EOL;
 
@@ -57,6 +57,9 @@ foreach ($rbis as $rb) {
 
     // If the script fails, we can use this to start the script from the last reportback migrated.
     variable_set('dosomething_rogue_last_rbi_migrated', $rb->fid);
+  } catch (GuzzleHttp\Exception\ServerException $e) {
+    // @todo handle failed migrations.
+
+    echo 'Something terrible '  . $rb->fid  . PHP_EOL;
   }
-  // @todo handle failed migrations.
 }

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -16,16 +16,14 @@ if ($last_saved) {
             FROM dosomething_reportback_file rbf
             INNER JOIN dosomething_reportback rb on rbf.rbid = rb.rbid
             WHERE rbf.fid > $last_saved
-            ORDER BY rbf.fid
-            LIMIT 1");
+            ORDER BY rbf.fid");
 }
 else {
   // Get all the things!
   $rbis = db_query('SELECT *
                    FROM dosomething_reportback_file rbf
                    INNER JOIN dosomething_reportback rb on rbf.rbid = rb.rbid
-                   ORDER BY rbf.fid
-                   LIMIT 15');
+                   ORDER BY rbf.fid');
 }
 
 $client = dosomething_rogue_client();
@@ -50,12 +48,15 @@ foreach ($rbis as $rb) {
 
   $response = $client->postReportback($data);
 
-  // Output progress to see what's going on.
-  echo 'Migrated reportback ' . $rb->fid . ' to Rogue [' . $rb->caption . ']' . PHP_EOL;
+  if ($response) {
+    // Output progress to see what's going on.
+    echo 'Migrated reportback ' . $rb->fid . ' to Rogue [' . $rb->caption . ']' . PHP_EOL;
 
-  // Store the reference in dosomething_rogue_reportbacks.
-  dosomething_rogue_store_rogue_references($rb->rbid, $rb->fid, $response);
+    // Store the reference in dosomething_rogue_reportbacks.
+    dosomething_rogue_store_rogue_references($rb->rbid, $rb->fid, $response);
 
-  // If the script fails, we can use this to start the script from the last reportback migrated.
-  variable_set('dosomething_rogue_last_rbi_migrated', $rb->fid);
+    // If the script fails, we can use this to start the script from the last reportback migrated.
+    variable_set('dosomething_rogue_last_rbi_migrated', $rb->fid);
+  }
+  // @todo handle failed migrations.
 }

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -32,9 +32,11 @@ $client = dosomething_rogue_client();
 
 
 foreach ($rbis as $rb) {
+  //@todo? Set a variable or header to disable the send back to phoenix for these.
 
   $data = [
     'northstar_id' => dosomething_northstar_get_user($rb->uid, 'drupal_id')->id,
+    'drupal_id' => $rb->uid,
     'campaign_id' => $rb->nid,
     'campaign_run_id' => $rb->run_nid,
     'quantity' => $rb->quantity,
@@ -46,23 +48,14 @@ foreach ($rbis as $rb) {
     'status' => dosomething_rogue_transform_status($rb->status),
   ];
 
+  $response = $client->postReportback($data);
 
-  // Transform Reviewer to NS id
-  // Transform user to NS id
-  // Transform status to the rogue status
+  // Output progress to see what's going on.
+  echo 'Migrated reportback ' . $rb->fid . ' to Rogue [' . $rb->caption . ']' . PHP_EOL;
 
-  print_r($data) . "\n";
+  // Store the reference in dosomething_rogue_reportbacks.
+  dosomething_rogue_store_rogue_references($rb->rbid, $rb->fid, $response);
 
-  // $response = $client->postReportback($data);
-
-  // Output progress to stdout so we can see our good work.
-
-
-  // Save any failed requests to the request log for debugging.
-
-
-  // Store the info in dosomething_rogue_reportbacks.
-
-  // If the script fails, we can use this to start the script from a previous person.
-  // variable_set('dosomething_rogue_last_rbi_migrated', $user->uid);
+  // If the script fails, we can use this to start the script from the last reportback migrated.
+  variable_set('dosomething_rogue_last_rbi_migrated', $rb->fid);
 }

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -15,6 +15,7 @@ if ($last_saved) {
   $rbis = db_query("SELECT *
             FROM dosomething_reportback_file rbf
             INNER JOIN dosomething_reportback rb on rbf.rbid = rb.rbid
+            INNER JOIN file_managed fm on fm.fid = rbf.fid
             WHERE rbf.fid > $last_saved
             AND rbf.fid NOT IN (SELECT fid FROM dosomething_rogue_reportbacks)
             ORDER BY rbf.fid");
@@ -24,6 +25,7 @@ else {
   $rbis = db_query('SELECT *
                    FROM dosomething_reportback_file rbf
                    INNER JOIN dosomething_reportback rb on rbf.rbid = rb.rbid
+                   INNER JOIN file_managed fm on fm.fid = rbf.fid
                    WHERE rbf.fid NOT IN (SELECT fid FROM dosomething_rogue_reportbacks)
                    ORDER BY rbf.fid');
 }
@@ -31,36 +33,40 @@ else {
 $client = dosomething_rogue_client();
 
 foreach ($rbis as $rb) {
-  //@todo? Set a variable or header to disable the send back to phoenix for these.
+  $northstar_id = dosomething_northstar_get_user($rb->uid, 'drupal_id');
+  if (isset($northstar_id)) {
+    $data = [
+      'northstar_id' => $northstar_id->id,
+      'drupal_id' => $rb->uid,
+      'campaign_id' => $rb->nid,
+      'campaign_run_id' => $rb->run_nid,
+      'quantity' => $rb->quantity,
+      'why_participated' => $rb->why_participated,
+      'file' => dosomething_helpers_get_data_uri_from_fid($rb->fid),
+      'caption' => $rb->caption,
+      'source' => $rb->source,
+      'remote_addr' => $rb->remote_addr,
+      'status' => dosomething_rogue_transform_status($rb->status),
+      // Tell rogue not to try to forward the reportback back to phoenix.
+      'do_not_forward' => TRUE,
+    ];
 
-  $data = [
-    'northstar_id' => dosomething_northstar_get_user($rb->uid, 'drupal_id')->id,
-    'drupal_id' => $rb->uid,
-    'campaign_id' => $rb->nid,
-    'campaign_run_id' => $rb->run_nid,
-    'quantity' => $rb->quantity,
-    'why_participated' => $rb->why_participated,
-    'file' => dosomething_helpers_get_data_uri_from_fid($rb->fid),
-    'caption' => $rb->caption,
-    'source' => $rb->source,
-    'remote_addr' => $rb->remote_addr,
-    'status' => dosomething_rogue_transform_status($rb->status),
-  ];
+    try {
+      $response = $client->postReportback($data);
+      // Output progress to see what's going on.
+      echo 'Migrated reportback ' . $rb->fid . ' to Rogue [' . $rb->caption . ']' . PHP_EOL;
 
-  try {
-    $response = $client->postReportback($data);
+      // Store the reference in dosomething_rogue_reportbacks.
+      dosomething_rogue_store_rogue_references($rb->rbid, $rb->fid, $response);
 
-    // Output progress to see what's going on.
-    echo 'Migrated reportback ' . $rb->fid . ' to Rogue [' . $rb->caption . ']' . PHP_EOL;
+      // If the script fails, we can use this to start the script from the last reportback migrated.
+      variable_set('dosomething_rogue_last_rbi_migrated', $rb->fid);
+    } catch (GuzzleHttp\Exception\ServerException $e) {
+      // @todo do we care about this?
+      echo 'Something guzzle and terrible ' . $rb->fid . PHP_EOL;
 
-    // Store the reference in dosomething_rogue_reportbacks.
-    dosomething_rogue_store_rogue_references($rb->rbid, $rb->fid, $response);
-
-    // If the script fails, we can use this to start the script from the last reportback migrated.
-    variable_set('dosomething_rogue_last_rbi_migrated', $rb->fid);
-  } catch (GuzzleHttp\Exception\ServerException $e) {
-    // @todo handle failed migrations.
-
-    echo 'Something terrible '  . $rb->fid  . PHP_EOL;
+    }
   }
+  echo 'No northstar id, that is terrible ' . $rb->uid . PHP_EOL;
+
 }

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -16,6 +16,7 @@ if ($last_saved) {
             FROM dosomething_reportback_file rbf
             INNER JOIN dosomething_reportback rb on rbf.rbid = rb.rbid
             WHERE rbf.fid > $last_saved
+            AND rbf.fid NOT IN (SELECT fid FROM dosomething_rogue_reportbacks)
             ORDER BY rbf.fid");
 }
 else {
@@ -23,11 +24,11 @@ else {
   $rbis = db_query('SELECT *
                    FROM dosomething_reportback_file rbf
                    INNER JOIN dosomething_reportback rb on rbf.rbid = rb.rbid
+                   WHERE rbf.fid NOT IN (SELECT fid FROM dosomething_rogue_reportbacks)
                    ORDER BY rbf.fid');
 }
 
 $client = dosomething_rogue_client();
-
 
 foreach ($rbis as $rb) {
   //@todo? Set a variable or header to disable the send back to phoenix for these.

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Script to export reportbacks from drupal into Rogue.
+ *
+ * to run:
+ * drush --script-path=../scripts/ php-script export-reportbacks-to-rogue.php
+ */
+
+include_once('../lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module');
+
+$last_saved = variable_get('dosomething_rogue_last_rbi_migrated', NULL);
+if ($last_saved) {
+  $rbis = db_query("SELECT *
+            FROM dosomething_reportback_file rbf
+            WHERE rbf.fid > $last_saved
+            ORDER BY rbf.fid");
+}
+else {
+  // Get all the users!
+  $rbis = db_query('SELECT *
+                   FROM dosomething_reportback_file rbf
+                   ORDER BY rbf.fid');
+}
+
+  $client = dosomething_rogue_client();
+  echo 'Client ' . $client;
+
+foreach ($rbis as $rbi) {
+  // Get the reportback item and info
+
+  // Get the reportback continer info
+
+  // Transform Reviewer to NS id
+  // Transform user to NS id
+  // Transform status to the rogue status
+
+  echo $rbi->fid . "\n";
+
+  // $response = $client->postReportback($data);
+
+  // Output progress to stdout so we can see our good work.
+
+
+  // Save any failed requests to the request log for debugging.
+
+
+  // Store the info in dosomething_rogue_reportbacks.
+
+  // If the script fails, we can use this to start the script from a previous person.
+  // variable_set('dosomething_rogue_last_rbi_migrated', $user->uid);
+}


### PR DESCRIPTION
#### What's this PR do?
- added a function to transform what a phoenix status is to a rogue status
- added script to migrate reportback data to phoenix

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
I still have a few todos/checks
- Once in rogue, does this retry sending back to phoenix? Can we disable that?
- If the script fails and we need to re-migrate all info, the call to `dosomething_rogue_store_rogue_references` will fail because it doesn't check for duplicate rows

#### Relevant tickets
Refs #7225

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
