### PR TITLE
only tries to re-send Rogue failed tasks if tries is less than 5

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -3,18 +3,19 @@
 /**
  * Implements hook_cron()
  */
- function dosomething_rogue_cron() {
-    dosomething_rogue_retry_failed_reportbacks();
- }
+function dosomething_rogue_cron() {
+  dosomething_rogue_retry_failed_reportbacks();
+}
 
- function dosomething_rogue_retry_failed_reportbacks() {
-    $task_log = db_select('dosomething_rogue_failed_task_log', 't')
-      ->fields('t')
-      ->execute()
-      ->fetchAll();
-    db_truncate('dosomething_rogue_failed_task_log')->execute();
+function dosomething_rogue_retry_failed_reportbacks() {
+  $task_log = db_select('dosomething_rogue_failed_task_log', 't')
+    ->fields('t')
+    ->execute()
+    ->fetchAll();
+  // db_truncate('dosomething_rogue_failed_task_log')->execute();
 
-    foreach ($task_log as $task) {
+  foreach ($task_log as $task) {
+    if ($task->tries < 5) {
       if ($task->type === 'reportback') {
         // Check to see if the MIME type is missing
         if (strpos($task->file, 'data:;') !== false) {
@@ -46,5 +47,6 @@
 
         dosomething_rogue_update_rogue_reportback_items($data);
       }
-   }
- }
+    }
+  }
+}


### PR DESCRIPTION
#### What's this PR do?
- Limits cron job to 5 tries when re-sending Rogue failed tasks in `dosomething_rogue_failed_task_log`.
- Fixes formatting.

#### How should this be reviewed?
- Change the Rogue API to something incorrect so failed jobs will continue failing when running the cron job.
- Run the cron job. The `tries` column should increment by one. 
- Continue to run the cron job until the `tries` column hits `5`. Run one more time and it should not try to send and the `tries` should stay at `5`. 