### PR TITLE
Custom share language

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -445,14 +445,22 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   }
 
   // Add social share bar.
-  if ($campaign->variables['custom_twitter_copy']) {
-    $tweet = $campaign->variables['custom_twitter_copy'];
-  }
-  elseif (isset($campaign->fact_problem['fact'])) {
-    $tweet = $campaign->fact_problem['fact'];
-  }
-  else {
-    $tweet = NULL;
+  $custom_social_copy_variables = [
+    'custom_facebook_copy' => $campaign->variables['custom_facebook_copy'],
+    'custom_twitter_copy' => $campaign->variables['custom_twitter_copy'],
+    'custom_tumblr_copy' => $campaign->variables['custom_tumblr_copy'],
+  ];
+
+  foreach ($custom_social_copy_variables as $key => $value) {
+    if ($value) {
+      $$key = $value;
+    }
+    elseif (isset($campaign->fact_problem['fact'])) {
+      $$key = $campaign->fact_problem['fact'];
+    }
+    else {
+      $$key = NULL;
+    }
   }
 
   $social_share_types = array(
@@ -460,10 +468,11 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
       'type' => 'feed_dialog',
       'parameters' => array(
       'picture' => $vars['share_image'],
+      'caption' => $custom_facebook_copy,
     ),
   ),
     'twitter' => array(
-      'tweet' => $tweet,
+      'tweet' => $custom_twitter_copy,
     ),
     'tumblr' => array(
       'posttype' => 'photo',

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -445,6 +445,16 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   }
 
   // Add social share bar.
+  if ($campaign->variables['custom_twitter_copy']) {
+    $tweet = $campaign->variables['custom_twitter_copy'];
+  }
+  elseif (isset($campaign->fact_problem['fact'])) {
+    $tweet = $campaign->fact_problem['fact'];
+  }
+  else {
+    $tweet = NULL;
+  }
+
   $social_share_types = array(
     'facebook' => array(
       'type' => 'feed_dialog',
@@ -453,7 +463,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     ),
   ),
     'twitter' => array(
-      'tweet' => (isset($campaign->fact_problem)) ? $campaign->fact_problem['fact'] : NULL,
+      'tweet' => $tweet,
     ),
     'tumblr' => array(
       'posttype' => 'photo',

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -477,7 +477,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
     'tumblr' => array(
       'posttype' => 'photo',
       'content' => $vars['share_image'],
-      'caption' => t("This is REAL, do something about this with me: "),
+      'caption' => $custom_tumblr_copy,
     ),
   );
 

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -48,6 +48,29 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
       'maxlength' => '140',
     ),
   ];
+  $form['custom_social_sharing']['custom_facebook_copy'] = [
+    '#type' => 'textarea',
+    '#title'=> t('Custom Facebook copy'),
+    '#description' => t("Custom Facebook copy to populate Facebook share. If blank, copy will default to the problem statement."),
+    '#default_value' => $vars['custom_facebook_copy'],
+    '#size' => 20,
+  ];
+  $form['custom_social_sharing']['custom_twitter_copy'] = [
+    '#type' => 'textfield',
+    '#title' => t('Custom Twitter copy'),
+    '#description' => t("Custom Twitter copy to populate Twitter share. If blank, copy will default to the problem statement."),
+    '#default_value' => $vars['custom_twitter_copy'],
+    '#attributes' => [
+      'maxlength' => '140',
+    ],
+  ];
+  $form['custom_social_sharing']['custom_tumblr_copy'] = [
+    '#type' => 'textarea',
+    '#title'=> t('Custom Tumblr copy'),
+    '#description' => t("Custom Tumblr copy to populate Tumblr share. If blank, copy will default to the problem statement."),
+    '#default_value' => $vars['custom_tumblr_copy'],
+    '#size' => 20,
+  ];
   $form['styles'] = array(
     '#type' => 'fieldset',
     '#title' => t('Styles'),
@@ -257,6 +280,9 @@ function dosomething_helpers_get_variable_names() {
     'count_flagged',
     'count_pending',
     'count_promoted',
+    'custom_facebook_copy',
+    'custom_tumblr_copy',
+    'custom_twitter_copy',
     'disable_onboarding',
     'enable_voter_registration',
     'magic_link_copy',


### PR DESCRIPTION
#### What's this PR do?
- Adds fields in `Custom Settings` to allow admins to add custom social copy when sharing per social platform. 

#### How should this be reviewed?
- Go to a campaign and click on `Custom Settings`.
- Add custom social copy in `Custom Facebook copy`, `Custom Twitter copy` and `Custom Tumblr copy` fields and save.
- Run `drush cc all`. 
- Go to campaign page and click on social sharing. You should now see your custom copy. 
- If no custom copy is added, the problem statement is inserted as copy. If there is no problem statement, it is left empty. 

#### Any background context you want to provide?
- Couldn't test the Tumblr functionality on local so will need to wait to test on Thor. 

#### Relevant tickets
Fixes #7278 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
