### PR TITLE
Adding missing isset() check.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -420,7 +420,7 @@ function _campaign_resource_reportback($nid, $values) {
     return $rb_info['rbid'];
   }
   else {
-    if ($headers['X-Request-Id']) {
+    if (isset($headers['X-Request-Id'])) {
       // Increment transaction id and log that the request has been received with new transaction id.
       $incremented_transaction_id = dosomething_api_increment_transaction_id($headers['X-Request-Id']);
 


### PR DESCRIPTION
#### What's this PR do?
This PR adds a quick `isset()` checkeroo to avoid unnecessary notices if the `X-Request-ID` header is missing, which @aaronschachter [reported](https://github.com/DoSomething/phoenix/pull/7338#issuecomment-291381467) was showing up when testing.

#### How should this be reviewed?
👁 

#### Relevant tickets
Refs #7338 
