### PR TITLE
Add drupal_id back to rogue request.

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -280,6 +280,7 @@ function dosomething_rogue_check_rbid_and_store_ref($rogue_reportback) {
   * Transform reportback into the appropriate scheme to send to Rogue.
   *
   * @param $values - Reportback values to send to Rogue.
+  * @param  $user - Loaded drupal user
   * @param $northstar_id - User's Northstar user id.
   * @return array
   */

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -68,7 +68,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
 
   $client = dosomething_rogue_client();
 
-  $data = dosomething_rogue_transform_reportback($values, $northstar_id);
+  $data = dosomething_rogue_transform_reportback($values, $user, $northstar_id);
   $data['type'] = 'reportback';
 
   try {
@@ -283,7 +283,7 @@ function dosomething_rogue_check_rbid_and_store_ref($rogue_reportback) {
   * @param $northstar_id - User's Northstar user id.
   * @return array
   */
- function dosomething_rogue_transform_reportback($values, $northstar_id) {
+ function dosomething_rogue_transform_reportback($values, $user, $northstar_id) {
    if ($values['nid']) {
      $campaign_id = $values['nid'];
    }
@@ -295,6 +295,7 @@ function dosomething_rogue_check_rbid_and_store_ref($rogue_reportback) {
 
    $data = [
      'northstar_id' => $northstar_id,
+     'drupal_id' => $user->uid,
      'campaign_id' => $campaign_id,
      'campaign_run_id' => $run->nid,
      'quantity' => $values['quantity'],


### PR DESCRIPTION
#### What's this PR do?
Sends `drupal_id` to rogue

#### How should this be reviewed?
:eye_speech_bubble: 

#### Any background context you want to provide?
Request on staging/thor are failing because `drupal_id, campaign_id & campaign_run_id`  has a [unique index on it](https://github.com/DoSomething/rogue/blob/9e945421c8d980b99db64e593b9d318c381834fc/database/migrations/2016_08_08_180346_add_unique_index_to_reportbacks_table.php#L18)
without this value, it was sending `0` and that caused anyone who was reporting back on a campaign that someone else has already reported back on to fail!

#### Relevant tickets
🙏 that this fixes phoenix//deploys

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  

