### PR TITLE
Custom social share modal 

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -117,7 +117,6 @@ function dosomething_campaign_load($node, $public = FALSE, $cache = TRUE) {
     $campaign->title = $node->title;
     $campaign->status = dosomething_campaign_is_closed($node) ? 'closed' : 'active';
     $campaign->type = dosomething_campaign_get_campaign_type($node);
-
     $campaign->scholarship = NULL;
     if (array_key_exists($current_lang, $node->field_scholarship_amount)) {
       $campaign->scholarship = (int) $node->field_scholarship_amount[$current_lang][0]['value'];

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -445,42 +445,8 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
       $vars['show_social_share_link'] = $campaign->variables['show_social_share_link'];
   }
 
-  // Add social share bar.
-  $custom_social_copy_variables = [
-    'custom_facebook_copy' => $campaign->variables['custom_facebook_copy'],
-    'custom_twitter_copy' => $campaign->variables['custom_twitter_copy'],
-    'custom_tumblr_copy' => $campaign->variables['custom_tumblr_copy'],
-  ];
-
-  foreach ($custom_social_copy_variables as $key => $value) {
-    if ($value) {
-      $$key = $value;
-    }
-    elseif (isset($campaign->fact_problem['fact'])) {
-      $$key = $campaign->fact_problem['fact'];
-    }
-    else {
-      $$key = NULL;
-    }
-  }
-
-  $social_share_types = array(
-    'facebook' => array(
-      'type' => 'feed_dialog',
-      'parameters' => array(
-      'picture' => $vars['share_image'],
-      'caption' => $custom_facebook_copy,
-    ),
-  ),
-    'twitter' => array(
-      'tweet' => $custom_twitter_copy,
-    ),
-    'tumblr' => array(
-      'posttype' => 'photo',
-      'content' => $vars['share_image'],
-      'caption' => $custom_tumblr_copy,
-    ),
-  );
+  // Add custom social share bar.
+  $social_share_types = dosomething_helpers_social_share_types($campaign);
 
   $share_button_markup = dosomething_helpers_share_bar($campaign_path, $social_share_types, $campaign->nid . '_referral', 'social-menu', $share_path);
 
@@ -620,4 +586,54 @@ function dosomething_campaign_preprocess_closed_reportback_gallery(&$vars, $styl
     $account = user_load($item->uid);
     $vars['reportback_gallery'][$delta]['first_name'] = dosomething_user_get_field('field_first_name', $account);
   }
+}
+
+/**
+ * Return social share types and custom content.
+ *
+ * @param object $campaign
+ *   The campaign object to get custom content from.
+ * @return array $social share types
+ *   An array of social share types and custom content.
+ */
+
+function dosomething_helpers_social_share_types($campaign) {
+  $custom_social_copy_variables = [
+    'custom_facebook_copy' => dosomething_helpers_get_variable('node', $campaign->nid, 'custom_facebook_copy'),
+    'custom_twitter_copy' => dosomething_helpers_get_variable('node', $campaign->nid, 'custom_twitter_copy'),
+    'custom_tumblr_copy' => dosomething_helpers_get_variable('node', $campaign->nid, 'custom_tumblr_copy'),
+  ];
+
+  foreach ($custom_social_copy_variables as $key => $value) {
+    if ($value) {
+      $$key = $value;
+    }
+    elseif (isset($campaign->fact_problem['fact'])) {
+      $$key = $campaign->fact_problem['fact'];
+    }
+    else {
+      $$key = NULL;
+    }
+  }
+
+  $social_share_types = array(
+    'facebook' => array(
+      'type' => 'feed_dialog',
+      'parameters' => array(
+      'picture' => dosomething_image_get_themed_image_url(dosomething_helpers_get_variable('node', $campaign->nid, 'share_image_nid'), 'landscape'),
+      'caption' => $custom_facebook_copy,
+    ),
+    ),
+    'twitter' => array(
+      'tweet' => $custom_twitter_copy,
+    ),
+    'tumblr' => array(
+      'posttype' => 'photo',
+      'content' => dosomething_image_get_themed_image_url(dosomething_helpers_get_variable('node', $campaign->nid, 'share_image_nid'), 'landscape'),
+      'caption' => $custom_tumblr_copy,
+    ),
+  );
+
+  return $social_share_types;
+
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -446,7 +446,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   }
 
   // Add custom social share bar.
-  $social_share_types = dosomething_helpers_social_share_types($campaign);
+  $social_share_types = dosomething_helpers_campaign_page_social_share_types($campaign);
 
   $share_button_markup = dosomething_helpers_share_bar($campaign_path, $social_share_types, $campaign->nid . '_referral', 'social-menu', $share_path);
 
@@ -588,52 +588,4 @@ function dosomething_campaign_preprocess_closed_reportback_gallery(&$vars, $styl
   }
 }
 
-/**
- * Return social share types and custom content.
- *
- * @param object $campaign
- *   The campaign object to get custom content from.
- * @return array $social share types
- *   An array of social share types and custom content.
- */
 
-function dosomething_helpers_social_share_types($campaign) {
-  $custom_social_copy_variables = [
-    'custom_facebook_copy' => dosomething_helpers_get_variable('node', $campaign->nid, 'custom_facebook_copy'),
-    'custom_twitter_copy' => dosomething_helpers_get_variable('node', $campaign->nid, 'custom_twitter_copy'),
-    'custom_tumblr_copy' => dosomething_helpers_get_variable('node', $campaign->nid, 'custom_tumblr_copy'),
-  ];
-
-  foreach ($custom_social_copy_variables as $key => $value) {
-    if ($value) {
-      $$key = $value;
-    }
-    elseif (isset($campaign->fact_problem['fact'])) {
-      $$key = $campaign->fact_problem['fact'];
-    }
-    else {
-      $$key = NULL;
-    }
-  }
-
-  $social_share_types = array(
-    'facebook' => array(
-      'type' => 'feed_dialog',
-      'parameters' => array(
-      'picture' => dosomething_image_get_themed_image_url(dosomething_helpers_get_variable('node', $campaign->nid, 'share_image_nid'), 'landscape'),
-      'caption' => $custom_facebook_copy,
-    ),
-    ),
-    'twitter' => array(
-      'tweet' => $custom_twitter_copy,
-    ),
-    'tumblr' => array(
-      'posttype' => 'photo',
-      'content' => dosomething_image_get_themed_image_url(dosomething_helpers_get_variable('node', $campaign->nid, 'share_image_nid'), 'landscape'),
-      'caption' => $custom_tumblr_copy,
-    ),
-  );
-
-  return $social_share_types;
-
-}

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -164,3 +164,4 @@ function dosomething_helpers_share_bar($path, $share_types, $share_description, 
 
   return $share_bar . "</ul>";
 }
+

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.share.inc
@@ -165,3 +165,52 @@ function dosomething_helpers_share_bar($path, $share_types, $share_description, 
   return $share_bar . "</ul>";
 }
 
+/**
+ * Return social share types and custom content.
+ *
+ * @param object $campaign
+ *   The campaign object to get custom content from.
+ * @return array $social share types
+ *   An array of social share types and custom content.
+ */
+
+function dosomething_helpers_campaign_page_social_share_types($campaign) {
+  $custom_social_copy_variables = [
+    'custom_facebook_copy' => dosomething_helpers_get_variable('node', $campaign->nid, 'custom_facebook_copy'),
+    'custom_twitter_copy' => dosomething_helpers_get_variable('node', $campaign->nid, 'custom_twitter_copy'),
+    'custom_tumblr_copy' => dosomething_helpers_get_variable('node', $campaign->nid, 'custom_tumblr_copy'),
+  ];
+
+  foreach ($custom_social_copy_variables as $key => $value) {
+    if ($value) {
+      $$key = $value;
+    }
+    elseif (isset($campaign->fact_problem['fact'])) {
+      $$key = $campaign->fact_problem['fact'];
+    }
+    else {
+      $$key = NULL;
+    }
+  }
+
+  $social_share_types = array(
+    'facebook' => array(
+      'type' => 'feed_dialog',
+      'parameters' => array(
+      'picture' => dosomething_image_get_themed_image_url(dosomething_helpers_get_variable('node', $campaign->nid, 'share_image_nid'), 'landscape'),
+      'caption' => $custom_facebook_copy,
+    ),
+    ),
+    'twitter' => array(
+      'tweet' => $custom_twitter_copy,
+    ),
+    'tumblr' => array(
+      'posttype' => 'photo',
+      'content' => dosomething_image_get_themed_image_url(dosomething_helpers_get_variable('node', $campaign->nid, 'share_image_nid'), 'landscape'),
+      'caption' => $custom_tumblr_copy,
+    ),
+  );
+
+  return $social_share_types;
+
+}

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -114,12 +114,6 @@ function dosomething_signup_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
-      'custom_social_share_signup' => [
-        'description' => 'Boolean indicating this is a custom social share signup form',
-        'type' => 'int',
-        'not null' => TRUE,
-        'default' => 0,
-      ],
       'link_text' => array(
         'description' => 'The text to display in the link to the form.',
         'type' => 'varchar',
@@ -727,5 +721,23 @@ function dosomething_signup_update_7025() {
   $column = 'source';
   if (!db_index_exists($table, $column)) {
     db_add_index($table, $column, array($column));
+  }
+}
+
+/**
+ * Adds field to support custom social share modal to the dosomething_signup_data_form table.
+ *
+ */
+function dosomething_signup_update_7026() {
+  $table = 'dosomething_signup_data_form';
+  $spec = array(
+    'type' => 'int',
+    'description' => 'Boolean indicating this is a custom social share signup form',
+    'length' => 11,
+    'not null' => TRUE,
+    'default' => 0,
+  );
+  if (!db_field_exists($table, 'custom_social_share_signup')) {
+    db_add_field($table, 'custom_social_share_signup', $spec);
   }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -735,27 +735,9 @@ function dosomething_signup_update_7026() {
     'description' => 'Boolean indicating this is a custom social share signup form',
     'length' => 11,
     'not null' => TRUE,
-    'default' => 1,
+    'default' => 0,
   );
   if (!db_field_exists($table, 'custom_social_share_signup')) {
     db_add_field($table, 'custom_social_share_signup', $spec);
-  }
-}
-
-/**
- * Updates so 'Collect additional signup data' checkbox is checked by default.
- *
- */
-function dosomething_signup_update_7027() {
-  $table = 'dosomething_signup_data_form';
-  if (db_table_exists($table)) {
-    $spec = [
-        'description' => 'Boolean indicating the form is enabled.',
-        'type' => 'int',
-        'not null' => TRUE,
-        'default' => 1,
-    ];
-
-    db_change_field($table, 'status', 'status', $spec);
   }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -735,9 +735,27 @@ function dosomething_signup_update_7026() {
     'description' => 'Boolean indicating this is a custom social share signup form',
     'length' => 11,
     'not null' => TRUE,
-    'default' => 0,
+    'default' => 1,
   );
   if (!db_field_exists($table, 'custom_social_share_signup')) {
     db_add_field($table, 'custom_social_share_signup', $spec);
+  }
+}
+
+/**
+ * Updates so 'Collect additional signup data' checkbox is checked by default.
+ *
+ */
+function dosomething_signup_update_7027() {
+  $table = 'dosomething_signup_data_form';
+  if (db_table_exists($table)) {
+    $spec = [
+        'description' => 'Boolean indicating the form is enabled.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 1,
+    ];
+
+    db_change_field($table, 'status', 'status', $spec);
   }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.install
@@ -114,6 +114,12 @@ function dosomething_signup_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'custom_social_share_signup' => [
+        'description' => 'Boolean indicating this is a custom social share signup form',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ],
       'link_text' => array(
         'description' => 'The text to display in the link to the form.',
         'type' => 'varchar',

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -316,11 +316,21 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     '#value' => $signup->run_nid,
     '#access' => FALSE,
   );
-  $form['header'] = array(
-    '#prefix' => '<div class="modal__block"><h2 class="heading">',
-    '#markup' => $config['form_header'],
-    '#suffix' => '</h2></div>',
-  );
+
+  // If custom social share signup is turned on, use the $config['form_header'] from signup data form.
+  if ($config['custom_social_share_signup']) {
+    $form['header'] = array(
+      '#prefix' => '<div class="modal__block"><h2 class="heading">',
+      '#markup' => dosomething_helpers_get_variable('node', $signup->nid, 'social_share_custom_text'),
+      '#suffix' => '</h2></div>',
+    );
+  } else {
+    $form['header'] = array(
+      '#prefix' => '<div class="modal__block"><h2 class="heading">',
+      '#markup' => $config['form_header'],
+      '#suffix' => '</h2></div>',
+    );
+  }
 
   // If the user has submitted form already:
   if (($timestamp = $signup->signup_data_form_timestamp) && $signup->signup_data_form_response == 1) {
@@ -465,16 +475,19 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     '#suffix' => '</div></div>',
   );
 
-  $submit_label = ($config['submit_text']) ? t($config['submit_text']) : t('Submit');
-  $form['actions']['submit'] = array(
-    '#type' => 'submit',
-    '#value' => $submit_label,
-    '#attributes' => array(
-      'class' => array(
-        'button',
+// if enable custom share modal is on, do not show this submit button.
+  if (! $config['custom_social_share_signup']) {
+    $submit_label = ($config['submit_text']) ? t($config['submit_text']) : t('Submit');
+    $form['actions']['submit'] = array(
+      '#type' => 'submit',
+      '#value' => $submit_label,
+      '#attributes' => array(
+        'class' => array(
+          'button',
+        ),
       ),
-    ),
-  );
+    );
+  }
 
   // @todo Hacky solution to deal with form elements when no elements added and eliminate empty container added.
   // @see https://github.com/DoSomething/phoenix/pull/5809

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -55,7 +55,7 @@ function dosomething_signup_node_signup_data_form($form, &$form_state, $node) {
     '#weight' => 60,
     '#collapsible' => TRUE,
     '#collapsed' => FALSE,
-    '#description' => t('Note: you must either chose Competition Signup or Enable Custom Share Modal, cannot have both.'),
+    '#description' => t('Note: You must either chose Competition Signup or Enable Custom Share Modal, you cannot have both. To customize the Competition Signup, fill out the below fields. To customize the Custom Social Share, scroll up to "Custom Social Sharing" section and fill out fields.'),
     // Config fieldset should only be visible if the status field is checked.
     '#states' => array(
       'visible' => array(
@@ -322,43 +322,9 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       '#suffix' => '">',
     );
 
-    $custom_social_copy_variables = [
-      'custom_facebook_copy' => dosomething_helpers_get_variable('node', $signup->nid, 'custom_facebook_copy'),
-      'custom_twitter_copy' => dosomething_helpers_get_variable('node', $signup->nid, 'custom_twitter_copy'),
-      'custom_tumblr_copy' => dosomething_helpers_get_variable('node', $signup->nid, 'custom_tumblr_copy'),
-    ];
-
     $campaign = dosomething_campaign_load(node_load($signup->nid));
 
-    foreach ($custom_social_copy_variables as $key => $value) {
-      if ($value) {
-        $$key = $value;
-      }
-      elseif (isset($campaign->fact_problem['fact'])) {
-        $$key = $campaign->fact_problem['fact'];
-      }
-      else {
-        $$key = NULL;
-      }
-    }
-
-    $social_share_types = array(
-      'facebook' => array(
-        'type' => 'feed_dialog',
-        'parameters' => array(
-        'picture' => dosomething_image_get_themed_image_url(dosomething_helpers_get_variable('node', $signup->nid, 'share_image_nid'), 'landscape'),
-        'caption' => $custom_facebook_copy,
-      ),
-    ),
-      'twitter' => array(
-        'tweet' => $custom_twitter_copy,
-      ),
-      'tumblr' => array(
-        'posttype' => 'photo',
-        'content' => dosomething_image_get_themed_image_url(dosomething_helpers_get_variable('node', $signup->nid, 'share_image_nid'), 'landscape'),
-        'caption' => $custom_tumblr_copy,
-      ),
-    );
+    $social_share_types = dosomething_helpers_social_share_types($campaign);
 
     $campaign_path = url(current_path(), array('absolute' => TRUE));
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -241,22 +241,6 @@ function dosomething_signup_node_signup_data_form($form, &$form_state, $node) {
 }
 
 /**
- * Validates node signup_data_form values.
- */
-function dosomething_signup_node_signup_data_form_validate(&$form, &$form_state) {
-  $values = $form_state['values'];
-  $prefix = 'signup_data_form_';
-  // If signup data form is enabled:
-  if ($values[$prefix . 'status'] == 1) {
-    // Confirm_msg is mandatory.
-    $confirm_msg = $prefix . 'confirm_msg';
-    if (empty($values[$confirm_msg])) {
-      form_set_error($confirm_msg, t('Signup Data Form Confirmation message is mandatory.'));
-    }
-  }
-}
-
-/**
  * Saves node signup_data_form values into dosomething_signup_data_form.
  */
 function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -104,6 +104,12 @@ function dosomething_signup_node_signup_data_form($form, &$form_state, $node) {
       ),
     ),
   );
+  $form[$fieldset]['config'][$prefix . 'custom_social_share_signup'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable Custom Share Modal'),
+    '#default_value' => $values['custom_social_share_signup'],
+    '#description' => t('If checked, the custom social share modal will be enabled after a user signs up.'),
+  );
   $form[$fieldset]['config'][$prefix . 'link_text'] = array(
     '#type' => 'textfield',
     '#title' => t('Link text'),
@@ -265,6 +271,7 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
         'required' => $values[$prefix . 'required'],
         'required_allow_skip' => $values[$prefix . 'required_allow_skip'],
         'competition_signup' => $values[$prefix . 'competition_signup'],
+        'custom_social_share_signup' => $values[$prefix . 'custom_social_share_signup'],
         'link_text' => $values[$prefix . 'link_text'],
         'submit_text' => $values[$prefix . 'submit_text'],
         'skip_text' => $values[$prefix . 'skip_text'],

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -337,52 +337,60 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       '#suffix' => '">',
     );
 
-    // $form['custom_social_share_signup_img'] = array(
-    //   // '#type' => 'markup',
-    //   '#prefix' => '<img src="',
-    //   '#markup' => dosomething_helpers_get_variable('node', $signup->nid, 'share_image_nid'),
-    //   '#suffix' => '">',
-    // );
+    $custom_social_copy_variables = [
+      'custom_facebook_copy' => dosomething_helpers_get_variable('node', $signup->nid, 'custom_facebook_copy'),
+      'custom_twitter_copy' => dosomething_helpers_get_variable('node', $signup->nid, 'custom_twitter_copy'),
+      'custom_tumblr_copy' => dosomething_helpers_get_variable('node', $signup->nid, 'custom_tumblr_copy'),
+    ];
 
-      // Add social share bar.
-  // $custom_social_copy_variables = [
-  //   'custom_facebook_copy' => $campaign->variables['custom_facebook_copy'],
-  //   'custom_twitter_copy' => $campaign->variables['custom_twitter_copy'],
-  //   'custom_tumblr_copy' => $campaign->variables['custom_tumblr_copy'],
-  // ];
+    $campaign = node_load($signup->nid);
 
-  // foreach ($custom_social_copy_variables as $key => $value) {
-  //   if ($value) {
-  //     $$key = $value;
-  //   }
-  //   elseif (isset($campaign->fact_problem['fact'])) {
-  //     $$key = $campaign->fact_problem['fact'];
-  //   }
-  //   else {
-  //     $$key = NULL;
-  //   }
-  // }
-  // $social_share_types = array(
-  //   'facebook' => array(
-  //     'type' => 'feed_dialog',
-  //     'parameters' => array(
-  //     'picture' => $vars['share_image'],
-  //     'caption' => $custom_facebook_copy,
-  //   ),
-  // ),
-  //   'twitter' => array(
-  //     'tweet' => $custom_twitter_copy,
-  //   ),
-  //   'tumblr' => array(
-  //     'posttype' => 'photo',
-  //     'content' => $vars['share_image'],
-  //     'caption' => $custom_tumblr_copy,
-  //   ),
-  // );
+    foreach ($custom_social_copy_variables as $key => $value) {
+      if ($value) {
+        $$key = $value;
+      }
+      elseif (isset($campaign->field_fact_problem['en'][0]['entity']->title)) {
+        $$key = $campaign->field_fact_problem['en'][0]['entity']->title;
+      }
+      else {
+        $$key = NULL;
+      }
+    }
 
-  // $share_button_markup = dosomething_helpers_share_bar($campaign_path, $social_share_types, $campaign->nid . '_referral', 'social-menu', $share_path);
-  // $vars['social_share_bar'] = $share_button_markup;
-  // $vars['custom_social_share_link'] = $custom_social_share_link;
+    $social_share_types = array(
+      'facebook' => array(
+        'type' => 'feed_dialog',
+        'parameters' => array(
+        'picture' => dosomething_image_get_themed_image_url(dosomething_helpers_get_variable('node', $signup->nid, 'share_image_nid'), 'landscape'),
+        'caption' => $custom_facebook_copy,
+      ),
+    ),
+      'twitter' => array(
+        'tweet' => $custom_twitter_copy,
+      ),
+      'tumblr' => array(
+        'posttype' => 'photo',
+        'content' => dosomething_image_get_themed_image_url(dosomething_helpers_get_variable('node', $signup->nid, 'share_image_nid'), 'landscape'),
+        'caption' => $custom_tumblr_copy,
+      ),
+    );
+
+    $campaign_path = url(current_path(), array('absolute' => TRUE));
+
+    if (dosomething_user_get_field('field_northstar_id')) {
+      $share_path = 'user/' . dosomething_user_get_field('field_northstar_id');
+    }
+    else {
+      $share_path = 'user/' . dosomething_user_get_field('uid');
+    }
+
+    $share_button_markup = dosomething_helpers_share_bar($campaign_path, $social_share_types, $campaign->nid . '_referral', 'social-menu', $share_path);
+
+    $form['custom_social_share_bar'] = array(
+      '#prefix' => '<div class="modal__block"><p>',
+      '#markup' => $share_button_markup,
+      '#suffix' => '</p></div>',
+    );
   } else {
     $form['header'] = array(
       '#prefix' => '<div class="modal__block"><h2 class="heading">',

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -324,7 +324,7 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
 
     $campaign = dosomething_campaign_load(node_load($signup->nid));
 
-    $social_share_types = dosomething_helpers_social_share_types($campaign);
+    $social_share_types = dosomething_helpers_campaign_page_social_share_types($campaign);
 
     $campaign_path = url(current_path(), array('absolute' => TRUE));
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -55,6 +55,7 @@ function dosomething_signup_node_signup_data_form($form, &$form_state, $node) {
     '#weight' => 60,
     '#collapsible' => TRUE,
     '#collapsed' => FALSE,
+    '#description' => t('Note: you must either chose Competition Signup or Enable Custom Share Modal, cannot have both.'),
     // Config fieldset should only be visible if the status field is checked.
     '#states' => array(
       'visible' => array(
@@ -72,7 +73,13 @@ function dosomething_signup_node_signup_data_form($form, &$form_state, $node) {
     '#type' => 'checkbox',
     '#title' => t('Competition Signup'),
     '#default_value' => $values['competition_signup'],
-    '#description' => t('If checked, when the user submits this form, they will be entered into a competition'),
+    '#description' => t('If checked, when the user submits this form, they will be entered into a competition.'),
+  );
+  $form[$fieldset]['config'][$prefix . 'custom_social_share_signup'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable Custom Share Modal'),
+    '#default_value' => $values['custom_social_share_signup'],
+    '#description' => t('If checked, the custom social share modal will be enabled after a user signs up.'),
   );
   $form[$fieldset]['config'][$prefix . 'required_allow_skip'] = array(
     '#type' => 'checkbox',
@@ -103,12 +110,6 @@ function dosomething_signup_node_signup_data_form($form, &$form_state, $node) {
         ':input[name="' . $prefix . 'prevent_old_people_submit"]' => array('checked' => TRUE),
       ),
     ),
-  );
-  $form[$fieldset]['config'][$prefix . 'custom_social_share_signup'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Enable Custom Share Modal'),
-    '#default_value' => $values['custom_social_share_signup'],
-    '#description' => t('If checked, the custom social share modal will be enabled after a user signs up.'),
   );
   $form[$fieldset]['config'][$prefix . 'link_text'] = array(
     '#type' => 'textfield',

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -324,11 +324,70 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       '#markup' => dosomething_helpers_get_variable('node', $signup->nid, 'social_share_custom_text'),
       '#suffix' => '</h2></div>',
     );
+
+    $form['copy'] = array(
+      '#prefix' => '<div class="modal__block"><p>',
+      '#markup' => dosomething_helpers_get_variable('node', $signup->nid, 'social_share_custom_description'),
+      '#suffix' => '</p></div>',
+    );
+
+    $form['custom_social_share_signup_img'] = array(
+    // '#type' => 'markup',
+    '#prefix' => '<imc src="',
+    '#markup' => dosomething_helpers_get_variable('node', $signup->nid, 'share_image_nid'),
+    '#suffix' => '">',
+  );
+
+      // Add social share bar.
+  // $custom_social_copy_variables = [
+  //   'custom_facebook_copy' => $campaign->variables['custom_facebook_copy'],
+  //   'custom_twitter_copy' => $campaign->variables['custom_twitter_copy'],
+  //   'custom_tumblr_copy' => $campaign->variables['custom_tumblr_copy'],
+  // ];
+
+  // foreach ($custom_social_copy_variables as $key => $value) {
+  //   if ($value) {
+  //     $$key = $value;
+  //   }
+  //   elseif (isset($campaign->fact_problem['fact'])) {
+  //     $$key = $campaign->fact_problem['fact'];
+  //   }
+  //   else {
+  //     $$key = NULL;
+  //   }
+  // }
+  // $social_share_types = array(
+  //   'facebook' => array(
+  //     'type' => 'feed_dialog',
+  //     'parameters' => array(
+  //     'picture' => $vars['share_image'],
+  //     'caption' => $custom_facebook_copy,
+  //   ),
+  // ),
+  //   'twitter' => array(
+  //     'tweet' => $custom_twitter_copy,
+  //   ),
+  //   'tumblr' => array(
+  //     'posttype' => 'photo',
+  //     'content' => $vars['share_image'],
+  //     'caption' => $custom_tumblr_copy,
+  //   ),
+  // );
+
+  // $share_button_markup = dosomething_helpers_share_bar($campaign_path, $social_share_types, $campaign->nid . '_referral', 'social-menu', $share_path);
+  // $vars['social_share_bar'] = $share_button_markup;
+  // $vars['custom_social_share_link'] = $custom_social_share_link;
   } else {
     $form['header'] = array(
       '#prefix' => '<div class="modal__block"><h2 class="heading">',
       '#markup' => $config['form_header'],
       '#suffix' => '</h2></div>',
+    );
+
+    $form['copy'] = array(
+      '#prefix' => '<div class="modal__block"><p>',
+      '#markup' => $config['form_copy'],
+      '#suffix' => '</p></div>',
     );
   }
 
@@ -346,11 +405,6 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     return $form;
   }
 
-  $form['copy'] = array(
-    '#prefix' => '<div class="modal__block"><p>',
-    '#markup' => $config['form_copy'],
-    '#suffix' => '</p></div>',
-  );
 
   // Container for form elements
   $form['elements'] = array(

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -332,11 +332,17 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     );
 
     $form['custom_social_share_signup_img'] = array(
-    // '#type' => 'markup',
-    '#prefix' => '<imc src="',
-    '#markup' => dosomething_helpers_get_variable('node', $signup->nid, 'share_image_nid'),
-    '#suffix' => '">',
-  );
+      '#prefix' => '<img src="',
+      '#markup' => dosomething_image_get_themed_image_url(dosomething_helpers_get_variable('node', $signup->nid, 'share_image_nid'), 'landscape'),
+      '#suffix' => '">',
+    );
+
+    // $form['custom_social_share_signup_img'] = array(
+    //   // '#type' => 'markup',
+    //   '#prefix' => '<img src="',
+    //   '#markup' => dosomething_helpers_get_variable('node', $signup->nid, 'share_image_nid'),
+    //   '#suffix' => '">',
+    // );
 
       // Add social share bar.
   // $custom_social_copy_variables = [

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -343,14 +343,14 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
       'custom_tumblr_copy' => dosomething_helpers_get_variable('node', $signup->nid, 'custom_tumblr_copy'),
     ];
 
-    $campaign = node_load($signup->nid);
+    $campaign = dosomething_campaign_load(node_load($signup->nid));
 
     foreach ($custom_social_copy_variables as $key => $value) {
       if ($value) {
         $$key = $value;
       }
-      elseif (isset($campaign->field_fact_problem['en'][0]['entity']->title)) {
-        $$key = $campaign->field_fact_problem['en'][0]['entity']->title;
+      elseif (isset($campaign->fact_problem['fact'])) {
+        $$key = $campaign->fact_problem['fact'];
       }
       else {
         $$key = NULL;


### PR DESCRIPTION
#### What's this PR do?
- Adds a checkbox under `SIGNUP DATA FORM` to enable custom share modal after signup. 
- Doesn't make `Confirmation message` field required any longer. 

#### How should this be reviewed?
- Run `drush updb`. 
- Make sure `Collect additional signup data` and `Enable Custom Share Modal` checkboxes are checked. 
- Under `CUSTOM SOCIAL SHARING` in `Custom Settings`, customize social sharing. If these are not filled out, no image will appear and the problem fact will populate custom social message. 

#### Any background context you want to provide?
Wanted to get this up as quickly as possible. If we want, I can play around with having both competitions and custom social sharing possible next! @ngjo can we sync about this? 

#### Relevant tickets
Fixes #7303 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
