### PR TITLE
Some cleanup in the signup API...?

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -267,7 +267,6 @@ function _campaign_resource_index($ids, $staff_pick, $term_ids, $count, $random,
  *       Defaults to sending messages.
  */
 function _campaign_resource_signup($nid, $values) {
-
   if (isset($values['northstar_id'])) {
     $values['uid'] = dosomething_user_get_user_by_northstar_id($values['northstar_id'])->uid;
   }
@@ -287,42 +286,19 @@ function _campaign_resource_signup($nid, $values) {
     watchdog('dosomething_api', '_campaign_resource_signup values:' . json_encode($values));
   }
 
-  $headers = getallheaders();
+  // Check to see if we should be sending requests to Rogue instead:
+  if (variable_get('rogue_collection', FALSE)) {
+    $rogue_signup = dosomething_rogue_send_signup_to_rogue(array_merge($values, [
+      'campaign_id' => $nid,
+    ]));
 
-  // Check to see if the request came from Rogue and if we should be sending it there
-  // $headers['X-Request-Id'] will only be set if the request is coming from Rogue
-  if ( !isset($headers['X-Request-Id'])) {
-    if (variable_get('rogue_collection', FALSE)) {
-      // Pass the campaign_id
-      $values['campaign_id'] = $nid;
-
-      // Get the run to pass
-      $user = user_load($values['uid']);
-      $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $user);
-
-      // Post the signup to Rogue
-      $rogue_signup = dosomething_rogue_send_signup_to_rogue($values);
-
-      // Store the reference to the Rogue signup
-      if ($rogue_signup) {
-        return dosomething_rogue_check_sid_and_store_ref($rogue_signup);
-      }
+    // Store the reference to the Rogue signup
+    if ($rogue_signup) {
+      return dosomething_rogue_check_sid_and_store_ref($rogue_signup);
     }
-    // The request is not from Rogue and we don't want to send it there, so just save to Phoenix
-    else {
-      // transactionals = FALSE will result in neither email or SMS transactional messages being sent.
-      return dosomething_signup_create($nid, $values['uid'], $values['source'], NULL, $values['transactionals']);
-    }
-  } else {
-    // Only try to increment transaction IDs if they were already set
-    // Increment transaction id and log that the request has been received with new transaction id.
-    $incremented_transaction_id = dosomething_api_increment_transaction_id($headers['X-Request-Id']);
-
-    watchdog('PhoenixTransactionBridge', 'Request received. Transaction ID: !incremented_transaction_id', ['!incremented_transaction_id' => $incremented_transaction_id], WATCHDOG_INFO);
-
-    // transactionals = FALSE will result in neither email or SMS transactional messages being sent.
-    return dosomething_signup_create($nid, $values['uid'], $values['source'], NULL, $values['transactionals']);
   }
+
+  return dosomething_signup_create($nid, $values['uid'], $values['source'], NULL, $values['transactionals']);
 }
 
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -254,9 +254,9 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
   $campaign = Campaign::get($nid);
   $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $user, $campaign);
 
-  // If a signup already exists, exit.
-  if (dosomething_signup_exists($nid, $run->nid, $uid)) {
-    return FALSE;
+  // If a signup already exists, return the signup ID.
+  if ($existing_id = dosomething_signup_exists($nid, $run->nid, $uid)) {
+    return $existing_id;
   }
 
   $values = array(

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -270,11 +270,11 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
 
   try {
     // Create a signup entity.
+    // @see: SignupsController.php save()
     $entity = entity_create('signup', $values);
-    // The SignupEntityController save method handles any NULL values.
     $entity->save();
-    if (isset($entity->sid)) {
 
+    if (isset($entity->sid)) {
       if (module_exists('stathat')) {
         // The source is often a string longer than just "reportback", but always starts with it if the page is a permalink
         if (strpos($source, 'reportback') === 0) {


### PR DESCRIPTION
#### What's this PR do?
Was diving in to try to figure out why Phoenix Next signups were returning `[false]` sometimes, and did some cleanup along the way: added a few comments, and removed some code that was used when Rogue used to "echo" signups back to Phoenix.

I'd also like to try [returning `["<signup_id>"]` here if a signup exists](https://github.com/DoSomething/phoenix/commit/3a8bb42f986c858b29577c28134bedc473b4199d), rather than `[false]`. I don't think that's a super crazy thing to do, but would love a sanity check from a few folks...

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Ehhhh

#### Relevant tickets
References #7353.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  