### PR TITLE
Switch to authorization_code for Phoenix <-> Northstar requests

### DIFF
--- a/lib/app/Auth/PhoenixOAuthBridge.php
+++ b/lib/app/Auth/PhoenixOAuthBridge.php
@@ -24,16 +24,11 @@ class PhoenixOAuthBridge implements OAuthBridgeContract {
    * @return NorthstarUserContract|null
    */
   public function getUser($id) {
-    $query = new EntityFieldQuery();
-    $query->entityCondition('entity_type', 'user')
-      ->fieldCondition('field_northstar_id', 'value', $id);
-    $results = $query->execute();
-    if (empty($results)) {
-      return null;
+    $user = dosomething_user_get_user_by_northstar_id($id);
+    if (empty($user)) {
+      return FALSE;
     }
-
-    $uid = key($results['user']);
-    $account = new PhoenixOAuthUser($uid);
+    $account = new PhoenixOAuthUser($user->uid);
     return $account;
   }
 
@@ -44,12 +39,7 @@ class PhoenixOAuthBridge implements OAuthBridgeContract {
    * @return NorthstarUserContract
    */
   public function getOrCreateUser($id) {
-    $account = $this->getUser($id);
-    if (!empty($account)) {
-      return $account;
-    }
-
-    // @TODO: Create user here, but with what info for username/email?
+    // This method can stay unimplemented for now because it isn't called.
   }
 
   /**

--- a/lib/app/Auth/PhoenixOAuthBridge.php
+++ b/lib/app/Auth/PhoenixOAuthBridge.php
@@ -94,7 +94,7 @@ class PhoenixOAuthBridge implements OAuthBridgeContract {
    * @return void
    */
   public function requestUserCredentials() {
-    user_logout();
+    $this->logout();
   }
 
   /**
@@ -134,6 +134,7 @@ class PhoenixOAuthBridge implements OAuthBridgeContract {
    * @return mixed
    */
   public function logout() {
+    module_load_include('pages.inc', 'user');
     user_logout();
   }
 

--- a/lib/app/Auth/PhoenixOAuthBridge.php
+++ b/lib/app/Auth/PhoenixOAuthBridge.php
@@ -13,7 +13,9 @@ class PhoenixOAuthBridge implements OAuthBridgeContract {
    * @return NorthstarUserContract|null
    */
   public function getCurrentUser() {
-    //
+    $user = new PhoenixOAuthUser();
+    // Grab Northstar ID and assign it here.
+    return $user;
   }
 
   /**

--- a/lib/app/Auth/PhoenixOAuthBridge.php
+++ b/lib/app/Auth/PhoenixOAuthBridge.php
@@ -49,7 +49,7 @@ class PhoenixOAuthBridge implements OAuthBridgeContract {
       return $account;
     }
 
-    // @TODO: Create user here.
+    // @TODO: Create user here, but with what info for username/email?
   }
 
   /**

--- a/lib/app/Auth/PhoenixOAuthBridge.php
+++ b/lib/app/Auth/PhoenixOAuthBridge.php
@@ -26,7 +26,7 @@ class PhoenixOAuthBridge implements OAuthBridgeContract {
   public function getUser($id) {
     $user = dosomething_user_get_user_by_northstar_id($id);
     if (empty($user)) {
-      return FALSE;
+      return NULL;
     }
     $account = new PhoenixOAuthUser($user->uid);
     return $account;

--- a/lib/app/Auth/PhoenixOAuthUser.php
+++ b/lib/app/Auth/PhoenixOAuthUser.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Phoenix\Auth;
+
+use DoSomething\Gateway\Contracts\NorthstarUserContract;
+use League\OAuth2\Client\Token\AccessToken;
+
+/**
+ * @property string $northstar_id
+ * @property string $access_token
+ * @property string $access_token_expiration
+ * @property string $refresh_token
+ * @property string $role
+ */
+class PhoenixOAuthUser implements NorthstarUserContract {
+  /**
+   * Get the Northstar ID for the user.
+   *
+   * @return string|null
+   */
+  public function getNorthstarIdentifier() {
+    return $this->northstar_id;
+  }
+
+  /**
+   * Save the Northstar ID for the user.
+   *
+   * @return void
+   */
+  public function setNorthstarIdentifier($id) {
+    $this->northstar_id = $id;
+  }
+
+  /**
+   * Save the user's Northstar role locally.
+   *
+   * @return void
+   */
+  public function setRole($role) {
+    $this->role = $role;
+  }
+
+  /**
+   * Get the user's Northstar role.
+   *
+   * @return string
+   */
+  public function getRole() {
+    return $this->role;
+  }
+
+  /**
+   * Get the access token for the user.
+   *
+   * @return AccessToken|null
+   */
+  public function getOAuthToken() {
+    return new AccessToken([
+      'resource_owner_id' => $this->getNorthstarIdentifier(),
+      'access_token' => $this->access_token,
+      'refresh_token' => $this->refresh_token,
+      'expires' => $this->access_token_expiration,
+      'role' => $this->role,
+    ]);
+  }
+
+  /**
+   * Save the access token for the user.
+   *
+   * @param AccessToken $token
+   * @return void
+   */
+  public function setOAuthToken(AccessToken $token) {
+    $this->access_token = $token->getToken();
+    $this->access_token_expiration = $token->getExpires();
+    $this->refresh_token = $token->getRefreshToken();
+    $this->role = $token->getValues()['role'];
+  }
+
+  /**
+   * Clear the access token for the user.
+   *
+   * @return void
+   */
+  public function clearOAuthToken() {
+    $this->access_token = null;
+    $this->access_token_expiration = null;
+    $this->refresh_token = null;
+  }
+}

--- a/lib/app/Auth/PhoenixOAuthUser.php
+++ b/lib/app/Auth/PhoenixOAuthUser.php
@@ -73,9 +73,9 @@ class PhoenixOAuthUser implements NorthstarUserContract {
     }
     return new AccessToken([
       'resource_owner_id' => $this->getNorthstarIdentifier(),
-      'access_token' => $this->user->field_access_token[LANGUAGE_NONE][0]['value'],
-      'refresh_token' => $this->user->field_refresh_token[LANGUAGE_NONE][0]['value'],
-      'expires' => $this->user->field_access_token_expiration[LANGUAGE_NONE][0]['value'],
+      'access_token' => dosomething_user_get_field('field_access_token', $this->user),
+      'refresh_token' => dosomething_user_get_field('field_refresh_token', $this->user),
+      'expires' => dosomething_user_get_field('field_access_token_expiration', $this->user),
       'role' => $this->getRole(),
     ]);
   }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -21,14 +21,10 @@ define('NORTHSTAR_URL', variable_get('dosomething_northstar_url', 'http://norths
  */
 function dosomething_northstar_client() {
   return new Northstar([
-    'grant' => 'client_credentials',
+    'grant' => 'authorization_code',
     'url' => NORTHSTAR_URL,
     'bridge' => PhoenixOAuthBridge::class,
-    'client_credentials' => [
-      'client_id' => variable_get('dosomething_northstar_app_id', 'trusted-test-client'),
-      'client_secret' => variable_get('dosomething_northstar_app_key', 'secret1'),
-      'scope' => ['admin', 'user'],
-    ],
+    // Other stuff will need to go here.
   ]);
 }
 

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -24,7 +24,7 @@ function dosomething_northstar_client() {
     'grant' => 'authorization_code',
     'url' => NORTHSTAR_URL,
     'bridge' => PhoenixOAuthBridge::class,
-    // Other stuff will need to go here.
+    // @TODO: Does other stuff need to go here?
   ]);
 }
 

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -26,10 +26,15 @@ function dosomething_northstar_client() {
     'grant' => 'authorization_code',
     'url' => NORTHSTAR_URL,
     'bridge' => PhoenixOAuthBridge::class,
+    'client_credentials' => [
+      'client_id' => variable_get('dosomething_northstar_app_id', 'trusted-test-client'),
+      'client_secret' => variable_get('dosomething_northstar_app_key', 'secret1'),
+      'scope' => ['admin', 'user'],
+    ],
     'authorization_code' => [
       'client_id' => $oauth_client['client_id'],
       'client_secret' => $oauth_client['client_secret'],
-      'scope' => ['user'],
+      'scope' => openid_connect_get_scopes(),
       'redirect_uri' => 'user/login',
     ],
   ]);

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -20,11 +20,17 @@ define('NORTHSTAR_URL', variable_get('dosomething_northstar_url', 'http://norths
  * @return DoSomething\Gateway\Northstar
  */
 function dosomething_northstar_client() {
+  $oauth_client = variable_get('openid_connect_client_northstar', array());
   return new Northstar([
     'grant' => 'authorization_code',
     'url' => NORTHSTAR_URL,
     'bridge' => PhoenixOAuthBridge::class,
-    // @TODO: Does other stuff need to go here?
+    'authorization_code' => [
+      'client_id' => $oauth_client['client_id'],
+      'client_secret' => $oauth_client['client_secret'],
+      'scope' => ['user'],
+      'redirect_uri' => 'user/login',
+    ],
   ]);
 }
 

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -20,7 +20,8 @@ define('NORTHSTAR_URL', variable_get('dosomething_northstar_url', 'http://norths
  * @return DoSomething\Gateway\Northstar
  */
 function dosomething_northstar_client() {
-  $oauth_client = variable_get('openid_connect_client_northstar', array());
+  $oauth_client = variable_get('openid_connect_client_northstar',
+    array('client_id' => NULL, 'client_secret' => NULL));
   return new Northstar([
     'grant' => 'authorization_code',
     'url' => NORTHSTAR_URL,


### PR DESCRIPTION
#### What's this PR do?

This PR makes Phoenix talk to Northstar using the `authorization_code` grant as opposed to the `client_credentials` grant, which in turns means telling Northstar about individual user accounts.

#### How should this be reviewed?

Besides the visual code review, testing would be very helpful. Check out the branch, then log into your local and do operations that require communicating with Northstar.

#### Any background context you want to provide?

I am not sure that this is REALLY working as expected. I can't seem to encounter any errors when using the site, but I'm also not sure how to ensure that methods like `PhoenixOAuthBridge::getUser()` even run, to test them. My testing so far has mostly comprised of doing everything I can find on the site to do, and fixing any errors that I see when doing it.

**Important: also see the 2 places that have `@TODO` statements - those are open questions that I have!**

#### Relevant tickets

I'm not sure of the ticket number(s).
