### PR TITLE
Reactions for current user in gallery powered by Rogue

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -158,22 +158,24 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
 
   if (variable_get('rogue_collection', FALSE)) {
     $client = dosomething_rogue_client('v1');
-    // is there anyway to get the url string here so we can grab the page number param?
-    // $query_parts = explode("&", $_SERVER['REQUEST_URI']);
-    // $page = end($query_parts);
-    // // // page=2
-    // $page = explode("=", $page);
-    // $page = end($page);
-    // if ($page) {
-    //   $response = $client->getAllReportbacks([
-    //     'filter' => [
-    //       'campaign_id' => $campaigns,
-    //     ],
-    //     'as_user' => dosomething_user_get_field('field_northstar_id'),
-    //     'limit' => 12,
-    //     'page' => 3,
-    //   ]);
-    // } else {
+    $query_parts = explode("&", $_SERVER['REQUEST_URI']);
+    $last_query_param = end($query_parts);
+
+    if ($last_query_param === 'page') {
+      $page_parts = explode("=", $$last_query_param);
+      $page_number = end($page_parts);
+
+      if ($page_number) {
+        $response = $client->getAllReportbacks([
+          'filter' => [
+            'campaign_id' => $campaigns,
+          ],
+          'as_user' => dosomething_user_get_field('field_northstar_id'),
+          'limit' => 12,
+          'page' => $page_number,
+        ]);
+      }
+    } else {
       $response = $client->getAllReportbacks([
         'filter' => [
           'campaign_id' => $campaigns,
@@ -181,7 +183,7 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
         'as_user' => dosomething_user_get_field('field_northstar_id'),
         'limit' => 12,
       ]);
-    // }
+    }
 
     return $response;
   }

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -163,8 +163,8 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
         'campaign_id' => $campaigns,
       ],
       'as_user' => dosomething_user_get_field('field_northstar_id'),
-      'limit' => 6
     ]);
+
     return $response;
   }
 

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -158,13 +158,30 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
 
   if (variable_get('rogue_collection', FALSE)) {
     $client = dosomething_rogue_client('v1');
-    $response = $client->getAllReportbacks([
-      'filter' => [
-        'campaign_id' => $campaigns,
-      ],
-      'as_user' => dosomething_user_get_field('field_northstar_id'),
-      'limit' => 12,
-    ]);
+    // is there anyway to get the url string here so we can grab the page number param?
+    // $query_parts = explode("&", $_SERVER['REQUEST_URI']);
+    // $page = end($query_parts);
+    // // // page=2
+    // $page = explode("=", $page);
+    // $page = end($page);
+    // if ($page) {
+    //   $response = $client->getAllReportbacks([
+    //     'filter' => [
+    //       'campaign_id' => $campaigns,
+    //     ],
+    //     'as_user' => dosomething_user_get_field('field_northstar_id'),
+    //     'limit' => 12,
+    //     'page' => 3,
+    //   ]);
+    // } else {
+      $response = $client->getAllReportbacks([
+        'filter' => [
+          'campaign_id' => $campaigns,
+        ],
+        'as_user' => dosomething_user_get_field('field_northstar_id'),
+        'limit' => 12,
+      ]);
+    // }
 
     return $response;
   }

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -158,7 +158,13 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
 
   if (variable_get('rogue_collection', FALSE)) {
     $client = dosomething_rogue_client('v1');
-    $response = $client->getAllReportbacks($inputs);
+    $response = $client->getAllReportbacks([
+      'filter' => [
+        'campaign_id' => $campaigns,
+      ],
+      'as_user' => dosomething_user_get_field('field_northstar_id'),
+      'limit' => 6
+    ]);
     return $response;
   }
 

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -158,32 +158,16 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
 
   if (variable_get('rogue_collection', FALSE)) {
     $client = dosomething_rogue_client('v1');
-    $query_parts = explode("&", $_SERVER['REQUEST_URI']);
-    $last_query_param = end($query_parts);
-    $last_query_param_parts = explode("=", $last_query_param);
 
-    if ($last_query_param_parts[0] === 'page') {
-      $page_number = end($last_query_param_parts);
-
-      if ($page_number) {
-        $response = $client->getAllReportbacks([
-          'filter' => [
-            'campaign_id' => $campaigns,
-          ],
-          'as_user' => dosomething_user_get_field('field_northstar_id'),
-          'limit' => 12,
-          'page' => $page_number,
-        ]);
-      }
-    } else {
-      $response = $client->getAllReportbacks([
-        'filter' => [
-          'campaign_id' => $campaigns,
-        ],
-        'as_user' => dosomething_user_get_field('field_northstar_id'),
-        'limit' => 12,
-      ]);
-    }
+    $response = $client->getAllReportbacks([
+      'filter' => [
+        'campaign_id' => $campaigns,
+        'exclude' => $exclude,
+      ],
+      'as_user' => dosomething_user_get_field('field_northstar_id'),
+      'limit' => 12,
+      'page' => $page,
+    ]);
 
     return $response;
   }

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -160,10 +160,10 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
     $client = dosomething_rogue_client('v1');
     $query_parts = explode("&", $_SERVER['REQUEST_URI']);
     $last_query_param = end($query_parts);
+    $last_query_param_parts = explode("=", $last_query_param);
 
-    if ($last_query_param === 'page') {
-      $page_parts = explode("=", $$last_query_param);
-      $page_number = end($page_parts);
+    if ($last_query_param_parts[0] === 'page') {
+      $page_number = end($last_query_param_parts);
 
       if ($page_number) {
         $response = $client->getAllReportbacks([

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -157,7 +157,7 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
   );
 
   if (variable_get('rogue_collection', FALSE)) {
-    $client = dosomething_rogue_client('v1');
+    $client = dosomething_rogue_client();
 
     $response = $client->getAllReportbacks([
       'filter' => [

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -163,7 +163,7 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
         'campaign_id' => $campaigns,
       ],
       'as_user' => dosomething_user_get_field('field_northstar_id'),
-      'limit' => 6,
+      'limit' => 12,
     ]);
 
     return $response;

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -163,6 +163,7 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
         'campaign_id' => $campaigns,
       ],
       'as_user' => dosomething_user_get_field('field_northstar_id'),
+      'limit' => 6,
     ]);
 
     return $response;

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -326,6 +326,7 @@ function dosomething_kudos_get_kudos_data_for_fid($fid = NULL, $total_rogue_kudo
   }
   $kudos = [];
   $kudos['fid'] = $fid;
+  // @TODO: update the below to grab from the Rogue response when we start sending reaction data to Rogue when a user newly reacts to a post.
   $kudos['existing_kids'] = dosomething_kudos_get_kudos_for_user_by_file($fid);
   $kudos['reaction_totals'] = [
     'heart' =>
@@ -333,7 +334,8 @@ function dosomething_kudos_get_kudos_data_for_fid($fid = NULL, $total_rogue_kudo
   ];
   $kudos['allowed_reactions'] = [dosomething_kudos_get_term_id_by_name('heart')];
 
-  $kudos['from_rogue'] = $liked_by_current_user ? $liked_by_current_user : FALSE;
+  // Use this in photo.tpl.php for the logged in user's reaction. If the user has reacted to the post, make the reaction button active.
+  $kudos['from_rogue'] = $liked_by_current_user;
 
   return $kudos;
 }

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -297,6 +297,10 @@ function dosomething_kudos_term_is_selected($kudos, $term) {
     return false;
   }
 
+  if ($kudos['from_rogue']) {
+    return true;
+  }
+
   return true;
 }
 
@@ -312,14 +316,14 @@ function dosomething_kudos_disable_reactions($nid) {
 /**
  * Grab all Kudos data required to render the markup for a given reportback fid
  * @param  int $fid Reportback file id
- * @param  int $total_rogue_kudos Total kudos from Rogue response (If Rogue is powering the gallery)
+ * @param  int $total_rogue_kudos Total kudos from Rogue response (If Rogue is powering the gallery).
+ * @param  bool $liked_by_current_user Response from Rogue if the current user has reacted to the post or not.
  * @return array Values needed to render Kudos markup
  */
-function dosomething_kudos_get_kudos_data_for_fid($fid = NULL, $total_rogue_kudos = NULL) {
+function dosomething_kudos_get_kudos_data_for_fid($fid = NULL, $total_rogue_kudos = NULL, $liked_by_current_user = NULL) {
   if (! $fid) {
     return [];
   }
-
   $kudos = [];
   $kudos['fid'] = $fid;
   $kudos['existing_kids'] = dosomething_kudos_get_kudos_for_user_by_file($fid);
@@ -328,6 +332,8 @@ function dosomething_kudos_get_kudos_data_for_fid($fid = NULL, $total_rogue_kudo
         $total_rogue_kudos ? $total_rogue_kudos : dosomething_kudos_get_total_for_file_by_term_name($fid, 'heart')
   ];
   $kudos['allowed_reactions'] = [dosomething_kudos_get_term_id_by_name('heart')];
+
+  $kudos['from_rogue'] = $liked_by_current_user ? $liked_by_current_user : FALSE;
 
   return $kudos;
 }

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -252,6 +252,7 @@ function dosomething_kudos_get_total_for_file_by_term_name($fid, $term) {
       ->condition('tid', $tid, '=')
       ->execute()
       ->rowCount();
+
   return $kudos;
 }
 
@@ -311,20 +312,21 @@ function dosomething_kudos_disable_reactions($nid) {
 /**
  * Grab all Kudos data required to render the markup for a given reportback fid
  * @param  int $fid Reportback file id
+ * @param  int $total_rogue_kudos Total kudos from Rogue response (If Rogue is powering the gallery)
  * @return array Values needed to render Kudos markup
  */
-function dosomething_kudos_get_kudos_data_for_fid($fid = NULL) {
+function dosomething_kudos_get_kudos_data_for_fid($fid = NULL, $total_rogue_kudos = NULL) {
   if (! $fid) {
     return [];
   }
 
   $kudos = [];
   $kudos['fid'] = $fid;
-  $kudos['reaction_totals'] = [
-    'heart' => dosomething_kudos_get_total_for_file_by_term_name($fid, 'heart'),
-  ];
   $kudos['existing_kids'] = dosomething_kudos_get_kudos_for_user_by_file($fid);
-  $kudos['reaction_totals'] = ['heart' => dosomething_kudos_get_total_for_file_by_term_name($fid, 'heart')];
+  $kudos['reaction_totals'] = [
+    'heart' =>
+        $total_rogue_kudos ? $total_rogue_kudos : dosomething_kudos_get_total_for_file_by_term_name($fid, 'heart')
+  ];
   $kudos['allowed_reactions'] = [dosomething_kudos_get_term_id_by_name('heart')];
 
   return $kudos;

--- a/lib/modules/dosomething/dosomething_kudos/style.css
+++ b/lib/modules/dosomething/dosomething_kudos/style.css
@@ -1,9 +1,0 @@
-/*
-Theme Name: My Child Theme
-Theme URI: http://http://repriseactivewear.com/
-Description: This is a custom child theme for Reprise Activewear's homepage "Coming Soon" placeholder.
-Author: My Name
-Author URI: http://mysite.com/
-Template: parenttheme
-Version: 0.1
-*/

--- a/lib/modules/dosomething/dosomething_kudos/style.css
+++ b/lib/modules/dosomething/dosomething_kudos/style.css
@@ -1,0 +1,9 @@
+/*
+Theme Name: My Child Theme
+Theme URI: http://http://repriseactivewear.com/
+Description: This is a custom child theme for Reprise Activewear's homepage "Coming Soon" placeholder.
+Author: My Name
+Author URI: http://mysite.com/
+Template: parenttheme
+Version: 0.1
+*/

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -368,17 +368,6 @@ function paraneue_dosomething_get_themed_reportback_item($data, $rogue_rb_item =
 
         $total_rogue_kudos = $data->kudos['total'];
         $liked_by_current_user = $data->kudos['data']['current_user']['reacted'] ? true : false;
-
-        if ($liked_by_current_user) {
-          drupal_add_js(
-            [
-              'dsKudosReactions' => [
-                'likedByCurrentUser' => $liked_by_current_user,
-              ]
-            ],
-            'setting'
-          );
-        }
       }
 
       $data->kudos = dosomething_kudos_get_kudos_data_for_fid($data->id, $total_rogue_kudos ? $total_rogue_kudos : null, $liked_by_current_user ? $liked_by_current_user : null);

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -367,9 +367,10 @@ function paraneue_dosomething_get_themed_reportback_item($data, $rogue_rb_item =
         // $data->id = db_query("SELECT rogue_rbs.fid FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rogue_event_id = :rogue_event_id", array(':rogue_event_id' => $data->event_id))->fetchField();
 
         $total_rogue_kudos = $data->kudos['total'];
+        $liked_by_current_user = $data->kudos['liked_by_current_user'] ? true : false;
       }
 
-      $data->kudos = dosomething_kudos_get_kudos_data_for_fid($data->id, $total_rogue_kudos ? $total_rogue_kudos : null);
+      $data->kudos = dosomething_kudos_get_kudos_data_for_fid($data->id, $total_rogue_kudos ? $total_rogue_kudos : null, $liked_by_current_user ? $liked_by_current_user : null);
   }
 
   if ($data instanceof ReportbackItem && user_access('view any reportback')) {

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -367,7 +367,7 @@ function paraneue_dosomething_get_themed_reportback_item($data, $rogue_rb_item =
         // $data->id = db_query("SELECT rogue_rbs.fid FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rogue_event_id = :rogue_event_id", array(':rogue_event_id' => $data->event_id))->fetchField();
 
         $total_rogue_kudos = $data->kudos['total'];
-        $liked_by_current_user = $data->kudos['liked_by_current_user'] ? true : false;
+        $liked_by_current_user = $data->kudos['data']['current_user']['reacted'] ? true : false;
 
         if ($liked_by_current_user) {
           drupal_add_js(

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -368,6 +368,16 @@ function paraneue_dosomething_get_themed_reportback_item($data, $rogue_rb_item =
 
         $total_rogue_kudos = $data->kudos['total'];
         $liked_by_current_user = $data->kudos['data']['current_user']['reacted'] ? true : false;
+
+        // Let the front end know that Rogue is powering the gallery.
+        drupal_add_js(
+          [
+            'dsRogue' => [
+              'poweringGallery' => true,
+            ]
+          ],
+          'setting'
+        );
       }
 
       $data->kudos = dosomething_kudos_get_kudos_data_for_fid($data->id, $total_rogue_kudos ? $total_rogue_kudos : null, $liked_by_current_user ? $liked_by_current_user : null);

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -361,11 +361,16 @@ function paraneue_dosomething_get_themed_reportback_item($data, $rogue_rb_item =
     return NULL;
   }
 
-  if ($data->id && !dosomething_kudos_disable_reactions($data->campaign->id) && !$rogue_rb_item) {
-    $data->kudos = dosomething_kudos_get_kudos_data_for_fid($data->id);
-  }
+  if ($data->id && !dosomething_kudos_disable_reactions($data->campaign->id)) {
+      if ($rogue_rb_item) {
+        // Find the fid from the rogue reference table
+        // $data->id = db_query("SELECT rogue_rbs.fid FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rogue_event_id = :rogue_event_id", array(':rogue_event_id' => $data->event_id))->fetchField();
 
-  // @TODO: do we want to add kudos from Rogue here?
+        $total_rogue_kudos = $data->kudos['total'];
+      }
+
+      $data->kudos = dosomething_kudos_get_kudos_data_for_fid($data->id, $total_rogue_kudos ? $total_rogue_kudos : null);
+  }
 
   if ($data instanceof ReportbackItem && user_access('view any reportback')) {
     $data->admin_link = '/admin/reportback/' . $data->reportback['id'];

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -368,6 +368,17 @@ function paraneue_dosomething_get_themed_reportback_item($data, $rogue_rb_item =
 
         $total_rogue_kudos = $data->kudos['total'];
         $liked_by_current_user = $data->kudos['liked_by_current_user'] ? true : false;
+
+        if ($liked_by_current_user) {
+          drupal_add_js(
+            [
+              'dsKudosReactions' => [
+                'likedByCurrentUser' => $liked_by_current_user,
+              ]
+            ],
+            'setting'
+          );
+        }
       }
 
       $data->kudos = dosomething_kudos_get_kudos_data_for_fid($data->id, $total_rogue_kudos ? $total_rogue_kudos : null, $liked_by_current_user ? $liked_by_current_user : null);

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -240,7 +240,13 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars, $count = 6) 
   if (variable_get('rogue_collection', FALSE)) {
     // Hit the GET /reportbacks endpoint in Rogue with campaign_id filter.
     // On the Rogue side, it will only return 'approved', which will be shown in the gallery.
-    $promotedReportbackItemsResponse = dosomething_rogue_get_reportback_items(['campaign_id' => $gallery['campaign_id'], 'limit' => 6]);
+    $promotedReportbackItemsResponse = dosomething_rogue_get_reportback_items([
+      'filter' => [
+        'campaign_id' => $gallery['campaign_id'],
+      ],
+      'as_user' => dosomething_user_get_field('field_northstar_id'),
+      'limit' => 6
+    ]);
 
     $promotedReportbackItems = $promotedReportbackItemsResponse['data'];
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -282,8 +282,20 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars, $count = 6) 
   foreach ($reportbackItems as $item) {
     if (variable_get('rogue_collection', FALSE)) {
       $item = (object) $item;
+      // @TODO: This is the fid. We need to update according to the reference table?
       $gallery['item_ids'][] = $item->id;
       $gallery['items'][] = paraneue_dosomething_get_themed_reportback_item($item, TRUE);
+
+      drupal_add_js(
+        [
+          'dsKudosReactions' => [
+            'sendToRogue' => true,
+            'northstarId' => $item->user,
+            'postId' => $item->event_id,
+          ]
+        ],
+        'setting'
+      );
     }
     else {
       if ($item instanceof ReportbackItem) {
@@ -310,10 +322,6 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars, $count = 6) 
 
   global $user;
 
-  // @TODO: how do we deal with the below?
-  // reactions in phoenix and rogue will not be the same (since we're not migrating)
-  // do we just display the reactions based on what they are in phoenix?
-  // this might not reflect accurately and seem like a bug to users. how much do we care?
   drupal_add_js(
     [
       'dsKudosReactions' => [

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -291,17 +291,16 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars, $count = 6) 
       // @TODO: This is the fid. We need to update according to the reference table?
       $gallery['item_ids'][] = $item->id;
       $gallery['items'][] = paraneue_dosomething_get_themed_reportback_item($item, TRUE);
-
-      drupal_add_js(
-        [
-          'dsKudosReactions' => [
-            'sendToRogue' => true,
-            'northstarId' => $item->user,
-            'postId' => $item->event_id,
-          ]
-        ],
-        'setting'
-      );
+      // drupal_add_js(
+      //   [
+      //     'dsKudosReactions' => [
+      //       'sendToRogue' => true,
+      //       'northstarId' => $item->user,
+      //       'postId' => $item->event_id,
+      //     ]
+      //   ],
+      //   'setting'
+      // );
     }
     else {
       if ($item instanceof ReportbackItem) {

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -61,20 +61,20 @@ $(document).on('click', '.js-kudos-button', function(event) {
   // if (setting('dsKudosReactions.sendToRogue')) {
   //   makeKudosRequestToRogue(setting('dsKudosReactions.northstarId'), setting('dsKudosReactions.postId'))
   // } else {
-    makeKudosRequest($el, dataKid)
-      .done((response) => {
-        const kid = get(response, '0.kid', '');
+  makeKudosRequest($el, dataKid)
+    .done((response) => {
+      const kid = get(response, '0.kid', '');
 
-        if (method === 'POST' && !kid) {
-          return;
-        }
+      if (method === 'POST' && !kid) {
+        return;
+      }
 
-        $el.attr('data-kid', kid);
+      $el.attr('data-kid', kid);
 
-        updateKudosInterface($el);
-      })
-      .always(() => {
-        $el.removeAttr('disabled');
-      });
+      updateKudosInterface($el);
+    })
+    .always(() => {
+      $el.removeAttr('disabled');
+    });
   // }
 });

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -69,9 +69,9 @@ $(document).on('click', '.js-kudos-button', function(event) {
   const dataKid = $el.attr('data-kid');
   const method = dataKid ? 'DELETE' : 'POST';
 
-  if (setting('dsKudosReactions.sendToRogue')) {
-    makeKudosRequestToRogue(setting('dsKudosReactions.northstarId'), setting('dsKudosReactions.postId'))
-  } else {
+  // if (setting('dsKudosReactions.sendToRogue')) {
+  //   makeKudosRequestToRogue(setting('dsKudosReactions.northstarId'), setting('dsKudosReactions.postId'))
+  // } else {
     makeKudosRequest($el, dataKid)
       .done((response) => {
         const kid = get(response, '0.kid', '');
@@ -87,5 +87,5 @@ $(document).on('click', '.js-kudos-button', function(event) {
       .always(() => {
         $el.removeAttr('disabled');
       });
-  }
+  // }
 });

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -1,3 +1,5 @@
+import setting from '../utilities/Setting';
+
 const $ = require('jquery');
 const get = require('lodash/get');
 
@@ -23,6 +25,17 @@ function makeKudosRequest($el, id)
     }),
   });
 }
+
+/**
+ * Make an API request to Rogue to create/delete the Reaction for that item.
+ *
+ * @param string User's northstar ID.
+ */
+ function makeKudosRequestToRogue($northstarId, $postId)
+ {
+  console.log($northstarId);
+  console.log($postId);
+ }
 
 /**
  * Show the things we've accomplished.
@@ -56,19 +69,23 @@ $(document).on('click', '.js-kudos-button', function(event) {
   const dataKid = $el.attr('data-kid');
   const method = dataKid ? 'DELETE' : 'POST';
 
-  makeKudosRequest($el, dataKid)
-    .done((response) => {
-      const kid = get(response, '0.kid', '');
+  if (setting('dsKudosReactions.sendToRogue')) {
+    makeKudosRequestToRogue(setting('dsKudosReactions.northstarId'), setting('dsKudosReactions.postId'))
+  } else {
+    makeKudosRequest($el, dataKid)
+      .done((response) => {
+        const kid = get(response, '0.kid', '');
 
-      if (method === 'POST' && !kid) {
-        return;
-      }
+        if (method === 'POST' && !kid) {
+          return;
+        }
 
-      $el.attr('data-kid', kid);
+        $el.attr('data-kid', kid);
 
-      updateKudosInterface($el);
-    })
-    .always(() => {
-      $el.removeAttr('disabled');
-    });
+        updateKudosInterface($el);
+      })
+      .always(() => {
+        $el.removeAttr('disabled');
+      });
+  }
 });

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -27,17 +27,6 @@ function makeKudosRequest($el, id)
 }
 
 /**
- * Make an API request to Rogue to create/delete the Reaction for that item.
- *
- * @param string User's northstar ID.
- */
- function makeKudosRequestToRogue($northstarId, $postId)
- {
-  console.log($northstarId);
-  console.log($postId);
- }
-
-/**
  * Show the things we've accomplished.
  *
  * @param {jQuery} $el

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -70,7 +70,6 @@ const Reportback = {
 
     // Total number of Reportbacks remaining to be displayed.
     this.itemsTotalRemaining = $container.data('remaining');
-
     if (this.itemsTotalRemaining > 0) {
       this.apiUrl = this.buildApiUrl();
       this.enableViewMore();
@@ -280,7 +279,23 @@ const Reportback = {
       },
     }).done(function(response) {
       if (setting('dsKudosReactions.likedByCurrentUser')) {
-        _this.apiUrl = response.meta.pagination.links.next;
+        console.log(this.url);
+        if (response.meta.pagination.links.next) {
+          var splitResponseUrl = response.meta.pagination.links.next.split("&");
+          var urlParts = this.url.split("&");
+          var pageParts = urlParts[urlParts.length-1].split("=");
+          if (pageParts[0] === "page") {
+            if (splitResponseUrl) {
+              var urlWithoutPageNumber = (this.url).slice(0, -1);
+              _this.apiUrl = urlWithoutPageNumber.concat(pageParts[1]);
+            }
+          } else {
+              _this.apiUrl = (this.url).concat("&").concat(splitResponseUrl[splitResponseUrl.length-1]);
+          }
+        console.log(_this.apiUrl);
+        } else {
+          _this.apiUrl = null;
+        }
       } else if (response.meta.pagination.links.next_uri) {
         _this.apiUrl = response.meta.pagination.links.next_uri;
       } else {

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -208,7 +208,7 @@ const Reportback = {
             }
           });
         } else {
-          reaction.kudosId = 0;
+          reaction.kudosId = null;
           reaction.term = data.term.name;
           reaction.termId = data.term.id;
           reaction.total = data.term.total;

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -185,9 +185,9 @@ const Reportback = {
    */
   getReactions: function(data, reactionFromRogue) {
     if (reactionFromRogue) {
-      let reactions = [];
+      var reactions = [];
 
-      let reaction = {
+      var reaction = {
         kudosId: null,
         term: null,
         termId: null,

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -183,34 +183,53 @@ const Reportback = {
    * @param  {array} data  Array of Kudos objects from API.
    * @return {array}
    */
-  getReactions: function(data) {
-    let reactions = [];
-
-    forEach(this.reactions.approved, (term) => {
-      const termId = this.reactions.terms[term];
+  getReactions: function(data, reactionFromRogue) {
+    if (reactionFromRogue) {
+      let reactions = [];
 
       let reaction = {
         kudosId: null,
-        term: term,
-        termId: termId,
+        term: null,
+        termId: null,
         total: 0,
         userReacted: false,
       };
 
-      if (data.length) {
-        forEach(data, (record) => {
-          if (record.term.name === term) {
-            reaction.kudosId = record.current_user.kudos_id;
-            reaction.term = record.term.name;
-            reaction.termId = record.term.id;
-            reaction.total = record.term.total;
-            reaction.userReacted = record.current_user.reacted;
-          }
-        });
-      }
+      reaction.term = 'heart';
+      reaction.termId = 641,
+      reaction.total = data.total;
+      reaction.userReacted = data.liked_by_current_user;
 
       reactions.push(reaction);
-    });
+    } else {
+      let reactions = [];
+
+      forEach(this.reactions.approved, (term) => {
+        const termId = this.reactions.terms[term];
+
+        let reaction = {
+          kudosId: null,
+          term: term,
+          termId: termId,
+          total: 0,
+          userReacted: false,
+        };
+
+        if (data.length) {
+          forEach(data, (record) => {
+            if (record.term.name === term) {
+              reaction.kudosId = record.current_user.kudos_id;
+              reaction.term = record.term.name;
+              reaction.termId = record.term.id;
+              reaction.total = record.term.total;
+              reaction.userReacted = record.current_user.reacted;
+            }
+          });
+        }
+
+        reactions.push(reaction);
+      });
+    }
 
     return reactions;
   },
@@ -308,7 +327,7 @@ const Reportback = {
         'isListItem': true,  // @TODO: probably a better way to address this... :insert shruggy emoji here:
         'reactions': {
           enabled: setting('dsKudosReactions.enabled'),
-          data: this.getReactions(items[i].kudos.data),
+          data: setting('dsKudosReactions.likedByCurrentUser') ? this.getReactions(items[i].kudos, true) : this.getReactions(items[i].kudos.data, false),
         }
       };
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -278,22 +278,27 @@ const Reportback = {
         }
       },
     }).done(function(response) {
-      // If response.meta.pagination.links.next, this is from Rogue.
-      if (response.meta.pagination.links.next) {
-        var splitResponseUrl = response.meta.pagination.links.next.split("&");
-        var urlParts = this.url.split("&");
-        var pageParts = urlParts[urlParts.length-1].split("=");
-        // We already have the page param here, don't append 'page' again to be page=2&page=3.
-        if (pageParts[0] === "page") {
-          if (splitResponseUrl) {
-            var urlWithoutPageNumber = (this.url).slice(0, -1);
-            _this.apiUrl = urlWithoutPageNumber.concat(pageParts[1]);
+      // Check to see if the response if from Rogue.
+      if (Drupal.settings.dsRogue.poweringGallery) {
+        if (response.meta.pagination.links.next_uri) {
+          var splitResponseUrl = response.meta.pagination.links.next_uri.split("&");
+          var pageParts = splitResponseUrl[splitResponseUrl.length - 1];
+          var page = pageParts.split("=")[1];
+
+          // We already have the page param here, don't append 'page' again to be page=2&page=3.
+          if (pageParts[0] === "page") {
+            if (splitResponseUrl) {
+              var urlWithoutPageNumber = (this.url).slice(0, -1);
+              _this.apiUrl = urlWithoutPageNumber.concat(page);
+            }
+          } else {
+            // The page param isn't added yet so do it here.
+            _this.apiUrl = (this.url).concat("&").concat(splitResponseUrl[splitResponseUrl.length-1]);
           }
+        // If there is no next_uri, there are no more posts. Do not show view more button.
         } else {
-          // The page param isn't added yet so do it here.
-          _this.apiUrl = (this.url).concat("&").concat(splitResponseUrl[splitResponseUrl.length-1]);
+          _this.apiUrl = null;
         }
-      // If response.meta.pagination.links.next_uri, this is from Phoenix.
       } else if (response.meta.pagination.links.next_uri) {
         _this.apiUrl = response.meta.pagination.links.next_uri;
       } else {

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -292,7 +292,7 @@ const Reportback = {
         }
       },
     }).done(function(response) {
-      _this.apiUrl = response.meta.pagination.links.next_uri || null;
+      _this.apiUrl = setting('dsKudosReactions.likedByCurrentUser') ? response.meta.pagination.links.next : response.meta.pagination.links.next_uri || null;
 
       _this.templatize(response);
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -293,8 +293,6 @@ const Reportback = {
               _this.apiUrl = (this.url).concat("&").concat(splitResponseUrl[splitResponseUrl.length-1]);
           }
         console.log(_this.apiUrl);
-        } else {
-          _this.apiUrl = null;
         }
       } else if (response.meta.pagination.links.next_uri) {
         _this.apiUrl = response.meta.pagination.links.next_uri;

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -182,40 +182,40 @@ const Reportback = {
    * @param  {array} data  Array of Kudos objects from API.
    * @return {array}
    */
-    getReactions: function(data) {
-      let reactions = [];
+  getReactions: function(data) {
+    let reactions = [];
 
-      forEach(this.reactions.approved, (term) => {
-        const termId = this.reactions.terms[term];
+    forEach(this.reactions.approved, (term) => {
+      const termId = this.reactions.terms[term];
 
-        let reaction = {
-          kudosId: null,
-          term: term,
-          termId: termId,
-          total: 0,
-          userReacted: false,
-        };
+      let reaction = {
+        kudosId: null,
+        term: term,
+        termId: termId,
+        total: 0,
+        userReacted: false,
+      };
 
-        if (data.length) {
-          forEach(data, (record) => {
-            if (record.term.name === term) {
-              reaction.kudosId = record.current_user.kudos_id;
-              reaction.term = record.term.name;
-              reaction.termId = record.term.id;
-              reaction.total = record.term.total;
-              reaction.userReacted = record.current_user.reacted;
-            }
-          });
-        } else {
-          reaction.kudosId = null;
-          reaction.term = data.term.name;
-          reaction.termId = data.term.id;
-          reaction.total = data.term.total;
-          reaction.userReacted = data.current_user.reacted;
-        }
+      if (data.length) {
+        forEach(data, (record) => {
+          if (record.term.name === term) {
+            reaction.kudosId = record.current_user.kudos_id;
+            reaction.term = record.term.name;
+            reaction.termId = record.term.id;
+            reaction.total = record.term.total;
+            reaction.userReacted = record.current_user.reacted;
+          }
+        });
+      } else {
+        reaction.kudosId = null;
+        reaction.term = data.term.name;
+        reaction.termId = data.term.id;
+        reaction.total = data.term.total;
+        reaction.userReacted = data.current_user.reacted;
+      }
 
-        reactions.push(reaction);
-      });
+      reactions.push(reaction);
+    });
 
     return reactions;
   },

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -278,8 +278,6 @@ const Reportback = {
         }
       },
     }).done(function(response) {
-      if (setting('dsKudosReactions.likedByCurrentUser')) {
-        console.log(this.url);
         if (response.meta.pagination.links.next) {
           var splitResponseUrl = response.meta.pagination.links.next.split("&");
           var urlParts = this.url.split("&");
@@ -292,8 +290,6 @@ const Reportback = {
           } else {
               _this.apiUrl = (this.url).concat("&").concat(splitResponseUrl[splitResponseUrl.length-1]);
           }
-        console.log(_this.apiUrl);
-        }
       } else if (response.meta.pagination.links.next_uri) {
         _this.apiUrl = response.meta.pagination.links.next_uri;
       } else {

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -278,21 +278,26 @@ const Reportback = {
         }
       },
     }).done(function(response) {
-        if (response.meta.pagination.links.next) {
-          var splitResponseUrl = response.meta.pagination.links.next.split("&");
-          var urlParts = this.url.split("&");
-          var pageParts = urlParts[urlParts.length-1].split("=");
-          if (pageParts[0] === "page") {
-            if (splitResponseUrl) {
-              var urlWithoutPageNumber = (this.url).slice(0, -1);
-              _this.apiUrl = urlWithoutPageNumber.concat(pageParts[1]);
-            }
-          } else {
-              _this.apiUrl = (this.url).concat("&").concat(splitResponseUrl[splitResponseUrl.length-1]);
+      // If response.meta.pagination.links.next, this is from Rogue.
+      if (response.meta.pagination.links.next) {
+        var splitResponseUrl = response.meta.pagination.links.next.split("&");
+        var urlParts = this.url.split("&");
+        var pageParts = urlParts[urlParts.length-1].split("=");
+        // We already have the page param here, don't append 'page' again to be page=2&page=3.
+        if (pageParts[0] === "page") {
+          if (splitResponseUrl) {
+            var urlWithoutPageNumber = (this.url).slice(0, -1);
+            _this.apiUrl = urlWithoutPageNumber.concat(pageParts[1]);
           }
+        } else {
+          // The page param isn't added yet so do it here.
+          _this.apiUrl = (this.url).concat("&").concat(splitResponseUrl[splitResponseUrl.length-1]);
+        }
+      // If response.meta.pagination.links.next_uri, this is from Phoenix.
       } else if (response.meta.pagination.links.next_uri) {
         _this.apiUrl = response.meta.pagination.links.next_uri;
       } else {
+        // There are no more reportbacks - don't show the view more button.
         _this.apiUrl = null;
       }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -183,25 +183,7 @@ const Reportback = {
    * @param  {array} data  Array of Kudos objects from API.
    * @return {array}
    */
-  getReactions: function(data, reactionFromRogue) {
-    if (reactionFromRogue) {
-      var reactions = [];
-
-      var reaction = {
-        kudosId: null,
-        term: null,
-        termId: null,
-        total: 0,
-        userReacted: false,
-      };
-
-      reaction.term = 'heart';
-      reaction.termId = 641,
-      reaction.total = data.total;
-      reaction.userReacted = data.liked_by_current_user;
-
-      reactions.push(reaction);
-    } else {
+    getReactions: function(data) {
       let reactions = [];
 
       forEach(this.reactions.approved, (term) => {
@@ -225,11 +207,16 @@ const Reportback = {
               reaction.userReacted = record.current_user.reacted;
             }
           });
+        } else {
+          reaction.kudosId = 0;
+          reaction.term = data.term.name;
+          reaction.termId = data.term.id;
+          reaction.total = data.term.total;
+          reaction.userReacted = data.current_user.reacted;
         }
 
         reactions.push(reaction);
       });
-    }
 
     return reactions;
   },
@@ -292,7 +279,13 @@ const Reportback = {
         }
       },
     }).done(function(response) {
-      _this.apiUrl = setting('dsKudosReactions.likedByCurrentUser') ? response.meta.pagination.links.next : response.meta.pagination.links.next_uri || null;
+      if (setting('dsKudosReactions.likedByCurrentUser')) {
+        _this.apiUrl = response.meta.pagination.links.next;
+      } else if (response.meta.pagination.links.next_uri) {
+        _this.apiUrl = response.meta.pagination.links.next_uri;
+      } else {
+        _this.apiUrl = null;
+      }
 
       _this.templatize(response);
 
@@ -327,7 +320,7 @@ const Reportback = {
         'isListItem': true,  // @TODO: probably a better way to address this... :insert shruggy emoji here:
         'reactions': {
           enabled: setting('dsKudosReactions.enabled'),
-          data: setting('dsKudosReactions.likedByCurrentUser') ? this.getReactions(items[i].kudos, true) : this.getReactions(items[i].kudos.data, false),
+          data: this.getReactions(items[i].kudos.data),
         }
       };
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -16,7 +16,11 @@
   <?php if (isset($content->kudos) && isset($content->kudos['fid'])): ?>
     <ul class="form-actions -inline kudos">
       <li>
-        <button class="js-kudos-button kudos__icon <?php print dosomething_kudos_term_is_selected($content->kudos, 'heart') ? 'is-active' : '' ?>" data-kudos-term-id="<?php print $content->kudos['allowed_reactions'][0]; ?>" data-kid="<?php print data_get($content->kudos['existing_kids'], [$content->kudos['allowed_reactions'][0], 'kid']) ?>"></button>
+        <?php if ($content->kudos['from_rogue']): ?>
+          <button class="js-kudos-button kudos__icon is-active" data-kudos-term-id="<?php print $content->kudos['allowed_reactions'][0]; ?>" data-kid="<?php print data_get($content->kudos['existing_kids'], [$content->kudos['allowed_reactions'][0], 'kid']) ?>"></button>
+        <?php else: ?>
+          <button class="js-kudos-button kudos__icon <?php print dosomething_kudos_term_is_selected($content->kudos, 'heart') ? 'is-active' : '' ?>" data-kudos-term-id="<?php print $content->kudos['allowed_reactions'][0]; ?>" data-kid="<?php print data_get($content->kudos['existing_kids'], [$content->kudos['allowed_reactions'][0], 'kid']) ?>"></button>
+        <?php endif; ?>
         <span class="counter"><?php print $content->kudos['reaction_totals']['heart']; ?></span>
       </li>
     </ul>


### PR DESCRIPTION
#### What's this PR do?
Pulls reaction data from Rogue into the gallery for the logged in user. 
- If the logged in user has reacted to any reportback items, the reaction buttons will be active for these reportback items in the gallery. 

#### How should this be reviewed?
Server Side Gallery Reaction Loading 
1. `preprocess_node.inc` lines `243-249`
2. `paraneue_dosomething_get_themed_reportback_item` gets called in ``preprocess_node.inc` on line `293`
3. `helpers.inc` lines `364-385`
4. `dosomething_kudos.module` lines `323-337` 
5. `photo.tpl.php` 

Client Side Gallery Reaction Loading 
`reportback_item_resource.inc` and `Reportback.js` files.

#### Any background context you want to provide?
I know this code is pretty hacky so would love to get suggestions on how to do things better!

#### Relevant tickets
Fixes #7358

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
