### PR TITLE
Send signups to Rogue

### DIFF
--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -131,3 +131,20 @@ function dosomething_api_get_reportback_files($params, $count = 25, $start = 0) 
   unset($record);
   return $result;
 }
+
+/**
+ * Handles incrementing the transaction IDs for requests.
+ *
+ * @param string $transaction_id
+ *   The transaction ID that Phoenix received and needs to increment.
+ *
+ * @return string
+ *   The incremented transaction ID.
+ */
+function dosomething_api_increment_transaction_id($transaction_id) {
+    $transaction_id_parts = explode('-', $transaction_id);
+    $transaction_id_base = $transaction_id_parts[0];
+    $incremented_step = $transaction_id_parts[1] + 1;
+
+    return $transaction_id_base . '-' . $incremented_step;
+}

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -284,23 +284,21 @@ function _campaign_resource_signup($nid, $values) {
 
   $headers = getallheaders();
 
+  // Check to see if the request came from Rogue and if we should be sending it there
   // $headers['X-Request-Id'] will only be set if the request is coming from Rogue
-  if ( !isset($headers['X-Request-Id'])) {
-    // Send to Rogue since the signup is not there yet
-    if (variable_get('rogue_signup_collection', FALSE)) {
-      // Pass the campaign_id
-      $values['campaign_id'] = $nid;
+  if ( !isset($headers['X-Request-Id']) && variable_get('rogue_signup_collection', FALSE)) {
+    // Pass the campaign_id
+    $values['campaign_id'] = $nid;
 
-      // Get the run to pass
-      $user = user_load($values['uid']);
-      $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $user);
+    // Get the run to pass
+    $user = user_load($values['uid']);
+    $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $user);
 
-      // Post the signup to Rogue
-      $rogue_signup = dosomething_rogue_send_signup_to_rogue($values);
+    // Post the signup to Rogue
+    $rogue_signup = dosomething_rogue_send_signup_to_rogue($values);
 
-      // Store the reference to the Rogue signup
-      return dosomething_rogue_check_sid_and_store_ref($rogue_signup);
-    }
+    // Store the reference to the Rogue signup
+    return dosomething_rogue_check_sid_and_store_ref($rogue_signup);
   } else {
     // @TODO: make helper function to do this?
     // Increment transaction id and log that the request has been received with new transaction id.

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -286,20 +286,28 @@ function _campaign_resource_signup($nid, $values) {
 
   // Check to see if the request came from Rogue and if we should be sending it there
   // $headers['X-Request-Id'] will only be set if the request is coming from Rogue
-  if ( !isset($headers['X-Request-Id']) && variable_get('rogue_signup_collection', FALSE)) {
-    // Pass the campaign_id
-    $values['campaign_id'] = $nid;
+  if ( !isset($headers['X-Request-Id'])) {
+    if (variable_get('rogue_signup_collection', FALSE)) {
+      // Pass the campaign_id
+      $values['campaign_id'] = $nid;
 
-    // Get the run to pass
-    $user = user_load($values['uid']);
-    $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $user);
+      // Get the run to pass
+      $user = user_load($values['uid']);
+      $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $user);
 
-    // Post the signup to Rogue
-    $rogue_signup = dosomething_rogue_send_signup_to_rogue($values);
+      // Post the signup to Rogue
+      $rogue_signup = dosomething_rogue_send_signup_to_rogue($values);
 
-    // Store the reference to the Rogue signup
-    return dosomething_rogue_check_sid_and_store_ref($rogue_signup);
+      // Store the reference to the Rogue signup
+      return dosomething_rogue_check_sid_and_store_ref($rogue_signup);
+    }
+    // The request is not from Rogue and we don't want to send it there, so just save to Phoenix
+    else {
+      // transactionals = FALSE will result in neither email or SMS transactional messages being sent.
+      return dosomething_signup_create($nid, $values['uid'], $values['source'], NULL, $values['transactionals']);
+    }
   } else {
+    // Only try to increment transaction IDs if they were already set
     // Increment transaction id and log that the request has been received with new transaction id.
     $transaction_id_parts = explode('-', $headers['X-Request-Id']);
     $transaction_id_base = $transaction_id_parts[0];
@@ -307,6 +315,7 @@ function _campaign_resource_signup($nid, $values) {
     $incremented_transaction_id = $transaction_id_base . '-' . $incremented_step;
 
     watchdog('PhoenixTransactionBridge', 'Request received. Transaction ID: !incremented_transaction_id', ['!incremented_transaction_id' => $incremented_transaction_id], WATCHDOG_INFO);
+
     // transactionals = FALSE will result in neither email or SMS transactional messages being sent.
     return dosomething_signup_create($nid, $values['uid'], $values['source'], NULL, $values['transactionals']);
   }

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -309,10 +309,7 @@ function _campaign_resource_signup($nid, $values) {
   } else {
     // Only try to increment transaction IDs if they were already set
     // Increment transaction id and log that the request has been received with new transaction id.
-    $transaction_id_parts = explode('-', $headers['X-Request-Id']);
-    $transaction_id_base = $transaction_id_parts[0];
-    $incremented_step = $transaction_id_parts[1] + 1;
-    $incremented_transaction_id = $transaction_id_base . '-' . $incremented_step;
+    $incremented_transaction_id = dosomething_api_increment_transaction_id($headers['X-Request-Id']);
 
     watchdog('PhoenixTransactionBridge', 'Request received. Transaction ID: !incremented_transaction_id', ['!incremented_transaction_id' => $incremented_transaction_id], WATCHDOG_INFO);
 
@@ -409,10 +406,7 @@ function _campaign_resource_reportback($nid, $values) {
   }
   else {
     // Increment transaction id and log that the request has been received with new transaction id.
-    $transaction_id_parts = explode('-', $headers['X-Request-Id']);
-    $transaction_id_base = $transaction_id_parts[0];
-    $incremented_step = $transaction_id_parts[1] + 1;
-    $incremented_transaction_id = $transaction_id_base . '-' . $incremented_step;
+    $incremented_transaction_id = dosomething_api_increment_transaction_id($headers['X-Request-Id']);
 
     watchdog('PhoenixTransactionBridge', 'Request received. Transaction ID: !incremented_transaction_id', ['!incremented_transaction_id' => $incremented_transaction_id], WATCHDOG_INFO);
 

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -299,7 +299,9 @@ function _campaign_resource_signup($nid, $values) {
       $rogue_signup = dosomething_rogue_send_signup_to_rogue($values);
 
       // Store the reference to the Rogue signup
-      return dosomething_rogue_check_sid_and_store_ref($rogue_signup);
+      if ($rogue_signup) {
+        return dosomething_rogue_check_sid_and_store_ref($rogue_signup);
+      }
     }
     // The request is not from Rogue and we don't want to send it there, so just save to Phoenix
     else {

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -274,14 +274,45 @@ function _campaign_resource_signup($nid, $values) {
   if (!isset($values['source'])) {
     $values['source'] = NULL;
   }
+  // @TODO: handle passing this to Rogue so it is not lost (and add to Phoenix documentation which is missing this)
   if (!isset($values['transactionals'])) {
     $values['transactionals'] = TRUE;
   }
   if (DOSOMETHING_SIGNUP_LOG_SIGNUPS) {
     watchdog('dosomething_api', '_campaign_resource_signup values:' . json_encode($values));
   }
-  // transactionals = FALSE will result in neither email or SMS transactional messages being sent.
-  return dosomething_signup_create($nid, $values['uid'], $values['source'], NULL, $values['transactionals']);
+
+  $headers = getallheaders();
+
+  // $headers['X-Request-Id'] will only be set if the request is coming from Rogue
+  if ( !isset($headers['X-Request-Id'])) {
+    // Send to Rogue since the signup is not there yet
+    if (variable_get('rogue_signup_collection', FALSE)) {
+      // Pass the campaign_id
+      $values['campaign_id'] = $nid;
+
+      // Get the run to pass
+      $user = user_load($values['uid']);
+      $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $user);
+
+      // Post the signup to Rogue
+      $rogue_signup = dosomething_rogue_send_signup_to_rogue($values);
+
+      // Store the reference to the Rogue signup
+      return dosomething_rogue_check_sid_and_store_ref($rogue_signup);
+    }
+  } else {
+    // @TODO: make helper function to do this?
+    // Increment transaction id and log that the request has been received with new transaction id.
+    $transaction_id_parts = explode('-', $headers['X-Request-Id']);
+    $transaction_id_base = $transaction_id_parts[0];
+    $incremented_step = $transaction_id_parts[1] + 1;
+    $incremented_transaction_id = $transaction_id_base . '-' . $incremented_step;
+
+    watchdog('PhoenixTransactionBridge', 'Request received. Transaction ID: !incremented_transaction_id', ['!incremented_transaction_id' => $incremented_transaction_id], WATCHDOG_INFO);
+    // transactionals = FALSE will result in neither email or SMS transactional messages being sent.
+    return dosomething_signup_create($nid, $values['uid'], $values['source'], NULL, $values['transactionals']);
+  }
 }
 
 

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -300,7 +300,6 @@ function _campaign_resource_signup($nid, $values) {
     // Store the reference to the Rogue signup
     return dosomething_rogue_check_sid_and_store_ref($rogue_signup);
   } else {
-    // @TODO: make helper function to do this?
     // Increment transaction id and log that the request has been received with new transaction id.
     $transaction_id_parts = explode('-', $headers['X-Request-Id']);
     $transaction_id_base = $transaction_id_parts[0];

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.admin.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.admin.inc
@@ -45,5 +45,13 @@ function dosomething_rogue_config_form($form, &$form_state) {
     '#size' => 20,
   ];
 
+  $form['rogue']['rogue_signup_collection'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Send signups to rogue'),
+    '#description' => t('If set, when a user signs up it will be sent to Rogue.'),
+    '#default_value' => variable_get('rogue_signup_collection', FALSE),
+    '#size' => 20,
+  ];
+
   return system_settings_form($form);
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -53,6 +53,24 @@ function dosomething_rogue_retry_failed_reportbacks() {
             ->condition('id', $task->id)
             ->execute();
         }
+      } elseif ($task->type === 'signup') {
+        $data = (array)$task;
+
+        // Load the user
+        $northstar_user = dosomething_northstar_get_user($task->northstar_id);
+        $user = user_load($northstar_user->drupal_id);
+
+        $rogue_signup = dosomething_rogue_send_signup_to_rogue($data, $user, $task->id);
+
+        if ($rogue_signup) {
+          // @TODO: signup ref storage
+          dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
+
+          // Remove signup from failed log once it has been send successfully
+          db_delete('dosomething_rogue_failed_task_log')
+            ->condition('id', $task->id)
+            ->execute();
+        }
       } else {
         $data = [
           [

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -63,8 +63,7 @@ function dosomething_rogue_retry_failed_reportbacks() {
         $rogue_signup = dosomething_rogue_send_signup_to_rogue($data, $user, $task->id);
 
         if ($rogue_signup) {
-          // @TODO: signup ref storage
-          dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
+          dosomething_rogue_check_sid_and_store_ref($rogue_signup);
 
           // Remove signup from failed log once it has been send successfully
           db_delete('dosomething_rogue_failed_task_log')

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -54,13 +54,11 @@ function dosomething_rogue_retry_failed_reportbacks() {
             ->execute();
         }
       } elseif ($task->type === 'signup') {
-        $data = (array)$task;
-
         // Load the user
         $northstar_user = dosomething_northstar_get_user($task->northstar_id);
         $user = user_load($northstar_user->drupal_id);
 
-        $rogue_signup = dosomething_rogue_send_signup_to_rogue($data, $user, $task->id);
+        $rogue_signup = dosomething_rogue_send_signup_to_rogue((array)$task, $user, $task->id);
 
         if ($rogue_signup) {
           dosomething_rogue_check_sid_and_store_ref($rogue_signup);

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -369,7 +369,7 @@ function dosomething_rogue_update_7010(&$sandbox) {
 /**
  * Adds dosomething_rogue_signups table.
  */
-function dosomething_rogue_update_7009(&$sandbox) {
+function dosomething_rogue_update_7011(&$sandbox) {
   $table_name = 'dosomething_rogue_signups';
   if (!db_table_exists($table_name)) {
     $schema = dosomething_rogue_schema();

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -118,6 +118,31 @@ function dosomething_rogue_schema() {
     ],
   ];
 
+  $schema['dosomething_rogue_signups'] = [
+    'description' => 'Table for tracking phoenix sid and corresponding rogue signups id and event id',
+    'fields' => [
+      'sid' => [
+        'description' => 'The sid of the signup as it is stored in phoenix.',
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'rogue_signup_id' => [
+        'description' => 'The signup id as it is stored in rogue.',
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'created_at' => [
+        'description' => 'The Unix timestamp of when the reportback was stored',
+        'type' => 'int',
+        'not null' => FALSE,
+      ],
+    ],
+    'primary key' => ['sid'],
+    'indexes' => [
+      'rbid' => ['rogue_signup_id'],
+    ],
+  ];
+
   return $schema;
 }
 
@@ -341,3 +366,13 @@ function dosomething_rogue_update_7010(&$sandbox) {
   }
 }
 
+/**
+ * Adds dosomething_rogue_signups table.
+ */
+function dosomething_rogue_update_7009(&$sandbox) {
+  $table_name = 'dosomething_rogue_signups';
+  if (!db_table_exists($table_name)) {
+    $schema = dosomething_rogue_schema();
+    db_create_table($table_name, $schema[$table_name]);
+  }
+}

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -520,7 +520,7 @@ function dosomething_rogue_check_sid_and_store_ref($rogue_signup) {
   $user = user_load($northstar_user->drupal_id);
 
   // Get the signup
-  $sid = dosomething_signup_exists($rogue_signup['data']['campaign_id'], $rogue_signup['data']['campaign_run_id'], $user->id);
+  $sid = dosomething_signup_exists($rogue_signup['data']['campaign_id'], $rogue_signup['data']['campaign_run_id'], $user->uid);
 
   // Make sure the signup exists before we try to use it
   if ($sid) {

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -519,7 +519,6 @@ function dosomething_rogue_transform_signup($values, $northstar_id, $user) {
 
   $run = dosomething_helpers_get_current_campaign_run_for_user($values['campaign_id'], $user);
 
-
  $data = [
    'northstar_id' => $northstar_id,
    'campaign_id' => $values['campaign_id'],

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -219,8 +219,6 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $failed_tas
   if (module_exists('stathat')) {
       if ($values['type'] === 'reportback') {
         stathat_send_ez_count('drupal - Rogue - reportback failed - count', 1);
-      } elseif ($values['type'] === 'signup') {
-        stathat_send_ez_count('drupal - Rogue - signup failed - count', 1);
       } else {
         stathat_send_ez_count('drupal - Rogue - reportback item status failed - count', 1);
       }
@@ -238,11 +236,38 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $failed_tas
   // Save fail to a db log so we can easily export.
   if ($values['type'] === 'reportback') {
     watchdog('dosomething_rogue', 'Reportback not migrated to Rogue: northstar_id: !northstar_id, campaign_id: !campaign_id, campaign run_nid: !campaign_run_id.', ['!northstar_id' => $values['northstar_id'], '!campaign_id' => $values['campaign_id'], '!campaign_run_id' => $values['campaign_run_id']], WATCHDOG_ERROR);
-  } elseif ($values['type'] === 'signup') {
-    watchdog('dosomething_rogue', 'Signup not migrated to Rogue: northstar_id: !northstar_id, campaign_id: !campaign_id, campaign run_nid: !campaign_run_id.', ['!northstar_id' => $values['northstar_id'], '!campaign_id' => $values['campaign_id'], '!campaign_run_id' => $values['campaign_run_id']], WATCHDOG_ERROR);
   } else {
     watchdog('dosomething_rogue', 'Reportback item status not migrated to Rogue: Rogue item id: !rogue_item_id, status: !status.', ['!rogue_item_id' => $values['rogue_event_id'], '!status' => $values['status']], WATCHDOG_ERROR);
   }
+}
+
+/**
+ * Insert record that stores the request data of to a signup that did
+ * not successfully post to Rogue
+ *
+ * @param array  $values
+ * @param array  $response
+ * @param int $failed_task_id
+ * @param object $user
+ * @param object $e
+ *
+ */
+function dosomething_rogue_handle_signup_failure($values, $response = NULL, $failed_task_id = NULL, $user = NULL, $e = NULL) {
+  if (module_exists('stathat')) {
+    stathat_send_ez_count('drupal - Rogue - signup failed - count', 1);
+  }
+
+  // If the signup has previously failed, do not enter a new record.
+  // Instead, increment the number of tries and update the time of most recent attempt to send to Rogue.
+  if (! is_null($failed_task_id)) {
+    $previously_failed = array_pop(dosomething_rogue_previously_failed($failed_task_id));
+    update_failed_task_log($previously_failed);
+  } else {
+    insert_failed_task_into_failed_task_log($values, $response, $e, $user);
+  }
+
+  // Save fail to a db log so we can easily export.
+  watchdog('dosomething_rogue', 'Signup not migrated to Rogue: northstar_id: !northstar_id, campaign_id: !campaign_id, campaign run_nid: !campaign_run_id.', ['!northstar_id' => $values['northstar_id'], '!campaign_id' => $values['campaign_id'], '!campaign_run_id' => $values['campaign_run_id']], WATCHDOG_ERROR);
 }
 
 /**
@@ -408,6 +433,7 @@ function insert_failed_task_into_failed_task_log($values, $response = NULL, $e =
             'response_code' => (isset($response->code)) ? $response->code : NULL,
             'response_values' => (isset($e)) ? $e->getMessage() : NULL,
             'type' => $values['type'],
+            'failed_at' => REQUEST_TIME,
           ])
           ->execute();
   } else {
@@ -464,15 +490,15 @@ function dosomething_rogue_send_signup_to_rogue($values, $user = NULL, $failed_t
     }
     if (!$response) {
       // This is a 404
-      dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user);
+      dosomething_rogue_handle_signup_failure($data, $response, $failed_task_id, $user);
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
     // These aren't yet caught by Gateway
-    dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
+    dosomething_rogue_handle_signup_failure($data, $response, $failed_task_id, $user, $e);
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
-    dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
+    dosomething_rogue_handle_signup_failure($data, $response, $failed_task_id, $user, $e);
   }
 
   return $response;

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -464,7 +464,6 @@ function dosomething_rogue_send_signup_to_rogue($values, $user = NULL, $failed_t
     }
     if (!$response) {
       // This is a 404
-      // @TODO: update dosomething_rogue_handle_failure to deal with signup failures
       dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user);
     }
   }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -216,7 +216,6 @@ function dosomething_rogue_transform_status($status) {
  *
  */
 function dosomething_rogue_handle_failure($values, $response = NULL, $failed_task_id = NULL, $user = NULL, $e = NULL) {
-
   if (module_exists('stathat')) {
       if ($values['type'] === 'reportback') {
         stathat_send_ez_count('drupal - Rogue - reportback failed - count', 1);
@@ -233,7 +232,6 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $failed_tas
     $previously_failed = array_pop(dosomething_rogue_previously_failed($failed_task_id));
     update_failed_task_log($previously_failed);
   } else {
-    // @TODO: this for signups
     insert_failed_task_into_failed_task_log($values, $response, $e, $user);
   }
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -205,9 +205,12 @@ function dosomething_rogue_transform_status($status) {
  *
  */
 function dosomething_rogue_handle_failure($values, $response = NULL, $failed_task_id = NULL, $user = NULL, $e = NULL) {
+
   if (module_exists('stathat')) {
       if ($values['type'] === 'reportback') {
         stathat_send_ez_count('drupal - Rogue - reportback failed - count', 1);
+      } elseif ($values['type'] === 'signup') {
+        stathat_send_ez_count('drupal - Rogue - signup failed - count', 1);
       } else {
         stathat_send_ez_count('drupal - Rogue - reportback item status failed - count', 1);
       }
@@ -219,13 +222,15 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $failed_tas
     $previously_failed = array_pop(dosomething_rogue_previously_failed($failed_task_id));
     update_failed_task_log($previously_failed);
   } else {
+    // @TODO: this for signups
     insert_failed_task_into_failed_task_log($values, $response, $e, $user);
   }
 
   // Save fail to a db log so we can easily export.
   if ($values['type'] === 'reportback') {
     watchdog('dosomething_rogue', 'Reportback not migrated to Rogue: northstar_id: !northstar_id, campaign_id: !campaign_id, campaign run_nid: !campaign_run_id.', ['!northstar_id' => $values['northstar_id'], '!campaign_id' => $values['campaign_id'], '!campaign_run_id' => $values['campaign_run_id']], WATCHDOG_ERROR);
-
+  } elseif ($values['type'] === 'signup') {
+    watchdog('dosomething_rogue', 'Signup not migrated to Rogue: northstar_id: !northstar_id, campaign_id: !campaign_id, campaign run_nid: !campaign_run_id.', ['!northstar_id' => $values['northstar_id'], '!campaign_id' => $values['campaign_id'], '!campaign_run_id' => $values['campaign_run_id']], WATCHDOG_ERROR);
   } else {
     watchdog('dosomething_rogue', 'Reportback item status not migrated to Rogue: Rogue item id: !rogue_item_id, status: !status.', ['!rogue_item_id' => $values['rogue_event_id'], '!status' => $values['status']], WATCHDOG_ERROR);
   }
@@ -383,6 +388,19 @@ function insert_failed_task_into_failed_task_log($values, $response = NULL, $e =
         'failed_at' => REQUEST_TIME,
       ])
       ->execute();
+  } elseif ($values['type'] === 'signup') {
+      db_insert('dosomething_rogue_failed_task_log')
+          ->fields([
+            'northstar_id' => $values['northstar_id'],
+            'campaign_id' => $values['campaign_id'],
+            'campaign_run_id' => $values['campaign_run_id'],
+            'source' => $values['source'],
+            'timestamp' => REQUEST_TIME,
+            'response_code' => (isset($response->code)) ? $response->code : NULL,
+            'response_values' => (isset($e)) ? $e->getMessage() : NULL,
+            'type' => $values['type'],
+          ])
+          ->execute();
   } else {
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([
@@ -397,4 +415,77 @@ function insert_failed_task_into_failed_task_log($values, $response = NULL, $e =
       ])
       ->execute();
   }
+}
+
+/**
+ * Send a signup to Rogue
+ *
+ * @param array $values
+ * @param object $user
+ * @param object $response
+ * @param object $e
+ *
+ */
+function dosomething_rogue_send_signup_to_rogue($values, $user = NULL, $failed_task_id = NULL) {
+  // Get the user in order to grab the northstar id
+  if (!isset($user)) {
+    global $user;
+  }
+
+  $northstar_id = dosomething_user_get_field('field_northstar_id', $user);
+
+  // Band-aid fix for an issue we are seeing with phoenix not being
+  // aware of a user's northstar id. If it doesn't find one, we just grab it
+  // from northstar directly.
+  if (!$northstar_id) {
+    $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
+    $northstar_id = $northstar_user->id;
+  }
+
+  $client = dosomething_rogue_client();
+
+  $data = dosomething_rogue_transform_signup($values, $northstar_id, $user);
+  $data['type'] = 'signup';
+
+  try {
+    $response = $client->postSignup($data);
+
+    if (module_exists('stathat')) {
+      stathat_send_ez_count('drupal - Rogue - signup sent - count', 1);
+    }
+    if (!$response) {
+      // This is a 404
+      // @TODO: update dosomething_rogue_handle_failure to deal with signup failures
+      dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user);
+    }
+  }
+  catch (GuzzleHttp\Exception\ServerException $e) {
+    // These aren't yet caught by Gateway
+    dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
+  }
+  catch (DoSomething\Gateway\Exceptions\ApiException $e) {
+    dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
+  }
+
+  return $response;
+}
+
+/**
+* Transform signup into the appropriate scheme to send to Rogue.
+*
+* @param $values - Signup values to send to Rogue.
+* @param $northstar_id - User's Northstar user id.
+* @return array
+*/
+function dosomething_rogue_transform_signup($values, $northstar_id, $user) {
+ $run = dosomething_helpers_get_current_campaign_run_for_user($values['campaign_id'], $user);
+
+ $data = [
+   'northstar_id' => $northstar_id,
+   'campaign_id' => $values['campaign_id'],
+   'campaign_run_id' => $run->nid,
+   'source' => $values['source'],
+ ];
+
+ return $data;
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -152,6 +152,17 @@ function dosomething_rogue_get_by_file_id($fid) {
 }
 
 /**
+ * Query to find Rogue signup id by Phoenix sid.
+ *
+ * @param string $sid
+ * Phoenix sid of signup.
+ *
+ */
+function dosomething_rogue_get_signup_by_sid($sid) {
+  return db_query("SELECT rogue_signups.rogue_signup_id FROM {dosomething_rogue_signups} rogue_signups WHERE sid = :sid", array(':sid' => $sid))->fetchAll();
+}
+
+/**
  * Insert record that stores reference to the most recent uploaded reportback item in
  * phoenix and it's corresponding id's in Rogue
  *
@@ -478,7 +489,13 @@ function dosomething_rogue_send_signup_to_rogue($values, $user = NULL, $failed_t
 * @return array
 */
 function dosomething_rogue_transform_signup($values, $northstar_id, $user) {
- $run = dosomething_helpers_get_current_campaign_run_for_user($values['campaign_id'], $user);
+  // Make sure we have the data in the right form (failed table stores campaign_id, not nid)
+  if (isset($values['nid'])) {
+    $values['campaign_id'] = $values['nid'];
+  }
+
+  $run = dosomething_helpers_get_current_campaign_run_for_user($values['campaign_id'], $user);
+
 
  $data = [
    'northstar_id' => $northstar_id,
@@ -488,4 +505,55 @@ function dosomething_rogue_transform_signup($values, $northstar_id, $user) {
  ];
 
  return $data;
+}
+
+/**
+ * Checks to see if the given signup data exists in Phoenix and if so stores in Rogue reference table.
+ *
+ * @param array $rogue_signup
+ * The response from dosomething_rogue_send_signup_to_rogue().
+ *
+ */
+function dosomething_rogue_check_sid_and_store_ref($rogue_signup) {
+  // Get user from Northstar ID
+  $northstar_user = dosomething_northstar_get_user($rogue_signup['data']['northstar_id']);
+  $user = user_load($northstar_user->drupal_id);
+
+  // Get the signup
+  $sid = dosomething_signup_exists($rogue_signup['data']['campaign_id'], $rogue_signup['data']['campaign_run_id'], $user->id);
+
+  // Make sure the signup exists before we try to use it
+  if ($sid) {
+    // Make sure that signup is not in the Rogue reference table yet
+    if (!dosomething_rogue_get_signup_by_sid($sid)) {
+      // Store reference to the signup in rogue
+      dosomething_rogue_store_rogue_signup_references($sid, $rogue_signup);
+    }
+
+    return $sid;
+  }
+
+  return false;
+}
+
+/**
+ * Insert record that stores reference to the signup in
+ * phoenix and corresponding signup id in Rogue
+ *
+ * @param string $sid
+ * @param object $rogue_signup
+ *
+ * @return
+ */
+function dosomething_rogue_store_rogue_signup_references($sid, $rogue_signup) {
+  if (! dosomething_rogue_get_signup_by_sid($sid)) {
+    // Store references to rogue IDs.
+    db_insert('dosomething_rogue_signups')
+    ->fields([
+      'sid' => $sid,
+      'rogue_signup_id' => $rogue_signup['data']['id'],
+      'created_at' => REQUEST_TIME,
+      ])
+    ->execute();
+  }
 }

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -38,4 +38,16 @@ class Rogue extends RestApiClient {
 
     return $response;
   }
+
+  /**
+   * Send a POST request of the signup to be saved in Rogue.
+   *
+   * @param array $data
+   * @return object|false
+   */
+  public function postSignup($data) {
+    $response = $this->post('signups', $data);
+
+    return $response;
+  }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -106,8 +106,14 @@ function dosomething_signup_form_submit($form, &$form_state) {
     $params['affiliate_messaging_opt_in'] = (bool) $form_state['values']['affiliate_messeging_opt_in'];
   }
 
-  // Create signup for logged in user.
-  dosomething_signup_user_signup($nid, NULL, $source, $params);
+  if (variable_get('rogue_signup_collection', FALSE)) {
+    $rogue_signup = dosomething_rogue_send_signup_to_rogue($form_state['values']);
+
+    dosomething_rogue_check_sid_and_store_ref($rogue_signup);
+  } else {
+    // Create signup for logged in user.
+    dosomething_signup_user_signup($nid, NULL, $source, $params);
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -109,7 +109,10 @@ function dosomething_signup_form_submit($form, &$form_state) {
   if (variable_get('rogue_signup_collection', FALSE)) {
     $rogue_signup = dosomething_rogue_send_signup_to_rogue($form_state['values']);
 
-    dosomething_rogue_check_sid_and_store_ref($rogue_signup);
+    // Make sure the signup exists before using it
+    if ($rogue_signup) {
+      dosomething_rogue_check_sid_and_store_ref($rogue_signup);
+    }
   } else {
     // Create signup for logged in user.
     dosomething_signup_user_signup($nid, NULL, $source, $params);


### PR DESCRIPTION
#### What's this PR do?
Send Phoenix signups to Rogue!

Admin:
- Adds feature flag in the Rogue settings for admins to turn on/off sending signups to Rogue

Failures:
- Retry failed signups with cron
- Send count to stathat for failed signups
- Includes failed signups in `dosomething_rogue_failed_task_log`

Sending:
- Ability to send signups to Rogue!
- Creates `dosomething_rogue_signups` table and stores references to Rogue signups in there
- Follows same logic as reportbacks for sending Phoenix API signups to Rogue (checks for transaction ID and if there isn't one and Rogue signups are on, sends it to Rogue)

#### How should this be reviewed?
In my tests the functionality that I was expecting was all working, so 👀  on the logic is probably the most helpful. Make sure that everything would work normally if the feature flag is off please!

#### Any background context you want to provide?
This won't be turned on until there is an experience planned for the user for the case that their signup fails to post.

The Rogue endpoint needs functionality added to deal with the `transactionals` value that can come to the signup endpoint. This was not included because it is not in the Phoenix docs, but should be easy enough to add.

#### Relevant tickets
Fixes #7293

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
