### PR TITLE
adds check to see if rogue collection is on

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -406,7 +406,7 @@ function _campaign_resource_reportback($nid, $values) {
 
   $headers = getallheaders();
 
-  if (! isset($headers['X-Request-Id'])) {
+  if (variable_get('rogue_collection', FALSE) && ! isset($headers['X-Request-Id'])) {
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
     // Make sure reportback made it back to Phoenix and store reference to the Rogue item if one was added
@@ -415,10 +415,12 @@ function _campaign_resource_reportback($nid, $values) {
     return $rb_info['rbid'];
   }
   else {
-    // Increment transaction id and log that the request has been received with new transaction id.
-    $incremented_transaction_id = dosomething_api_increment_transaction_id($headers['X-Request-Id']);
+    if ($headers['X-Request-Id']) {
+      // Increment transaction id and log that the request has been received with new transaction id.
+      $incremented_transaction_id = dosomething_api_increment_transaction_id($headers['X-Request-Id']);
 
-    watchdog('PhoenixTransactionBridge', 'Request received. Transaction ID: !incremented_transaction_id', ['!incremented_transaction_id' => $incremented_transaction_id], WATCHDOG_INFO);
+      watchdog('PhoenixTransactionBridge', 'Request received. Transaction ID: !incremented_transaction_id', ['!incremented_transaction_id' => $incremented_transaction_id], WATCHDOG_INFO);
+    }
 
     return dosomething_reportback_save($values, $user);
   }


### PR DESCRIPTION
#### What's this PR do?
- Adds a check to see if Rogue collection is turned on before sending RBs to Rogue from API.

#### How should this be reviewed?
- Turn off Rogue collection. 
- Submit reportback via `/api/v1/campaigns/:nid/reportback` endpoint with no `X-Request-Id` header.
- Reportback should be saved in Phoenix database and should return `rbid` as response.

#### Any background context you want to provide?
- @aaronschachter reportbacks from the API _might_ have been saved to the database even though the response was `null`. When testing, I saw that the rbs actually were saved. 

#### Relevant tickets
Fixes #7313 
