### PR TITLE
One feature flag to turn Rogue on/off 

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -292,7 +292,7 @@ function _campaign_resource_signup($nid, $values) {
   // Check to see if the request came from Rogue and if we should be sending it there
   // $headers['X-Request-Id'] will only be set if the request is coming from Rogue
   if ( !isset($headers['X-Request-Id'])) {
-    if (variable_get('rogue_signup_collection', FALSE)) {
+    if (variable_get('rogue_collection', FALSE)) {
       // Pass the campaign_id
       $values['campaign_id'] = $nid;
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.admin.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.admin.inc
@@ -39,17 +39,9 @@ function dosomething_rogue_config_form($form, &$form_state) {
 
   $form['rogue']['rogue_collection'] = [
     '#type' => 'checkbox',
-    '#title' => t('Send reportbacks to rogue'),
-    '#description' => t('If set, when a user submits a reportback it will be sent to our reportback service.'),
+    '#title' => t('Send signups and reportbacks to Rogue'),
+    '#description' => t('If set, when a user signs up for a campaign and submits a reportback, it will be sent to our activity service.'),
     '#default_value' => variable_get('rogue_collection', FALSE),
-    '#size' => 20,
-  ];
-
-  $form['rogue']['rogue_signup_collection'] = [
-    '#type' => 'checkbox',
-    '#title' => t('Send signups to rogue'),
-    '#description' => t('If set, when a user signs up it will be sent to Rogue.'),
-    '#default_value' => variable_get('rogue_signup_collection', FALSE),
     '#size' => 20,
   ];
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -97,7 +97,7 @@ function dosomething_signup_form_submit($form, &$form_state) {
     $params['affiliate_messaging_opt_in'] = (bool) $form_state['values']['affiliate_messaging_opt_in'];
   }
 
-  if (variable_get('rogue_signup_collection', FALSE)) {
+  if (variable_get('rogue_collection', FALSE)) {
     $rogue_signup = dosomething_rogue_send_signup_to_rogue($form_state['values']);
 
     // Make sure the signup exists before using it


### PR DESCRIPTION
#### What's this PR do?
- Combines signup and reportback Rogue feature flags into one. 
  - Updates signup to check if `rogue_collection` is on instead of `rogue_signup_collection`

#### How should this be reviewed?
- Go to `/admin/config/services/rogue`. You should now only see one checkbox as follows:
![screen shot 2017-03-27 at 3 12 14 pm](https://cloud.githubusercontent.com/assets/9019452/24373588/d1685c82-12ff-11e7-93ad-483d3461e59b.png)
- When signing up and reporting back on Phoenix (when the box is checked), all data should be reflected in Rogue as well. Right now (3/27/17), we can't test this though because Rogue needs to be updated. However, can confirm that able to see that the flag itself works - when checked, the reportback item/signup gets sent to the failed task log and when not checked, all works as expected. 

#### Relevant tickets
Fixes #7330 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
