### PR TITLE
Properly pass form by reference for alter.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/auth/login.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/auth/login.inc
@@ -5,15 +5,13 @@
  *
  * Implements hook_form_alter().
  */
-function paraneue_dosomething_form_alter_login($form, &$form_state, $form_id) {
+function paraneue_dosomething_form_alter_login(&$form, &$form_state, $form_id) {
   // Add some changes for the reset password form.
   if ( $form_id ==  'user_pass' ) {
     $form['#after_build'][] = 'paraneue_dosomething_pass_reset_after_build';
     $form['#submit'][] = 'paraneue_dosomething_pass_submit';
     $form['#validate'][] = 'paraneue_dosomething_pass_validate';
   }
-
-  return $form;
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?
I made a silly goof when reading [the diff](https://github.com/DoSomething/phoenix/pull/7283/files#diff-c8d6a2dbaeaf1fd60e9022149b18c0baL73) to re-add this old code (the `$form` should be passed by reference in function declaration, and the `return` isn't necessary). This fixes it so the after-build, submit, and validate hooks are correctly applied.

#### How should this be reviewed?
👁 

#### Any background context you want to provide?
💧 

#### Relevant tickets
Fixes 🐛.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  