### PR TITLE
Send reactions to rogue

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -189,13 +189,15 @@ function _kudos_resource_index($reportbackitems, $count) {
  */
 function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
   if (variable_get('rogue_collection', FALSE)) {
+    global $user;
+    $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
+
     $data = [
-      'northstar_id' => $northstar_id,
+      'northstar_id' => $northstar_user->id,
       'post_id' => $reportback_item_id,
     ];
 
-    $client = dosomething_rogue_client();
-    $response = $client->postReaction($data);
+    $response = dosomething_rogue_client()->postReaction($data);
 
     return [
       [
@@ -213,7 +215,6 @@ function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
   return (new KudosTransformer)->create($parameters);
 }
 
-
 /**
  * Delete the specified kudos record.
  *
@@ -222,23 +223,21 @@ function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
  * @return string
  */
 function _kudos_resource_delete($kudos_id) {
-  // if (variable_get('rogue_collection', FALSE)) {
-  //   // @TODO: we need to get the below values
-  //   $data = [
-  //     'northstar_id' => $northstar_id,
-  //     'post_id' => $reportback_item_id,
-  //   ];
+  if (variable_get('rogue_collection', FALSE)) {
+    global $user;
+    $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
 
-  //   $response = dosomething_rogue_client()->postReaction($data);
+    $data = [
+      'northstar_id' => $northstar_user->id,
+      'post_id' => $kudos_id,
+    ];
 
-  //   if ($response['meta']['action'] === 'unliked') {
-  //     return [
-  //       [
-  //         'kid' => 0,
-  //       ]
-  //     ];
-  //   }
-  // }
+    $response = dosomething_rogue_client()->postReaction($data);
+
+    if ($response['meta']['action'] === 'unliked') {
+      return;
+    }
+  }
 
   return (new KudosTransformer)->delete($kudos_id);
 }

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -180,7 +180,6 @@ function _kudos_resource_index($reportbackitems, $count) {
   return (new KudosTransformer)->index($parameters);
 }
 
-
 /**
  * Create a new kudos record.
  *
@@ -194,6 +193,22 @@ function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
     'tids' => $term_ids,
     'northstar_id' => $northstar_id,
   ];
+
+  if (variable_get('rogue_collection', FALSE)) {
+    $data = [
+      'northstar_id' => $northstar_id,
+      'post_id' => $reportback_item_id,
+    ];
+    $response = dosomething_rogue_client()->postReaction($data);
+    print_r($response);
+    die();
+
+    return [
+      [
+        'kid' => $response['post_id'],
+      ]
+    ];
+  }
 
   return (new KudosTransformer)->create($parameters);
 }

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -211,9 +211,6 @@ function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
     }
     else {
       return;
-      // return [
-      //     'kid' => 'unliked',
-      // ];
     }
   }
 

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -189,8 +189,12 @@ function _kudos_resource_index($reportbackitems, $count) {
  */
 function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
   if (variable_get('rogue_collection', FALSE)) {
-    global $user;
-    $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
+    if (isset($northstar_id)) {
+      $northstar_user->id = $northstar_id;
+    } else {
+      global $user;
+      $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
+    }
 
     $data = [
       'northstar_id' => $northstar_user->id,

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -188,27 +188,27 @@ function _kudos_resource_index($reportbackitems, $count) {
  * @param $term_ids
  */
 function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
-  $parameters = [
-    'fid' => $reportback_item_id,
-    'tids' => $term_ids,
-    'northstar_id' => $northstar_id,
-  ];
-
   if (variable_get('rogue_collection', FALSE)) {
     $data = [
       'northstar_id' => $northstar_id,
       'post_id' => $reportback_item_id,
     ];
-    $response = dosomething_rogue_client()->postReaction($data);
-    print_r($response);
-    die();
+
+    $client = dosomething_rogue_client();
+    $response = $client->postReaction($data);
 
     return [
       [
-        'kid' => $response['post_id'],
+        'kid' => $response['data']['post_id'],
       ]
     ];
   }
+
+  $parameters = [
+    'fid' => $reportback_item_id,
+    'tids' => $term_ids,
+    'northstar_id' => $northstar_id,
+  ];
 
   return (new KudosTransformer)->create($parameters);
 }
@@ -222,5 +222,23 @@ function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
  * @return string
  */
 function _kudos_resource_delete($kudos_id) {
+  // if (variable_get('rogue_collection', FALSE)) {
+  //   // @TODO: we need to get the below values
+  //   $data = [
+  //     'northstar_id' => $northstar_id,
+  //     'post_id' => $reportback_item_id,
+  //   ];
+
+  //   $response = dosomething_rogue_client()->postReaction($data);
+
+  //   if ($response['meta']['action'] === 'unliked') {
+  //     return [
+  //       [
+  //         'kid' => 0,
+  //       ]
+  //     ];
+  //   }
+  // }
+
   return (new KudosTransformer)->delete($kudos_id);
 }

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -189,15 +189,13 @@ function _kudos_resource_index($reportbackitems, $count) {
  */
 function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
   if (variable_get('rogue_collection', FALSE)) {
-    if (isset($northstar_id)) {
-      $northstar_user->id = $northstar_id;
-    } else {
+    if (!isset($northstar_id)) {
       global $user;
       $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
     }
 
     $data = [
-      'northstar_id' => $northstar_user->id,
+      'northstar_id' => $northstar_id ? $northstar_id : $northstar_user->id,
       'post_id' => $reportback_item_id,
     ];
 

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -209,7 +209,9 @@ function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
       ];
     }
     else {
-      return;
+      return [
+          'kid' => 'unliked',
+      ];
     }
   }
 

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -199,11 +199,16 @@ function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
 
     $response = dosomething_rogue_client()->postReaction($data);
 
-    return [
-      [
-        'kid' => $response['data']['post_id'],
-      ]
-    ];
+    if ($response['meta']['action'] === 'liked') {
+      return [
+        [
+          'kid' => $response['data']['post_id'],
+        ]
+      ];
+    }
+    else {
+      return;
+    }
   }
 
   $parameters = [

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -188,9 +188,10 @@ function _kudos_resource_index($reportbackitems, $count) {
  * @param $term_ids
  */
 function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
+  global $user;
+
   if (variable_get('rogue_collection', FALSE)) {
     if (!isset($northstar_id)) {
-      global $user;
       $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
     }
 
@@ -209,9 +210,10 @@ function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
       ];
     }
     else {
-      return [
-          'kid' => 'unliked',
-      ];
+      return;
+      // return [
+      //     'kid' => 'unliked',
+      // ];
     }
   }
 
@@ -232,8 +234,9 @@ function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
  * @return string
  */
 function _kudos_resource_delete($kudos_id) {
+  global $user;
+
   if (variable_get('rogue_collection', FALSE)) {
-    global $user;
     $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
 
     $data = [

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -297,7 +297,7 @@ function dosomething_kudos_term_is_selected($kudos, $term) {
     return false;
   }
 
-  if ($kudos['from_rogue']) {
+  if ($kudos['liked_in_rogue']) {
     return true;
   }
 
@@ -334,7 +334,7 @@ function dosomething_kudos_get_kudos_data_for_fid($fid = NULL, $total_rogue_kudo
   $kudos['allowed_reactions'] = [dosomething_kudos_get_term_id_by_name('heart')];
 
   // Use this in photo.tpl.php for the logged in user's reaction. If the user has reacted to the post, make the reaction button active.
-  $kudos['from_rogue'] = $liked_by_current_user;
+  $kudos['liked_in_rogue'] = $liked_by_current_user;
 
   return $kudos;
 }

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -326,7 +326,6 @@ function dosomething_kudos_get_kudos_data_for_fid($fid = NULL, $total_rogue_kudo
   }
   $kudos = [];
   $kudos['fid'] = $fid;
-  // @TODO: update the below to grab from the Rogue response when we start sending reaction data to Rogue when a user newly reacts to a post.
   $kudos['existing_kids'] = dosomething_kudos_get_kudos_for_user_by_file($fid);
   $kudos['reaction_totals'] = [
     'heart' =>

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -28,6 +28,20 @@ class Rogue extends RestApiClient {
   }
 
   /**
+   * Send a POST request of a reaction to be saved/deleted in Rogue.
+   *
+   * @param string $baseurl
+   * @param array $data
+   * @return object|false
+   */
+  public function postReaction($data)
+  {
+    $response = $this->post('v2/reactions', $data);
+
+    return $response;
+  }
+
+  /**
    * Send a POST request of the reportback to be saved in Rogue.
    *
    * @param string $baseurl

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -30,7 +30,6 @@ class Rogue extends RestApiClient {
   /**
    * Send a POST request of a reaction to be saved/deleted in Rogue.
    *
-   * @param string $baseurl
    * @param array $data
    * @return object|false
    */

--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -363,9 +363,6 @@ function paraneue_dosomething_get_themed_reportback_item($data, $rogue_rb_item =
 
   if ($data->id && !dosomething_kudos_disable_reactions($data->campaign->id)) {
       if ($rogue_rb_item) {
-        // Find the fid from the rogue reference table
-        // $data->id = db_query("SELECT rogue_rbs.fid FROM {dosomething_rogue_reportbacks} rogue_rbs WHERE rogue_event_id = :rogue_event_id", array(':rogue_event_id' => $data->event_id))->fetchField();
-
         $total_rogue_kudos = $data->kudos['total'];
         $liked_by_current_user = $data->kudos['data']['current_user']['reacted'] ? true : false;
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -288,19 +288,8 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars, $count = 6) 
   foreach ($reportbackItems as $item) {
     if (variable_get('rogue_collection', FALSE)) {
       $item = (object) $item;
-      // @TODO: This is the fid. We need to update according to the reference table?
       $gallery['item_ids'][] = $item->id;
       $gallery['items'][] = paraneue_dosomething_get_themed_reportback_item($item, TRUE);
-      // drupal_add_js(
-      //   [
-      //     'dsKudosReactions' => [
-      //       'sendToRogue' => true,
-      //       'northstarId' => $item->user,
-      //       'postId' => $item->event_id,
-      //     ]
-      //   ],
-      //   'setting'
-      // );
     }
     else {
       if ($item instanceof ReportbackItem) {

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -54,9 +54,7 @@ $(document).on('click', '.js-kudos-button', function(event) {
   const $el = $(this);
 
   $el.attr('disabled','disabled');
-
   const dataKid = $el.attr('data-kid');
-
   const method = dataKid ? 'DELETE' : 'POST';
 
   makeKudosRequest($el, dataKid)

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -34,7 +34,7 @@ function makeKudosRequest($el, id)
 function updateKudosInterface($el)
 {
   const hasKudos = $el.attr('data-kid') !== '';
-
+  console.log(hasKudos);
   let $counter = $el.next('.counter');
   let currentCount = parseInt($counter.text());
   let diff = hasKudos ? 1 : -1;
@@ -60,17 +60,12 @@ $(document).on('click', '.js-kudos-button', function(event) {
 
   makeKudosRequest($el, dataKid)
     .done((response) => {
-      console.log(response);
       const kid = get(response, '0.kid', '');
-      console.log(kid);
-      console.log(1);
-      if (method === 'POST' && !kid) {
-        console.log(2);
-        return;
-      }
-      console.log(3);
+      // if (method === 'POST' && !kid) {
+      //   return;
+      // }
       $el.attr('data-kid', kid);
-
+      console.log($el.attr('data-kid'));
       updateKudosInterface($el);
     })
     .always(() => {

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -34,7 +34,6 @@ function makeKudosRequest($el, id)
 function updateKudosInterface($el)
 {
   const hasKudos = $el.attr('data-kid') !== '';
-  console.log(hasKudos);
   let $counter = $el.next('.counter');
   let currentCount = parseInt($counter.text());
   let diff = hasKudos ? 1 : -1;
@@ -65,7 +64,6 @@ $(document).on('click', '.js-kudos-button', function(event) {
       //   return;
       // }
       $el.attr('data-kid', kid);
-      console.log($el.attr('data-kid'));
       updateKudosInterface($el);
     })
     .always(() => {

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -58,11 +58,10 @@ $(document).on('click', '.js-kudos-button', function(event) {
   const dataKid = $el.attr('data-kid');
   const method = dataKid ? 'DELETE' : 'POST';
 
-  // if (setting('dsKudosReactions.sendToRogue')) {
-  //   makeKudosRequestToRogue(setting('dsKudosReactions.northstarId'), setting('dsKudosReactions.postId'))
-  // } else {
   makeKudosRequest($el, dataKid)
     .done((response) => {
+      console.log(8);
+      console.log(response);
       const kid = get(response, '0.kid', '');
 
       if (method === 'POST' && !kid) {
@@ -76,5 +75,4 @@ $(document).on('click', '.js-kudos-button', function(event) {
     .always(() => {
       $el.removeAttr('disabled');
     });
-  // }
 });

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -60,9 +60,11 @@ $(document).on('click', '.js-kudos-button', function(event) {
   makeKudosRequest($el, dataKid)
     .done((response) => {
       const kid = get(response, '0.kid', '');
-      // if (method === 'POST' && !kid) {
-      //   return;
-      // }
+
+      if (method === 'POST' && (!kid || kid === 'unliked')) {
+        return;
+      }
+
       $el.attr('data-kid', kid);
       updateKudosInterface($el);
     })

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -60,14 +60,15 @@ $(document).on('click', '.js-kudos-button', function(event) {
 
   makeKudosRequest($el, dataKid)
     .done((response) => {
-      console.log(8);
       console.log(response);
       const kid = get(response, '0.kid', '');
-
+      console.log(kid);
+      console.log(1);
       if (method === 'POST' && !kid) {
+        console.log(2);
         return;
       }
-
+      console.log(3);
       $el.attr('data-kid', kid);
 
       updateKudosInterface($el);

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -61,7 +61,7 @@ $(document).on('click', '.js-kudos-button', function(event) {
     .done((response) => {
       const kid = get(response, '0.kid', '');
 
-      if (method === 'POST' && (!kid || kid === 'unliked')) {
+      if (method === 'POST' && !kid) {
         return;
       }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/prototype.js
@@ -54,7 +54,9 @@ $(document).on('click', '.js-kudos-button', function(event) {
   const $el = $(this);
 
   $el.attr('disabled','disabled');
+
   const dataKid = $el.attr('data-kid');
+
   const method = dataKid ? 'DELETE' : 'POST';
 
   makeKudosRequest($el, dataKid)

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/untitled
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/untitled
@@ -1,7 +1,0 @@
-/*
-Theme Name: Azalea Child
-Theme URI: https://justgoodthemes.com/themes/azalea/
-Description: Azalea Child Theme
-Author: Chloe Lee
-Template: azalea
-*/

--- a/lib/themes/dosomething/paraneue_dosomething/js/campaign/untitled
+++ b/lib/themes/dosomething/paraneue_dosomething/js/campaign/untitled
@@ -1,0 +1,7 @@
+/*
+Theme Name: Azalea Child
+Theme URI: https://justgoodthemes.com/themes/azalea/
+Description: Azalea Child Theme
+Author: Chloe Lee
+Template: azalea
+*/

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -180,9 +180,10 @@ const Reportback = {
    * Get Kudos Reactions for a Reportback item.
    *
    * @param  {array} data  Array of Kudos objects from API.
+   * @param  {int} kudosId if from Rogue.
    * @return {array}
    */
-  getReactions: function(data) {
+  getReactions: function(data, kudosId = null) {
     let reactions = [];
 
     forEach(this.reactions.approved, (term) => {
@@ -207,7 +208,12 @@ const Reportback = {
           }
         });
       } else {
-        reaction.kudosId = null;
+        if (data.current_user.reacted && kudosId) {
+          reaction.kudosId = kudosId;
+        } else {
+          reaction.kudosId = null;
+        }
+
         reaction.term = data.term.name;
         reaction.termId = data.term.id;
         reaction.total = data.term.total;
@@ -339,7 +345,7 @@ const Reportback = {
         'isListItem': true,  // @TODO: probably a better way to address this... :insert shruggy emoji here:
         'reactions': {
           enabled: setting('dsKudosReactions.enabled'),
-          data: this.getReactions(items[i].kudos.data),
+          data: this.getReactions(items[i].kudos.data, items[i].id),
         }
       };
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -16,8 +16,8 @@
   <?php if (isset($content->kudos) && isset($content->kudos['fid'])): ?>
     <ul class="form-actions -inline kudos">
       <li>
-        <?php if ($content->kudos['from_rogue']): ?>
-          <button class="js-kudos-button kudos__icon is-active" data-kudos-term-id="<?php print $content->kudos['allowed_reactions'][0]; ?>" data-kid="<?php print data_get($content->kudos['existing_kids'], [$content->kudos['allowed_reactions'][0], 'kid']) ?>"></button>
+        <?php if (variable_get('rogue_collection', FALSE)): ?>
+          <button class="js-kudos-button kudos__icon <?php print $content->kudos['liked_in_rogue'] ? 'is-active' : '' ?>" data-kudos-term-id="1" data-kid="<?php print $content->kudos['liked_in_rogue'] ? $content->id : null ?>"></button>
         <?php else: ?>
           <button class="js-kudos-button kudos__icon <?php print dosomething_kudos_term_is_selected($content->kudos, 'heart') ? 'is-active' : '' ?>" data-kudos-term-id="<?php print $content->kudos['allowed_reactions'][0]; ?>" data-kid="<?php print data_get($content->kudos['existing_kids'], [$content->kudos['allowed_reactions'][0], 'kid']) ?>"></button>
         <?php endif; ?>


### PR DESCRIPTION
#### What's this PR do?
When a user reacts to a post, Phoenix sends the request to Rogue's `/reactions` endpoint to log in the database. 

#### How should this be reviewed?
- When logged in, react to a post you haven't reacted to before. 
  - This reaction should be added in the Rogue `reactions` table. 
  - The reaction button should be active and the counter should be incremented.
- "Un-react" to the same post. 
  - The reaction should be soft deleted in the Rogue `reactions` table. 
  The reaction button should not be active and the counter should decrease by one. 

#### Any background context you want to provide?
Final step for Rogue to power the Phoenix-ashes gallery! 

#### Relevant tickets
Fixes #7365

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
