### PR TITLE
Adds Reaction User param to Reportback endpoints

### DIFF
--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -467,4 +467,19 @@ abstract class Transformer {
     ];
   }
 
+  /**
+   * Set the global user to a different account based on Northstar id.
+   *
+   * @param  String $northstarUserId
+   */
+  protected function asNorthstarUser($northstarUserId) {
+    if (!user_access('view any reportback')) return;
+
+    $userOverride = dosomething_user_get_user_by_northstar_id($northstarUserId);
+    if ($userOverride) {
+      global $user;
+      $user = $userOverride;
+    }
+  }
+
 }

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -92,11 +92,11 @@ function _reportback_item_resource_definition() {
             'default value' => FALSE,
           ],
           [
-            'name' => 'reaction_user',
-            'description' => 'Override the current user in respect to Reaction data',
+            'name' => 'as_user',
+            'description' => 'Override the current global user',
             'optional' => TRUE,
-            'type' => 'int',
-            'source' => ['param' => 'reaction_user'],
+            'type' => 'string',
+            'source' => ['param' => 'as_user'],
             'default_value' => NULL,
           ],
         ],
@@ -141,19 +141,10 @@ function _reportback_item_resource_access($op) {
  * @param  bool    $random
  * @param  int     $page
  * @param  bool    $load_user
- * @param  int     $reaction_user
+ * @param  string  $as_user
  * @return array
  */
-function _reportback_item_resource_index($campaigns, $exclude, $status, $count, $random, $page, $load_user, $reaction_user) {
-  if ($reaction_user) {
-    $reaction_user = user_load($reaction_user);
-
-    if ($reaction_user) {
-      global $user;
-      $user = $reaction_user;
-    }
-  }
-
+function _reportback_item_resource_index($campaigns, $exclude, $status, $count, $random, $page, $load_user, $as_user) {
   $parameters = array(
     'campaigns' => $campaigns,
     'exclude' => $exclude,
@@ -162,6 +153,7 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
     'random' => $random,
     'page' => $page,
     'load_user' => $load_user,
+    'as_user' => $as_user,
   );
 
   $reportbackItems = new ReportbackItemTransformer;

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -91,6 +91,14 @@ function _reportback_item_resource_definition() {
             'source' => array('param' => 'load_user'),
             'default value' => FALSE,
           ],
+          [
+            'name' => 'reaction_user',
+            'description' => 'Override the current user in respect to Reaction data',
+            'optional' => TRUE,
+            'type' => 'int',
+            'source' => ['param' => 'reaction_user'],
+            'default_value' => NULL,
+          ],
         ],
         'access callback' => '_reportback_item_resource_access',
         'access arguments' => array('index'),
@@ -133,9 +141,19 @@ function _reportback_item_resource_access($op) {
  * @param  bool    $random
  * @param  int     $page
  * @param  bool    $load_user
+ * @param  int     $reaction_user
  * @return array
  */
-function _reportback_item_resource_index($campaigns, $exclude, $status, $count, $random, $page, $load_user) {
+function _reportback_item_resource_index($campaigns, $exclude, $status, $count, $random, $page, $load_user, $reaction_user) {
+  if ($reaction_user) {
+    $reaction_user = user_load($reaction_user);
+
+    if ($reaction_user) {
+      global $user;
+      $user = $reaction_user;
+    }
+  }
+
   $parameters = array(
     'campaigns' => $campaigns,
     'exclude' => $exclude,

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
@@ -157,7 +157,7 @@ function _reportback_resource_access($op) {
  * @param  bool    $random
  * @param  int     $page
  * @param  bool    $load_user
- * @param  int     $reaction_user
+ * @param  string  $reaction_user
  * @param  bool    $flagged
  * @return array
  */

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
@@ -92,6 +92,14 @@ function _reportback_resource_definition() {
             'default value' => FALSE,
           ],
           [
+            'name' => 'reaction_user',
+            'description' => 'Override the current user in respect to Reaction data',
+            'optional' => TRUE,
+            'type' => 'int',
+            'source' => ['param' => 'reaction_user'],
+            'default_value' => NULL,
+          ],
+          [
             'name' => 'flagged',
             'description' => 'Boolean to indicate whether to also retrieve flagged reportbacks.',
             'optional' => TRUE,
@@ -149,10 +157,20 @@ function _reportback_resource_access($op) {
  * @param  bool    $random
  * @param  int     $page
  * @param  bool    $load_user
+ * @param  int     $reaction_user
  * @param  bool    $flagged
  * @return array
  */
-function _reportback_resource_index($ids, $campaigns, $status, $count, $random, $page, $load_user, $flagged, $runs) {
+function _reportback_resource_index($ids, $campaigns, $status, $count, $random, $page, $load_user, $reaction_user, $flagged, $runs) {
+  if ($reaction_user) {
+    $reaction_user = user_load($reaction_user);
+
+    if ($reaction_user) {
+      global $user;
+      $user = $reaction_user;
+    }
+  }
+
   $parameters =  [
     'ids' => $ids,
     'campaigns' => $campaigns,

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
@@ -92,11 +92,11 @@ function _reportback_resource_definition() {
             'default value' => FALSE,
           ],
           [
-            'name' => 'reaction_user',
-            'description' => 'Override the current user in respect to Reaction data',
+            'name' => 'as_user',
+            'description' => 'Override the current global user',
             'optional' => TRUE,
-            'type' => 'int',
-            'source' => ['param' => 'reaction_user'],
+            'type' => 'string',
+            'source' => ['param' => 'as_user'],
             'default_value' => NULL,
           ],
           [
@@ -161,16 +161,7 @@ function _reportback_resource_access($op) {
  * @param  bool    $flagged
  * @return array
  */
-function _reportback_resource_index($ids, $campaigns, $status, $count, $random, $page, $load_user, $reaction_user, $flagged, $runs) {
-  if ($reaction_user) {
-    $reaction_user = user_load($reaction_user);
-
-    if ($reaction_user) {
-      global $user;
-      $user = $reaction_user;
-    }
-  }
-
+function _reportback_resource_index($ids, $campaigns, $status, $count, $random, $page, $load_user, $as_user, $flagged, $runs) {
   $parameters =  [
     'ids' => $ids,
     'campaigns' => $campaigns,
@@ -179,6 +170,7 @@ function _reportback_resource_index($ids, $campaigns, $status, $count, $random, 
     'random' => $random,
     'page' => $page,
     'load_user' => $load_user,
+    'as_user' => $as_user,
     'flagged' => $flagged,
     'runs' => $runs,
   ];

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItemTransformer.php
@@ -11,6 +11,10 @@ class ReportbackItemTransformer extends ReportbackTransformer {
   public function index($parameters) {
     $filters = $this->setDatabaseQueryFilters($parameters);
 
+    if ($parameters['as_user']) {
+      $this->asNorthstarUser($parameters['as_user']);
+    }
+
     try {
       $reportbackItems = ReportbackItem::find($filters);
       $reportbackItems = services_resource_build_index_list($reportbackItems, 'reportback-items', 'id');

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackTransformer.php
@@ -22,6 +22,10 @@ class ReportbackTransformer extends Transformer {
   public function index($parameters) {
     $filters = $this->setFilters($parameters);
 
+    if ($parameters['as_user']) {
+      $this->asNorthstarUser($parameters['as_user']);
+    }
+
     try {
       $reportbacks = Reportback::find($filters);
       $reportbacks = services_resource_build_index_list($reportbacks, 'reportbacks', 'id');


### PR DESCRIPTION
#### What's this PR do?
This pull request adds a `reaction_user` parameter to the RB + RB Item index endpoints. This parameter lets you override what the `current_user` is in the Kudos response.

*Why do we need this?*
When making requests from a generic admin api account, the current user is not properly reflected in the Kudos response. Additionally, we have no other way to query whether a given user has reacted to a reportback item.

*Why didn't you just edit the `dosomething_kudos_group_by_taxonomy_term`?*
That was my initial idea, less hacky, simpler, etc. Unfortunately, there is several layers of functions between this & the API response, and it would look quite ugly to pass a "user override" through that many functions (I think)

#### How should this be reviewed?
Hit these two endpoints (Change the reaction_user with other users as well)

`http://dev.dosomething.org:8888/api/v1/reportback-items?reaction_user=1700225`
`http://dev.dosomething.org:8888/api/v1/reportbacks?reaction_user=1700229`

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
