### PR TITLE
Adds northstar id to partner markup

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -157,7 +157,10 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
     // Check for partner embed
     $partner_embed_enabled = dosomething_helpers_get_variable('node', $campaign->nid, 'partner_embed_enable');
     if ($partner_embed_enabled) {
-      $vars['partner_embed_markup'] = dosomething_helpers_get_variable('node', $campaign->nid, 'partner_embed_markup');
+      global $user;
+      $markup = dosomething_helpers_get_variable('node', $campaign->nid, 'partner_embed_markup');
+      $markup = str_replace('${northstarId}', dosomething_user_get_northstar_id($user->uid), $markup);
+      $vars['partner_embed_markup'] = $markup;
     }
 
     // Check for sponsors.


### PR DESCRIPTION
#### What's this PR do?
This PR adds the Northstar ID to the partner embed markup is a variable is specified by the admin

#### How should this be reviewed?
Confirm the northstar id is present in the URL 

![screen shot 2017-03-20 at 12 55 50 pm](https://cloud.githubusercontent.com/assets/897368/24111365/93e8bf0c-0d6c-11e7-8130-57e9e0a90a56.png)
![screen shot 2017-03-20 at 12 56 13 pm](https://cloud.githubusercontent.com/assets/897368/24111383/a0f679aa-0d6c-11e7-82e8-85c598b77360.png)