### PR TITLE
Correctly parse ISO-8601 dates provided for birthdate.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
+++ b/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
@@ -137,6 +137,12 @@ class OpenIDConnectClientNorthstar extends OpenIDConnectClientBase {
    */
   public function retrieveUserInfo($access_token) {
     $base = parent::retrieveUserInfo($access_token);
+
+    // Parse birthdate to timestamp, if provided.
+    if (! empty($base['data']['birthdate'])) {
+      $base['data']['birthdate'] = strtotime($base['data']['birthdate']);
+    }
+
     if ($base) {
       return $base['data'];
     }


### PR DESCRIPTION
#### What's this PR do?
This fixes a fatal error that occurred when trying to parse a date string as a user's birthdate from their user info. Drupal expects all dates to be UNIX timestamps, but the spec says that field in the JSON response should be a ISO-8601 string  (e.g. `1990-10-25`) so we'll handle that here.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
🍃

#### Relevant tickets
References DoSomething/northstar#531.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  