### PR TITLE
Update to fix some bugs with /signups endpoint.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/includes/Signup.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/Signup.php
@@ -86,11 +86,22 @@ class Signup extends Entity {
    * @param $data
    */
   private function build($data) {
+    $northstar_user = (object) [];
+
     $this->id = $data->sid;
     $this->created_at = $data->timestamp;
 
+    if (module_exists('dosomething_northstar')) {
+      $northstar_user = dosomething_northstar_get_user($data->uid, 'drupal_id');
+    }
+
     $this->user = [
-      'drupal_id' => $data->uid,
+      'drupal_id' => data_get($northstar_user, 'drupal_id') ?: $data->uid,
+      'id' => data_get($northstar_user, 'id') ?: $data->field_northstar_id_value,
+      'first_name' => data_get($northstar_user, 'first_name'),
+      'last_initial' => data_get($northstar_user, 'last_initial'),
+      'photo' => data_get($northstar_user, 'photo'),
+      'country' => data_get($northstar_user, 'country'),
     ];
 
     try {

--- a/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
+++ b/lib/modules/dosomething/dosomething_signup/includes/SignupTransformer.php
@@ -170,10 +170,10 @@ class SignupTransformer extends Transformer {
    * @return array
    */
   private function setFilters($parameters) {
-    $users = dosomething_helpers_format_data($parameters['user'], true);
+    $users = !empty($parameters['user']) ? dosomething_helpers_format_data($parameters['user'], true) : NULL;
 
     $filters = [
-      'user' => array_map('dosomething_user_convert_to_legacy_id', $users),
+      'user' => $users ? array_map('dosomething_user_convert_to_legacy_id', $users) : NULL,
       'campaigns' => dosomething_helpers_format_data($parameters['campaigns']),
       'count' => (int) $parameters['count'] ?: 25,
       'page' => (int) $parameters['page'],

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1155,6 +1155,10 @@ function dosomething_user_create_user_by_mobile($number) {
  * @return string
  */
 function dosomething_user_convert_to_legacy_id($id) {
+  if (!$id) {
+    return NULL;
+  }
+
   if (is_numeric($id)) {
     return $id;
   }


### PR DESCRIPTION
#### What's this PR do?
This PR provides an update to the `/signups` endpoint to allow passing through user data properly for each signup item, including the Northstar ID for the user. It also makes an update to fix a bug which was causing the endpoint to break at times if no `users=...` url parameter was added to the endpoint API request.

The `/signups` endpoints should work better now. As a bonus aside, I think this also fixed up the index `/signups` endpoint so now it actually returns something (on my local anyhoo 😬)

#### How should this be reviewed?
🔍 

#### Any background context you want to provide?
The [Trying to get property of non-object](https://github.com/DoSomething/phoenix/issues/7329) issue was related to the problem with the `users` url parameter.

The issue with the [missing NS ID](https://github.com/DoSomething/gambit/issues/827#issuecomment-289496978) in the response was because when switching to use the Phoenix `/signups` endpoint, we weren't passing along the user's NS ID. Prior to switching to using this endpoint, the endpoint was proxied via Northstar and NS was doing its due-diligence and likely auto-filling it out for us.

#### Relevant tickets
Fixes #7329 
Refs https://github.com/DoSomething/gambit/issues/827

#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
