### PR TITLE
only send to rogue once from cron

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -34,9 +34,6 @@
         $data = (array)$task;
 
         $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($data, $user);
-        $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
-
-        $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
         dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
       } else {


### PR DESCRIPTION
#### What's this PR do?
Removes a duplicate call to `dosomething_rogue_send_reportback_to_rogue` in the Rogue cron job. 

#### How should this be reviewed?
Make sure that good reportbacks still go through and that ones that still fail do not double.

#### Any background context you want to provide?
There was one reportback from me on staging that didn't have enough data to make it to Rogue but now there are a lot more of them.

#### Relevant tickets
Fixes #

#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love

