### PR TITLE
Fix around getting transaction id when sending RB from API -> Rogue 

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -359,9 +359,9 @@ function _campaign_resource_reportback($nid, $values) {
     watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
   }
 
-  $transaction_id = $_SERVER['HTTP_X_REQUEST_ID'];
+  $headers = getallheaders();
 
-  if (is_null($transaction_id)) {
+  if (! isset($headers['X-Request-Id'])) {
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
     // Make sure reportback made it back to Phoenix and store reference to the Rogue item if one was added

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -361,7 +361,7 @@ function _campaign_resource_reportback($nid, $values) {
 
   $transaction_id = $_SERVER['HTTP_X_REQUEST_ID'];
 
-  if (! $transaction_id) {
+  if (is_null($transaction_id)) {
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
     // Make sure reportback made it back to Phoenix and store reference to the Rogue item if one was added

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -308,7 +308,7 @@ function dosomething_rogue_check_rbid_and_store_ref($rogue_reportback) {
      'type' => isset($values['type']) ? $values['type'] : NULL,
    ];
 
-   if ($values['crop_x']) {
+   if (isset($values['crop_x'])) {
     $cropped_values = dosomething_helpers_extract_values_by_keys($values, ['crop_x', 'crop_y', 'crop_width', 'crop_height', 'crop_rotate']);
     $data = array_merge($data, $cropped_values);
    }


### PR DESCRIPTION
#### What's this PR do?
- Changes the way we are grabbing the transaction id (`X-Request-Id`) from the header.
- Changes a check to `isset()` to get rid of log messages.

#### How should this be reviewed?
Same as testing from [this PR](https://github.com/DoSomething/phoenix/pull/7233).

#### Any background context you want to provide?
- When testing on Thor, it thought that it had a transaction id so skipped lines 365-370 and went straight to 373 to save to Phoenix. 
- I saw this error in the logs and realized that it wasn't grabbing the header correctly: 
![screen shot 2016-12-06 at 4 29 48 pm](https://cloud.githubusercontent.com/assets/9019452/20944871/27fbed18-bbd3-11e6-88a5-7ef2f37dd493.png)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
