### PR TITLE
Fix to api mess

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -370,6 +370,8 @@ function _campaign_resource_reportback($nid, $values) {
     $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
   }
   else {
+    print_r($values);
+    die();
     dosomething_reportback_save($values, $user);
   }
 

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -303,6 +303,7 @@ function _campaign_resource_signup($nid, $values) {
  */
 function _campaign_resource_reportback($nid, $values) {
   // @todo: Return error if signup doesn't exist.
+
   $values['nid'] = $nid;
 
   if (!isset($values['uid'])) {
@@ -348,9 +349,6 @@ function _campaign_resource_reportback($nid, $values) {
     $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
   }
 
-  // @todo: Move this logic into dosomething_reportback_save().
-  $rbid = dosomething_reportback_exists($nid, NULL, $uid);
-
   if (!$rbid) {
     $rbid = 0;
   }
@@ -364,14 +362,13 @@ function _campaign_resource_reportback($nid, $values) {
   $transaction_id = $_SERVER['HTTP_X_REQUEST_ID'];
 
   if (! $transaction_id) {
+
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
     // Make sure reportback made it back to Phoenix and store reference to the Rogue item if one was added
     $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
   }
   else {
-    print_r($values);
-    die();
     dosomething_reportback_save($values, $user);
   }
 

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -362,16 +362,15 @@ function _campaign_resource_reportback($nid, $values) {
   $transaction_id = $_SERVER['HTTP_X_REQUEST_ID'];
 
   if (! $transaction_id) {
-
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
     // Make sure reportback made it back to Phoenix and store reference to the Rogue item if one was added
     $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
+
+    return $rb_info['rbid'];
   }
   else {
-    dosomething_reportback_save($values, $user);
+    return dosomething_reportback_save($values, $user);
   }
-
-  return $rbid;
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -380,7 +380,8 @@ function dosomething_reportback_form_submit($form, &$form_state) {
   // Collect reportbacks in Rogue if rogue collection is turned on for this campaign.
   if (variable_get('rogue_collection', FALSE)) {
     // If this is a reportback update, grab the file most recent file in case we need it later
-    $rbid = dosomething_reportback_exists($form_state['build_info']['args'][0]->nid, $form_state['build_info']['args'][0]->run_nid, $form_state['build_info']['args'][0]->uid);
+    $rbid = dosomething_reportback_exists($values['nid'], $values['run_nid'], $values['uid']);
+
     if ($rbid) {
       $reportback = reportback_load($rbid);
       $fid = array_pop($reportback->fids);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -349,7 +349,7 @@ function dosomething_reportback_form_validate($form, &$form_state) {
 function dosomething_reportback_form_submit($form, &$form_state) {
   $values = $form_state['values'];
   $campaign = node_load($values['nid']);
-  $language_code = $language_code = $campaign->language;
+  $language_code = $campaign->language;
   $values['run_nid'] = $campaign->field_current_run[$language_code][0]['target_id'];
 
   // If username field is set, this is an admin form.

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -65,10 +65,10 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL) {
   }
 
   $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
-
   $client = dosomething_rogue_client();
 
   $data = dosomething_rogue_transform_reportback($values, $user, $northstar_id);
+
   $data['type'] = 'reportback';
 
   try {


### PR DESCRIPTION
#### What's this PR do?
- Fixes error and gets new reportbacks and new reportback items to send to Rogue from both Phoenix web and Phoenix API. 
  - Problem was if this was a new reportback, the reportback was being saved twice. 
- Cleans up values in `dosomething_reportback.forms.inc` so it's easier to read and removes typo. 

#### How should this be reviewed?
Test that the following work: 

1. Creating a new reportback from Phoenix web.
2. Creating a new reportback item from Phoenix web.
3. Hitting `/api/v1/campaigns/[nid]/reportback` with a new reportback.
4. Hitting `/api/v1/campaigns/[nid]/reportback` with a new reportback item. 

And all of the above items make it into the following tables: 
1. Check the Rogue reportback_items table for the reportback item.
2. Check the Phoenix dosomething_reportback_file table for the reportback item.
3. Check that Phoenix's dosoemthing_rogue_reportbacks table has the reportback item with all correct data.

Lastly, make sure the cron job works. 

#### Relevant tickets
Fixes #7232

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
