### PR TITLE
Do not redirect to Northstar profile page when resetting password.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -203,8 +203,10 @@ function paraneue_dosomething_form_dosomething_payment_form_alter(&$form, &$form
  * Preprocesses the User Profile Form.
  */
 function paraneue_dosomething_form_user_profile_form_alter(&$form, &$form_state, $form_id) {
-  // If user was created by Northstar, redirect them to edit profile there.
-  if (module_exists('dosomething_northstar') && dosomething_user_get_field('field_created_by_openid_connect')) {
+  $is_resetting_password = $form['account']['current_pass']['#access'] === false;
+
+  // If user was created by Northstar & isn't resetting their password, redirect them to edit profile there.
+  if (module_exists('dosomething_northstar') && dosomething_user_get_field('field_created_by_openid_connect') && !$is_resetting_password) {
     drupal_goto(NORTHSTAR_URL . '/users/' . dosomething_user_get_northstar_id($form['account']['uid']) . '/edit', ['absolute' => TRUE]);
   }
 


### PR DESCRIPTION
#### What's this PR do?
Users whose accounts have been created by Northstar (either via the API or the OpenID Connect flow) do not have hashed passwords stored in the Phoenix database. Because of this, we redirect them to Northstar when editing their profile since Phoenix could never verify their current password.

This causes a problem for users who are resetting their passwords though, because that happens on the profile page – and because of the above logic, they're always just redirected to log in on Northstar. 💩! This pull request adds a conditional to skip that redirect when resetting password.

#### How should this be reviewed?
I'm going to deploy this branch to staging to test.

#### Any background context you want to provide?
🤕

#### Relevant tickets
Fixes 🐛.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  