### PR TITLE
Fix dosomething_user update hooks

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.install
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.install
@@ -70,9 +70,9 @@ function dosomething_user_update_7008() {
  * northstar_id and entitiy_id fields.
  */
 function dosomething_user_update_7009() {
-  db_add_unique_key('field_data_field_northstar_id', 'field_northstar_id_value', ['field_northstar_id_value']);
+  db_add_index('field_data_field_northstar_id', 'field_northstar_id_value', ['field_northstar_id_value']);
 
-  db_add_unique_key('field_data_field_northstar_id', 'entity_id', ['entity_id']);
+  db_add_index('field_data_field_northstar_id', 'entity_id', ['entity_id']);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.install
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.install
@@ -66,13 +66,14 @@ function dosomething_user_update_7008() {
 }
 
 /**
- * Add a unique constraint to the `field_mobile_value` field for the
- * mobile field (since fields don't support unique database constraints).
+ * Add a unique constraint to the `field_data_field_northstar_id` field for the
+ * northstar_id and entitiy_id fields.
  */
 function dosomething_user_update_7009() {
-  db_add_unique_key('field_data_field_mobile', 'field_mobile_value', ['field_mobile_value']);
-}
+  db_add_unique_key('field_data_field_northstar_id', 'field_northstar_id_value', ['field_northstar_id_value']);
 
+  db_add_unique_key('field_data_field_northstar_id', 'entity_id', ['entity_id']);
+}
 /**
  * Implements hook_uninstall().
  */
@@ -101,14 +102,4 @@ function dosomething_user_uninstall() {
   foreach ($vars as $var) {
     variable_del($var);
   }
-}
-
-/**
- * Add a unique constraint to the `field_data_field_northstar_id` field for the
- * northstar_id and entitiy_id fields.
- */
-function dosomething_user_update_7010() {
-  db_add_unique_key('field_data_field_northstar_id', 'field_northstar_id_value', ['field_northstar_id_value']);
-
-  db_add_unique_key('field_data_field_northstar_id', 'entity_id', ['entity_id']);
 }

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.install
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.install
@@ -74,6 +74,7 @@ function dosomething_user_update_7009() {
 
   db_add_unique_key('field_data_field_northstar_id', 'entity_id', ['entity_id']);
 }
+
 /**
  * Implements hook_uninstall().
  */


### PR DESCRIPTION
#### What's this PR do?

Removes `dosomething_user_update_7009` that added the key to that table. This hook was failing and blocking other update hooks from executing. This should clear the lane for the update to the northstar field table that adds unique keys. 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
