### PR TITLE
Cron job bug

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -30,14 +30,19 @@ function dosomething_rogue_retry_failed_reportbacks() {
           $task->file = $mime_split[0] . ':' . $mimetype . $mime_split[1];
         }
 
+        $data = (array)$task;
+
         if ($task->drupal_id) {
           $user = user_load($task->drupal_id);
-        } else {
+        }
+        elseif ($task->northstar_id) {
           $northstar_user = dosomething_northstar_get_user($task->northstar_id);
           $user = user_load($northstar_user->drupal_id);
         }
-
-        $data = (array)$task;
+        else {
+          dosomething_rogue_handle_failure($data, NULL, $task->id);
+          continue;
+        }
 
         $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($data, $user, $task->id);
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -29,6 +29,7 @@ function dosomething_rogue_retry_failed_reportbacks() {
           $mime_split = explode(':', $task->file);
           $task->file = $mime_split[0] . ':' . $mimetype . $mime_split[1];
         }
+
         $user = user_load($task->drupal_id);
         $data = (array)$task;
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -30,7 +30,13 @@ function dosomething_rogue_retry_failed_reportbacks() {
           $task->file = $mime_split[0] . ':' . $mimetype . $mime_split[1];
         }
 
-        $user = user_load($task->drupal_id);
+        if ($task->drupal_id) {
+          $user = user_load($task->drupal_id);
+        } else {
+          $northstar_user = dosomething_northstar_get_user($task->northstar_id);
+          $user = user_load($northstar_user->drupal_id);
+        }
+
         $data = (array)$task;
 
         $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($data, $user, $task->id);

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -65,12 +65,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
   // aware of a user's northstar id. If it doesn't find one, we just grab it
   // from northstar directly.
   if (!$northstar_id) {
-    if ($user->uid) {
-      $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
-    } else {
-      $northstar_user = dosomething_northstar_get_user($values['northstar_id']);
-      $user = user_load($northstar_user->drupal_id);
-    }
+    $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
     $northstar_id = $northstar_user->id;
   }
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -67,10 +67,11 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
   if (!$northstar_id) {
     if ($user->uid) {
       $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
-      $northstar_id = $northstar_user->id;
     } else {
-      $northstar_id = dosomething_northstar_get_user($values['northstar_id']);
+      $northstar_user = dosomething_northstar_get_user($values['northstar_id']);
+      $user = user_load($northstar_user->drupal_id);
     }
+    $northstar_id = $northstar_user->id;
   }
 
   $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
@@ -287,7 +288,7 @@ function dosomething_rogue_check_rbid_and_store_ref($rogue_reportback) {
   * Transform reportback into the appropriate scheme to send to Rogue.
   *
   * @param $values - Reportback values to send to Rogue.
-  * @param  $user - Loaded drupal user
+  * @param $user - Loaded drupal user
   * @param $northstar_id - User's Northstar user id.
   * @return array
   */

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -218,7 +218,7 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $failed_tas
   // Instead, increment the number of tries and update the time of most recent attempt to send to Rogue.
   if (! is_null($failed_task_id)) {
     $previously_failed = array_pop(dosomething_rogue_previously_failed($failed_task_id));
-    update_failed_task_log($values, $previously_failed);
+    update_failed_task_log($previously_failed);
   } else {
     insert_failed_task_into_failed_task_log($values, $response, $e, $user);
   }
@@ -333,11 +333,10 @@ function dosomething_rogue_previously_failed($id) {
 /**
  * Update the timestamp and tries in the dosomething_rogue_failed_task_log for a failed reportback item.
  *
- * @param array $values
  * @param object $previously_failed
  *
  */
-function update_failed_task_log($values, $previously_failed) {
+function update_failed_task_log($previously_failed) {
   // Increment the number of tries the cron job attempted to send failed record to Rogue.
   $incremented_tries = $previously_failed->tries + 1;
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -65,8 +65,12 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
   // aware of a user's northstar id. If it doesn't find one, we just grab it
   // from northstar directly.
   if (!$northstar_id) {
-    $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
-    $northstar_id = $northstar_user->id;
+    if ($user->uid) {
+      $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
+      $northstar_id = $northstar_user->id;
+    } else {
+      $northstar_id = dosomething_northstar_get_user($values['northstar_id']);
+    }
   }
 
   $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);


### PR DESCRIPTION
#### What's this PR do?
- If a reportback record in the `dosomething_rogue_failed_task_log` does not have a `drupal_id`, it currently breaks the job and never makes it to the remaining records to try to re-send. 
- This PR fixes this by getting the `drupal_id` with the user's `northstar_id`

#### How should this be reviewed?
- Delete a record's `drupal_id` in the `dosomething_rogue_failed_task_log` table.
- Run the cron job. 
- The record should be removed from the table and you should see this successfully migrated to Rogue.

#### Relevant tickets
Fixes #7269 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
