### PR TITLE
Add endpoint to trigger transactional message.

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -69,6 +69,12 @@ Endpoint                                       | Functionality
 `GET /api/v1/taxonomy_term/:id`                | [Retrieve a term](endpoints/terms.md#retrieve-a-term)
 
 
+#### Transactionals
+Endpoint                                       | Functionality                                           
+---------------------------------------------- | --------------------------------------------------------
+`POST /api/v1/transactionals`                  | [Create a Transactional](endpoints/transactionals.md#create-a-transactional)
+
+
 #### Users
 Endpoint                                       | Functionality                                           
 ---------------------------------------------- | --------------------------------------------------------

--- a/documentation/endpoints/transactionals.md
+++ b/documentation/endpoints/transactionals.md
@@ -1,0 +1,40 @@
+# Transactionals
+
+## Create a user
+
+Send a transactional message and add user to the appropriate MailChimp and Mobile Commons lists.
+
+This endpoint requires administrative privileges.
+
+```
+POST https://www.dosomething.org/api/v1/transactionals
+```
+
+**Body Parameters:**
+
+```js
+// Content-Type: application/json
+
+{
+  id: String // required, Northstar ID.
+  template: String // required, "register"
+}
+```
+
+**Example request:**
+
+```sh
+curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  -d '{"id": "58333fbc9a892003da782d0d", "template":"register"}' \
+  http://dev.dosomething.org:8888/api/v1/transactionals
+```
+
+**Example response:**
+
+```js
+// 200 Okay
+
+{
+    "success": true
+}
+```

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.module
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.module
@@ -22,6 +22,7 @@ include_once 'resources/reportback_item_resource.inc';
 include_once 'resources/reportback_file_resource.inc';
 include_once 'resources/signup_resource.inc';
 include_once 'resources/term_resource.inc';
+include_once 'resources/transactional_resource.inc';
 
 
 /**
@@ -40,6 +41,7 @@ function dosomething_api_services_resources() {
   $resources += _reportback_file_resource_definition();
   $resources += _signup_resource_definition();
   $resources += _term_resource_definition();
+  $resources += _transactional_resource_definition();
 
   return $resources;
 }

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -195,6 +195,13 @@ function dosomething_api_default_services_endpoint() {
         ),
       ),
     ),
+    'transactionals' => array(
+      'operations' => array(
+        'create' => array(
+          'enabled' => '1',
+        ),
+      ),
+    ),
     'users' => array(
       'operations' => array(
         'create' => array(

--- a/lib/modules/dosomething/dosomething_api/resources/transactional_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/transactional_resource.inc
@@ -1,0 +1,76 @@
+<?php
+
+function _transactional_resource_definition() {
+  return [
+    'transactionals' => [
+      'operations' => [
+        'create' => [
+          'help' => 'Create a transactional message.',
+          'file' => [
+            'type' => 'inc',
+            'module' => 'dosomething_api',
+            'name' => 'resources/transactional_resource',
+          ],
+          'callback' => '_transactional_resource_create',
+          'args' => [
+            [
+              'name' => 'id',
+              'type' => 'string',
+              'description' => 'The user\'s Northstar ID.',
+              'source' => 'data',
+              'optional' => FALSE,
+            ],
+            [
+              'name' => 'template',
+              'type' => 'string',
+              'description' => 'The type of transactional to send.',
+              'source' => 'data',
+              'optional' => FALSE,
+            ],
+          ],
+          'access callback' => '_transactional_resource_access',
+          'access arguments' => ['create'],
+        ],
+      ],
+    ]
+  ];
+}
+
+/**
+ * Access callback for User resources.
+ */
+function _transactional_resource_access() {
+  global $user;
+
+  return in_array('administrator', $user->roles);
+}
+
+/**
+ * Callback for triggering a transactional.
+ *
+ * @param array $request
+ *   Array passed to the endpoint. Possible keys:
+ *   - $id (string). The user's Northstar ID
+ *   - $template (string). The type of transactional to send.
+ *
+ * @return mixed
+ */
+function _transactional_resource_create($request) {
+  global $user;
+
+  $account = user_load(dosomething_user_convert_to_legacy_id($request['id']));
+
+  if (! $account) {
+    return services_error('Could not load Drupal account for the given ID.');
+  }
+
+  $templates = ['register'];
+  if (! in_array($request['template'], $templates)) {
+    return services_error('Template must be one of: ' . implode(',', $templates) . '.');
+  }
+
+  $user = $account;
+  _dosomething_user_send_to_message_broker();
+
+  return ['success' => true];
+}

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -647,7 +647,7 @@ function _dosomething_user_send_to_message_broker() {
     if ($template_name) {
       $params['email_template'] = $template_name;
     }
-   }
+  }
 
   dosomething_mbp_request('user_register', $params);
 }


### PR DESCRIPTION
#### What's this PR do?
This pull request adds a `/api/v1/transactionals` endpoint to send a "welcome" email to a newly registered user and sign them up for the appropriate MailChimp and MobileCommons lists.

#### How should this be reviewed?
I tested that the right parameters get filled briefly on my local, but planning on doing more extensive testing on this on Thor since Message Broker is configured there.

#### Any background context you want to provide?
This was added as a new endpoint (rather than part of `/api/v1/users`) because it simplifies [implementation in Northstar](https://github.com/DoSomething/northstar/pull/565) (no need to pass a parameter down through the Registrar to the Phoenix API client), and should also be easier to tear out when we want this to live in Blink/Customer.io instead.

:v:

#### Relevant tickets
[Trello Card](https://trello.com/c/rPFyZcsu/571-5-as-a-developer-i-want-northstar-to-tell-phoenix-ashes-to-send-transactional-messaging-to-new-users)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  