### PR TITLE
Remove emoji when creating Phoenix users via API.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -201,9 +201,9 @@ function _member_resource_create($request) {
   // Map request input to Drupal fields, or use default values.
   $fields = [
     'birthdate' => $request['birthdate'],
-    'first_name' => $request['first_name'],
+    'first_name' => dosomething_helpers_remove_emoji_from_string($request['first_name']),
     'country' => !empty($request['country']) ? $request['country'] : 'US',
-    'last_name' => !empty($request['last_name']) ? $request['last_name'] : NULL,
+    'last_name' => !empty($request['last_name']) ? dosomething_helpers_remove_emoji_from_string($request['last_name']) : NULL,
     'mobile' => !empty($request['mobile']) ? dosomething_user_clean_mobile_number($request['mobile']) : NULL,
     'user_registration_source' => !empty($request['user_registration_source']) ? $request['user_registration_source'] : NULL,
     'northstar_id' => $request['_id'],
@@ -217,9 +217,6 @@ function _member_resource_create($request) {
 
   // Infer the user's language from their country code field.
   $edit['language'] = dosomething_global_convert_country_to_language($fields['country']);
-
-  // Strip all emoji from the first name.
-  $edit['first_name'] = dosomething_helpers_remove_emoji_from_string($fields['first_name']);
 
   try {
     $user = user_save('', $edit);


### PR DESCRIPTION
#### What's this PR do?
This fixes an issue with #7244, which was supposed to fix an issue where users with emoji in their `first_name` would cause a fatal error on Phoenix. It was sanitizing the (unused) value for `first_name` in the `$edit` array, rather than sanitizing the value set for the field.

This PR also sanitizes the `last_name` field just in case people are extra crafty.

#### How should this be reviewed?
Here's the error that was previously being reported:

```json
{
  "error": {
    "code": 500,
    "message": "Server error: `POST http:\/\/dev.dosomething.org:8888\/api\/v1\/users?forward=0` resulted in a `500 Internal Server Error : An error occurred (0): PDOException: SQLSTATE[HY000]: General error: 1366 Incorrect string value: '\\xF0\\x9F\\x98\\x84da' for column 'field_first_name_value' at row 1 in \/var\/www\/dev.dosomething.org\/html\/includes\/database\/database.inc:2227Stack trace:#0 \/var\/www\/dev.dosomething.org\/html\/includes\/database\/database.inc(2227): PDOStatement->execute(Array)#1 \/var\/www\/dev.dosomething.org\/html\/includes\/database\/database.inc(697): DatabaseStatementBase->execute(Array, Array)#2 \/var\/www\/dev.dosomething.org\/html\/includes\/database\/mysql\/query.inc(36): DatabaseConnection->query('INSERT INTO {fi...', Array, Array)#3 \/var\/www\/dev.dosomething.org\/html\/modules\/field\/modules\/field_sql_storage\/field_sql_storage.module(514): InsertQuery_mysql->execute()#4 \/var\/www\/dev.dosomething.org\/html\/includes\/module.inc(926): field_sql_storage_field_storage_write('user', Object(stdClass), 'insert', Array)#5 \/var\/www\/dev.dosomething.org\/html\/modules\/field\/field.attach.inc(967): module_invoke('field_sql_stoExpires: Sun, 19 Nov 1978 05:00:00 GMT` response:\n\n\n{\"errorInfo\":[\"HY000\",1366,\"Incorrect string value: '\\\\xF0\\\\x9F\\\\x98\\\\x84da' for column 'field_first_name_value' at ro (truncated...)\n"
  }
}
```

And here's some screen-grabs of the successful request & Phoenix user after applying these fixes:

![the paw request](https://cloud.githubusercontent.com/assets/583202/21614431/6dc2c1a2-d1a7-11e6-857d-bc9cf97c157e.png)

![the droop user](https://cloud.githubusercontent.com/assets/583202/21614447/772bc680-d1a7-11e6-88d8-923ad8e23d5e.png)

#### Any background context you want to provide?
💁‍♂️

#### Relevant tickets
Fixes #7244.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  