### PR TITLE
Add northstar id to api campaign routes

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -267,10 +267,15 @@ function _campaign_resource_index($ids, $staff_pick, $term_ids, $count, $random,
  *       Defaults to sending messages.
  */
 function _campaign_resource_signup($nid, $values) {
-  global $user;
-  if (!isset($values['uid'])) {
+
+  if (isset($values['northstar_id'])) {
+    $values['uid'] = dosomething_user_get_user_by_northstar_id($values['northstar_id'])->uid;
+  }
+  else if (!isset($values['uid'])) {
+    global $user;
     $values['uid'] = $user->uid;
   }
+
   if (!isset($values['source'])) {
     $values['source'] = NULL;
   }
@@ -343,12 +348,15 @@ function _campaign_resource_reportback($nid, $values) {
 
   $values['nid'] = $nid;
 
-  if (!isset($values['uid'])) {
-    global $user;
-    $values['uid'] = $user->uid;
+  if (isset($values['northstar_id'])) {
+    $values['uid'] = dosomething_user_get_user_by_northstar_id($values['northstar_id'])->uid;
+  }
+  else if (isset($values['uid'])) {
+    $user = user_load($values['uid']);
   }
   else {
-    $user = user_load($values['uid']);
+    global $user;
+    $values['uid'] = $user->uid;
   }
 
   $uid = $values['uid'];


### PR DESCRIPTION
#### What's this PR do?
This PR lets you use a Northstar ID in the /campaigns API routes!

#### How should this be reviewed?
Try making some API requests! Heres some examples I used,

```js
function signupUser1(northstarId, campaignId) {
  makePhoenixPostRequest(`campaigns/${campaignId}/signup`, {
    northstarId,
  }, function(data) {
    console.log(data);
  });
}

function signupUser2(uid, campaignId) {
  makePhoenixPostRequest(`campaigns/${campaignId}/signup`, {
    uid,
  }, function(data) {
    console.log(data);
  });
}
```

#### Any background context you want to provide?
Super useful for phoenix-next, I imagine other services as well!

#### Relevant tickets
Fixes #

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
