### PR TITLE
Add a script to sanitize invalid email addresses.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -271,8 +271,6 @@ function dosomething_northstar_transform_user($user, $password = null) {
   // field and Northstar can then verify via its DrupalPasswordHash class.
   if (! is_null($password)) {
     $northstar_user['password'] = $password;
-  } else {
-    $northstar_user['drupal_password'] = $user->pass;
   }
 
   // If user has a "1234565555@mobile" or "1234565555@mobile.import" placeholder

--- a/scripts/sanitize-email-addresses.php
+++ b/scripts/sanitize-email-addresses.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Sanitize email addresses on user accounts from ages ago.
+ *
+ * drush --script-path=../scripts php-script sanitize-email-addresses.php
+ */
+
+// Any invalid email addresses weren't synced to Northstar, so we can start there.
+$wild_typers = db_query('SELECT uid, mail FROM users WHERE uid NOT IN (SELECT uid FROM authmap);');
+
+foreach($wild_typers as $wilder) {
+  if ($wilder->uid == 0) {
+    continue;
+  }
+
+  if (! (filter_var($wilder->mail, FILTER_VALIDATE_EMAIL))) {
+    print 'Removing invalid email for ' . $wilder->uid . ' (' . $wilder->mail . ')' . PHP_EOL;
+
+    $user = user_load($wilder->uid);
+    user_save($user, ['mail' => 'bad-email-' . $user->uid . '@dosomething.invalid']);
+  }
+
+  // Now, update (or create) the corresponding profile in Northstar by Drupal ID.
+  dosomething_northstar_create_user($user);
+}
+
+print 'done';


### PR DESCRIPTION
#### What's this PR do?
This pull request includes a quick little script to iterate over the 5,183 users that exist in Phoenix but not Northstar and either sanitize their email if it's invalid or attempt to re-sync them if not. (c62d63d)

This account also removes the code which would sync a user's hashed password to Northstar, since we'll now have a significant segment of users who do not have a valid password stored in the Phoenix database and we'd never want to overwrite the real one in Northstar with that. (17cc4e3)

#### How should this be reviewed?
👀

#### Any background context you want to provide?
I'm investigating an issue reported by @mikefantini where his Phoenix account had disappeared from the `authmap` table and therefore couldn't log in. While this doesn't fix whatever _caused_ that to happen, it's a good short-term fix for other potentially affected accounts.

#### Relevant tickets
Fixes 🐛.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  