### PR TITLE
Allow passing NS ID to signups endpoint, and function for converting to legacy ID.

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -315,14 +315,19 @@ function dosomething_helpers_export_csv(array $data) {
  * Format a string of comma separated data items into an array, or
  * if a single item, return it without formatting.
  *
- * @param string $data Single or multiple comma separated data items.
+ * @param  string $data Single or multiple comma separated data items.
+ * @param  boolean $asArray
  * @return string|array
  */
-function dosomething_helpers_format_data($data) {
+function dosomething_helpers_format_data($data, $asArray = false) {
   $array = explode(',', $data);
 
   if (count($array) > 1) {
     return $array;
+  }
+
+  if ($asArray) {
+    return [$data];
   }
 
   return $data;

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -170,8 +170,10 @@ class SignupTransformer extends Transformer {
    * @return array
    */
   private function setFilters($parameters) {
+    $users = dosomething_helpers_format_data($parameters['user'], true);
+
     $filters = [
-      'user' => dosomething_helpers_format_data($parameters['user']),
+      'user' => array_map('dosomething_user_convert_to_legacy_id', $users),
       'campaigns' => dosomething_helpers_format_data($parameters['campaigns']),
       'count' => (int) $parameters['count'] ?: 25,
       'page' => (int) $parameters['page'],

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1148,6 +1148,21 @@ function dosomething_user_create_user_by_mobile($number) {
 
   return FALSE;
 }
+/**
+ * Convert a supplied ID into a legacy Drupal ID.
+ *
+ * @param  string $id
+ * @return string
+ */
+function dosomething_user_convert_to_legacy_id($id) {
+  if (is_numeric($id)) {
+    return $id;
+  }
+
+  $user = dosomething_user_get_user_by_northstar_id($id);
+
+  return $user->uid;
+}
 
 /**
  * Returns value for given field on given user.

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -16,8 +16,8 @@
 
       <?php if (isset($signup_button_primary)): ?>
         <div class="header__signup">
-          <?php print render($signup_button_primary); ?>
           <?php print $campaign_scholarship; ?>
+          <?php print render($signup_button_primary); ?>
         </div>
       <?php endif; ?>
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -16,8 +16,8 @@
 
       <?php if (isset($signup_button_primary)): ?>
         <div class="header__signup">
-          <?php print $campaign_scholarship; ?>
           <?php print render($signup_button_primary); ?>
+          <?php print $campaign_scholarship; ?>
         </div>
       <?php endif; ?>
 


### PR DESCRIPTION
#### What's this PR do?
This PR updates the Signups transform to allow receiving a Northstar ID OR a Legacy Drupal ID. It references a function that converts the ID from Northstar to Legacy and returns the same, expected data. 

#### Any background context you want to provide?
This is an update to slowly strangle-out the use of legacy IDs in the system, and needed for an upcoming update to Phoenix-Next to add Reportback gallery submissions.

#### Relevant tickets
Refs https://trello.com/c/ty5jx7nv/382-3-as-a-user-when-i-refresh-phoenix-next-i-want-to-see-any-previously-uploaded-rbs-so-i-can-see-my-progress
