### PR TITLE
handle sending missing images

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -958,7 +958,12 @@ function dosomething_helpers_get_data_uri_from_fid($fid) {
   }
 
   // Return the formated data uri: data:{mime};base64,{data};
-  return 'data:' . $mime . ';base64,' . $data;
+  if ($data) {
+    return 'data:' . $mime . ';base64,' . $data;
+  }
+
+  // @TODO: what are implications of this
+  return false;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -963,7 +963,7 @@ function dosomething_helpers_get_data_uri_from_fid($fid) {
   }
 
   // @TODO: what are implications of this
-  return false;
+  return null;
 }
 
 /**

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -53,13 +53,12 @@ foreach ($rbis as $rb) {
       'status' => dosomething_rogue_transform_status($rb->status),
       // Tell rogue not to try to forward the reportback back to phoenix.
       'do_not_forward' => TRUE,
-      'default_image' => isset($file) ? NULL : TRUE,
     ];
 
     try {
       $response = $client->postReportback($data);
       // Output progress to see what's going on.
-      echo 'Migrated reportback ' . $rb->fid . ' to Rogue [' . $rb->caption . ']' . PHP_EOL;
+      echo 'Migrated reportback with fid ' . $rb->fid . ' to Rogue [' . $rb->caption . ']' . PHP_EOL;
 
       // Store the reference in dosomething_rogue_reportbacks.
       dosomething_rogue_store_rogue_references($rb->rbid, $rb->fid, $response);

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -17,7 +17,6 @@ if ($last_saved) {
             INNER JOIN file_managed fm on fm.fid = rbf.fid
             WHERE rbf.fid > $last_saved
             AND rbf.fid NOT IN (SELECT fid FROM dosomething_rogue_reportbacks)
-            AND rbf.fid NOT IN (SELECT fid FROM _the_departed)
             ORDER BY rbf.fid");
 }
 else {
@@ -27,7 +26,6 @@ else {
                    INNER JOIN dosomething_reportback rb on rbf.rbid = rb.rbid
                    INNER JOIN file_managed fm on fm.fid = rbf.fid
                    WHERE rbf.fid NOT IN (SELECT fid FROM dosomething_rogue_reportbacks)
-                   AND rbf.fid NOT IN (SELECT fid FROM _the_departed)
                    ORDER BY rbf.fid');
 }
 
@@ -40,11 +38,6 @@ foreach ($rbis as $rb) {
   if (isset($northstar_id)) {
     // Grab the image
     $file = dosomething_helpers_get_data_uri_from_fid($rb->fid);
-
-    // If the image is missing, use the default image
-    if (!$file) {
-      $default_image = 1;
-    }
 
     $data = [
       'northstar_id' => $northstar_id->id,
@@ -60,7 +53,7 @@ foreach ($rbis as $rb) {
       'status' => dosomething_rogue_transform_status($rb->status),
       // Tell rogue not to try to forward the reportback back to phoenix.
       'do_not_forward' => TRUE,
-      'default_image' => isset($default_image) ? $default_image : NULL,
+      'default_image' => isset($file) ? NULL : TRUE,
     ];
 
     try {

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -36,7 +36,6 @@ foreach ($rbis as $rb) {
 
   // Only try to send to Rogue if we have a Northstar ID
   if (isset($northstar_id)) {
-
     $data = [
       'northstar_id' => $northstar_id->id,
       'drupal_id' => $rb->uid,

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -38,6 +38,13 @@ foreach ($rbis as $rb) {
 
   // Only try to send to Rogue if we have a Northstar ID
   if (isset($northstar_id)) {
+    // See if the image is broken
+    $file = dosomething_helpers_get_data_uri_from_fid($rb->fid);
+    // Test seeing contents of known broken image
+    if (!$file) {
+      // assign file to be data of the default image
+    }
+
     $data = [
       'northstar_id' => $northstar_id->id,
       'drupal_id' => $rb->uid,

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -53,7 +53,7 @@ foreach ($rbis as $rb) {
       'campaign_run_id' => $rb->run_nid,
       'quantity' => $rb->quantity,
       'why_participated' => $rb->why_participated,
-      'file' => $file ? $file : NULL,
+      'file' => $file,
       'caption' => $rb->caption,
       'source' => $rb->source,
       'remote_addr' => $rb->remote_addr,

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -52,7 +52,7 @@ foreach ($rbis as $rb) {
       'campaign_run_id' => $rb->run_nid,
       'quantity' => $rb->quantity,
       'why_participated' => $rb->why_participated,
-      'file' => dosomething_helpers_get_data_uri_from_fid($rb->fid),
+      'file' => $file,
       'caption' => $rb->caption,
       'source' => $rb->source,
       'remote_addr' => $rb->remote_addr,

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -43,7 +43,7 @@ foreach ($rbis as $rb) {
 
     // If the image is missing, use the default image
     if (!$file) {
-      // assign file to be data of the default image
+      $default_image = 1;
     }
 
     $data = [

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -36,8 +36,6 @@ foreach ($rbis as $rb) {
 
   // Only try to send to Rogue if we have a Northstar ID
   if (isset($northstar_id)) {
-    // Grab the image
-    $file = dosomething_helpers_get_data_uri_from_fid($rb->fid);
 
     $data = [
       'northstar_id' => $northstar_id->id,
@@ -46,7 +44,7 @@ foreach ($rbis as $rb) {
       'campaign_run_id' => $rb->run_nid,
       'quantity' => $rb->quantity,
       'why_participated' => $rb->why_participated,
-      'file' => $file,
+      'file' => dosomething_helpers_get_data_uri_from_fid($rb->fid),
       'caption' => $rb->caption,
       'source' => $rb->source,
       'remote_addr' => $rb->remote_addr,

--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -38,9 +38,10 @@ foreach ($rbis as $rb) {
 
   // Only try to send to Rogue if we have a Northstar ID
   if (isset($northstar_id)) {
-    // See if the image is broken
+    // Grab the image
     $file = dosomething_helpers_get_data_uri_from_fid($rb->fid);
-    // Test seeing contents of known broken image
+
+    // If the image is missing, use the default image
     if (!$file) {
       // assign file to be data of the default image
     }
@@ -52,13 +53,14 @@ foreach ($rbis as $rb) {
       'campaign_run_id' => $rb->run_nid,
       'quantity' => $rb->quantity,
       'why_participated' => $rb->why_participated,
-      'file' => $file,
+      'file' => $file ? $file : NULL,
       'caption' => $rb->caption,
       'source' => $rb->source,
       'remote_addr' => $rb->remote_addr,
       'status' => dosomething_rogue_transform_status($rb->status),
       // Tell rogue not to try to forward the reportback back to phoenix.
       'do_not_forward' => TRUE,
+      'default_image' => isset($default_image) ? $default_image : NULL,
     ];
 
     try {


### PR DESCRIPTION
#### What's this PR do?
Reworked `dosomething_helpers_get_data_uri_from_fid` to return `null` if there is no data in the file. If there is no image, pass a flag to Rogue so we can set it as the default. Through many iterations I ended up pretty close to where we started.

#### How should this be reviewed?
Run on some reportbacks with missing images and make sure everything shows up as expected in Rogue.

#### Checklist
- [ ] Tested on staging.
