### PR TITLE
Sends reportbacks/items and updates to Rogue's /posts and /reviews endpoints 

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -289,7 +289,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
       $rogue_item_id = dosomething_rogue_get_by_file_id($fid);
 
       // If there is a rogue_item_id in the dosomething_rogue_reportbacks table, send update to Rogue.
-      if ($rogue_item_id[0]->rogue_item_id) {
+      if ($rogue_item_id[0]->rogue_event_id) {
         if ($values['status'] === 'promoted' || $values['status'] === 'approved' || $values['status'] === 'excluded') {
           $rogue_status = 'accepted';
         } else {
@@ -297,7 +297,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
         }
 
         $data = [
-          'rogue_reportback_item_id' => $rogue_item_id[0]->rogue_item_id,
+          'rogue_event_id' => $rogue_item_id[0]->rogue_event_id,
           'status' => $rogue_status,
           'reviewer' => dosomething_user_get_field('field_northstar_id'),
         ];
@@ -309,7 +309,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
 
   // Send updates to Rogue.
   if (variable_get('rogue_collection', FALSE)) {
-    $response = dosomething_rogue_update_rogue_reportback_items($updates_to_send_to_rogue);
+    $response = dosomething_rogue_send_reportback_to_rogue($updates_to_send_to_rogue);
     if ($response->code != 201) {
       drupal_set_message(print_r($response->code, TRUE) . ' ' . print_r($response->status_message, TRUE), 'warning');
     } else {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -310,7 +310,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
 
   // Send updates to Rogue.
   if (variable_get('rogue_collection', FALSE)) {
-    $response = dosomething_rogue_send_reportback_to_rogue($updates_to_send_to_rogue);
+    $response = dosomething_rogue_update_rogue_reportback_items($updates_to_send_to_rogue);
     if ($response->code != 201) {
       drupal_set_message(print_r($response->code, TRUE) . ' ' . print_r($response->status_message, TRUE), 'warning');
     } else {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -299,7 +299,8 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
         $data = [
           'rogue_event_id' => $rogue_item_id[0]->rogue_event_id,
           'status' => $rogue_status,
-          'reviewer' => dosomething_user_get_field('field_northstar_id'),
+          'event_type' => 'post_photo',
+          // 'reviewer' => dosomething_user_get_field('field_northstar_id'),
         ];
 
         $updates_to_send_to_rogue[] = $data;

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -287,7 +287,6 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
     // Check to see if Rogue feature flag is enabled.
     if (variable_get('rogue_collection', FALSE)) {
       $rogue_item_id = dosomething_rogue_get_by_file_id($fid);
-
       // If there is a rogue_item_id in the dosomething_rogue_reportbacks table, send update to Rogue.
       if ($rogue_item_id[0]->rogue_event_id) {
         if ($values['status'] === 'promoted' || $values['status'] === 'approved' || $values['status'] === 'excluded') {
@@ -300,7 +299,6 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
           'rogue_event_id' => $rogue_item_id[0]->rogue_event_id,
           'status' => $rogue_status,
           'event_type' => 'post_photo',
-          // 'reviewer' => dosomething_user_get_field('field_northstar_id'),
         ];
 
         $updates_to_send_to_rogue[] = $data;

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -721,7 +721,7 @@ function dosomething_reportback_delete_reportback($rbid) {
 function dosomething_reportback_exists($nid, $run_nid = NULL, $uid = NULL, $northstar_id = NULL) {
   if ($northstar_id) {
     $user = dosomething_northstar_get_user($northstar_id);
-    $uid = $user->uid;
+    $uid = $user->drupal_id;
   }
   else if (!isset($uid)) {
     global $user;

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -703,7 +703,6 @@ function dosomething_reportback_delete_reportback($rbid) {
   return entity_delete('reportback', $rbid);
 }
 
-
 /**
  * Checks if a reportback exists for given $nid and $uid.
  *
@@ -714,11 +713,17 @@ function dosomething_reportback_delete_reportback($rbid) {
  * @param  int  $uid
  *   Optional - the user uid of reportback to check.
  *   If not given, uses global $user->uid.
+ * @param int $northstar_id
+ *   Optional - the user's Northstar id of reportback to check.
  * @return mixed
  *   The rbid of reportback or FALSE if it doesn't exist.
  */
-function dosomething_reportback_exists($nid, $run_nid = NULL, $uid = NULL) {
-  if (!isset($uid)) {
+function dosomething_reportback_exists($nid, $run_nid = NULL, $uid = NULL, $northstar_id = NULL) {
+  if ($northstar_id) {
+    $user = dosomething_northstar_get_user($northstar_id);
+    $uid = $user->uid;
+  }
+  else if (!isset($uid)) {
     global $user;
     $uid = $user->uid;
   }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -62,7 +62,7 @@ function dosomething_rogue_retry_failed_reportbacks() {
           ]
         ];
 
-        $response = dosomething_rogue_send_reportback_to_rogue($data, NULL, $task->id);
+        $response = dosomething_rogue_update_rogue_reportback_items($data, NULL, $task->id);
 
         if ($response) {
           db_delete('dosomething_rogue_failed_task_log')

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -56,13 +56,13 @@ function dosomething_rogue_retry_failed_reportbacks() {
       } else {
         $data = [
           [
-            'rogue_reportback_item_id' => $task->rogue_item_id,
+            'rogue_event_id' => $task->rogue_event_id,
             'status' => $task->status,
-            'reviewer' => $task->reviewer,
+            'event_type' => 'post_photo',
           ]
         ];
 
-        $response = dosomething_rogue_update_rogue_reportback_items($data, NULL, $task->id);
+        $response = dosomething_rogue_update_rogue_reportback_items($data, $task->id);
 
         if ($response) {
           db_delete('dosomething_rogue_failed_task_log')

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -62,7 +62,7 @@ function dosomething_rogue_retry_failed_reportbacks() {
           ]
         ];
 
-        $response = dosomething_rogue_update_rogue_reportback_items($data, $task->id);
+        $response = dosomething_rogue_send_reportback_to_rogue($data, NULL, $task->id);
 
         if ($response) {
           db_delete('dosomething_rogue_failed_task_log')

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -301,3 +301,18 @@ function dosomething_rogue_update_7008(&$sandbox) {
   }
 }
 
+/**
+ * Changes rogue_reportback_id column to rogue_signup_id in the dosomething_rogue_reportbacks table.
+ */
+function dosomething_rogue_update_7009(&$sandbox) {
+  $table = 'dosomething_rogue_reportbacks';
+  if (db_table_exists($table)) {
+    $spec = [
+      'type' => 'int',
+      'length' => '11',
+      'description' => 'The Rogue signup id that is associated with the same Phoenix reportback.',
+    ];
+
+    db_change_field($table, 'rogue_reportback_id', 'rogue_signup_id', $spec);
+  }
+}

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -307,12 +307,20 @@ function dosomething_rogue_update_7008(&$sandbox) {
 function dosomething_rogue_update_7009(&$sandbox) {
   $table = 'dosomething_rogue_reportbacks';
   if (db_table_exists($table)) {
-    $spec = [
+    $rogue_signup_id_spec = [
       'type' => 'int',
       'length' => '11',
       'description' => 'The Rogue signup id that is associated with the same Phoenix reportback.',
     ];
 
-    db_change_field($table, 'rogue_reportback_id', 'rogue_signup_id', $spec);
+    db_change_field($table, 'rogue_reportback_id', 'rogue_signup_id', $rogue_signup_id_spec);
+
+    $rogue_event_id_spec = [
+      'type' => 'int',
+      'length' => '11',
+      'description' => 'The Rogue event id that is associated with the same Phoenix reportback item (fid).',
+    ];
+
+    db_change_field($table, 'rogue_item_id', 'rogue_event_id', $rogue_event_id_spec);
   }
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -324,3 +324,20 @@ function dosomething_rogue_update_7009(&$sandbox) {
     db_change_field($table, 'rogue_item_id', 'rogue_event_id', $rogue_event_id_spec);
   }
 }
+
+/**
+ * Changes rogue_item_id column to rogue_event_id in the dosomething_rogue_failed_task_log.
+ */
+function dosomething_rogue_update_7010(&$sandbox) {
+  $table = 'dosomething_rogue_failed_task_log';
+  if (db_table_exists($table)) {
+    $spec = [
+      'description' => 'The event id of the reportback item as it is stored in rogue.',
+      'type' => 'int',
+      'length' => '11',
+    ];
+
+    db_change_field($table, 'rogue_item_id', 'rogue_event_id', $spec);
+  }
+}
+

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -77,7 +77,13 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
 
   $data = dosomething_rogue_transform_reportback($values, $user, $northstar_id);
   $data['type'] = 'reportback';
-  $data['event_type'] = 'post_photo';
+
+  if ($data['file']) {
+    $data['event_type'] = 'post_photo';
+  }
+  else {
+    $data['event_type'] = 'update_signup';
+  }
 
   try {
     $response = $client->postReportback($data);

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -77,13 +77,7 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
 
   $data = dosomething_rogue_transform_reportback($values, $user, $northstar_id);
   $data['type'] = 'reportback';
-
-  if ($data['file']) {
-    $data['event_type'] = 'post_photo';
-  }
-  else {
-    $data['event_type'] = 'update_signup';
-  }
+  $data['event_type'] = 'post_photo';
 
   try {
     $response = $client->postReportback($data);

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -70,7 +70,10 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
   }
 
   $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
-  $client = dosomething_rogue_client();
+  // $client = dosomething_rogue_client();
+  $client = new Rogue(ROGUE_API_URL . '/v2/',
+    ['headers' => ['X-DS-Rogue-API-Key' => ROGUE_API_KEY]]
+  );
 
   $data = dosomething_rogue_transform_reportback($values, $user, $northstar_id);
   $data['type'] = 'reportback';

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -70,13 +70,14 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
   }
 
   $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
-  $client = dosomething_rogue_client();
-  // $client = new Rogue(ROGUE_API_URL . '/v2/',
-  //   ['headers' => ['X-DS-Rogue-API-Key' => ROGUE_API_KEY]]
-  // );
+  // $client = dosomething_rogue_client();
+  $client = new Rogue(ROGUE_API_URL . '/v2/',
+    ['headers' => ['X-DS-Rogue-API-Key' => ROGUE_API_KEY]]
+  );
 
   $data = dosomething_rogue_transform_reportback($values, $user, $northstar_id);
   $data['type'] = 'reportback';
+  $data['event_type'] = 'post_photo';
 
   try {
     $response = $client->postReportback($data);
@@ -86,14 +87,20 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
     }
     if (!$response) {
       // This is a 404
+      print_r('hi');
+      die();
       dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user);
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
     // These aren't yet caught by Gateway
+    print_r('hi2');
+    die();
     dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
+    print_r('hi3');
+    die();
     dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
   }
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -59,29 +59,22 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
     global $user;
   }
 
-  if (!array_key_exists('rogue_event_id', $values[0])) {
-    $northstar_id = dosomething_user_get_field('field_northstar_id', $user);
+  $northstar_id = dosomething_user_get_field('field_northstar_id', $user);
 
-    // Band-aid fix for an issue we are seeing with phoenix not being
-    // aware of a user's northstar id. If it doesn't find one, we just grab it
-    // from northstar directly.
-    if (!$northstar_id) {
-      $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
-      $northstar_id = $northstar_user->id;
-    }
-
-    $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
-
-    $data = dosomething_rogue_transform_reportback($values, $user, $northstar_id);
-    $data['type'] = 'reportback';
-  } else {
-    $data = $values;
-    $data['type'] = 'reportback item';
+  // Band-aid fix for an issue we are seeing with phoenix not being
+  // aware of a user's northstar id. If it doesn't find one, we just grab it
+  // from northstar directly.
+  if (!$northstar_id) {
+    $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
+    $northstar_id = $northstar_user->id;
   }
 
-  $data['event_type'] = 'post_photo';
-
+  $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
   $client = dosomething_rogue_client();
+
+  $data = dosomething_rogue_transform_reportback($values, $user, $northstar_id);
+  $data['type'] = 'reportback';
+  $data['event_type'] = 'post_photo';
 
   try {
     $response = $client->postReportback($data);
@@ -90,42 +83,64 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
       stathat_send_ez_count('drupal - Rogue - reportback sent - count', 1);
     }
     if (!$response) {
-      if (!array_key_exists('rogue_event_id', $values[0])) {
-        // This is a 404
-        dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user);
-      } else {
-        foreach ($data as $values) {
-          $values['type'] = 'reportback item';
-          dosomething_rogue_handle_failure($values, $response, $failed_task_id);
-        }
-      }
+      // This is a 404
+      dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user);
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
-    if (!array_key_exists('rogue_event_id', $values[0])) {
-      // These aren't yet caught by Gateway
-      dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
-    } else {
-      foreach ($data as $values) {
-        $values['type'] = 'reportback item';
-         dosomething_rogue_handle_failure($values, $response, $failed_task_id);
-      }
-    }
+    // These aren't yet caught by Gateway
+    dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
-    if (!array_key_exists('rogue_event_id', $values[0])) {
-      dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
-    } else {
+    dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
+  }
+
+  return $response;
+}
+
+/**
+ * Sends updated reportback item(s) to Rogue.
+ *
+ * @param array $data
+ *    Values to send to Rogue.
+ * @param int $failed_task_id
+ *    Index of failed reportback item if it exists in the dosomething_rogue_failed_task_log.
+ *
+ */
+function dosomething_rogue_update_rogue_reportback_items($data, $failed_task_id = NULL) {
+  $client = dosomething_rogue_client();
+  try {
+    $response = $client->updateReportback($data);
+
+    if (module_exists('stathat')) {
+      stathat_send_ez_count('drupal - Rogue - reportback items(s) updated status sent - count', count($data));
+    }
+
+    if (!$response) {
       foreach ($data as $values) {
         $values['type'] = 'reportback item';
         dosomething_rogue_handle_failure($values, $response, $failed_task_id);
       }
     }
   }
+  catch (GuzzleHttp\Exception\ServerException $e) {
+    // These aren't yet caught by Gateway
+    foreach ($data as $values) {
+      $values['type'] = 'reportback item';
+      dosomething_rogue_handle_failure($values, $response, $failed_task_id, $e);
+    }
+  }
+  catch (DoSomething\Gateway\Exceptions\ApiException $e) {
+    foreach ($data as $values) {
+      $values['type'] = 'reportback item';
+      dosomething_rogue_handle_failure($values, $response, $failed_task_id, $e);
+    }
+  }
 
   return $response;
 }
 
+/**
  * Query to find Rogue reportback item id by Phoenix fid.
  *
  * @param string $fid

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -151,7 +151,7 @@ function dosomething_rogue_update_rogue_reportback_items($data, $failed_task_id 
  *
  */
 function dosomething_rogue_get_by_file_id($fid) {
-  return db_query("SELECT rogue_rbs.rogue_item_id FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE fid = :fid", array(':fid' => $fid))->fetchAll();
+  return db_query("SELECT rogue_rbs.rogue_event_id FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE fid = :fid", array(':fid' => $fid))->fetchAll();
 }
 
 /**
@@ -165,15 +165,12 @@ function dosomething_rogue_get_by_file_id($fid) {
  * @return
  */
 function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback) {
-  print_r($rogue_reportback['data']['event']);
-  die();
-  $most_recent_rogue_item = array_pop($rogue_reportback['data']['reportback_items']['data']);
   if (! dosomething_rogue_get_by_file_id($fid)) {
     // Store references to rogue IDs.
     db_insert('dosomething_rogue_reportbacks')
     ->fields([
       'fid' => $fid,
-      'rogue_item_id' => $most_recent_rogue_item['id'],
+      'rogue_event_id' => $rogue_reportback['data']['event']['data']['event_id'],
       'rbid' => $rbid,
       'rogue_signup_id' => $rogue_reportback['data']['signup_id'],
       'created_at' => REQUEST_TIME,

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -70,10 +70,10 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
   }
 
   $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
-  // $client = dosomething_rogue_client();
-  $client = new Rogue(ROGUE_API_URL . '/v2/',
-    ['headers' => ['X-DS-Rogue-API-Key' => ROGUE_API_KEY]]
-  );
+  $client = dosomething_rogue_client();
+  // $client = new Rogue(ROGUE_API_URL . '/v2/',
+  //   ['headers' => ['X-DS-Rogue-API-Key' => ROGUE_API_KEY]]
+  // );
 
   $data = dosomething_rogue_transform_reportback($values, $user, $northstar_id);
   $data['type'] = 'reportback';

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -87,20 +87,14 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
     }
     if (!$response) {
       // This is a 404
-      print_r('hi');
-      die();
       dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user);
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
     // These aren't yet caught by Gateway
-    print_r('hi2');
-    die();
     dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
-    print_r('hi3');
-    die();
     dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
   }
 
@@ -180,7 +174,7 @@ function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback
       'fid' => $fid,
       'rogue_item_id' => $most_recent_rogue_item['id'],
       'rbid' => $rbid,
-      'rogue_reportback_id' => $rogue_reportback['data']['id'],
+      'rogue_signup_id' => $rogue_reportback['data']['signup_id'],
       'created_at' => REQUEST_TIME,
       ])
     ->execute();
@@ -261,7 +255,7 @@ function dosomething_rogue_rb_exists_in_rogue($rbid) {
  *
  */
 function dosomething_rogue_check_rbid_and_store_ref($rogue_reportback) {
-  $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], $rogue_reportback['data']['drupal_id']);
+  $rbid = dosomething_reportback_exists($rogue_reportback['data']['campaign_id'], $rogue_reportback['data']['campaign_run_id'], NULL, $rogue_reportback['data']['northstar_id']);
 
   // Make sure the reportback exists before we try to use it
   if ($rbid) {

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -59,25 +59,29 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
     global $user;
   }
 
-  $northstar_id = dosomething_user_get_field('field_northstar_id', $user);
+  if (!array_key_exists('rogue_event_id', $values[0])) {
+    $northstar_id = dosomething_user_get_field('field_northstar_id', $user);
 
-  // Band-aid fix for an issue we are seeing with phoenix not being
-  // aware of a user's northstar id. If it doesn't find one, we just grab it
-  // from northstar directly.
-  if (!$northstar_id) {
-    $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
-    $northstar_id = $northstar_user->id;
+    // Band-aid fix for an issue we are seeing with phoenix not being
+    // aware of a user's northstar id. If it doesn't find one, we just grab it
+    // from northstar directly.
+    if (!$northstar_id) {
+      $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
+      $northstar_id = $northstar_user->id;
+    }
+
+    $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
+
+    $data = dosomething_rogue_transform_reportback($values, $user, $northstar_id);
+    $data['type'] = 'reportback';
+  } else {
+    $data = $values;
+    $data['type'] = 'reportback item';
   }
 
-  $run = dosomething_helpers_get_current_campaign_run_for_user($values['nid']);
-  // $client = dosomething_rogue_client();
-  $client = new Rogue(ROGUE_API_URL . '/v2/',
-    ['headers' => ['X-DS-Rogue-API-Key' => ROGUE_API_KEY]]
-  );
-
-  $data = dosomething_rogue_transform_reportback($values, $user, $northstar_id);
-  $data['type'] = 'reportback';
   $data['event_type'] = 'post_photo';
+
+  $client = dosomething_rogue_client();
 
   try {
     $response = $client->postReportback($data);
@@ -86,64 +90,42 @@ function dosomething_rogue_send_reportback_to_rogue($values, $user = NULL, $fail
       stathat_send_ez_count('drupal - Rogue - reportback sent - count', 1);
     }
     if (!$response) {
-      // This is a 404
-      dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user);
+      if (!array_key_exists('rogue_event_id', $values[0])) {
+        // This is a 404
+        dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user);
+      } else {
+        foreach ($data as $values) {
+          $values['type'] = 'reportback item';
+          dosomething_rogue_handle_failure($values, $response, $failed_task_id);
+        }
+      }
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
-    // These aren't yet caught by Gateway
-    dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
+    if (!array_key_exists('rogue_event_id', $values[0])) {
+      // These aren't yet caught by Gateway
+      dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
+    } else {
+      foreach ($data as $values) {
+        $values['type'] = 'reportback item';
+         dosomething_rogue_handle_failure($values, $response, $failed_task_id);
+      }
+    }
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
-    dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
-  }
-
-  return $response;
-}
-
-/**
- * Sends updated reportback item(s) to Rogue.
- *
- * @param array $data
- *    Values to send to Rogue.
- * @param int $failed_task_id
- *    Index of failed reportback item if it exists in the dosomething_rogue_failed_task_log.
- *
- */
-function dosomething_rogue_update_rogue_reportback_items($data, $failed_task_id = NULL) {
-  $client = dosomething_rogue_client();
-  try {
-    $response = $client->updateReportback($data);
-
-    if (module_exists('stathat')) {
-      stathat_send_ez_count('drupal - Rogue - reportback items(s) updated status sent - count', count($data));
-    }
-
-    if (!$response) {
+    if (!array_key_exists('rogue_event_id', $values[0])) {
+      dosomething_rogue_handle_failure($data, $response, $failed_task_id, $user, $e);
+    } else {
       foreach ($data as $values) {
         $values['type'] = 'reportback item';
         dosomething_rogue_handle_failure($values, $response, $failed_task_id);
       }
     }
   }
-  catch (GuzzleHttp\Exception\ServerException $e) {
-    // These aren't yet caught by Gateway
-    foreach ($data as $values) {
-      $values['type'] = 'reportback item';
-      dosomething_rogue_handle_failure($values, $response, $failed_task_id, $e);
-    }
-  }
-  catch (DoSomething\Gateway\Exceptions\ApiException $e) {
-    foreach ($data as $values) {
-      $values['type'] = 'reportback item';
-      dosomething_rogue_handle_failure($values, $response, $failed_task_id, $e);
-    }
-  }
 
   return $response;
 }
 
-/**
  * Query to find Rogue reportback item id by Phoenix fid.
  *
  * @param string $fid

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -165,8 +165,9 @@ function dosomething_rogue_get_by_file_id($fid) {
  * @return
  */
 function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback) {
+  print_r($rogue_reportback['data']['event']);
+  die();
   $most_recent_rogue_item = array_pop($rogue_reportback['data']['reportback_items']['data']);
-
   if (! dosomething_rogue_get_by_file_id($fid)) {
     // Store references to rogue IDs.
     db_insert('dosomething_rogue_reportbacks')

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -227,7 +227,7 @@ function dosomething_rogue_handle_failure($values, $response = NULL, $failed_tas
     watchdog('dosomething_rogue', 'Reportback not migrated to Rogue: northstar_id: !northstar_id, campaign_id: !campaign_id, campaign run_nid: !campaign_run_id.', ['!northstar_id' => $values['northstar_id'], '!campaign_id' => $values['campaign_id'], '!campaign_run_id' => $values['campaign_run_id']], WATCHDOG_ERROR);
 
   } else {
-    watchdog('dosomething_rogue', 'Reportback item status not migrated to Rogue: Rogue item id: !rogue_item_id, status: !status.', ['!rogue_item_id' => $values['rogue_reportback_item_id'], '!status' => $values['status']], WATCHDOG_ERROR);
+    watchdog('dosomething_rogue', 'Reportback item status not migrated to Rogue: Rogue item id: !rogue_item_id, status: !status.', ['!rogue_item_id' => $values['rogue_event_id'], '!status' => $values['status']], WATCHDOG_ERROR);
   }
 }
 
@@ -386,7 +386,7 @@ function insert_failed_task_into_failed_task_log($values, $response = NULL, $e =
   } else {
     db_insert('dosomething_rogue_failed_task_log')
       ->fields([
-        'rogue_item_id' => $values['rogue_reportback_item_id'],
+        'rogue_event_id' => $values['rogue_event_id'],
         'status' => $values['status'],
         'type' => $values['type'],
         'timestamp' => REQUEST_TIME,

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -34,7 +34,7 @@ class Rogue extends RestApiClient {
    * @return object|false
    */
   public function updateReportback($data) {
-    $response = $this->put('items', $data);
+    $response = $this->put('reviews', $data);
 
     return $response;
   }

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -21,7 +21,7 @@ class Rogue extends RestApiClient {
    * @return object|false
    */
   public function postReportback($data) {
-    $response = $this->post('reportbacks', $data);
+    $response = $this->post('posts', $data);
 
     return $response;
   }


### PR DESCRIPTION
#### What's this PR do?
This PR updates Phoenix code to send reportbacks, reportback items (new and reviewed/updated statuses) to Rogue's `/posts` and `/reviews` endpoints. 

In order to update the above, it also: 
- updates columns in the `dosomething_rogue_reportbacks` and `dosomething_rogue_failed_task_log` tables
- updates Rogue cron jobs 

#### How should this be reviewed?
This should be tested with https://github.com/DoSomething/rogue/pull/112
1. Change Rogue API version number field to `v2` in the Rogue API settings.
2. Run `drush updb` to reflect new database changes.  

Make sure all information matches up between Phoenix and Rogue databases for below scenarios:
- Create a new signup (RB) and photo (reportback item) from Phoenix web. 
- Add another photo (rb item).
- Add another photo (rb item) and update the signup (reportback's `quantity` and `why_participated`).
- Only update the signup (reportback's `quantity` and `why_participated`).
- Review a photo (reportback item's status as an admin). 
- Cron job for reportbacks and reportback items. 

#### Any background context you want to provide?
**NOTE** once we merge this and update the table columns, we should make a note of the timing - anything after merge will have `rogue_event_id` instead of `rogue_item_id` in `dosomething_rogue_reportbacks` and `dosomething_rogue_failed_task_log` (this is less important than the first table). 

#### Relevant tickets
Fixes #7280 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
