### PR TITLE
Profile form redirect

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/form.inc
@@ -230,6 +230,19 @@ function paraneue_dosomething_form_user_profile_form_alter(&$form, &$form_state,
   // Add our process function to the array:
   $process[] = 'paraneue_dosomething_process_password_confirm';
   $form['account']['pass']['#process'] = $process;
+
+  $form['#submit'][] = 'paraneue_dosomething_user_profile_submit_handler';
+}
+
+/**
+ * Form submission handler for the profile form.
+ *
+ * @param $form
+ * @param $form_state
+ */
+function paraneue_dosomething_user_profile_submit_handler(&$form, &$form_state)
+{
+  $form_state['redirect'] = 'user';
 }
 
 function paraneue_dosomething_form_user_profile_after_build($form, &$form_state) {


### PR DESCRIPTION
#### What's this PR do?
This pull request updates the user profile form to redirect to the main "profile" page after submission. This fixes a weird lil' bug with #7254 where submitting the form to complete the reset password flow would just refresh the same "edit" page and then redirect the user to Northstar.

#### How should this be reviewed?
💧🚭 🤔

#### Any background context you want to provide?
This change is the result of a [Slack conversation](https://dosomething.slack.com/archives/team-rocket/p1481748539000503) and some IRL discussion.

#### Relevant tickets
Fixes 🙅‍♂️.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  