### PR TITLE
add unique keys to northstar id field

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.install
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.install
@@ -102,3 +102,13 @@ function dosomething_user_uninstall() {
     variable_del($var);
   }
 }
+
+/**
+ * Add a unique constraint to the `field_data_field_northstar_id` field for the
+ * northstar_id and entitiy_id fields.
+ */
+function dosomething_user_update_7010() {
+  db_add_unique_key('field_data_field_northstar_id', 'field_northstar_id_value', ['field_northstar_id_value']);
+
+  db_add_unique_key('field_data_field_northstar_id', 'entity_id', ['entity_id']);
+}


### PR DESCRIPTION
#### What's this PR do?

This PR adds indexes to the `northstar_id` and the `entity_id` fields in `field_data_northstar_id` table.

In new relic, it was showing that this query was taking a lot of time, because there were no indexes on this table. 

```  
SELECT f.entity_id AS entity_id
FROM 
field_data_field_northstar_id f
WHERE  (f.field_northstar_id_value = :db_condition_placeholder_?)
```

#### How should this be reviewed?
one commit to review, make sure keys are being set correctly. 

**QUESTION:** Looking at the query above are there any other keys that should be set on this table to make it run faster?

#### Any background context you want to provide?

I did work in gladiator to use the Phoenix API `/signups` endpoint to grab user activity for competitions. 

This was done to solve an issue in gladiator where no activity was showing across all campaigns.

This change then broke functionality in gladiator that would cause timeouts when grabing user activity for bulk users. 

#### Relevant tickets
Fixes #

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
