### PR TITLE
Create or merge local Drupal UID when fetching userinfo.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
+++ b/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
@@ -143,10 +143,27 @@ class OpenIDConnectClientNorthstar extends OpenIDConnectClientBase {
       $base['data']['birthdate'] = strtotime($base['data']['birthdate']);
     }
 
-    if ($base) {
-      return $base['data'];
+    if (! $base) {
+      return null;
     }
 
-    return null;
+    $userinfo = $base['data'];
+
+    // @HACK: Ensure we have a valid local Drupal account.
+    // The `openid_connect` module won't merge a Northstar user to an existing local
+    // user account, so we need to make sure that's done before continuing to auth.
+    if (! empty($userinfo['id'])) {
+      $id = $userinfo['id'];
+      $account = openid_connect_user_load_by_sub($id, $this->getName());
+
+      // If the account doesn't exist but email or mobile does, link the existing account!
+      if (! $account && $existingEmail = user_load_by_mail($userinfo['email'])) {
+        dosomething_northstar_save_id_field($existingEmail->uid, $base);
+      } else if (! $account && $existingMobile = dosomething_user_get_user_by_mobile($userinfo['phone_number'])) {
+        dosomething_northstar_save_id_field($existingMobile->uid, $base);
+      }
+    }
+
+    return $userinfo;
   }
 }


### PR DESCRIPTION
#### What's this PR do?
This pull request should fix an error where a user couldn't log in if they had lost their `authmap` record. Since we can't change any code in the [OpenID Connect module](https://github.com/sanduhrs/drupal-openid_connect/tree/7.x-1.x), we'll perform this check in the user info method.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
We need to make sure [this conditional](https://github.com/sanduhrs/drupal-openid_connect/blob/82ba5ed175a6cc8ae72124112c975a8b35c2e151/openid_connect.module#L808-L814) doesn't execute because it's a real poor user experience.

#### Relevant tickets
Fixes #7302. Potentially fixes #7304?

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  