### PR TITLE
Adding NS id to the users current activity api method

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -299,7 +299,12 @@ function _member_resource_get_activity($uid, $nid = NULL) {
     $uid = (int) $uid;
   }
   else {
-    return services_error(t('Invalid uid value @uid.', array('@uid' => $uid)), 403);
+    $northstar_user = dosomething_user_get_user_by_northstar_id($uid);
+    if (!$northstar_user) {
+      return services_error(t('Invalid uid value @uid.', array('@uid' => $uid)), 403);
+    }
+
+    $uid = $northstar_user->uid;
   }
 
   // If nid is specified, we just want one Activity result for the nid.


### PR DESCRIPTION
#### What's this PR do?
This PR allows us to use the `users/<id>/activity` endpoint with northstar ids, and thus phoenix-next. (specifically this is blocking https://github.com/DoSomething/phoenix-next/pull/77#issuecomment-286529622 )

#### How should this be reviewed?
1. check normal uid's still work
2. check northstar id's work
3. check you still get an error for a bad id all together

eg:
`http://dev.dosomething.org:8888/api/v1/users/559442c4a59dbfc9578b4b6a/activity` ✅ 

`http://dev.dosomething.org:8888/api/v1/users/1700226/activity1` ✅ 

`http://dev.dosomething.org:8888/api/v1/users/dsfdsfsdfsd/activity` ⚠️ 
