### PR TITLE
Fixes `failed_at` and `tries` logic error with cron job and limits cron job tries to 5.

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -12,7 +12,6 @@
       ->fields('t')
       ->execute()
       ->fetchAll();
-    db_truncate('dosomething_rogue_failed_task_log')->execute();
 
     foreach ($task_log as $task) {
       if ($task->type === 'reportback') {

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -3,17 +3,18 @@
 /**
  * Implements hook_cron()
  */
- function dosomething_rogue_cron() {
-    dosomething_rogue_retry_failed_reportbacks();
- }
+function dosomething_rogue_cron() {
+  dosomething_rogue_retry_failed_reportbacks();
+}
 
- function dosomething_rogue_retry_failed_reportbacks() {
-    $task_log = db_select('dosomething_rogue_failed_task_log', 't')
-      ->fields('t')
-      ->execute()
-      ->fetchAll();
+function dosomething_rogue_retry_failed_reportbacks() {
+  $task_log = db_select('dosomething_rogue_failed_task_log', 't')
+    ->fields('t')
+    ->execute()
+    ->fetchAll();
 
-    foreach ($task_log as $task) {
+  foreach ($task_log as $task) {
+    if ($task->tries < 5) {
       if ($task->type === 'reportback') {
         // Check to see if the MIME type is missing
         if (strpos($task->file, 'data:;') !== false) {
@@ -33,8 +34,16 @@
         $data = (array)$task;
 
         $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($data, $user);
+        if ($rogue_reportback) {
+          dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
 
-        dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
+          db_delete('dosomething_rogue_failed_task_log')
+            ->condition('northstar_id', $data['northstar_id'])
+            ->condition('campaign_run_id', $data['campaign_run_id'])
+            ->condition('caption', $data['caption'])
+            ->condition('file', $data['file'])
+            ->execute();
+        }
       } else {
         $data = [
           [
@@ -43,7 +52,14 @@
           ]
         ];
 
-        dosomething_rogue_update_rogue_reportback_items($data);
+        $response = dosomething_rogue_update_rogue_reportback_items($data);
+
+        if ($response) {
+          db_delete('dosomething_rogue_failed_task_log')
+            ->condition('rogue_item_id', $data['rogue_reportback_item_id'])
+            ->execute();
+        }
       }
-   }
- }
+    }
+  }
+}

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -206,7 +206,7 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
       }
   }
   // Check to see if the reportback item is in the dosomething_rogue_failed_task_log.
-  $previously_failed = dosomething_rogue_previously_failed($values);
+  $previously_failed = array_pop(dosomething_rogue_previously_failed($values));
   // If the reportback has previously failed, do not enter a new record.
   // Instead, increment the number of tries and update the time of most recent attempt to send to Rogue.
   if ($previously_failed) {
@@ -330,12 +330,12 @@ function dosomething_rogue_previously_failed($values) {
  * Update the timestamp and tries in the dosomething_rogue_failed_task_log for a failed reportback item.
  *
  * @param array $values
- * @param array $previously_failed
+ * @param object $previously_failed
  *
  */
 function update_failed_task_log($values, $previously_failed) {
   // Increment the number of tries the cron job attempted to send failed record to Rogue.
-  $incremented_tries = $previously_failed[0]->tries + 1;
+  $incremented_tries = $previously_failed->tries + 1;
 
   if ($values['type'] === 'reportback') {
     db_update('dosomething_rogue_failed_task_log')
@@ -343,10 +343,10 @@ function update_failed_task_log($values, $previously_failed) {
         'tries' => $incremented_tries,
         'timestamp' => REQUEST_TIME,
       ])
-      ->condition ('northstar_id', $values['northstar_id'])
-      ->condition ('campaign_run_id', $values['campaign_run_id'])
-      ->condition ('caption', $values['caption'])
-      ->condition ('file', $values['file'])
+      ->condition('northstar_id', $values['northstar_id'])
+      ->condition('campaign_run_id', $values['campaign_run_id'])
+      ->condition('caption', $values['caption'])
+      ->condition('file', $values['file'])
       ->execute();
   } else {
     db_update('dosomething_rogue_failed_task_log')
@@ -354,7 +354,7 @@ function update_failed_task_log($values, $previously_failed) {
         'tries' => $incremented_tries,
         'timestamp' => REQUEST_TIME,
       ])
-      ->condition ('rogue_item_id', $values['rogue_reportback_item_id'])
+      ->condition('rogue_item_id', $values['rogue_reportback_item_id'])
       ->execute();
   }
 }


### PR DESCRIPTION
#### What's this PR do?
- Refactors `$previously_failed` and makes it an object so code is more readable. 
- Deletes `db_truncate` of `dosomething_rogue_failed_task_log` so logic works for `failed_at` and `tries` columns. 
- Limits cron job to 5 tries when re-sending Rogue failed tasks in `dosomething_rogue_failed_task_log`.
- Fixes formatting.

#### How should this be reviewed?
- Change the Rogue API to something incorrect so failed jobs will continue failing when running the cron job. 
- Run the cron job. Original `failed_at` times should be the same (not the same as `timestamp`) and `tries` should be incremented by one. 
- Continue to run the cron job until the `tries` column hits `5`. Run one more time and it should not try to send and the `tries` should stay at `5`. 
- Reset `tries` column to equal `4`. 
- Change the Rogue API url back to what is it supposed to be.
- Run the cron job. 
- All of the reportbacks and items should make it to Rogue and Phoenix and the `dosomething_rogue_failed_task_log` should be empty. 

#### Relevant tickets
Fixes #7249 and #7251 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  

