### PR TITLE
Adding partner embed to settings and template

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -285,6 +285,25 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     '#disabled' => FALSE,
   ];
 
+  $form['partner_embed'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Partner embed'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  ];
+  $form['partner_embed']['partner_embed_markup'] = [
+    '#type' => 'textarea',
+    '#title' => t('Markup for the iframe embed'),
+    '#description' => t('HTML Markup containing an iframe from a partner'),
+    '#default_value' => $vars['partner_embed_markup'],
+  ];
+  $form['partner_embed']['partner_embed_enable'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Enable the partner embed.'),
+    '#description' => t('Display the iframe markup on this campaign page'),
+    '#default_value' => $vars['partner_embed_enable'],
+  ];
+
   return $form;
 }
 
@@ -345,6 +364,8 @@ function dosomething_helpers_get_variable_names() {
     'magic_link_copy',
     'mobilecommons_opt_in_path',
     'mobilecommons_friends_opt_in_path',
+    'partner_embed_markup',
+    'partner_embed_enable',
     'progress',
     'registration_form_copy',
     'share_image_nid',

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -154,6 +154,12 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
       $vars['campaign_creator'] = theme('campaign_creator', $creator);
     }
 
+    // Check for partner embed
+    $partner_embed_enabled = dosomething_helpers_get_variable('node', $campaign->nid, 'partner_embed_enable');
+    if ($partner_embed_enabled) {
+      $vars['partner_embed_markup'] = dosomething_helpers_get_variable('node', $campaign->nid, 'partner_embed_markup');
+    }
+
     // Check for sponsors.
     $vars['sponsor_logos'] = paraneue_dosomething_get_sponsor_logos($campaign->partners);
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -241,7 +241,7 @@
             <h2 class="heading -emphasized"><span><?php print t('Step 3: Do It'); ?></span></h2>
           </div>
         </div>
-        <?php if (!empty($partner_embed_markup)): ?>
+        <?php if (isset($partner_embed_markup)): ?>
           <div class="container__row">
             <?php print ($partner_embed_markup) ?>
           </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -241,7 +241,7 @@
             <h2 class="heading -emphasized"><span><?php print t('Step 3: Do It'); ?></span></h2>
           </div>
         </div>
-        <?php if (!empty($do)): ?>
+        <?php if (!empty($partner_embed_markup)): ?>
           <div class="container__row">
             <?php print ($partner_embed_markup) ?>
           </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -241,6 +241,11 @@
             <h2 class="heading -emphasized"><span><?php print t('Step 3: Do It'); ?></span></h2>
           </div>
         </div>
+        <?php if (!empty($do)): ?>
+          <div class="container__row">
+            <?php print ($partner_embed_markup) ?>
+          </div>
+        <?php endif; ?>
         <?php foreach ($do as $key => $content): ?>
         <div class="container__row">
           <div class="container__block -narrow">


### PR DESCRIPTION
#### What's this PR do?
Adds the partner embed option to the settings (per campaign)
Renders the markup on the template

<img width="1610" alt="screen shot 2017-03-14 at 11 35 40 am" src="https://cloud.githubusercontent.com/assets/897368/23908432/62356c38-08aa-11e7-87e9-c440dd58c471.png">

<img width="887" alt="screen shot 2017-03-14 at 11 35 59 am" src="https://cloud.githubusercontent.com/assets/897368/23908449/702528ba-08aa-11e7-9bc0-dfbe357a56c9.png">


#### How should this be reviewed?
does the buttons do what they say they do