### PR TITLE
send Rogue remote addr from Phoenix web

### DIFF
--- a/documentation/endpoints/campaigns.md
+++ b/documentation/endpoints/campaigns.md
@@ -322,6 +322,8 @@ Must be authenticated to post.
     Corresponding caption for the reportback image.
   - **source**: (string).
     Where the reportback file was submitted from.
+  - **remote_addr**: (string). optional
+    Remote address the reportback file was submitted from.
 
 Response: The reportback rbid if success, `FALSE` if not.
 

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -300,6 +300,7 @@ function _campaign_resource_signup($nid, $values) {
  *   - quantity (int).
  *   - why_participated (string).
  *   - num_participants (int).
+ *   - remote_addr (string).
  */
 function _campaign_resource_reportback($nid, $values) {
   // @todo: Return error if signup doesn't exist.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -863,6 +863,10 @@ function dosomething_reportback_set_files(&$entity, $values) {
     if (!empty($values['source'])) {
       $entity->source = filter_xss($values['source'], array());
     }
+
+    if (!empty($values['remote_addr'])) {
+      $entity->remote_addr = filter_xss($values['remote_addr'], array());
+    }
   }
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/Reportback.php
@@ -256,7 +256,7 @@ class Reportback extends Entity {
       'rbid' => $this->rbid,
       'fid' => $values->fid,
       'caption' => $values->caption,
-      'remote_addr' => dosomething_helpers_ip_address(),
+      'remote_addr' => isset($values->remote_addr) ? $values->remote_addr : dosomething_helpers_ip_address(),
       'status' => $status,
       'source' => $values->source,
     ]);

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -306,7 +306,7 @@ function dosomething_rogue_check_rbid_and_store_ref($rogue_reportback) {
      'status' => isset($values['status']) ? $values['status'] : 'pending',
      'source' => isset($values['source']) ? $values['source'] : NULL,
      'type' => isset($values['type']) ? $values['type'] : NULL,
-     'remote_addr' => 'do I get overwritten yo?',
+     'remote_addr' => dosomething_helpers_ip_address(),
    ];
 
    if ($values['crop_x']) {

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -306,6 +306,7 @@ function dosomething_rogue_check_rbid_and_store_ref($rogue_reportback) {
      'status' => isset($values['status']) ? $values['status'] : 'pending',
      'source' => isset($values['source']) ? $values['source'] : NULL,
      'type' => isset($values['type']) ? $values['type'] : NULL,
+     'remote_addr' => 'do I get overwritten yo?',
    ];
 
    if ($values['crop_x']) {


### PR DESCRIPTION
#### What's this PR do?
Before sending a reportback to Rogue, grab the remote address and send that too. Then, allow requests coming into the Phoenix API to specify a remote address instead of grabbing the address when the reportback item is created. If none is specified, grab it like we were before. 

This allows reportbacks submitted via Phoenix web to get created with the address of where they were actually created, instead of the address of Rogue.

#### How should this be reviewed?
I tested by hardcoding the address that got sent to Rogue and making sure that that is the address that showed up in the Phoenix database as well. Also make sure everything still works when hitting the Phoenix API directly and _not_ providing a `remote_addr`.

#### Any background context you want to provide?
This was maybe the most confused I've ever been by Drupal. 

#### Relevant tickets
Fixes #7241

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
