### PR TITLE
Don't allow a default UID on signup endpoint.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -270,9 +270,9 @@ function _campaign_resource_signup($nid, $values) {
   if (isset($values['northstar_id'])) {
     $values['uid'] = dosomething_user_get_user_by_northstar_id($values['northstar_id'])->uid;
   }
-  else if (!isset($values['uid'])) {
-    global $user;
-    $values['uid'] = $user->uid;
+
+  if (!isset($values['uid'])) {
+    return services_error('Cannot create signup without a `northstar_id` or `uid`.');
   }
 
   if (!isset($values['source'])) {


### PR DESCRIPTION
#### What's this PR do?
This pull request no longer allows the signup endpoint to create a signup for the logged-in user (which would just be `ds-api@dosomething.org`) because that's confusing when tracking down errors.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
🔥

#### Relevant tickets
References #7353.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  