### PR TITLE
Removes reference to old validator.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -324,8 +324,6 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
     break;
 
     case 'user_pass':
-      $form['name']['#attributes']['data-validate'] = "email";
-      $form['name']['#attributes']['data-validate-required'] = true;
       $form['name']['#description'] = t('Forgot your password? We’ve all been there. Reset by entering your email.');
       $form['#submit'][] = 'dosomething_user_user_pass_submit';
     break;

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -100,10 +100,6 @@ function dosomething_zendesk_form($form, &$form_state, $entity = NULL)  {
       '#type' => 'textfield',
       '#title' => 'Your Email',
       '#required' => TRUE,
-      '#attributes' => array(
-        'data-validate' => 'email',
-        'data-validate-required' => '',
-      ),
     );
   }
 


### PR DESCRIPTION
#### What's this PR do?
Last one. I had removed the `email` client-side validator in #7288 (it's a fairly complicated function, and also lets us remove Mailcheck dependency from Phoenix), but hadn't noticed it was still used in the password reset form.

Since we'll be moving this flow to Northstar pretty soon, I'm just going to remove the `data-validate` attribute to unbork this flow and unblock deploys.

#### How should this be reviewed?
😩

#### Any background context you want to provide?
👓

#### Relevant tickets
Fixes 🐞.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  