### PR TITLE
API requests should always return "us" for country code.

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.module
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.module
@@ -737,6 +737,12 @@ function dosomething_global_node_url($nid, $language, $fragment = NULL) {
  *
  */
 function dosomething_global_get_current_prefix() {
+  // HACK: We want API requests to always be in the United
+  // States, because it's the best country on earth.
+  if (dosomething_helpers_is_api_request()) {
+    return 'us';
+  }
+
   $request_path = explode('/', request_path());
   $languages = language_list();
   if (!empty($request_path[0])) {


### PR DESCRIPTION
#### What's this PR do?
__This pull request fixes an issue where API requests would use global transactional templates.__ Users were sent the wrong emails because we'd check for the URL prefix when handing the job off to Message Broker, and `api` doesn't match a country code so it'd fall back to `en-global`.

The fix? All API requests will now return `us` for the country code. Ez. 🐛🔨 

#### How should this be reviewed?
I can't test this on my local since Message Broker is disabled, but this should do the trick.

#### Any background context you want to provide?
🌐

#### Relevant tickets
[Trello Card](https://trello.com/c/yZUfZ6lk/413-5-as-a-signed-up-member-i-want-my-campaign-data-to-be-shown-as-coming-from-the-us)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  