### PR TITLE
Fix issue with new users' campaign signups.

### DIFF
--- a/lib/app/Auth/PhoenixOAuthUser.php
+++ b/lib/app/Auth/PhoenixOAuthUser.php
@@ -71,11 +71,19 @@ class PhoenixOAuthUser implements NorthstarUserContract {
     if (empty($this->user)) {
       return null;
     }
+
+    $access_token = dosomething_user_get_field('field_access_token', $this->user);
+    $refresh_token = dosomething_user_get_field('field_refresh_token', $this->user);
+    $expires = dosomething_user_get_field('field_access_token_expiration', $this->user);
+    if (empty($access_token) || empty($refresh_token) || empty($expires)) {
+      return null;
+    }
+
     return new AccessToken([
       'resource_owner_id' => $this->getNorthstarIdentifier(),
-      'access_token' => dosomething_user_get_field('field_access_token', $this->user),
-      'refresh_token' => dosomething_user_get_field('field_refresh_token', $this->user),
-      'expires' => dosomething_user_get_field('field_access_token_expiration', $this->user),
+      'access_token' => $access_token,
+      'refresh_token' => $refresh_token,
+      'expires' => $expires,
       'role' => $this->getRole(),
     ]);
   }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -93,18 +93,22 @@ function dosomething_northstar_openid_connect_claims_alter(&$claims) {
  * @param string $provider - The provider used to authenticate
  */
 function dosomething_northstar_openid_connect_post_authorize($tokens, $account, $userinfo, $provider) {
-  $edit = [];
+  // Determine the user's language code if possible.
+  $language_code = dosomething_global_get_language($account);
 
+  $edit = [];
   dosomething_user_set_fields($edit, [
     'access_token' => $tokens['access_token'],
     'refresh_token' => $tokens['refresh_token'],
     'access_token_expiration' => $tokens['expire'],
+    'language' => $language_code ? $language_code : 'en-global',
+    'timezone' => 'UTC',
   ]);
+  user_save($account, $edit);
 
-  // HACK: Did this local account exist already? If not, mark as "remote"
-  // so that we know we can't use it's local password for login/profile.
-  if ($account->created > time() - 15) {
-    dosomething_user_set_fields($edit, ['created_by_openid_connect' => 1]);
+  // Make sure the user's Northstar ID is set in the field_data_field_northstar_id table.
+  if (!dosomething_user_get_northstar_id($account->uid)) {
+    dosomething_northstar_save_id_field($account->uid, ['data' => $userinfo]);
   }
 
   // HACK: Was this account registered just now (last 15s)? If so, send transactional
@@ -116,26 +120,8 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
     dosomething_helpers_add_analytics_event('Authentication', 'Login');
   }
 
-  // Make sure the user's Northstar ID is set in the field_data_field_northstar_id table.
-  if (!dosomething_user_get_northstar_id($account->uid)) {
-    dosomething_northstar_save_id_field($account->uid, ['data' => $userinfo]);
-  }
-
   // If we saved a "post-authorization" action, do it now.
   dosomething_northstar_perform_authorization_actions();
-
-  if (empty($account->language)) {
-    // Determine the user's language code if possible.
-    $language_code = dosomething_global_get_language($account);
-
-    $edit['language'] = $language_code ? $language_code : 'en-global';
-  }
-
-  if (empty($account->timezone)) {
-    $edit['timezone'] = 'UTC';
-  }
-
-  user_save($account, $edit);
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?
This fixes #7348, and adds a little error-checking so this doesn't fail as bad in the future:

🔃 Shuffles around the post-auth actions so we don't try to perform them before finishing everything else – otherwise part of this function was getting skipped because campaign signups include a `drupal_goto`.

👮 Adds some checks in the `PhoenixOAuthUser` class so we don't try to create [an `AccessToken` without the required fields](https://github.com/thephpleague/oauth2-client/blob/56f6860e8773a2fc2bb4524f344d04bc28bb1c09/src/Token/AccessToken.php#L62-L64). This means we'd return `null` (and gracefully logout or try to refresh token) rather than giving the user a big ol' error message.

#### How should this be reviewed?
👀

#### Any background context you want to provide?


#### Relevant tickets
Fixes #

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  