### PR TITLE
Removes emoji from first name

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -218,6 +218,9 @@ function _member_resource_create($request) {
   // Infer the user's language from their country code field.
   $edit['language'] = dosomething_global_convert_country_to_language($fields['country']);
 
+  // Strip all emoji from the first name.
+  $edit['first_name'] = dosomething_helpers_remove_emoji_from_string($fields['first_name']);
+
   try {
     $user = user_save('', $edit);
 


### PR DESCRIPTION
#### What's this PR do?
When creating a user through the Phoenix API, we should strip all emoji's from the first name.

#### How should this be reviewed?
Hit the users endpoint with an emoji in the first name

#### Any background context you want to provide?
Currently new CGG users are putting emoji's in there name, preventing a phoenix account from being created

#### Relevant tickets
https://github.com/DoSomething/gambit/issues/769
https://github.com/DoSomething/gambit/issues/768