### PR TITLE
gets rid of Rogue API version and hard codes in url

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.admin.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.admin.inc
@@ -23,13 +23,6 @@ function dosomething_rogue_config_form($form, &$form_state) {
     '#default_value' => variable_get('dosomething_rogue_url', 'https://rogue.dosomething.org/api'),
   ];
 
-  $form['rogue']['dosomething_rogue_api_version'] = [
-    '#type' => 'textfield',
-    '#title' => t('Rogue API version number'),
-    '#required' => TRUE,
-    '#default_value' => variable_get('dosomething_rogue_api_version', 'v1'),
-  ];
-
   $form['rogue']['dosomething_rogue_api_key'] = [
     '#type' => 'textfield',
     '#title' => t('Rogue API Key'),

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -38,8 +38,8 @@ function dosomething_rogue_menu() {
  *
  * https://github.com/DoSomething/rogue
  */
-function dosomething_rogue_client($version = ROGUE_API_VERSION) {
-  return new Rogue(ROGUE_API_URL . '/' . $version . '/',
+function dosomething_rogue_client() {
+  return new Rogue(ROGUE_API_URL . '/',
     ['headers' => ['X-DS-Rogue-API-Key' => ROGUE_API_KEY]]
   );
 }
@@ -52,7 +52,7 @@ function dosomething_rogue_client($version = ROGUE_API_VERSION) {
   */
 function dosomething_rogue_get_reportback_items($inputs)
 {
-  $client = dosomething_rogue_client('v1');
+  $client = dosomething_rogue_client();
 
   $response = $client->getAllReportbacks($inputs);
 

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -22,7 +22,7 @@ class Rogue extends RestApiClient {
    */
   public function getAllReportbacks($inputs = [])
   {
-    $response = $this->get('reportbacks', $inputs);
+    $response = $this->get('v1/reportbacks', $inputs);
 
     return $response;
   }
@@ -36,7 +36,7 @@ class Rogue extends RestApiClient {
    */
   public function postReportback($data)
   {
-    $response = $this->post('posts', $data);
+    $response = $this->post('v2/posts', $data);
 
     return $response;
   }
@@ -50,7 +50,7 @@ class Rogue extends RestApiClient {
    */
   public function updateReportback($data)
   {
-    $response = $this->put('reviews', $data);
+    $response = $this->put('v2/reviews', $data);
 
     return $response;
   }
@@ -63,7 +63,7 @@ class Rogue extends RestApiClient {
    */
   public function postSignup($data)
   {
-    $response = $this->post('signups', $data);
+    $response = $this->post('v2/signups', $data);
 
     return $response;
   }


### PR DESCRIPTION
#### What's this PR do?
- Gets rid of `Rogue API version number` field. 
- Hardcodes version in URL. 

#### How should this be reviewed?
👀 

#### Relevant tickets
Fixes #7345 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
