### PR TITLE
Make sure get_user request is made as client.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -107,7 +107,7 @@ function dosomething_northstar_get_user($id, $type = 'id') {
     return $northstar_user->data;
   }
 
-  $northstar_user = dosomething_northstar_client()->getUser($type, $id);
+  $northstar_user = dosomething_northstar_client()->asClient()->getUser($type, $id);
 
   if ($northstar_user) {
     cache_set($cache_key, $northstar_user, $cache_bin, REQUEST_TIME + 60*60*24);


### PR DESCRIPTION
#### What's this PR do?
This updates the `dosomething_northstar_get_user` to always use the Client Credentials grant, so that it'll fetch the full profile before caching it. This also fixes this method so that it works in Drush scripts (where we won't have a logged in user).

#### How should this be reviewed?
👀

#### Any background context you want to provide?
When running the Rogue export script, @katiecrane noticed this error:

```
PHP Fatal error:  Call to a member function getRefreshToken() on a non-object in /var/www/dev.dosomething.org/vendor/dosomething/gateway/src/AuthorizesWithNorthstar.php on line 191
```

This was happening because it couldn't refresh the token of a non-existant user.

#### Relevant tickets
References #7335.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  