### PR TITLE
Custom gray box

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -442,9 +442,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   if (dosomething_campaign_feature_on($campaign, 'social_share_unique_link')) {
       $vars['social_share_custom_description'] = $campaign->variables['social_share_custom_description'];
       $vars['share_image'] = dosomething_image_get_themed_image_url($campaign->variables['share_image_nid'], 'landscape');
-      if ($campaign->variables['show_social_share_link']) {
-        $vars['show_social_share_link'] = $campaign->variables['show_social_share_link'];
-      }
+      $vars['show_social_share_link'] = $campaign->variables['show_social_share_link'];
   }
 
   // Add social share bar.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -442,6 +442,9 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   if (dosomething_campaign_feature_on($campaign, 'social_share_unique_link')) {
       $vars['social_share_custom_description'] = $campaign->variables['social_share_custom_description'];
       $vars['share_image'] = dosomething_image_get_themed_image_url($campaign->variables['share_image_nid'], 'landscape');
+      if ($campaign->variables['show_social_share_link']) {
+        $vars['show_social_share_link'] = $campaign->variables['show_social_share_link'];
+      }
   }
 
   // Add social share bar.

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -70,6 +70,11 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     '#description' => t("Custom Tumblr copy to populate Tumblr share. If blank, copy will default to the problem statement."),
     '#default_value' => $vars['custom_tumblr_copy'],
     '#size' => 20,
+  $form['custom_social_sharing']['show_social_share_link'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Visible custom social share link'),
+    '#default_value' => $vars['show_social_share_link'],
+    '#description' => t('If checked, the custom social share link will be visible in a gray padded box for the user to copy and paste.'),
   ];
   $form['styles'] = array(
     '#type' => 'fieldset',
@@ -300,6 +305,7 @@ function dosomething_helpers_get_variable_names() {
     'shipment_form_submit_label',
     'shipment_form_submitted_copy',
     'shipment_item',
+    'show_social_share_link',
     'signup_count',
     'signup_form_submit_label',
     'sms_game_mp_story_id',

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -70,6 +70,7 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     '#description' => t("Custom Tumblr copy to populate Tumblr share. If blank, copy will default to the problem statement."),
     '#default_value' => $vars['custom_tumblr_copy'],
     '#size' => 20,
+  ];
   $form['custom_social_sharing']['show_social_share_link'] = [
     '#type' => 'checkbox',
     '#title' => t('Visible custom social share link'),

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -433,6 +433,11 @@
             <?php if ($register_voters) : ?>
               <p><?php print $voter_reg_share_modal_text_2 ?></p>
             <?php endif; ?>
+            <?php if ($show_social_share_link) : ?>
+              <div class="padded-gray-box">
+                <?php print $custom_social_share_link ?>
+              </div>
+            <?php endif; ?>
           </div>
         </div>
        <?php endif; ?>


### PR DESCRIPTION
#### What's this PR do?
- Adds a checkbox to add the option to show the user's custom share url in a gray box below the share image.

#### How should this be reviewed?
- In custom settings, make sure `Create unique social share links for each user.` is checked off. 
- Also check the `Visible custom social share link` box. 
- Run `drush cc all`. 
- On the campaign page, the custom social modal should look like the below:
![screen shot 2017-01-11 at 10 35 13 am](https://cloud.githubusercontent.com/assets/9019452/21854705/bf5658a6-d7e9-11e6-9c1f-2c5759b93b7c.png)

#### Any background context you want to provide?
Refs #7273

#### Relevant tickets
Fixes #7274 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
