### PR TITLE
Reportback Permalink Page Notices

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -600,7 +600,6 @@ function dosomething_reportback_view_entity($entity) {
       'share_bar' => $share_bar,
       'share_enabled' => $share_enabled,
       'why_participated_short' => isset($why_participated_short) ? $why_participated_short : $participated_copy,
-      'kudos' => $kudos,
     );
 
     cache_set('ds_permalink_' . $entity->rbid . '_' . $fid . '_' . $is_owner, $permalink_vars, 'cache_dosomething_reportback');

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -599,7 +599,7 @@ function dosomething_reportback_view_entity($entity) {
       'subtitle' => $subtitle,
       'share_bar' => $share_bar,
       'share_enabled' => $share_enabled,
-      'why_participated_short' => $why_participated_short,
+      'why_participated_short' => isset($why_participated_short) ? $why_participated_short : $participated_copy,
       'kudos' => $kudos,
     );
 

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -9,7 +9,6 @@
 include_once('../lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module');
 include_once('../lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module');
 
-
 $last_saved = variable_get('dosomething_rogue_last_rbi_migrated', NULL);
 if ($last_saved) {
   $rbis = db_query("SELECT *


### PR DESCRIPTION
#### What's this PR do?
Clears up some notices we were seeing on the reportback permalink page. 

The main one we wanted to clean up was fixed already by @chloealee [here](https://github.com/DoSomething/phoenix/commit/874f0e77e139d4d0776f66df7723296a41bcaa82)

But for good measure I fixed some issues where we were trying to use the truncated `why_participated` copy even when the submitted value for that field was so short, it never got truncated. 

Also fixed and issue where we were passing a `$kudos` variable that hadn't been set yet. 

#### How should this be reviewed?
Submit a reportback and you should only see warnings that look like this 

![image](https://cloud.githubusercontent.com/assets/1700409/20977499/c9aadf98-bc73-11e6-9537-2e9c1e28df02.png)


#### Any background context you want to provide?
Yes, there are still notices. Not all of these have to do with our Rogue work. Some things seem to have to do with the API and the Kudos button on the permalink page. I am not going to try and fix those as it could bring up other things and I am not familiar with those pieces of the codebase. 

#### Relevant tickets
Fixes #7236 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
