### PR TITLE
Adding new affiliate configurations form in CMS specific to each campaign.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.admin.inc
@@ -344,6 +344,10 @@ function dosomething_campaign_admin_custom_settings_page($node) {
     $output .= render($variable_form);
   }
 
+  // Exports
+  $exports_form = drupal_get_form('dosomething_helpers_exports_form', $node);
+  $output .= render($exports_form);
+
   // Render third party form.
   $form_id = 'dosomething_helpers_third_party_variable_form';
   $third_party_form = drupal_get_form($form_id, $node);

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -275,14 +275,10 @@ function dosomething_campaign_load($node, $public = FALSE, $cache = TRUE) {
       $campaign->image_header = $campaign->image_cover;
     }
 
-    // dump($node);
-    // die();
-
     // Load Creator property.
     dosomething_campaign_load_creator($campaign, $wrapper);
 
-    // @TODO: Uncomment following line.
-    // cache_set('ds_campaign_' . $campaign->nid .'_'. $current_lang, $campaign, 'cache_dosomething_campaign', REQUEST_TIME + 60*60*24);
+    cache_set('ds_campaign_' . $campaign->nid .'_'. $current_lang, $campaign, 'cache_dosomething_campaign', REQUEST_TIME + 60*60*24);
 
     // If this is accessed via API:
     if ($public) {
@@ -293,9 +289,6 @@ function dosomething_campaign_load($node, $public = FALSE, $cache = TRUE) {
     }
   }
 
-  $campaign->poop = TRUE;
-  // dump($campaign);
-  // die();
   return $campaign;
 }
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -275,10 +275,14 @@ function dosomething_campaign_load($node, $public = FALSE, $cache = TRUE) {
       $campaign->image_header = $campaign->image_cover;
     }
 
+    // dump($node);
+    // die();
+
     // Load Creator property.
     dosomething_campaign_load_creator($campaign, $wrapper);
 
-    cache_set('ds_campaign_' . $campaign->nid .'_'. $current_lang, $campaign, 'cache_dosomething_campaign', REQUEST_TIME + 60*60*24);
+    // @TODO: Uncomment following line.
+    // cache_set('ds_campaign_' . $campaign->nid .'_'. $current_lang, $campaign, 'cache_dosomething_campaign', REQUEST_TIME + 60*60*24);
 
     // If this is accessed via API:
     if ($public) {
@@ -289,6 +293,9 @@ function dosomething_campaign_load($node, $public = FALSE, $cache = TRUE) {
     }
   }
 
+  $campaign->poop = TRUE;
+  // dump($campaign);
+  // die();
   return $campaign;
 }
 
@@ -635,4 +642,40 @@ function dosomething_campaign_get_runs($nid, $language) {
                              ))->fetchAll();
 
   return $campaign_runs;
+}
+
+/**
+ * Get all the affiliate configurations data for a campaign.
+ *
+ * @param  string|array $campaign_info Either a node ID or an array of campaign variables.
+ * @return array
+ */
+function dosomething_campaign_get_affiliate_data($campaign_info) {
+  if (!$campaign_info) {
+    return FALSE;
+  }
+
+  // Is provided info an array of campaign variables?
+  if (is_array($campaign_info)) {
+    $variables = $campaign_info;
+  }
+
+  // Is provided info a string node ID?
+  if (is_string($campaign_info)) {
+    $variables = dosomething_helpers_get_variables('node', $campaign_info);
+  }
+
+  $data = [
+    'messaging_opt_in' => [
+      'enabled' => $variables['affiliate_opt_in_toggle'] ? TRUE : FALSE,
+    ],
+  ];
+
+  if ($data['messaging_opt_in']['enabled']) {
+    $data['messaging_opt_in']['label'] = $variables['affiliate_opt_in_toggle_label'];
+    $data['messaging_opt_in']['info_label'] = $variables['affiliate_opt_in_toggle_information_label'];
+    $data['messaging_opt_in']['info_message'] = $variables['affiliate_opt_in_toggle_information_message'];
+  }
+
+  return $data;
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -641,11 +641,11 @@ function dosomething_campaign_get_runs($nid, $language) {
  * Get all the affiliate configurations data for a campaign.
  *
  * @param  string|array $campaign_info Either a node ID or an array of campaign variables.
- * @return array
+ * @return array|null
  */
 function dosomething_campaign_get_affiliate_data($campaign_info) {
   if (!$campaign_info) {
-    return FALSE;
+    return NULL;
   }
 
   // Is provided info an array of campaign variables?
@@ -660,7 +660,7 @@ function dosomething_campaign_get_affiliate_data($campaign_info) {
 
   $data = [
     'messaging_opt_in' => [
-      'enabled' => $variables['affiliate_opt_in_toggle'] ? TRUE : FALSE,
+      'enabled' => (bool) $variables['affiliate_opt_in_toggle'],
     ],
   ];
 

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -528,14 +528,23 @@ function dosomething_campaign_preprocess_shipment_form(&$vars) {
  *   The corresponding entity wrapper for the node in $vars.
  */
 function dosomething_campaign_preprocess_pitch_page(&$vars, &$wrapper) {
+  $campaign = $vars['campaign'];
+
   // Use the pitch page template to theme.
   $vars['theme_hook_suggestions'][] = 'node__' . $vars['type'] . '__pitch';
 
   // Track that we're viewing a pitch page.
-  $vars['campaign']->is_pitch_page = TRUE;
+  $campaign->is_pitch_page = TRUE;
+
+  // Affiliate Data
+  $campaign->affiliate = dosomething_campaign_get_affiliate_data($campaign->variables);
+
+  if ($campaign->affiliate['messaging_opt_in']['enabled']) {
+    $campaign->secondary_call_to_action = NULL;
+  }
 
   // Check for a signup button copy override.
-  $label = $vars['campaign']->variables['signup_form_submit_label'];
+  $label = $campaign->variables['signup_form_submit_label'];
 
   // Adds signup_button_primary and signup_button_secondary variables.
   $ids = array('primary', 'secondary');

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -283,6 +283,16 @@ function dosomething_helpers_extract_id($data, $property = 'nid') {
   return $data->$property;
 }
 
+/**
+ * Utility function to export provided data as a CSV.
+ *
+ * @param  array  $data
+ * @return void
+ */
+function dosomething_helpers_export_csv(array $data) {
+  // @TODO: export the data!
+}
+
 
 /**
  * Format a string of comma separated data items into an array, or

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -7,6 +7,7 @@
 
 function dosomething_helpers_variable_form($form, &$form_state, $node) {
   $vars = dosomething_helpers_get_variables('node', $node->nid);
+
   $form['nid'] = array(
     '#type' => 'hidden',
     '#value' => $node->nid,
@@ -15,7 +16,7 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     '#type' => 'fieldset',
     '#title' => t('Custom Social Sharing'),
     '#collapsible' => TRUE,
-    '#collapsed' => FALSE,
+    '#collapsed' => TRUE,
   ];
   $form['custom_social_sharing']['social_share_unique_link'] = [
     '#type' => 'checkbox',
@@ -201,6 +202,7 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     );
   }
 
+  // Magic Link
   $form['magic_link'] = [
     '#type' => 'fieldset',
     '#title' => t('Magic Link'),
@@ -217,6 +219,7 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     ),
   ];
 
+  // Onboarding
   $form['onboarding'] = [
     '#type' => 'fieldset',
     '#title' => t('Onboarding'),
@@ -237,6 +240,50 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
       '#value' => 'Save',
     ),
   );
+
+  // Affiliate Configurations
+  $form['affiliate_configurations'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Affiliate Configurations'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  ];
+  $form['affiliate_configurations']['messaging_opt-in'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Messaging Opt-in'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  ];
+  $affiliate_form = &$form['affiliate_configurations']['messaging_opt-in'];
+
+  $affiliate_form['affiliate_opt_in_toggle'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Affiliate Opt-in enabled?'),
+    '#default_value' => $vars['affiliate_opt_in_toggle'],
+    '#description' => t('If checked, this campaign shows a toggle for adding a user to affiliate marketing emails when signing up.'),
+    '#disabled' => FALSE,
+  ];
+  $affiliate_form['affiliate_opt_in_toggle_label'] = [
+    '#type' => 'textfield',
+    '#title' => t('Affiliate Opt-in Checkbox Toggle Label'),
+    '#default_value' => $vars['affiliate_opt_in_toggle_label'] ? $vars['affiliate_opt_in_toggle_label'] : 'Also sign me up for messages from our partner',
+    '#description' => t('The copy to show next to the checkbox.'),
+    '#disabled' => FALSE,
+  ];
+  $affiliate_form['affiliate_opt_in_toggle_information_label'] = [
+    '#type' => 'textfield',
+    '#title' => t('Affiliate Opt-in More Information Label'),
+    '#default_value' => $vars['affiliate_opt_in_toggle_information_label'],
+    '#description' => t('The copy to indicate the "more information" link.'),
+    '#disabled' => FALSE,
+  ];
+  $affiliate_form['affiliate_opt_in_toggle_information_message'] = [
+    '#type' => 'textarea',
+    '#title' => t('Affiliate Opt-in More Information Message'),
+    '#default_value' => $vars['affiliate_opt_in_toggle_information_message'],
+    '#description' => t('The copy to explain what the affiliate opt-in is for.'),
+    '#disabled' => FALSE,
+  ];
 
   return $form;
 }
@@ -277,6 +324,10 @@ function dosomething_helpers_get_variable_names() {
   return [
     'alt_bg_fid',
     'sponsor_color',
+    'affiliate_opt_in_toggle',
+    'affiliate_opt_in_toggle_label',
+    'affiliate_opt_in_toggle_information_label',
+    'affiliate_opt_in_toggle_information_message',
     'alt_background_color',
     'alt_text_color',
     'alt_image_campaign_cover_nid',
@@ -397,13 +448,58 @@ function dosomething_helpers_set_variable($entity_type, $entity_id, $var_name, $
 }
 
 /**
+ * Export form for designating data to be exported.
+ */
+function dosomething_helpers_exports_form($form, &$form_state, $node) {
+  $nid = $node->nid;
+
+  $form['exports'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Exports'),
+    '#description' => t('Export data associated with this campaign.'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  ];
+  $form['exports']['export_affiliate_messaging_optins'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Export CSV of users that opted to receive affiliate messaging.'),
+    '#default_value' => FALSE,
+  ];
+  $form['exports']['actions'] = [
+    '#type' => 'actions',
+    'submit' => [
+      '#type' => 'submit',
+      '#value' => 'Export',
+    ],
+  ];
+
+  return $form;
+}
+
+/**
+ * Export form submit handler.
+ * @todo form added, but functionality is forthcoming... stay tuned!
+ */
+function dosomething_helpers_exports_form_submit(&$form, &$form_state) {
+  $data = [];
+
+  if ($form_state['values']['export_affiliate_messaging_optins']) {
+    // @TODO: gather the data to export!
+  }
+
+  dosomething_helpers_export_csv($data);
+
+  drupal_set_message('Check yer downloads folder kiddo.');
+}
+
+/**
  * Displays a node's relevant signup variables.
  */
 function dosomething_helpers_third_party_variable_form($form, &$form_state, $node) {
   $nid = $node->nid;
   $form['optins'] = array(
     '#type' => 'fieldset',
-    '#title' => t('Third Party Opt-ins'),
+    '#title' => t('Third Party Service Opt-ins'),
     '#description' => t('Custom campaign opt-in values.'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -35,8 +35,7 @@ function dosomething_signup_forms($form_id, $args) {
  *   The label to display on the form submit button.
  */
 function dosomething_signup_form($form, &$form_state, $nid, $label = "Sign Up") {
-
-  $campaign_variables = dosomething_campaign_get_affiliate_data($nid);
+  $affiliate_data = dosomething_campaign_get_affiliate_data($nid);
 
   $form['nid'] = [
     '#type' => 'hidden',
@@ -64,8 +63,8 @@ function dosomething_signup_form($form, &$form_state, $nid, $label = "Sign Up") 
     ],
   ];
 
-  if ($campaign_variables['messaging_opt_in']['enabled']) {
-    $messaging_opt_in = $campaign_variables['messaging_opt_in'];
+  if ($affiliate_data['messaging_opt_in']['enabled']) {
+    $messaging_opt_in = $affiliate_data['messaging_opt_in'];
 
     $form['affiliate_messeging_opt_in'] = [
       '#type' => 'checkbox',

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -35,11 +35,15 @@ function dosomething_signup_forms($form_id, $args) {
  *   The label to display on the form submit button.
  */
 function dosomething_signup_form($form, &$form_state, $nid, $label = "Sign Up") {
+
+  $campaign_variables = dosomething_campaign_get_affiliate_data($nid);
+
   $form['nid'] = [
     '#type' => 'hidden',
     '#value' => $nid,
     '#access' => FALSE,
   ];
+
   // Check query string for signup source value.
   if ($source = dosomething_signup_get_query_source()) {
     $form['source'] = [
@@ -48,6 +52,7 @@ function dosomething_signup_form($form, &$form_state, $nid, $label = "Sign Up") 
       '#access' => FALSE,
     ];
   }
+
   $form['submit'] = [
     '#type' => 'submit',
     '#value' => t($label),
@@ -58,6 +63,22 @@ function dosomething_signup_form($form, &$form_state, $nid, $label = "Sign Up") 
       'data-track-label' => 'Signup (Authenticated)',
     ],
   ];
+
+  if ($campaign_variables['messaging_opt_in']['enabled']) {
+    $messaging_opt_in = $campaign_variables['messaging_opt_in'];
+
+    $form['affiliate_messeging_opt_in'] = [
+      '#type' => 'checkbox',
+      '#title' => t($messaging_opt_in['label']),
+      '#default_value' => TRUE, // @TODO: eventually, this should be false so it's OPT-IN!
+    ];
+
+    if ($messaging_opt_in['info_label'] && $messaging_opt_in['info_message'])
+    $form['affiliate_messeging_opt_in_info'] = [
+      '#markup' => '<div class="opt-in-info"><p>'.$messaging_opt_in['info_label'].'</p><div>'.$messaging_opt_in['info_message'].'</div></div>',
+    ];
+  }
+
   return $form;
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
@@ -25,13 +25,16 @@ function dosomething_signup_preprocess_signup_button(&$vars, $label = "Sign Up",
   if ($label == NULL) {
     $label = "Sign Up";
   }
+
   $label = t($label);
   $var_name = 'signup_button';
   $form_id = 'dosomething_signup_form';
+
   // If this is a presignup form:
   if ($presignup) {
     $form_id = 'dosomething_signup_presignup_form';
   }
+
   // If we have an array of signup forms to render:
   if (!empty($ids)) {
     // Loop through each id:


### PR DESCRIPTION
#### What's this PR do?
This PR adds a custom form for specifying affiliate information on a per campaign basis and updates the pitch page to render the form with the custom settings as needed, when a user is signed in. It also adds a new per campaign export form where it will allow export of the users that opted in (opting out for this first one ;), but could be used for exporting other campaign specific data in the future.

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
This is Part 1 of work related to https://trello.com/c/YmS6rixd/216-5-as-a-biz-dev-i-want-to-build-an-opt-out-option-for-3rd-party-messaging-during-sign-up

Part 2 will expand on this work and enable saving the opt-outs (ins) and exporting them. It will also handle the logged out pitch page and the redirect over to Northstar and back with the info.

#### Relevant tickets
Refs #7296
