### PR TITLE
Sends Reportback from Phoenix API -> Rogue Take 2

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -344,19 +344,28 @@ function _campaign_resource_reportback($nid, $values) {
     }
   }
 
+  $values['fid'] = $file->fid;
+  $values['file'] = dosomething_helpers_get_data_uri_from_image(image_load($file->uri));
+
   // @todo: Move this logic into dosomething_reportback_save().
-  if ($file) {
-    $values['fid'] = $file->fid;
-  }
+  $rbid = dosomething_reportback_exists($nid, NULL, $uid);
 
   if (!$rbid) {
     $rbid = 0;
   }
 
-  // if (DOSOMETHING_REPORTBACK_LOG) {
-  //   watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
-  // }
-  return dosomething_rogue_send_reportback_to_rogue($values, $user);
+  $values['rbid'] = $rbid;
+
+  if (DOSOMETHING_REPORTBACK_LOG) {
+    watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
+  }
+
+  $transaction_id = drupal_get_http_header('X-Request-ID');
+  print_r($transaction_id);
+  die();
+  // if the flag is less than 2, send to rogue
+  // dosomething_rogue_send_reportback_to_rogue($values, $user);
+  return $rbid;
   // return dosomething_reportback_save($values, $user);
 }
 

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -343,8 +343,10 @@ function _campaign_resource_reportback($nid, $values) {
     }
   }
 
-  $values['fid'] = $file->fid;
-  $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
+  if ($file) {
+    $values['fid'] = $file->fid;
+    $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
+  }
 
   // @todo: Move this logic into dosomething_reportback_save().
   $rbid = dosomething_reportback_exists($nid, NULL, $uid);
@@ -368,7 +370,7 @@ function _campaign_resource_reportback($nid, $values) {
     $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
 
     // Store reference to the rb in rogue.
-    if ($rbid) {
+    if ($rbid && $file) {
       dosomething_rogue_store_rogue_references($rbid, $rogue_reportback);
     }
   }

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -371,7 +371,9 @@ function _campaign_resource_reportback($nid, $values) {
 
     // Store reference to the rb in rogue.
     if ($rbid && $file) {
-      dosomething_rogue_store_rogue_references($rbid, $rogue_reportback);
+      $reportback = entity_load_unchanged('reportback', [$rbid]);
+      $fid = array_pop($reportback->fids);
+      dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
     }
   }
   else {

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -303,7 +303,6 @@ function _campaign_resource_signup($nid, $values) {
  */
 function _campaign_resource_reportback($nid, $values) {
   // @todo: Return error if signup doesn't exist.
-
   $values['nid'] = $nid;
 
   if (!isset($values['uid'])) {
@@ -345,7 +344,7 @@ function _campaign_resource_reportback($nid, $values) {
   }
 
   $values['fid'] = $file->fid;
-  $values['file'] = dosomething_helpers_get_data_uri_from_image(image_load($file->uri));
+  $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
 
   // @todo: Move this logic into dosomething_reportback_save().
   $rbid = dosomething_reportback_exists($nid, NULL, $uid);
@@ -360,12 +359,23 @@ function _campaign_resource_reportback($nid, $values) {
     watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
   }
 
-  $transaction_id = drupal_get_http_header('X-Request-ID');
-  print_r($transaction_id);
-  die();
-  // if the flag is less than 2, send to rogue
-  // dosomething_rogue_send_reportback_to_rogue($values, $user);
+  $transaction_id = $_SERVER['HTTP_X_REQUEST_ID'];
+
+  if (! $transaction_id) {
+    $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
+
+    // Make sure the reportback exists (meaning it got back from Rogue).
+    $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
+
+    // Store reference to the rb in rogue.
+    if ($rbid) {
+      dosomething_rogue_store_rogue_references($rbid, $rogue_reportback);
+    }
+  }
+  else {
+    dosomething_reportback_save($values, $user);
+  }
+
   return $rbid;
-  // return dosomething_reportback_save($values, $user);
 }
 

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -353,12 +353,10 @@ function _campaign_resource_reportback($nid, $values) {
     $rbid = 0;
   }
 
-  $values['rbid'] = $rbid;
-
-  if (DOSOMETHING_REPORTBACK_LOG) {
-    watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
-  }
-
-  return dosomething_reportback_save($values, $user);
+  // if (DOSOMETHING_REPORTBACK_LOG) {
+  //   watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
+  // }
+  return dosomething_rogue_send_reportback_to_rogue($values, $user);
+  // return dosomething_reportback_save($values, $user);
 }
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -969,3 +969,18 @@ function dosomething_helpers_get_data_uri_from_fid($fid) {
 function dosomething_helpers_remove_emoji_from_string($text) {
   return preg_replace('/([0-9#][\x{20E3}])|[\x{00ae}\x{00a9}\x{203C}\x{2047}\x{2048}\x{2049}\x{3030}\x{303D}\x{2139}\x{2122}\x{3297}\x{3299}][\x{FE00}-\x{FEFF}]?|[\x{2190}-\x{21FF}][\x{FE00}-\x{FEFF}]?|[\x{2300}-\x{23FF}][\x{FE00}-\x{FEFF}]?|[\x{2460}-\x{24FF}][\x{FE00}-\x{FEFF}]?|[\x{25A0}-\x{25FF}][\x{FE00}-\x{FEFF}]?|[\x{2600}-\x{27BF}][\x{FE00}-\x{FEFF}]?|[\x{2900}-\x{297F}][\x{FE00}-\x{FEFF}]?|[\x{2B00}-\x{2BF0}][\x{FE00}-\x{FEFF}]?|[\x{1F000}-\x{1F6FF}][\x{FE00}-\x{FEFF}]?/u', '', $text);
 }
+
+/**
+ * Given an array of key/value pairs, create a new array with only the
+ * keys given.
+ *
+ * @param  associative array  $data
+ * @param  array $desiredKeys
+ *
+ * @return array
+ */
+function dosomething_helpers_extract_values_by_keys($array, $desiredKeys)
+{
+    $desiredValues = array_intersect_key($array, array_flip($desiredKeys));
+    return (count($array) > 0) ? $desiredValues : null;
+}

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -975,12 +975,12 @@ function dosomething_helpers_remove_emoji_from_string($text) {
  * keys given.
  *
  * @param  associative array  $data
- * @param  array $desiredKeys
+ * @param  array $desired_keys
  *
  * @return array
  */
-function dosomething_helpers_extract_values_by_keys($array, $desiredKeys)
+function dosomething_helpers_extract_values_by_keys($array, $desired_keys)
 {
-    $desiredValues = array_intersect_key($array, array_flip($desiredKeys));
-    return (count($array) > 0) ? $desiredValues : null;
+    $desired_values = array_intersect_key($array, array_flip($desired_keys));
+    return (count($array) > 0) ? $desired_values : null;
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -415,10 +415,11 @@ function dosomething_reportback_form_submit($form, &$form_state) {
 
     // Store reference to the rb in rogue, redirect user to permalink page.
     if ($rbid) {
-      $reportback = entity_load_unchanged('reportback', [$rbid]);
       // If a file was added, store references to the relevant Rogue data
       if (isset($file)) {
-        dosomething_rogue_store_rogue_references($rbid, $rogue_reportback);
+        $reportback = entity_load_unchanged('reportback', [$rbid]);
+        $fid = array_pop($reportback->fids);
+        dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
       }
 
       // Redirect to permalink page.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -418,8 +418,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
       $reportback = entity_load_unchanged('reportback', [$rbid]);
       // If a file was added, store references to the relevant Rogue data
       if (isset($file)) {
-        $fid = array_pop($reportback->fids);
-        dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
+        dosomething_rogue_store_rogue_references($rbid, $rogue_reportback);
       }
 
       // Redirect to permalink page.

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -38,7 +38,9 @@
 
         // Store reference to the rb in rogue.
         if ($rbid) {
-          dosomething_rogue_store_rogue_references($rbid, $rogue_reportback);
+          $reportback = entity_load_unchanged('reportback', [$rbid]);
+          $fid = array_pop($reportback->fids);
+          dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback);
         }
       } else {
         $data = [

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -37,12 +37,15 @@
           'file' => $task->file,
           'caption' => $task->caption,
           'type' => $task->type,
-          'crop_x' => $task->crop_x,
-          'crop_y' => $task->crop_y,
-          'crop_width' => $task->crop_width,
-          'crop_height' => $task->crop_height,
-          'crop_rotate' => $task->crop_rotate,
         ];
+
+        if ($task->crop_x) {
+          $values['crop_x'] = $task->crop_x;
+          $values['crop_y'] = $task->crop_y;
+          $values['crop_width'] = $task->crop_width;
+          $values['crop_height'] = $task->crop_height;
+          $values['crop_rotate'] = $task->crop_rotate;
+        }
 
         $user = user_load($task->drupal_id);
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -29,36 +29,26 @@
           $mime_split = explode(':', $task->file);
           $task->file = $mime_split[0] . ':' . $mimetype . $mime_split[1];
         }
-        $values = [
-          'nid' => $task->campaign_id,
-          'campaign_run_id' => $task->campaign_run_id,
-          'quantity' => $task->quantity,
-          'why_participated' => $task->why_participated,
-          'file' => $task->file,
-          'caption' => $task->caption,
-          'type' => $task->type,
-        ];
-
-        if ($task->crop_x) {
-          $values['crop_x'] = $task->crop_x;
-          $values['crop_y'] = $task->crop_y;
-          $values['crop_width'] = $task->crop_width;
-          $values['crop_height'] = $task->crop_height;
-          $values['crop_rotate'] = $task->crop_rotate;
-        }
 
         $user = user_load($task->drupal_id);
+        $data = (array)$task;
 
-        dosomething_rogue_send_reportback_to_rogue($values, $user);
+        $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($data, $user);
+        $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
+
+        // Store reference to the rb in rogue.
+        if ($rbid) {
+          dosomething_rogue_store_rogue_references($rbid, $rogue_reportback);
+        }
       } else {
-        $values = [
+        $data = [
           [
             'rogue_reportback_item_id' => $task->rogue_item_id,
             'status' => $task->status,
           ]
         ];
 
-        dosomething_rogue_update_rogue_reportback_items($values);
+        dosomething_rogue_update_rogue_reportback_items($data);
       }
    }
  }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -78,13 +78,16 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     'file' => isset($values['file']) ? $values['file'] : NULL,
     'caption' => isset($values['caption']) ? $values['caption'] : NULL,
     'status' => isset($values['status']) ? $values['status'] : 'pending',
-    'crop_x' => isset($values['crop_x']) ? $values['crop_x'] : NULL,
-    'crop_y' => isset($values['crop_y']) ? $values['crop_y'] : NULL,
-    'crop_width' => isset($values['crop_width']) ? $values['crop_width'] : NULL,
-    'crop_height' => isset($values['crop_height']) ? $values['crop_height'] : NULL,
-    'crop_rotate' => isset($values['crop_rotate']) ? $values['crop_rotate'] : NULL,
     'source' => isset($values['source']) ? $values['source'] : NULL,
   ];
+
+  if ($values['crop_x']) {
+    $data['crop_x'] = $values['crop_x'];
+    $data['crop_y'] = $values['crop_y'];
+    $data['crop_width'] = $values['crop_width'];
+    $data['crop_height'] = $values['crop_height'];
+    $data['crop_rotate'] = $values['crop_rotate'];
+  }
 
   $values['type'] = 'reportback';
   $values['northstar_id'] = $northstar_id;

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -150,15 +150,13 @@ function dosomething_rogue_get_by_file_id($fid)
  * phoenix and it's corresponding id's in Rogue
  *
  * @param string $rbid
+ * @param string $fid
  * @param object $rogue_reportback
  *
  * @return InsertQuery object
  */
-function dosomething_rogue_store_rogue_references($rbid, $rogue_reportback)
+function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback)
 {
-  $reportback = entity_load_unchanged('reportback', [$rbid]);
-  $fid = array_pop($reportback->fids);
-
   $most_recent_rogue_item = array_pop($rogue_reportback['data']['reportback_items']['data']);
 
   // Store references to rogue IDs.

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -276,28 +276,9 @@ function dosomething_rogue_rb_exists_in_rogue($rbid)
    ];
 
    if ($values['crop_x']) {
-     $cropped_values = dosomething_rogue_format_crop_values($values);
-
-     foreach ($cropped_values as $key => $value) {
-       $data[$key] = $value;
-     }
+    $cropped_values = dosomething_helpers_extract_values_by_keys($values, ['crop_x', 'crop_y', 'crop_width', 'crop_height', 'crop_rotate']);
+    $data = array_merge($data, $cropped_values);
    }
 
    return $data;
  }
-
- /**
-  * Format cropped values to send to Rogue.
-  * @param object $values
-  *
-   */
-  function dosomething_rogue_format_crop_values($values) {
-    $cropped_values = [];
-    $cropped_values['crop_x'] = $values['crop_x'];
-    $cropped_values['crop_y'] = $values['crop_y'];
-    $cropped_values['crop_width'] = $values['crop_width'];
-    $cropped_values['crop_height'] = $values['crop_height'];
-    $cropped_values['crop_rotate'] = $values['crop_rotate'];
-
-    return $cropped_values;
-  }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -68,29 +68,8 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
 
   $client = dosomething_rogue_client();
 
-  $data = [
-    'northstar_id' => $northstar_id,
-    'drupal_id' => $user->uid,
-    'campaign_id' => $values['nid'],
-    'campaign_run_id' => $run->nid,
-    'quantity' => $values['quantity'],
-    'why_participated' => $values['why_participated'],
-    'file' => isset($values['file']) ? $values['file'] : NULL,
-    'caption' => isset($values['caption']) ? $values['caption'] : NULL,
-    'status' => isset($values['status']) ? $values['status'] : 'pending',
-    'source' => isset($values['source']) ? $values['source'] : NULL,
-  ];
-
-  if ($values['crop_x']) {
-    $data['crop_x'] = $values['crop_x'];
-    $data['crop_y'] = $values['crop_y'];
-    $data['crop_width'] = $values['crop_width'];
-    $data['crop_height'] = $values['crop_height'];
-    $data['crop_rotate'] = $values['crop_rotate'];
-  }
-
-  $values['type'] = 'reportback';
-  $values['northstar_id'] = $northstar_id;
+  $data = dosomething_rogue_transform_reportback($values, $northstar_id);
+  $data['type'] = 'reportback';
 
   try {
     $response = $client->postReportback($data);
@@ -100,7 +79,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     }
     if (!$response) {
       // This is a 404
-      dosomething_rogue_handle_failure($values, $response, $e, $user);
+      dosomething_rogue_handle_failure($data, $response, $e, $user);
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
@@ -171,13 +150,15 @@ function dosomething_rogue_get_by_file_id($fid)
  * phoenix and it's corresponding id's in Rogue
  *
  * @param string $rbid
- * @param string $fid
  * @param object $rogue_reportback
  *
  * @return InsertQuery object
  */
-function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback)
+function dosomething_rogue_store_rogue_references($rbid, $rogue_reportback)
 {
+  $reportback = entity_load_unchanged('reportback', [$rbid]);
+  $fid = array_pop($reportback->fids);
+
   $most_recent_rogue_item = array_pop($rogue_reportback['data']['reportback_items']['data']);
 
   // Store references to rogue IDs.
@@ -214,12 +195,11 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
 
   // Save fail to a db log so we can easily export.
   if ($values['type'] === 'reportback') {
-    $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([
         'drupal_id' => $user->uid,
-        'campaign_id' => $values['nid'],
-        'campaign_run_id' => $run->nid,
+        'campaign_id' => $values['campaign_id'],
+        'campaign_run_id' => $values['campaign_run_id'],
         'quantity' => $values['quantity'],
         'why_participated' => $values['why_participated'],
         'file' => $values['file'],
@@ -237,7 +217,8 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
       ])
       ->execute();
 
-    watchdog('dosomething_rogue', 'Reportback not migrated to Rogue: northstar_id: !northstar_id, campaign_id: !campaign_id, campaign run_nid: !campaign_run_id.', ['!northstar_id' => $values['northstar_id'], '!campaign_id' => $values['nid'], '!campaign_run_id' => $run->nid], WATCHDOG_ERROR);
+    watchdog('dosomething_rogue', 'Reportback not migrated to Rogue: northstar_id: !northstar_id, campaign_id: !campaign_id, campaign run_nid: !campaign_run_id.', ['!northstar_id' => $values['northstar_id'], '!campaign_id' => $values['campaign_id'], '!campaign_run_id' => $values['campaign_run_id']], WATCHDOG_ERROR);
+
   } else {
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([
@@ -265,3 +246,60 @@ function dosomething_rogue_rb_exists_in_rogue($rbid)
 {
   return db_query("SELECT * FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rbid = :rbid", array(':rbid' => $rbid))->fetchAll();
 }
+
+/**
+  * Transform reportback into the appropriate scheme to send to Rogue.
+  *
+  * @param $values - Reportback values to send to Rogue.
+  * @param $northstar_id - User's Northstar user id.
+  * @return array
+  */
+ function dosomething_rogue_transform_reportback($values, $northstar_id) {
+   if ($values['nid']) {
+     $campaign_id = $values['nid'];
+   }
+   elseif ($values['campaign_id']) {
+     $campaign_id = $values['campaign_id'];
+   }
+
+   $run = dosomething_helpers_get_current_campaign_run_for_user($campaign_id);
+
+   $data = [
+     'northstar_id' => $northstar_id,
+     'campaign_id' => $campaign_id,
+     'campaign_run_id' => $run->nid,
+     'quantity' => $values['quantity'],
+     'why_participated' => $values['why_participated'],
+     'file' => isset($values['file']) ? $values['file'] : NULL,
+     'caption' => isset($values['caption']) ? $values['caption'] : NULL,
+     'status' => isset($values['status']) ? $values['status'] : 'pending',
+     'source' => isset($values['source']) ? $values['source'] : NULL,
+     'type' => isset($values['type']) ? $values['type'] : NULL,
+   ];
+
+   if ($values['crop_x']) {
+     $cropped_values = dosomething_rogue_format_crop_values($values);
+
+     foreach ($cropped_values as $key => $value) {
+       $data[$key] = $value;
+     }
+   }
+
+   return $data;
+ }
+
+ /**
+  * Format cropped values to send to Rogue.
+  * @param object $values
+  *
+   */
+  function dosomething_rogue_format_crop_values($values) {
+    $cropped_values = [];
+    $cropped_values['crop_x'] = $values['crop_x'];
+    $cropped_values['crop_y'] = $values['crop_y'];
+    $cropped_values['crop_width'] = $values['crop_width'];
+    $cropped_values['crop_height'] = $values['crop_height'];
+    $cropped_values['crop_rotate'] = $values['crop_rotate'];
+
+    return $cropped_values;
+  }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -54,7 +54,6 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
   if (!isset($user)) {
     global $user;
   }
-
   $northstar_id = dosomething_user_get_field('field_northstar_id', $user);
 
   // Band-aid fix for an issue we are seeing with phoenix not being
@@ -79,11 +78,11 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
     'file' => isset($values['file']) ? $values['file'] : NULL,
     'caption' => isset($values['caption']) ? $values['caption'] : NULL,
     'status' => isset($values['status']) ? $values['status'] : 'pending',
-    'crop_x' => $values['crop_x'],
-    'crop_y' => $values['crop_y'],
-    'crop_width' => $values['crop_width'],
-    'crop_height' => $values['crop_height'],
-    'crop_rotate' => $values['crop_rotate'],
+    'crop_x' => isset($values['crop_x']) ? $values['crop_x'] : NULL,
+    'crop_y' => isset($values['crop_y']) ? $values['crop_y'] : NULL,
+    'crop_width' => isset($values['crop_width']) ? $values['crop_width'] : NULL,
+    'crop_height' => isset($values['crop_height']) ? $values['crop_height'] : NULL,
+    'crop_rotate' => isset($values['crop_rotate']) ? $values['crop_rotate'] : NULL,
     'source' => isset($values['source']) ? $values['source'] : NULL,
   ];
 

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -22,6 +22,7 @@ class Rogue extends RestApiClient {
    */
   public function postReportback($data) {
     $response = $this->post('reportbacks', $data);
+
     return $response;
   }
 

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -22,7 +22,6 @@ class Rogue extends RestApiClient {
    */
   public function postReportback($data) {
     $response = $this->post('reportbacks', $data);
-
     return $response;
   }
 


### PR DESCRIPTION
#### What's this PR do?
- When an app hits Phoenix's `/api/v1/campaigns/[nid]/reportback` endpoint, instead of saving directly to Phoenix, it will send along to Rogue first and then Rogue will send back to Phoenix to be saved.
- If crop values aren't set, don't send to Rogue (both on first send and on cron job).
- Adds helper functions to prepare rb item to send to Rogue. 
- When cron job runs, insert the rogue rb reference in the `dosomething_rogue_reportbacks` table.

#### How should this be reviewed?
- Hit the `/api/v1/campaigns/[nid]/reportback` endpoint.
- Check the Rogue `reportback_items` table for the reportback item.
- Check the Phoenix `dosomething_reportback_file` table for the reportback item. 
- Check that Phoenix's `dosoemthing_rogue_reportbacks` table has the reportback item with all correct data.
- Test cron job.
- Test that reportingback from phoenix web works.

#### Relevant tickets
#7198 got borked so starting over in this PR.
Fixes #7183 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
