### PR TITLE
Ensure access token is always current.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -2,6 +2,7 @@
 
 use DoSomething\Gateway\Northstar;
 use Phoenix\Auth\PhoenixOAuthBridge;
+use Phoenix\Auth\PhoenixOAuthUser;
 
 /**
  * @file
@@ -60,6 +61,24 @@ function dosomething_northstar_menu() {
       'type' => MENU_CALLBACK,
     ],
   ];
+}
+
+/**
+ * Implements hook_init().
+ */
+function dosomething_northstar_init() {
+  global $user;
+
+  // If a user is logged in, check their access token & ensure they
+  // have a valid session by refreshing it if it's expired.
+  if (user_is_logged_in()) {
+    $account = new PhoenixOAuthUser($user->uid);
+    $token = $account->getOAuthToken();
+
+    if ($token->hasExpired()) {
+      dosomething_northstar_client()->getTokenByRefreshTokenGrant($token);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?
This pull request will check a user's access token on page load, and refresh it if it's expired. This is important because it lets Northstar know accurate activity information (to within 1 hour), which is necessary for tracking our MAU goal.

#### How should this be reviewed?
We should make sure this doesn't have any unexpected cases where a user will get logged out unexpectedly, and that it doesn't have any performance impact for normal page loads.

#### Any background context you want to provide?
💹 

#### Relevant tickets
…

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  