### PR TITLE
Custom share on all campaigns (other than LYCV) 

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -443,9 +443,6 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
       $vars['social_share_custom_description'] = $campaign->variables['social_share_custom_description'];
       $vars['share_image'] = dosomething_image_get_themed_image_url($campaign->variables['share_image_nid'], 'landscape');
   }
-  else {
-    $vars['share_image'] = $base_url . 'sites/default/files/images/problem-' . $campaign->nid . '-' . $country_prefix_for_share . '.png';
-  }
 
   // Add social share bar.
   $social_share_types = array(

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -439,7 +439,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $base_url = url(base_path(), array('absolute'=> TRUE, 'language' => 'en-global'));
   $campaign_path = url(current_path(), array('absolute' => TRUE));
   $country_prefix_for_share = (dosomething_global_get_current_prefix()) ? strtoupper(dosomething_global_get_current_prefix()) : 'global';
-  if (dosomething_campaign_feature_on($campaign, 'enable_voter_registration', TRUE)) {
+  if (dosomething_campaign_feature_on($campaign, 'social_share_unique_link')) {
       $vars['share_image'] = dosomething_image_get_themed_image_url($campaign->variables['share_image_nid'], 'landscape');
   }
   else {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -440,6 +440,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   $campaign_path = url(current_path(), array('absolute' => TRUE));
   $country_prefix_for_share = (dosomething_global_get_current_prefix()) ? strtoupper(dosomething_global_get_current_prefix()) : 'global';
   if (dosomething_campaign_feature_on($campaign, 'social_share_unique_link')) {
+      $vars['social_share_custom_description'] = $campaign->variables['social_share_custom_description'];
       $vars['share_image'] = dosomething_image_get_themed_image_url($campaign->variables['share_image_nid'], 'landscape');
   }
   else {

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -37,9 +37,9 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     '#title' => t('Custom social share description'),
     '#description' => t("Custom description to share with social links."),
     '#default_value' => $vars['social_share_custom_description'],
-    '#attributes' => array(
+    '#attributes' => array[
       'maxlength' => '140',
-    ),
+    ],
   ];
   $form['custom_social_sharing']['share_image_nid'] = [
     '#type' => 'textfield',

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -33,13 +33,11 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     ),
   ];
   $form['custom_social_sharing']['social_share_custom_description'] = [
-    '#type' => 'textfield',
+    '#type' => 'textarea',
     '#title' => t('Custom social share description'),
     '#description' => t("Custom description to share with social links."),
     '#default_value' => $vars['social_share_custom_description'],
-    '#attributes' => array[
-      'maxlength' => '140',
-    ],
+    '#size' => 20,
   ];
   $form['custom_social_sharing']['share_image_nid'] = [
     '#type' => 'textfield',

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -32,6 +32,15 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
       'maxlength' => '140',
     ),
   ];
+  $form['custom_social_sharing']['social_share_custom_description'] = [
+    '#type' => 'textfield',
+    '#title' => t('Custom social share description'),
+    '#description' => t("Custom description to share with social links."),
+    '#default_value' => $vars['social_share_custom_description'],
+    '#attributes' => array(
+      'maxlength' => '140',
+    ),
+  ];
   $form['custom_social_sharing']['share_image_nid'] = [
     '#type' => 'textfield',
     '#title' => t('Photo nid'),
@@ -291,8 +300,9 @@ function dosomething_helpers_get_variable_names() {
     'signup_form_submit_label',
     'sms_game_mp_story_id',
     'sms_game_mp_story_type',
-    'social_share_unique_link',
+    'social_share_custom_description',
     'social_share_custom_text',
+    'social_share_unique_link',
   ];
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -443,6 +443,9 @@
               <p><?php print $voter_reg_share_modal_text_1 ?></p>
             <?php else : ?>
               <h3><?php print t('Share This Campaign') ?></h3><br>
+              <?php if ($social_share_custom_description) : ?>
+                <p><?php print $social_share_custom_description ?></p><br>
+              <?php endif; ?>
             <?php endif; ?>
             <?php if ($share_image) : ?>
               <img src="<?php print $share_image ?>">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -451,9 +451,6 @@
             <?php if ($register_voters) : ?>
               <p><?php print $voter_reg_share_modal_text_2 ?></p>
             <?php endif; ?>
-            <div class="padded-gray-box">
-              <?php print $custom_social_share_link ?>
-            </div>
           </div>
         </div>
        <?php endif; ?>


### PR DESCRIPTION
#### What's this PR do?
- Adds a photo by photo's `nid` if `social_share_unique_link` is enabled (even if voter reg is not).
- Adds field to customize description under "Share This Campaign" in share modal (by campaign basis). 
- Removes all text below image. 

#### How should this be reviewed?
- On any campaign, go to the "Custom Settings" tab.
- Check off `Create unique social share links for each user.` box.
- Fill out all fields and save.
- On campaign page, make sure the custom share setting is there with all information you put in the form. 

#### Relevant tickets
Fixes #7272 