### PR TITLE
Adding HTTP error response if first time post and missing file.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -390,6 +390,11 @@ function _campaign_resource_reportback($nid, $values) {
     $file = NULL;
   }
 
+  // If first time user is submitting RB, then a file is required.
+  if (!$file && $rbid === 0) {
+    return dosomething_helpers_basic_http_response(422, 'Cannot create new reportback without a file.');
+  }
+
   // Update or set values.
   if ($file) {
     $values['fid'] = $file->fid;


### PR DESCRIPTION
#### What's this PR do?
This PR make s quick fix for the `/api/v1/campaigns/:nid/reportbacks` endpoint after @katiecrane [clarified something in the old logic](https://github.com/DoSomething/phoenix/pull/7338#discussion_r109524502) that was confusing to me based on how it was written. 

This makes sure that if this is the first Reportback submission for the specified campaign by the specified user, than a `$file` is required, otherwise the endpoint responds with an HTTP error response.

#### How should this be reviewed?
👁 

#### Relevant tickets
Refs #7338
