### PR TITLE
Store fid and rbid of failed migration requests

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.install
@@ -511,3 +511,27 @@ function dosomething_rogue_update_7012(&$sandbox) {
     db_create_table($table_name, $schema[$table_name]);
   }
 }
+
+/**
+ * Adds rbid and fid column to dosomething_rogue_failed_migrations.
+ */
+function dosomething_rogue_update_7013(&$sandbox) {
+  $table = 'dosomething_rogue_failed_migrations';
+  if (db_table_exists($table)) {
+    $rbid_spec = [
+      'description' => 'The rbid as it is stored in phoenix.',
+      'type' => 'int',
+      'not null' => FALSE,
+    ];
+
+    db_add_field($table, 'rbid', $rbid_spec);
+
+    $fid_spec = [
+      'description' => 'The fid of the reportback item as it is stored in phoenix.',
+      'type' => 'int',
+      'not null' => FALSE,
+    ];
+
+    db_add_field($table, 'fid', $fid_spec);
+  }
+}

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -590,7 +590,7 @@ function dosomething_rogue_store_rogue_signup_references($sid, $rogue_signup) {
  * @param object $e
  *
  */
-function dosomething_rogue_handle_migration_failure($values, $sid, $response = NULL, $e = NULL) {
+function dosomething_rogue_handle_migration_failure($values, $sid, $rbid = NULL, $fids = NULL, $response = NULL, $e = NULL) {
   // one row for each photo, just the sid if no northstar id, or just the signup info
   if (!isset($values)) {
       db_insert('dosomething_rogue_failed_migrations')
@@ -619,8 +619,10 @@ function dosomething_rogue_handle_migration_failure($values, $sid, $response = N
         'quantity' => $values['quantity'],
         'quantity_pending' => $values['quantity_pending'],
         'why_participated' => $values['why_participated'],
+        'rbid' => $rbid,
 
         // Files
+        'fid' => array_shift($fids),
         'photo_source' => $photo['source'],
         'remote_addr' => $photo['remote_addr'],
         'caption' => $photo['caption'],

--- a/scripts/export-activity-to-rogue.php
+++ b/scripts/export-activity-to-rogue.php
@@ -112,7 +112,6 @@ foreach ($signups as $signup) {
         // Store signup reference
         dosomething_rogue_store_rogue_signup_references($signup->sid, $response);
 
-
         if ($signup->rbid) {
           foreach ($response['data']['posts']['data'] as $post) {
             echo 'Rogue event_id: ' . $post['post_event_id'] . PHP_EOL;

--- a/scripts/export-activity-to-rogue.php
+++ b/scripts/export-activity-to-rogue.php
@@ -30,6 +30,7 @@ $client = dosomething_rogue_client();
 
 foreach ($signups as $signup) {
   $data = [];
+
   echo 'Trying sid ' . $signup->sid . '...' . PHP_EOL;
 
   $northstar_user = dosomething_northstar_get_user($signup->uid, 'drupal_id');
@@ -111,6 +112,7 @@ foreach ($signups as $signup) {
         // Store signup reference
         dosomething_rogue_store_rogue_signup_references($signup->sid, $response);
 
+
         if ($signup->rbid) {
           foreach ($response['data']['posts']['data'] as $post) {
             echo 'Rogue event_id: ' . $post['post_event_id'] . PHP_EOL;
@@ -137,7 +139,7 @@ foreach ($signups as $signup) {
       // Handle getting a 404
       if (!$response) {
         // Put request in failed table for future investigation
-        dosomething_rogue_handle_migration_failure($data, $signup->sid);
+        dosomething_rogue_handle_migration_failure($data, $signup->sid, $signup->rbid, $fids);
 
         // Set where we left off so we don't keep trying this one forever
         variable_set('dosomething_rogue_last_signup_migrated', $signup->sid);
@@ -148,14 +150,14 @@ foreach ($signups as $signup) {
       // These aren't yet caught by Gateway
 
       // Put request in failed table for future investigation
-      dosomething_rogue_handle_migration_failure($data, $signup->sid, $response, $e);
+      dosomething_rogue_handle_migration_failure($data, $signup->sid, $signup->rbid, $fids);
 
       // Set where we left off so we don't keep trying this one forever
       variable_set('dosomething_rogue_last_signup_migrated', $signup->sid);
     }
     catch (DoSomething\Gateway\Exceptions\ApiException $e) {
       // Put request in failed table for future investigation
-      dosomething_rogue_handle_migration_failure($data, $signup->sid, $response, $e);
+      dosomething_rogue_handle_migration_failure($data, $signup->sid, $signup->rbid, $fids);
 
       // Set where we left off so we don't keep trying this one forever
       variable_set('dosomething_rogue_last_signup_migrated', $signup->sid);


### PR DESCRIPTION
#### What's this PR do?
Adds `rbid` and `fid` columns to `dosomething_rogue_failed_migrations` and populates those columns for failed requests that have those values.

#### How should this be reviewed?
I think just 👀  will do it!

#### Any background context you want to provide?
Reportbacks with many images fail because the requests are too large, so it's good that we are storing the full failed request, but we need the `rbid` and `fid` to store in `dosomething_rogue_reportbacks` when they eventually make it to Rogue with a cleanup script.

#### Relevant tickets
Fixes #

#### Checklist
- [ ] Tested on staging.
