### PR TITLE
Log received transaction ids

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -370,7 +370,14 @@ function _campaign_resource_reportback($nid, $values) {
     return $rb_info['rbid'];
   }
   else {
+    // Increment transaction id and log that the request has been received with new transaction id.
+    $transaction_id_parts = explode('-', $headers['X-Request-Id']);
+    $transaction_id_base = $transaction_id_parts[0];
+    $incremented_step = $transaction_id_parts[1] + 1;
+    $incremented_transaction_id = $transaction_id_base . '-' . $incremented_step;
+
+    watchdog('PhoenixTransactionBridge', 'Request received. Transaction ID: !incremented_transaction_id', ['!incremented_transaction_id' => $incremented_transaction_id], WATCHDOG_INFO);
+
     return dosomething_reportback_save($values, $user);
   }
 }
-


### PR DESCRIPTION
#### What's this PR do?
Logs transaction id when a request is received from Rogue. 

#### How should this be reviewed?
1. Reportback from phoenix web. 
  - Check the drupal logs and you should see two messages: 
    - `Request made. {"method":"POST","Transaction ID":"1481132857.8349-0","Path":"http:\/\/rogue.dev:8000\/api\/v1\/reportbacks"}`
    - `Request received. Transaction ID: 1481132857.8349-3`
2. Reportback using api endpoing `/campaigns/[nid]/reportbacks`.
  - Check the laravel logs and you should see two messages: 
    -`Request received. Transaction ID: 1481132857.8349-1`
    -`Request made. {"method":"POST","Transaction ID":"1481132857.8349-2","Path":"//dev.dosomething.org:8888/api/v1/campaigns/1283/reportback"}`

#### Any background context you want to provide?
The above follows the below flow: 
1. Reportback from Phoenix web or API -> Rogue is step `-0`
2. Rogue receives request is step `-1`
3. Rogue makes request to Phoenix is step `-2`
3. Phoenix receives request from Rogue is step `-3` 

#### Relevant tickets
Fixes #7220 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
