### PR TITLE
catch api exceptions when migrating rbs to rogue

### DIFF
--- a/scripts/export-reportbacks-to-rogue.php
+++ b/scripts/export-reportbacks-to-rogue.php
@@ -66,7 +66,8 @@ foreach ($rbis as $rb) {
     } catch (GuzzleHttp\Exception\ServerException $e) {
       // @todo do we care about this?
       echo 'Something guzzle and terrible ' . $rb->fid . PHP_EOL;
-
+    } catch (DoSomething\Gateway\Exceptions\ApiException $e) {
+      echo 'Something terrible from Rogue or Gateway ' . $rb->fid . PHP_EOL;
     }
   }
   else {


### PR DESCRIPTION
#### What's this PR do?
Adds a catch for `DoSomething\Gateway\Exceptions\ApiException` like we do in the Rogue module. Hopefully this will catch the `422`s we are getting (if there are more after that first one) when testing on Thor. I'm thinking it might be helpful to get everything not causing trouble migrated over so we can see how many are actually causing trouble and try to find a pattern.

#### Checklist
- [ ] Tested on staging.
