### PR TITLE
Only grab open campaigns on taxonomy pages

### DIFF
--- a/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
+++ b/lib/modules/dosomething/dosomething_taxonomy/dosomething_taxonomy.module
@@ -118,7 +118,13 @@ function dosomething_taxonomy_preprocess_taxonomy_term(&$vars) {
  */
 function dosomething_taxonomy_get_campaigns($tid) {
   $campaigns = node_load_multiple(taxonomy_select_nodes($tid, FALSE), ['type' => 'campaign']);
-  $nids = array_map(function($node) { return $node->nid; }, $campaigns);
+  $nids = [];
+
+  foreach ($campaigns as $campaign) {
+    if (! dosomething_campaign_is_closed($campaign)) {
+      $nids[] = $campaign->nid;
+    }
+  }
 
   return $nids;
 }


### PR DESCRIPTION
#### What's this PR do?
Only grab open campaigns on taxonomy pages

#### How should this be reviewed?
Checkout a taxonomy page
![screen shot 2017-02-21 at 1 04 37 pm](https://cloud.githubusercontent.com/assets/897368/23178430/61f0db90-f838-11e6-9982-dfb2a5e0c254.png)

And then close a campaign
![screen shot 2017-02-21 at 1 16 43 pm](https://cloud.githubusercontent.com/assets/897368/23178440/6bac24d2-f838-11e6-928b-faf07a8af8a2.png)


#### Any background context you want to provide?
_[Why didn't you add a conditional field to the view?](https://github.com/DoSomething/phoenix/issues/7305#issuecomment-278682005)_

As I mentioned in sprint planning earlier, this is an old diff. Here is the PR where that changed https://github.com/DoSomething/phoenix/pull/7119

_Right but can't you query by a field in node_load_multiple?_
Yes but no. The `status` field on a campaign doesn't appear to update when the run closes, only the Admin UI updates. Unfortunately, that means I have to loop over everything & run a function call on it.

![screen shot 2017-02-21 at 1 26 15 pm](https://cloud.githubusercontent.com/assets/897368/23178685/5d79b162-f839-11e6-9212-a1a5303e5e89.png)
![screen shot 2017-02-21 at 1 27 20 pm](https://cloud.githubusercontent.com/assets/897368/23178727/83f65782-f839-11e6-90f4-9fc2e9edf54d.png)
(This is the campaign from my test above ^^ )

#### Relevant tickets
Fixes #7305

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
