### PR TITLE
Affiliate opt ins saving to db

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -372,6 +372,30 @@ function dosomething_campaign_load_stats(&$campaign) {
 }
 
 /**
+ * Create a new record to store the user's messaging opt-in preference.
+ *
+ * @param  object $user
+ * @param  string $campaign_id
+ * @return void
+ */
+function dosomething_campaign_create_affiliate_messaging_opt_in($user, $campaign_id) {
+  $campaign_run = dosomething_helpers_get_current_campaign_run_for_user($campaign_id, $user);
+  $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
+
+  db_insert('dosomething_campaign_affiliate_opt_ins')
+    ->fields([
+      'campaign_id' => $campaign_id,
+      'campaign_run_id' => $campaign_run->nid,
+      'northstar_id' => $northstar_user->id,
+      'first_name' => $northstar_user->first_name,
+      'email' => $northstar_user->email,
+      'mobile' => $northstar_user->mobile,
+    ])->execute();
+
+  drupal_set_message('And thanks for signing up for messaging from our affiliate!');
+}
+
+/**
  * Creates and returns a campaign node from given JSON string.
  */
 function dosomething_campaign_create_node_from_json($string) {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
@@ -6,6 +6,61 @@
 
 function dosomething_campaign_schema() {
   $schema['cache_dosomething_campaign'] = drupal_get_schema_unprocessed('system', 'cache');
+
+  $schema['dosomething_campaign_affiliate_opt_ins'] = [
+    'description' => 'Table of affiliate messaging opt-ins.',
+    'fields' => [
+      'id' => [
+        'description' => 'Primary key.',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'campaign_id' => [
+        'description' => 'The campaign ID containing the affiliate opt-in.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ],
+      'campaign_run_id' => [
+        'description' => 'The campaign run ID containing the affiliate opt-in.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ],
+      'northstar_id' => [
+        'description' => 'The Northstar ID for the user that opted-in.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ],
+      'first_name' => [
+        'description' => 'The first name for the user that opted-in.',
+        'type' => 'varchar',
+        'not null' => FALSE,
+        'length' => '255',
+      ],
+      'email' => [
+        'description' => 'The email for the user that opted-in.',
+        'type' => 'varchar',
+        'not null' => FALSE,
+        'length' => '255',
+      ],
+      'mobile' => [
+        'description' => 'The mobile number for the user that opted-in.',
+        'type' => 'varchar',
+        'not null' => FALSE,
+        'length' => '255',
+      ],
+    ],
+    'primary key' => ['id'],
+    'indexes' => [
+      'campaign_id' => ['campaign_id'],
+      'campaign_run_id' => ['campaign_run_id'],
+      'northstar_id' => ['northstar_id'],
+    ]
+  ];
+
   return $schema;
 }
 
@@ -153,4 +208,17 @@ function dosomething_campaign_update_7012() {
 function dosomething_campaign_update_7013() {
   field_delete_field('field_mobile_app_date');
   field_delete_field('field_on_mobile_app');
+}
+
+/**
+ * Add new dosomething_campaign_affiliate_opt_ins table.
+ */
+function dosomething_campaign_update_7014() {
+  $table_name = 'dosomething_campaign_affiliate_opt_ins';
+
+  if (!db_table_exists($table_name)) {
+    $schema = dosomething_campaign_schema();
+
+    db_create_table($table_name, $schema[$table_name]);
+  }
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
@@ -30,9 +30,9 @@ function dosomething_campaign_schema() {
       ],
       'northstar_id' => [
         'description' => 'The Northstar ID for the user that opted-in.',
-        'type' => 'int',
+        'type' => 'varchar',
         'not null' => TRUE,
-        'default' => 0,
+        'length' => '255',
       ],
       'first_name' => [
         'description' => 'The first name for the user that opted-in.',

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -92,13 +92,22 @@ function dosomething_signup_form_submit($form, &$form_state) {
     drupal_set_message(t("Please sign in first."));
     return;
   }
+
+  $params = [];
+
   $nid = $form_state['values']['nid'];
+
   $source = NULL;
   if (isset($form_state['values']['source'])) {
     $source = $form_state['values']['source'];
   }
+
+  if (isset($form_state['values']['affiliate_messeging_opt_in'])) {
+    $params['affiliate_messaging_opt_in'] = (bool) $form_state['values']['affiliate_messeging_opt_in'];
+  }
+
   // Create signup for logged in user.
-  dosomething_signup_user_signup($nid, NULL, $source);
+  dosomething_signup_user_signup($nid, NULL, $source, $params);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -580,8 +580,7 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL, $
   }
 
   // Insert signup.
-  // if ($sid = dosomething_signup_create($nid, $account->uid, $source)) {
-  if (true) {
+  if ($sid = dosomething_signup_create($nid, $account->uid, $source)) {
     $node = node_load($nid);
 
     // Set default signup message if we're still in this function.

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -573,18 +573,25 @@ function dosomething_signup_third_party_subscribe($account, $node, $options = []
  * @param string $source
  *   (optional) The signup source.
  */
-function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL) {
+function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL, $params = []) {
   if ($account == NULL) {
     global $user;
     $account = $user;
   }
 
   // Insert signup.
-  if ($sid = dosomething_signup_create($nid, $account->uid, $source)) {
+  // if ($sid = dosomething_signup_create($nid, $account->uid, $source)) {
+  if (true) {
     $node = node_load($nid);
 
     // Set default signup message if we're still in this function.
     dosomething_signup_set_signup_message($node->title);
+
+    if ($params) {
+      if (isset($params['affiliate_messaging_opt_in']) && $params['affiliate_messaging_opt_in']) {
+        dosomething_campaign_create_affiliate_messaging_opt_in($account, $nid, $node);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
#### What's this PR do?
This PR updates the affiliate messaging opt-in(out) feature to respond to whether the opt-in has been enabled for the campaign and then when the form is submitted account for this and create a record in the database if the user has decided _not_ to uncheck the toggle to receive messaging. Currently this only works for the auth'd user. Next up will be allowing this to also happen for users that haven't logged in yet and get redirected to Northstar, but this PR sets up a lot of the ground work to ideally just call a function with some info and have the same process happen 😄 

#### How should this be reviewed?
🕵️ 

#### Any background context you want to provide?
Exporting the records from the database is coming in a near-future update.

#### Relevant tickets
Fixes #7291
Refs #7296