### PR TITLE
Fixes email script & a bug where a user's Northstar ID field could be wiped.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -197,6 +197,10 @@ function dosomething_northstar_save_id_field($uid, $northstar_response) {
   $northstar_id = !empty($northstar_response['data']['id']) ? $northstar_response['data']['id'] : null;
   $user = user_load($uid);
 
+  if (is_null($northstar_id)) {
+    return;
+  }
+
   // Save a record to the `authmap` table if Northstar user exists:
   user_set_authmaps($user, ['authname_openid_connect_northstar' => $northstar_id]);
 


### PR DESCRIPTION
#### What's this PR do?
This pull request updates the `sanitize-email-addresses.php` to work correctly, since I had removed the "sync" functions when refactoring Northstar code last week. This will fix up ~5k users with missing authmap records so we can more easily see if the problem in #7302 is still occurring.

This also includes an update to the `dosomething_northstar_save_id_field` so that it will not automatically remove a user's `authmap` record if it's given a bad `$response` body – there's a chance that a bad response (like a 503) from Northstar could have caused issues for these users.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
This also removes some noise to help with debugging #7304.

#### Relevant tickets
References #7302.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  