### PR TITLE
Updates to logic for post RBs via the API.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -333,10 +333,10 @@ function _campaign_resource_signup($nid, $values) {
  *   The Node nid to post the reportback to.
  * @param array $values
  *   The reportback data to post. Expected keys:
- *   - uid: The user uid (int).  Optional, uses global $user if not set.
- *   - file: Base64 encoded file string to save.
- *   - filename: The filename of the file provided as file.
- *   - file_url: The URL of the reportback file to save (used if no file/filename exist).
+ *   - uid: The user uid (int).
+ *   - file: Base64 encoded file string to save (required if using 'filename').
+ *   - filename: The filename of the file provided as file (required if using 'file').
+ *   - file_url: The URL of the reportback file to save (used if no 'file'/'filename' exist).
  *   - caption: The caption for the Reportback File if provided.
  *   - quantity (int).
  *   - why_participated (string).
@@ -344,62 +344,62 @@ function _campaign_resource_signup($nid, $values) {
  *   - remote_addr (string).
  */
 function _campaign_resource_reportback($nid, $values) {
+  global $user;
+  $api_user = $user;
+
+  if (!user_access('view any reportback', $api_user)) {
+    return dosomething_helpers_basic_http_response(401, 'Unauthorized.');
+  }
+
+  if (empty($values['uid'])) {
+    return dosomething_helpers_basic_http_response(422, 'Missing uid query parameter specifying a user id.');
+  }
+
+  $user = user_load(dosomething_user_convert_to_legacy_id($values['uid']));
+
+  if (!$user) {
+    return dosomething_helpers_basic_http_response(404, 'The specified user was not found.');
+  }
+
+  // Set uid to member user submitting reportback.
+  $values['uid'] = $uid = $user->uid;
+
   // @todo: Return error if signup doesn't exist.
 
-  $values['nid'] = $nid;
-
-  if (isset($values['northstar_id'])) {
-    $values['uid'] = dosomething_user_get_user_by_northstar_id($values['northstar_id'])->uid;
-  }
-  else if (isset($values['uid'])) {
-    $user = user_load($values['uid']);
-  }
-  else {
-    global $user;
-    $values['uid'] = $user->uid;
-  }
-
-  $uid = $values['uid'];
-
-  $file = NULL;
-
   // @todo: Move this logic into dosomething_reportback_save().
-  $rbid = dosomething_reportback_exists($nid, NULL, $uid);
+  $rbid = dosomething_reportback_exists($nid, NULL, $uid) ?: 0;
 
-  // If this is creating a new reportback, there must be a file
+  // If file is submitted as an upload, the 'file' and 'filename' values must be provided.
   if (!empty($values['file']) && !empty($values['filename'])) {
     $values['filepath'] = dosomething_reportback_get_file_dest($values['filename'], $nid, $uid);
+
     // Use Services module's File Create resource to save the file.
     module_load_include('inc', 'services', 'resources/file_resource');
+
     $result = _file_resource_create($values);
+
     $file = file_load($result['fid']);
   }
+  elseif (!empty($values['file_url'])) {
+    $file = dosomething_reportback_save_file_from_url($nid, $uid, $values['file_url']);
 
-  if (!$file) {
-    // If this is to create a new reportback, there must be an image
-    if (!array_key_exists('file_url', $values) && !$rbid) {
-      return services_error(t("Reportback file_url not found."), 500);
+    if (!$file) {
+      return dosomething_helpers_basic_http_response(500, 'Could not write file to destination.');
     }
-    // Create a file from the $file_url if there is one.
-    if (!empty($values['file_url'])) {
-      $file = dosomething_reportback_save_file_from_url($nid, $uid, $values['file_url']);
-      if (!$file) {
-        return services_error(t("Could not write file to destination"), 500);
-      }
-    }
+  } else {
+    $file = NULL;
   }
 
+  // Update or set values.
   if ($file) {
     $values['fid'] = $file->fid;
     $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
   }
 
-  if (!$rbid) {
-    $rbid = 0;
-  }
-
+  $values['nid'] = $nid;
   $values['rbid'] = $rbid;
 
+  // Logging.
   if (DOSOMETHING_REPORTBACK_LOG) {
     watchdog('dosomething_api', '_campaign_resource_reportback:' . json_encode($values));
   }
@@ -409,7 +409,7 @@ function _campaign_resource_reportback($nid, $values) {
   if (variable_get('rogue_collection', FALSE) && ! isset($headers['X-Request-Id'])) {
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
-    // Make sure reportback made it back to Phoenix and store reference to the Rogue item if one was added
+    // Make sure reportback made it back to Phoenix and store reference to the Rogue item if one was added.
     $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
 
     return $rb_info['rbid'];

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.module
@@ -1023,3 +1023,21 @@ function dosomething_helpers_extract_values_by_keys($array, $desired_keys)
     $desired_values = array_intersect_key($array, array_flip($desired_keys));
     return (count($array) > 0) ? $desired_values : null;
 }
+
+/**
+ * Return a basic HTTP response.
+ *
+ * @param  Integer $code
+ * @param  String $message
+ * @return Array
+ */
+function dosomething_helpers_basic_http_response($code, $message) {
+  http_response_code($code);
+
+  return [
+    'error' => [
+      'code' => $code,
+      'message' => $message,
+    ]
+  ];
+}


### PR DESCRIPTION
#### What's this PR do?
This PR updates the `/api/v1/campaigns/:nid/reportback` endpoint to update the logic so that submitted Reportbacks are not submitted as the DS API User, instead the DS API User just grants access for posting, but then the RB is posted as the actual user. We were running into scenarios where depending on how the logic ran, the system would default to using the `global $user` for posting RBs which was causing problems for the submission gallery in Phoenix-Next to accurately showcase member submissions.

Successful insert and update as the specified `uid` user:
![image](https://cloud.githubusercontent.com/assets/105849/24631687/39e6c61a-188f-11e7-80e0-7b821cd4862e.png)

One breaking change to note, is that now the `uid` is a required URL parameter to successfully post a RB as the user, otherwise an error response is returned.

The endpoint is also updated to provide some useful HTTP error responses depending on issues with a request.

#### How should this be reviewed?
🔎 👁 

#### Any background context you want to provide?
This was a necessary update to get things working correctly for the new campaign experience provided by Phoenix-Next.

#### Relevant tickets
Refs: https://trello.com/c/X1X46JMq/424-8-as-as-user-i-want-to-be-able-to-upload-photos-that-aren-t-sized-for-ants


#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
