### PR TITLE
Fixes Rogue cron job bug that didn't send rb items updated status 

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -14,50 +14,6 @@ function dosomething_rogue_retry_failed_reportbacks() {
     ->fetchAll();
 
   foreach ($task_log as $task) {
-<<<<<<< HEAD
-      if ($task->tries < 5) {
-        if ($task->type === 'reportback') {
-          // Check to see if the MIME type is missing
-          if (strpos($task->file, 'data:;') !== false) {
-            // Split file string to access the data
-            $data = explode(',', $task->file)[1];
-
-            // Decode and use getimagesizefromstring() to access the MIME type
-            $image_size_info = getimagesizefromstring(base64_decode($data));
-            $mimetype = $image_size_info['mime'];
-
-            // Split the file string where the MIME type will go and rebuild to include MIME type
-            $mime_split = explode(':', $task->file);
-            $task->file = $mime_split[0] . ':' . $mimetype . $mime_split[1];
-          }
-          $user = user_load($task->drupal_id);
-          $data = (array)$task;
-
-          $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($data, $user, $task->id);
-
-          if ($rogue_reportback) {
-            dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
-
-            db_delete('dosomething_rogue_failed_task_log')
-              ->condition('id', $task->id)
-              ->execute();
-          }
-        } else {
-          $data = [
-            [
-              'rogue_reportback_item_id' => $task->rogue_item_id,
-              'status' => $task->status,
-            ]
-          ];
-
-          $response = dosomething_rogue_update_rogue_reportback_items($data, $task->id);
-
-          if ($response) {
-            db_delete('dosomething_rogue_failed_task_log')
-              ->condition('id', $task->id)
-              ->execute();
-          }
-=======
     if ($task->tries < 5) {
       if ($task->type === 'reportback') {
         // Check to see if the MIME type is missing
@@ -73,19 +29,16 @@ function dosomething_rogue_retry_failed_reportbacks() {
           $mime_split = explode(':', $task->file);
           $task->file = $mime_split[0] . ':' . $mimetype . $mime_split[1];
         }
-
         $user = user_load($task->drupal_id);
         $data = (array)$task;
 
-        $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($data, $user);
+        $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($data, $user, $task->id);
+
         if ($rogue_reportback) {
           dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
 
           db_delete('dosomething_rogue_failed_task_log')
-            ->condition('northstar_id', $data['northstar_id'])
-            ->condition('campaign_run_id', $data['campaign_run_id'])
-            ->condition('caption', $data['caption'])
-            ->condition('file', $data['file'])
+            ->condition('id', $task->id)
             ->execute();
         }
       } else {
@@ -97,14 +50,14 @@ function dosomething_rogue_retry_failed_reportbacks() {
           ]
         ];
 
-        $response = dosomething_rogue_update_rogue_reportback_items($data);
+        $response = dosomething_rogue_update_rogue_reportback_items($data, $task->id);
 
         if ($response) {
           db_delete('dosomething_rogue_failed_task_log')
-            ->condition('rogue_item_id', $data[0]['rogue_reportback_item_id'])
+            ->condition('id', $task->id)
             ->execute();
->>>>>>> cron job works for rb items
         }
       }
+    }
   }
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -14,6 +14,7 @@ function dosomething_rogue_retry_failed_reportbacks() {
     ->fetchAll();
 
   foreach ($task_log as $task) {
+<<<<<<< HEAD
       if ($task->tries < 5) {
         if ($task->type === 'reportback') {
           // Check to see if the MIME type is missing
@@ -56,6 +57,53 @@ function dosomething_rogue_retry_failed_reportbacks() {
               ->condition('id', $task->id)
               ->execute();
           }
+=======
+    if ($task->tries < 5) {
+      if ($task->type === 'reportback') {
+        // Check to see if the MIME type is missing
+        if (strpos($task->file, 'data:;') !== false) {
+          // Split file string to access the data
+          $data = explode(',', $task->file)[1];
+
+          // Decode and use getimagesizefromstring() to access the MIME type
+          $image_size_info = getimagesizefromstring(base64_decode($data));
+          $mimetype = $image_size_info['mime'];
+
+          // Split the file string where the MIME type will go and rebuild to include MIME type
+          $mime_split = explode(':', $task->file);
+          $task->file = $mime_split[0] . ':' . $mimetype . $mime_split[1];
+        }
+
+        $user = user_load($task->drupal_id);
+        $data = (array)$task;
+
+        $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($data, $user);
+        if ($rogue_reportback) {
+          dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
+
+          db_delete('dosomething_rogue_failed_task_log')
+            ->condition('northstar_id', $data['northstar_id'])
+            ->condition('campaign_run_id', $data['campaign_run_id'])
+            ->condition('caption', $data['caption'])
+            ->condition('file', $data['file'])
+            ->execute();
+        }
+      } else {
+        $data = [
+          [
+            'rogue_reportback_item_id' => $task->rogue_item_id,
+            'status' => $task->status,
+            'reviewer' => $task->reviewer,
+          ]
+        ];
+
+        $response = dosomething_rogue_update_rogue_reportback_items($data);
+
+        if ($response) {
+          db_delete('dosomething_rogue_failed_task_log')
+            ->condition('rogue_item_id', $data[0]['rogue_reportback_item_id'])
+            ->execute();
+>>>>>>> cron job works for rb items
         }
       }
   }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -284,3 +284,20 @@ function dosomething_rogue_update_7007(&$sandbox) {
     }
   }
 }
+
+/**
+ * Adds reviewer column to the dosomething_rogue_failed_task_log.
+ */
+function dosomething_rogue_update_7008(&$sandbox) {
+  $table = 'dosomething_rogue_failed_task_log';
+  if (db_table_exists($table)) {
+    $reviewer_spec = [
+      'type' => 'varchar',
+      'length' => '255',
+      'description' => 'The Northstar id of reviewer who updated the reportback item.',
+    ];
+
+    db_add_field($table, 'reviewer', $reviewer_spec);
+  }
+}
+

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -214,6 +214,11 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
       }
   }
 
+<<<<<<< HEAD
+=======
+  // Check to see if the reportback item is in the dosomething_rogue_failed_task_log.
+  $previously_failed = array_pop(dosomething_rogue_previously_failed($values));
+>>>>>>> cron job works for rb items
   // If the reportback has previously failed, do not enter a new record.
   // Instead, increment the number of tries and update the time of most recent attempt to send to Rogue.
   if (! is_null($failed_task_id)) {

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -395,6 +395,7 @@ function insert_failed_task_into_failed_task_log($values, $response = NULL, $e =
         'response_code' => (isset($response->code)) ? $response->code : NULL, // @TODO: this is currently null until there a better way to get it from Gateway
         'response_values' => (isset($e)) ? $e->getMessage() : NULL,
         'failed_at' => REQUEST_TIME,
+        'reviewer' => $values['reviewer'],
       ])
       ->execute();
   }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -66,7 +66,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
   // from northstar directly.
   if (!$northstar_id) {
     $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
-   $northstar_id = $northstar_user->id;
+    $northstar_id = $northstar_user->id;
   }
 
   $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
@@ -83,15 +83,15 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
     }
     if (!$response) {
       // This is a 404
-      dosomething_rogue_handle_failure($data, $response, $e, $failed_task_id, $user);
+      dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user);
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
     // These aren't yet caught by Gateway
-    dosomething_rogue_handle_failure($values, $response, $e, $failed_task_id, $user);
+    dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
-    dosomething_rogue_handle_failure($values, $response, $e, $failed_task_id, $user);
+    dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
   }
 
   return $response;
@@ -118,7 +118,7 @@ function dosomething_rogue_update_rogue_reportback_items($data, $failed_task_id 
     if (!$response) {
       foreach ($data as $values) {
         $values['type'] = 'reportback item';
-        dosomething_rogue_handle_failure($values, $response, $e, $failed_task_id);
+        dosomething_rogue_handle_failure($values, $response, $failed_task_id);
       }
     }
   }
@@ -126,13 +126,15 @@ function dosomething_rogue_update_rogue_reportback_items($data, $failed_task_id 
     // These aren't yet caught by Gateway
     foreach ($data as $values) {
       $values['type'] = 'reportback item';
-      dosomething_rogue_handle_failure($values, $response, $e, $failed_task_id);
+      $user = NULL;
+      dosomething_rogue_handle_failure($values, $response, $failed_task_id, $e);
     }
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
     foreach ($data as $values) {
       $values['type'] = 'reportback item';
-      dosomething_rogue_handle_failure($values, $response, $e, $failed_task_id);
+      $user = NULL;
+      dosomething_rogue_handle_failure($values, $response, $failed_task_id, $e);
     }
   }
 
@@ -205,7 +207,7 @@ function dosomething_rogue_transform_status($status) {
  * @param object $user
  *
  */
-function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, $failed_task_id = NULL, $user = NULL) {
+function dosomething_rogue_handle_failure($values, $response = NULL, $failed_task_id = NULL, $user = NULL, $e = NULL) {
   if (module_exists('stathat')) {
       if ($values['type'] === 'reportback') {
         stathat_send_ez_count('drupal - Rogue - reportback failed - count', 1);
@@ -214,11 +216,6 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $e = NULL, 
       }
   }
 
-<<<<<<< HEAD
-=======
-  // Check to see if the reportback item is in the dosomething_rogue_failed_task_log.
-  $previously_failed = array_pop(dosomething_rogue_previously_failed($values));
->>>>>>> cron job works for rb items
   // If the reportback has previously failed, do not enter a new record.
   // Instead, increment the number of tries and update the time of most recent attempt to send to Rogue.
   if (! is_null($failed_task_id)) {

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -126,14 +126,12 @@ function dosomething_rogue_update_rogue_reportback_items($data, $failed_task_id 
     // These aren't yet caught by Gateway
     foreach ($data as $values) {
       $values['type'] = 'reportback item';
-      $user = NULL;
       dosomething_rogue_handle_failure($values, $response, $failed_task_id, $e);
     }
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
     foreach ($data as $values) {
       $values['type'] = 'reportback item';
-      $user = NULL;
       dosomething_rogue_handle_failure($values, $response, $failed_task_id, $e);
     }
   }


### PR DESCRIPTION
#### What's this PR do?
- Fixes bug in Rogue cron job that doesn't successfully send updated rb item's status.
  - Adds `reviewer` column to `dosomething_rogue_failed_task_log`.
  - Updates `insert_failed_task_into_failed_task_log()` to insert `reviewer` to table.
  - Updates cron job to send `reviewer` in `$data` to Rogue. 

#### How should this be reviewed?
1. Make sure there are reportback items in `dosomething_rogue_failed_task_log`.
2. Run the cron job.
3. Reportback items should clear out of the table and updates should be reflected in Rogue. 

#### Any background context you want to provide?
Cron job was breaking because Rogue [saves the `reviewer` to the reportback item](https://github.com/DoSomething/rogue/pull/73) but the cron job was not updated so [this line](https://github.com/DoSomething/rogue/blob/master/app/Repositories/ReportbackRepository.php#L179) broke.  

#### Relevant tickets
Fixes #7253 
