### PR TITLE
Allow Northstar to create users without providing a password.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -207,6 +207,7 @@ function _member_resource_create($request) {
     'mobile' => !empty($request['mobile']) ? dosomething_user_clean_mobile_number($request['mobile']) : NULL,
     'user_registration_source' => !empty($request['user_registration_source']) ? $request['user_registration_source'] : NULL,
     'northstar_id' => $request['_id'],
+    'created_by_openid_connect' => empty($request['password']) ? 1 : 0, // If no password given, specify that this user *must* login via Northstar.
   ];
 
   dosomething_user_set_fields($edit, $fields);

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -103,7 +103,7 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
 
   dosomething_user_set_fields($edit, [
     'access_token' => $tokens['access_token'],
-    'refresh_token' => $tokens['access_token'],
+    'refresh_token' => $tokens['refresh_token'],
     'access_token_expiration' => $tokens['expire'],
   ]);
 


### PR DESCRIPTION
#### What's this PR do?
This pull request updates Drupal's "create user" endpoint to set the `created_by_openid_connect` boolean on a user profile if a password was not provided. This will cause logins for that user account to  always be routed to Northstar, and will allow us to sync any Northstar accounts to Phoenix regardless of whether we have the password on hand.

It also fixes a typo when saving refresh token to a user's Phoenix account.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
🍃

#### Relevant tickets
References DoSomething/northstar#406.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  