### PR TITLE
Automatically create dispatchDelayedTextsQueue.

### DIFF
--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -152,6 +152,14 @@ function dosomething_mbp_update_7009() {
 }
 
 /**
+ * Updates mbp productions to include dispatchDelayedTextsQueue.
+ */
+function dosomething_mbp_update_7010() {
+  db_drop_table('message_broker_producer_productions');
+  dosomething_mbp_install_productions();
+}
+
+/**
  * Common function for install and update of related DoSomething specific
  * message_broker_producer produciton settings.
  */
@@ -201,6 +209,7 @@ function dosomething_mbp_install_productions() {
   $productions[2]['queues'][] = 'userAPICampaignActivityQueue';
   $productions[2]['queues'][] = 'mobileCommonsQueue';
   $productions[2]['queues'][] = 'messagingGroupsQueue';
+  $productions[2]['queues'][] = 'dispatchDelayedTextsQueue';
   $productions[2]['routing_key'] = 'campaign.signup.transactional';
   $productions[2]['status'] = 1;
 
@@ -215,6 +224,7 @@ function dosomething_mbp_install_productions() {
   $productions[3]['queues'][] = 'userAPICampaignActivityQueue';
   $productions[3]['queues'][] = 'mobileCommonsQueue';
   $productions[3]['queues'][] = 'messagingGroupsQueue';
+  $productions[3]['queues'][] = 'dispatchDelayedTextsQueue';
   $productions[3]['routing_key'] = 'campaign.signup.transactional';
   $productions[3]['status'] = 1;
 
@@ -226,6 +236,7 @@ function dosomething_mbp_install_productions() {
   $productions[4]['queues'][] = 'userAPICampaignActivityQueue';
   $productions[4]['queues'][] = 'imageProcessingQueue';
   $productions[4]['queues'][] = 'messagingGroupsQueue';
+  $productions[4]['queues'][] = 'dispatchDelayedTextsQueue';
   $productions[4]['routing_key'] = 'campaign.report_back.transactional';
   $productions[4]['status'] = 1;
 


### PR DESCRIPTION
#### What's this PR do?
Includes new `dispatchDelayedTextsQueue` into Quicksilver (ex. Message Broker) queue mapping.

#### How should this be reviewed?
Run the update.
Tested locally:

![image](https://cloud.githubusercontent.com/assets/672669/21018639/93cac0dc-bd3b-11e6-8dbd-176a0b095e74.png)

#### Relevant tickets
A part of DoSomething/Quicksilver-PHP#78.
Similar PR: #7184.

#### Checklist
- [ ] Tested on Thor
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  

