### PR TITLE
Messaging opt in for unauth users

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -152,9 +152,11 @@ function dosomething_northstar_set_authorization_action($action, $nid, $params =
   }
 
   $_SESSION['openid_connect_action'] = [
-    'signup' => $nid,
-    'params' => [
-      'affiliate_messaging_opt_in' => isset($params['affiliate_messaging_opt_in']) ? $params['affiliate_messaging_opt_in'] : FALSE,
+    'signup' => [
+      'nid' => $nid,
+      'params' => [
+        'affiliate_messaging_opt_in' => isset($params['affiliate_messaging_opt_in']) ? $params['affiliate_messaging_opt_in'] : FALSE,
+      ],
     ],
   ];
 }
@@ -176,9 +178,9 @@ function dosomething_northstar_perform_authorization_actions() {
   foreach ($actions as $action => $target) {
     if ($action === 'signup') {
       $source = dosomething_signup_get_query_source();
-      dosomething_signup_user_signup((int) $target, $user, $source, $actions['params']);
+      dosomething_signup_user_signup((int) $target['nid'], $user, $source, $target['params']);
 
-      drupal_goto('node/' . $target);
+      drupal_goto('node/' . $target['nid']);
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -41,7 +41,14 @@ function dosomething_northstar_openid_authorize() {
   }
 
   if(isset($_GET['action']) && isset($_GET['node'])) {
-    dosomething_northstar_set_authorization_action($_GET['action'], $_GET['node']);
+    $params = [];
+
+    if (isset($_GET['affiliate_messaging_opt_in'])) {
+      $params['affiliate_messaging_opt_in'] = (bool) $_GET['affiliate_messaging_opt_in'];
+    }
+
+    dosomething_northstar_set_authorization_action($_GET['action'], $_GET['node'], $params);
+
     // @TODO: Rename parameter on the Northstar side to 'title'.
     $url_options['query'] = ['destination' => $_GET['title']];
   }
@@ -135,15 +142,17 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
  * Save a post-authorization destination in the session (e.g. for signing
  * up for a campaign).
  *
- * @param $action
- * @param $nid
+ * @param string $action
+ * @param string $nid
+ * @param array $param
  */
-function dosomething_northstar_set_authorization_action($action, $nid) {
+function dosomething_northstar_set_authorization_action($action, $nid, $params = []) {
   if ($action !== 'signup') {
     return;
   }
 
   $_SESSION['openid_connect_action'] = ['signup' => $nid];
+  $_SESSION['affiliate_messaging_opt_in'] = isset($params['affiliate_messaging_opt_in']) ? $params['affiliate_messaging_opt_in'] : FALSE;
 }
 
 /**
@@ -159,10 +168,12 @@ function dosomething_northstar_perform_authorization_actions() {
   }
 
   $actions = $_SESSION['openid_connect_action'];
+  $params = ['affiliate_messaging_opt_in' => $_SESSION['affiliate_messaging_opt_in']];
+
   foreach ($actions as $action => $target) {
-    if($action === 'signup') {
+    if ($action === 'signup') {
       $source = dosomething_signup_get_query_source();
-      dosomething_signup_user_signup((int) $target, $user, $source);
+      dosomething_signup_user_signup((int) $target, $user, $source, $params);
 
       drupal_goto('node/' . $target);
     }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -151,8 +151,12 @@ function dosomething_northstar_set_authorization_action($action, $nid, $params =
     return;
   }
 
-  $_SESSION['openid_connect_action'] = ['signup' => $nid];
-  $_SESSION['affiliate_messaging_opt_in'] = isset($params['affiliate_messaging_opt_in']) ? $params['affiliate_messaging_opt_in'] : FALSE;
+  $_SESSION['openid_connect_action'] = [
+    'signup' => $nid,
+    'params' => [
+      'affiliate_messaging_opt_in' => isset($params['affiliate_messaging_opt_in']) ? $params['affiliate_messaging_opt_in'] : FALSE,
+    ],
+  ];
 }
 
 /**
@@ -168,12 +172,11 @@ function dosomething_northstar_perform_authorization_actions() {
   }
 
   $actions = $_SESSION['openid_connect_action'];
-  $params = ['affiliate_messaging_opt_in' => $_SESSION['affiliate_messaging_opt_in']];
 
   foreach ($actions as $action => $target) {
     if ($action === 'signup') {
       $source = dosomething_signup_get_query_source();
-      dosomething_signup_user_signup((int) $target, $user, $source, $params);
+      dosomething_signup_user_signup((int) $target, $user, $source, $actions['params']);
 
       drupal_goto('node/' . $target);
     }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -66,15 +66,23 @@ function dosomething_signup_form($form, &$form_state, $nid, $label = "Sign Up") 
   if ($affiliate_data['messaging_opt_in']['enabled']) {
     $messaging_opt_in = $affiliate_data['messaging_opt_in'];
 
-    $form['affiliate_messeging_opt_in'] = [
+    $form['affiliate_messaging_opt_in'] = [
+      '#type' => 'container',
+      '#id' => 'messaging-opt-in',
+      '#attributes' => [
+        'class' => ['messaging-opt-in'],
+      ],
+    ];
+
+    $form['affiliate_messaging_opt_in']['toggle'] = [
       '#type' => 'checkbox',
       '#title' => t($messaging_opt_in['label']),
       '#default_value' => TRUE, // @TODO: eventually, this should be false so it's OPT-IN!
     ];
 
     if ($messaging_opt_in['info_label'] && $messaging_opt_in['info_message'])
-    $form['affiliate_messeging_opt_in_info'] = [
-      '#markup' => '<div class="opt-in-info"><p>'.$messaging_opt_in['info_label'].'</p><div>'.$messaging_opt_in['info_message'].'</div></div>',
+    $form['affiliate_messaging_opt_in']['info'] = [
+      '#markup' => '<div class="opt-in-info footnote"><p class="info-toggle js-footnote-toggle">'.$messaging_opt_in['info_label'].'</p><div class="info-message js-footnote-hidden">'.$messaging_opt_in['info_message'].'</div></div>',
     ];
   }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -63,27 +63,10 @@ function dosomething_signup_form($form, &$form_state, $nid, $label = "Sign Up") 
     ],
   ];
 
-  if ($affiliate_data['messaging_opt_in']['enabled']) {
-    $messaging_opt_in = $affiliate_data['messaging_opt_in'];
+  $affiliate_messaging_form = dosomething_signup_get_affiliate_form_component($nid);
 
-    $form['affiliate_messaging_opt_in'] = [
-      '#type' => 'container',
-      '#id' => 'messaging-opt-in',
-      '#attributes' => [
-        'class' => ['messaging-opt-in'],
-      ],
-    ];
-
-    $form['affiliate_messaging_opt_in']['toggle'] = [
-      '#type' => 'checkbox',
-      '#title' => t($messaging_opt_in['label']),
-      '#default_value' => TRUE, // @TODO: eventually, this should be false so it's OPT-IN!
-    ];
-
-    if ($messaging_opt_in['info_label'] && $messaging_opt_in['info_message'])
-    $form['affiliate_messaging_opt_in']['info'] = [
-      '#markup' => '<div class="opt-in-info footnote"><p class="info-toggle js-footnote-toggle">'.$messaging_opt_in['info_label'].'</p><div class="info-message js-footnote-hidden">'.$messaging_opt_in['info_message'].'</div></div>',
-    ];
+  if ($affiliate_messaging_form) {
+    $form = array_merge($form, $affiliate_messaging_form);
   }
 
   return $form;
@@ -110,12 +93,69 @@ function dosomething_signup_form_submit($form, &$form_state) {
     $source = $form_state['values']['source'];
   }
 
-  if (isset($form_state['values']['affiliate_messeging_opt_in'])) {
-    $params['affiliate_messaging_opt_in'] = (bool) $form_state['values']['affiliate_messeging_opt_in'];
+  if (isset($form_state['values']['affiliate_messaging_opt_in'])) {
+    $params['affiliate_messaging_opt_in'] = (bool) $form_state['values']['affiliate_messaging_opt_in'];
   }
 
   // Create signup for logged in user.
   dosomething_signup_user_signup($nid, NULL, $source, $params);
+}
+
+/**
+ * Form constructor for unathenticated user signup form.
+ * Displayed for an unathenticated user to signup for a node,
+ * requiring them first to login via Northstar.
+ *
+ * @param  array $form
+ * @param  array $form_state
+ * @param  string $nid
+ * @param  string $label
+ * @return array
+ */
+function dosomething_signup_unauthenticated_form($form, &$form_state, $nid, $label = "Sign Up") {
+  $campaign = Campaign::get($nid);
+
+  $form['#method'] = 'get';
+
+  $form['#action'] = url('user/authorize');
+
+  $form['action'] = array(
+    '#type' => 'hidden',
+    '#value' => 'signup',
+    '#access' => TRUE,
+  );
+
+  $form['node'] = array(
+    '#type' => 'hidden',
+    '#value' => $nid,
+    '#access' => TRUE,
+  );
+
+  $form['title'] = array(
+    '#type' => 'hidden',
+    '#value' => $campaign->title,
+    '#access' => TRUE,
+  );
+
+  $form['submit'] = [
+    '#type' => 'submit',
+    '#value' => t($label),
+    '#attributes' => [
+      'id' => 'link--openid-connect-campaign-signup-login',
+      'class' => ['button'],
+      'data-track-category' => 'Link',
+      'data-track-action' => 'Click',
+      'data-track-label' => 'Signup (Unauthenticated)',
+    ],
+  ];
+
+  $affiliate_messaging_form = dosomething_signup_get_affiliate_form_component($nid);
+
+  if ($affiliate_messaging_form) {
+    $form = array_merge($form, $affiliate_messaging_form);
+  }
+
+  return $form;
 }
 
 /**
@@ -478,4 +518,47 @@ function dosomething_signup_reset_signup_data_form_submit($form, &$form_state) {
   $signup->signup_data_form_response = NULL;
   entity_save('signup', $signup);
   drupal_set_message(t("The Signup data form has been reset."));
+}
+
+/**
+ * Get form structure for adding the affiliate messaging opt-in to
+ * the sign up forms.
+ *
+ * @param  string $campaign_id
+ * @return array
+ */
+function dosomething_signup_get_affiliate_form_component($campaign_id) {
+  if (!$campaign_id) {
+    return NULL;
+  }
+
+  $affiliate_data = dosomething_campaign_get_affiliate_data($campaign_id);
+
+  if (!$affiliate_data['messaging_opt_in']['enabled']) {
+    return NULL;
+  }
+
+  $messaging_opt_in = $affiliate_data['messaging_opt_in'];
+
+  $form['affiliate_messaging'] = [
+    '#type' => 'container',
+    '#id' => 'messaging-opt-in',
+    '#attributes' => [
+      'class' => ['messaging-opt-in'],
+    ],
+  ];
+
+  $form['affiliate_messaging']['affiliate_messaging_opt_in'] = [
+    '#type' => 'checkbox',
+    '#title' => t($messaging_opt_in['label']),
+    '#default_value' => TRUE, // @TODO: eventually, this should be false so it's OPT-IN!
+  ];
+
+  if ($messaging_opt_in['info_label'] && $messaging_opt_in['info_message'])
+  $form['affiliate_messaging']['info'] = [
+    '#markup' => '<div class="opt-in-info footnote"><p class="info-toggle js-footnote-toggle">'.$messaging_opt_in['info_label'].'</p><div class="info-message js-footnote-hidden">'.$messaging_opt_in['info_message'].'</div></div>',
+  ];
+
+  return $form;
+
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.theme.inc
@@ -66,5 +66,5 @@ function dosomething_signup_get_signup_button($label, $nid, $form_id) {
   // Otherwise, for anonymous user, return a #markup array to be rendered.
   $node = node_load($nid);
 
-  return ['#markup' => dosomething_user_get_sign_up_link_markup($label, $nid, $node->title)];
+  return drupal_get_form('dosomething_signup_unauthenticated_form', $nid, $label);
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -52,6 +52,7 @@ $asset-path: "";
 @import "content/search";
 @import "content/takeover";
 @import "content/user";
+@import "content/messaging-opt-in";
 
 // One-off pages
 @import "content/campaign/hunt-mcc";

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_messaging-opt-in.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_messaging-opt-in.scss
@@ -1,0 +1,9 @@
+.messaging-opt-in {
+  color: $white;
+
+  .info-message {
+    background-color: rgba(0,0,0,0.7);
+    border-radius: 4px;
+    padding: 5px;
+  }
+}


### PR DESCRIPTION
#### What's this PR do?
This PR adds some styles to the messaging opt-in feature and also enables unauthenticated users to be able to Signup and opt-in _after_ logging in via Northstar.

#### How should this be reviewed?
👁 

#### Any background context you want to provide?
There are some small CSS related quirks that result from this messaging opt-in but seems to mostly apply to member created campaigns.

#### Relevant tickets
Refs #7296
