### PR TITLE
Don't trigger transactionals in post-auth.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -114,11 +114,10 @@ function dosomething_northstar_openid_connect_post_authorize($tokens, $account, 
     dosomething_northstar_save_id_field($account->uid, ['data' => $userinfo]);
   }
 
-  // HACK: Was this account registered just now (last 15s)? If so, send transactional
-  // and fire a Registration analytics event. Otherwise, fire Login event.
+  // HACK: Was this account registered just now (last 15s)? If so, fire
+  // a Registration analytics event. Otherwise, fire Login event.
   if ($userinfo['created_at'] > time() - 15) {
     dosomething_helpers_add_analytics_event('Authentication', 'Register');
-    _dosomething_user_send_to_message_broker();
   } else {
     dosomething_helpers_add_analytics_event('Authentication', 'Login');
   }


### PR DESCRIPTION
#### What's this PR do?
This pull request removes the transactional trigger from the post-authorization actions, since Northstar is now responsible for telling Phoenix to send these via the `/api/v1/transactionals` endpoint.

References #7362 and DoSomething/northstar#565.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Otherwise users who register via Phoenix Ashes will get double-welcomed! Too much! 🙅‍♂️ 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  