### PR TITLE
Changes check for $transaction_id

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -361,7 +361,7 @@ function _campaign_resource_reportback($nid, $values) {
 
   $transaction_id = $_SERVER['HTTP_X_REQUEST_ID'];
 
-  if (! $transaction_id) {
+  if (is_null($transaction_id)) {
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
     // Make sure reportback made it back to Phoenix and store reference to the Rogue item if one was added


### PR DESCRIPTION
#### What's this PR do?
Checks to see if `$transaction_id` is `NULL` instead of `if (! $transaction_id)` check.

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Right now, testing from the API works on local and staging but not on Thor. 

It seems like when reporting back from Thor via API, it seems to think it has a `$transaction_id` so just skips the code in lines 365-370 and just saves to Phoenix directly instead in line 373. 

This `is_null` check could be a more deliberate check to see if there is a `$transaction_id`?

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  

