### PR TITLE
Keeper upper script

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -194,7 +194,7 @@ function dosomething_rogue_store_rogue_references($rbid, $fid, $rogue_reportback
     db_insert('dosomething_rogue_reportbacks')
     ->fields([
       'fid' => $fid,
-      'rogue_event_id' => $rogue_reportback['data']['event']['data']['event_id'],
+      'rogue_post_id' => $rogue_reportback['data']['id'],
       'rbid' => $rbid,
       'rogue_signup_id' => $rogue_reportback['data']['signup_id'],
       'created_at' => REQUEST_TIME,
@@ -617,8 +617,8 @@ function dosomething_rogue_handle_migration_failure($values, $sid, $rbid = NULL,
         'timestamp' => REQUEST_TIME,
       ])
       ->execute();
-  } elseif (array_key_exists('photo', $values)) {
-    foreach ($values['photo'] as $photo) {
+      // keeper upper script when sending just a post
+  } elseif (array_key_exists('file', $values)) {
       db_insert('dosomething_rogue_failed_migrations')
       ->fields([
         // Signup
@@ -626,24 +626,18 @@ function dosomething_rogue_handle_migration_failure($values, $sid, $rbid = NULL,
         'northstar_id' => $values['northstar_id'],
         'campaign_id' => $values['campaign_id'],
         'campaign_run_id' => $values['campaign_run_id'],
-        'signup_created_at' => $values['created_at'],
-        'signup_updated_at' => $values['updated_at'],
-        'signup_source' => $values['source'],
 
         // Reportback
-        'quantity' => $values['quantity'],
-        'quantity_pending' => $values['quantity_pending'],
-        'why_participated' => $values['why_participated'],
         'rbid' => $rbid,
 
         // Files
-        'fid' => array_shift($fids),
-        'photo_source' => $photo['source'],
-        'remote_addr' => $photo['remote_addr'],
-        'caption' => $photo['caption'],
-        'status' => $photo['status'],
-        'file' => $photo['file'],
-        'photo_created_at' => $photo['created_at'],
+        'fid' => $fids,
+        'photo_source' => $values['source'],
+        'remote_addr' => $values['remote_addr'],
+        'caption' => $values['caption'],
+        'status' => $values['status'],
+        'file' => $values['file'],
+        'photo_created_at' => $values['created_at'],
 
         // Fail data
         'timestamp' => REQUEST_TIME,
@@ -651,6 +645,40 @@ function dosomething_rogue_handle_migration_failure($values, $sid, $rbid = NULL,
         'response_values' => (isset($e)) ? $e->getMessage() : NULL,
       ])
       ->execute();
+    } elseif (array_key_exists('photo', $values)) {
+      foreach ($values['photo'] as $photo) {
+        db_insert('dosomething_rogue_failed_migrations')
+        ->fields([
+          // Signup
+          'sid' => $sid,
+          'northstar_id' => $values['northstar_id'],
+          'campaign_id' => $values['campaign_id'],
+          'campaign_run_id' => $values['campaign_run_id'],
+          'signup_created_at' => $values['created_at'],
+          'signup_updated_at' => $values['updated_at'],
+          'signup_source' => $values['source'],
+
+          // Reportback
+          'quantity' => $values['quantity'],
+          'quantity_pending' => $values['quantity_pending'],
+          'why_participated' => $values['why_participated'],
+          'rbid' => $rbid,
+
+          // Files
+          'fid' => array_shift($fids),
+          'photo_source' => $photo['source'],
+          'remote_addr' => $photo['remote_addr'],
+          'caption' => $photo['caption'],
+          'status' => $photo['status'],
+          'file' => $photo['file'],
+          'photo_created_at' => $photo['created_at'],
+
+          // Fail data
+          'timestamp' => REQUEST_TIME,
+          'response_code' => (isset($response->code)) ? $response->code : NULL, // @TODO: this is currently null until there a better way to get it from Gateway
+          'response_values' => (isset($e)) ? $e->getMessage() : NULL,
+        ])
+        ->execute();
       }
     } else {
      db_insert('dosomething_rogue_failed_migrations')

--- a/scripts/rogue-keeper-upper.php
+++ b/scripts/rogue-keeper-upper.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * Keeper-Upper Script to export Signups, Reportbacks, and whatever else from drupal into Rogue.
+ * This is to be run on a recurring basis after the big migration has completed. 
+ *
+ * to run:
+ * drush --script-path=../scripts/ php-script rogue-keeper-upper.php
+ */
+
+// Pick up from where we left off, if we want to
+$last_saved = variable_get('dosomething_rogue_last_signup_kept_up', NULL);
+
+// Get ALL the unmigrated signups first
+if ($last_saved) {
+  $signups = db_query("SELECT signups.sid, signups.uid, signups.nid, signups.run_nid, signups.source, signups.timestamp, rb.quantity, rb.why_participated, rb.rbid, rb.flagged, rb.updated
+                      FROM dosomething_signup signups
+                      LEFT JOIN dosomething_reportback rb ON signups.uid = rb.uid AND signups.nid = rb.nid AND signups.run_nid = rb.run_nid
+                      WHERE signups.sid > $last_saved AND signups.sid NOT IN (SELECT sid FROM dosomething_rogue_signups)
+                      ORDER BY signups.sid");
+}
+else {
+  $signups = db_query('SELECT signups.sid, signups.uid, signups.nid, signups.run_nid, signups.source, signups.timestamp, rb.quantity, rb.why_participated, rb.rbid, rb.flagged, rb.updated
+                      FROM dosomething_signup signups
+                      LEFT JOIN dosomething_reportback rb ON signups.uid = rb.uid AND signups.nid = rb.nid AND signups.run_nid = rb.run_nid
+                      WHERE signups.sid NOT IN (SELECT sid FROM dosomething_rogue_signups)
+                      ORDER BY signups.sid');
+}
+
+$client = dosomething_rogue_client();
+
+foreach ($signups as $signup) {
+  $data = [];
+
+  echo 'Trying sid ' . $signup->sid . '...' . PHP_EOL;
+
+  $northstar_user = dosomething_northstar_get_user($signup->uid, 'drupal_id');
+
+  // Only try to send to Rogue if we have a Northstar ID
+  if (isset($northstar_user)) {
+    // Match Rogue's timestamp format
+    $created_at = date('Y-m-d H:i:s', $signup->timestamp);
+
+    // Format signup data
+    $data = [
+      'northstar_id' => $northstar_user->id,
+      'campaign_id' => $signup->nid,
+      'campaign_run_id' => $signup->run_nid,
+      'do_not_forward' => TRUE,
+      'source' => $signup->source,
+      'created_at' => $created_at,
+      'updated_at' => $created_at, // Set updated same as created, will be overwritten if there was a RB submitted
+    ];
+
+    // Include all the Reportback data and files if they exist
+    if ($signup->rbid) {
+      // Pull the quantity and why
+      $data['quantity'] = $signup->quantity;
+      $data['why_participated'] = $signup->why_participated;
+
+      // Match Rogue's timestamp format
+      $updated_at = date('Y-m-d H:i:s', $signup->updated);
+      $data['updated_at'] = $updated_at;
+    }
+
+    // Send the request to Rogue
+    try {
+      $response = $client->postSignup($data);
+
+      // Make sure we get a successful response
+      if ($response) {
+        // Store signup reference
+        dosomething_rogue_store_rogue_signup_references($signup->sid, $response);
+
+        echo 'Migrated signup ' . $signup->sid . ' to Rogue.' . PHP_EOL;
+
+        // Set where we left off so we don't keep trying this one forever
+        variable_set('dosomething_rogue_last_signup_kept_up', $signup->sid);
+
+        //
+        variable_set('dosomething_rogue_last_timestamp_sent', isset($signup->updated) ? $signup->updated : $signup->timestamp);
+
+        if (module_exists('stathat')) {
+          stathat_send_ez_count('drupal - Rogue - signup migrated - count', 1);
+        }
+      }
+
+      // Handle getting a 404
+      if (!$response) {
+        // Put request in failed table for future investigation
+        dosomething_rogue_handle_migration_failure($data, $signup->sid, $signup->rbid, $fids);
+
+        // Set where we left off so we don't keep trying this one forever
+        variable_set('dosomething_rogue_last_signup_kept_up', $signup->sid);
+
+      }
+    }
+    catch (GuzzleHttp\Exception\ServerException $e) {
+      // These aren't yet caught by Gateway
+
+      // Put request in failed table for future investigation
+      dosomething_rogue_handle_migration_failure($data, $signup->sid, $signup->rbid, $fids);
+
+      // Set where we left off so we don't keep trying this one forever
+      variable_set('dosomething_rogue_last_signup_kept_up', $signup->sid);
+    }
+    catch (DoSomething\Gateway\Exceptions\ApiException $e) {
+      // Put request in failed table for future investigation
+      dosomething_rogue_handle_migration_failure($data, $signup->sid, $signup->rbid, $fids);
+
+      // Set where we left off so we don't keep trying this one forever
+      variable_set('dosomething_rogue_last_signup_kept_up', $signup->sid);
+    }
+  }
+  else {
+    echo 'No northstar id, that is terrible ' . $signup->sid . PHP_EOL;
+
+    // Put request in failed table for future investigation
+    dosomething_rogue_handle_migration_failure($data, $signup->sid);
+
+    // Set where we left off so we don't keep trying this one forever
+    variable_set('dosomething_rogue_last_signup_kept_up', $signup->sid);
+
+  }
+}
+
+// Get all posts that are not in Rogue, but belong to a signup that IS in Rogue
+// Do not include posts that are already in the failed table
+$posts = db_query('SELECT rbf.fid, rb.rbid, rb.flagged, rbf.source, rbf.remote_addr, rbf.caption, rbf.status, rb.nid, rb.run_nid, signup.sid, rblog.timestamp, rb.uid, rb.nid, rb.run_nid, rb.quantity, rb.why_participated
+                  FROM dosomething_reportback_file rbf
+                  LEFT JOIN dosomething_reportback rb ON rbf.rbid = rb.rbid
+                  JOIN dosomething_signup signup ON signup.uid = rb.uid
+                    AND signup.nid = rb.nid
+                    AND signup.run_nid = rb.run_nid
+                  JOIN dosomething_reportback_log rblog ON rbf.fid = substring_index(rblog.files, \',\',-1)
+                  WHERE rbf.fid NOT IN (SELECT fid FROM dosomething_rogue_reportbacks)
+                    AND rbf.fid NOT IN (SELECT fid FROM dosomething_rogue_failed_migrations WHERE fid IS NOT NULL)
+                    AND signup.sid IN (SELECT sid from dosomething_rogue_signups)
+                  GROUP BY rbf.fid');
+
+// Prepare client to send to Rogue
+$client = dosomething_rogue_client();
+
+// Iterate through all the new posts and send them off
+foreach ($posts as $post) {
+  $data = [];
+
+  echo 'Trying fid ' . $post->fid . ' sid ' . $post->sid . '...' . PHP_EOL;
+
+  // Get the user info
+  $northstar_user = dosomething_northstar_get_user($post->uid, 'drupal_id');
+
+  if (isset($northstar_user)) {
+  // Format the Post data to send to Rogue
+    // Get the status as a Rogue status
+    $rogue_status = dosomething_rogue_transform_status($post->status);
+
+    // Match Rogue's timestamp format
+    $photo_created_at = date('Y-m-d H:i:s', $post->timestamp);
+
+    // Format the photo data
+    $data = [
+      // Post
+      'northstar_id' => $northstar_user->id,
+      'campaign_id' => $post->nid,
+      'campaign_run_id' => $post->run_nid,
+      'caption' => $post->caption,
+      'source' => $post->source,
+      'remote_addr' => $post->remote_addr,
+      'status' => $rogue_status, //can you send this? not in docs
+      'do_not_forward' => TRUE,
+      'file' => dosomething_helpers_get_data_uri_from_fid($post->fid),
+      'created_at' => $photo_created_at,
+
+      // Signup (but /posts will update)
+      // @TODO: will this respect timestamps?
+      'why_participated' => $post->why_participated,
+      'quantity' => $post->quantity,
+      'updated_at' => $photo_created_at,
+    ];
+
+  // Send to Rogue
+    try {
+      $response = $client->postReportback($data);
+
+      // Make sure we get a successful response
+      if ($response) {
+        // Store Post reference
+        dosomething_rogue_store_rogue_references($post->rbid, $post->fid, $response);
+
+        variable_set('dosomething_rogue_last_timestamp_sent', $post->timestamp);
+
+        if (module_exists('stathat')) {
+          stathat_send_ez_count('drupal - Rogue - post migrated - count', 1);
+        }
+
+        echo 'Migrated file ' . $post->fid . ' to Rogue.' . PHP_EOL;
+      }
+
+      // Handle getting a 404
+      if (!$response) {
+        echo '404' . PHP_EOL;
+
+        // Put request in failed table for future investigation
+        dosomething_rogue_handle_migration_failure($data, $post->sid, $post->rbid, $post->fid, $response);
+      }
+    }
+    catch (GuzzleHttp\Exception\ServerException $e) {
+        echo 'server exception' . PHP_EOL;
+
+      // These aren't yet caught by Gateway
+
+      // Put request in failed table for future investigation
+      // @TODO: only put in this table if it's not already there
+      dosomething_rogue_handle_migration_failure($data, $post->sid, $post->rbid, $post->fid, $response, $e);
+    }
+    catch (DoSomething\Gateway\Exceptions\ApiException $e) {
+      echo 'api exception' . PHP_EOL;
+      // Put request in failed table for future investigation
+      dosomething_rogue_handle_migration_failure($data, $post->sid, $post->rbid, $post->fid, $response, $e);
+    }
+  }
+  else {
+    echo 'No northstar id, that is terrible ' . $post->fid . PHP_EOL;
+
+    // Put request in failed table for future investigation
+    dosomething_rogue_handle_migration_failure($data, $post->sid, $post->rbid, $post->fid);
+  }
+}
+
+$last_timestamp = variable_get('dosomething_rogue_last_timestamp_sent', NULL);
+
+$postless_updates = db_query("SELECT rblog.rbid, rblog.quantity, rblog.why_participated, rb.nid, rb.run_nid, rb.uid, rblog.timestamp
+                              FROM dosomething_reportback_log rblog
+                              JOIN dosomething_reportback rb on rb.rbid = rblog.rbid
+                              WHERE rblog.timestamp>$last_timestamp");
+
+foreach ($postless_updates as $update) {
+  echo 'Trying to update rbid ' . $update->rbid . '...' . PHP_EOL;
+
+  // Send to Rogue (make sure timestamps are correct AKA only signup updated_at should change) <- does this actually even matter?
+
+  // Get the user info
+  $northstar_user = dosomething_northstar_get_user($update->uid, 'drupal_id');
+
+  if ($northstar_user) {
+
+    $updated_at = date('Y-m-d H:i:s', $update->timestamp);
+
+    $data = [
+      'northstar_id' => $northstar_user->id,
+      'campaign_id' => $update->nid,
+      'campaign_run_id' => $update->run_nid,
+      'quantity' => $update->quantity,
+      'why_participated' => $update->why_participated,
+      'do_not_forward' => TRUE,
+      'updated_at' => $updated_at,
+    ];
+
+    // send it and all the other stuff
+     try {
+        $response = $client->postReportback($data);
+
+        // Make sure we get a successful response
+        if ($response) {
+          variable_set('dosomething_rogue_last_timestamp_sent', $update->timestamp);
+
+          if (module_exists('stathat')) {
+            stathat_send_ez_count('drupal - Rogue - post migrated - count', 1);
+          }
+        }
+
+        // Handle getting a 404
+        if (!$response) {
+          echo '404' . PHP_EOL;
+
+          // Put request in failed table for future investigation
+          dosomething_rogue_handle_migration_failure($data, $post->sid, $post->rbid, $post->fid, $response);
+        }
+      }
+      catch (GuzzleHttp\Exception\ServerException $e) {
+          echo 'server exception' . PHP_EOL;
+        // These aren't yet caught by Gateway
+
+        // Put request in failed table for future investigation
+        // @TODO: only put in this table if it's not already there
+        dosomething_rogue_handle_migration_failure($data, $post->sid, $post->rbid, $post->fid, $response, $e);
+      }
+      catch (DoSomething\Gateway\Exceptions\ApiException $e) {
+        echo 'api exception' . PHP_EOL;
+        // Put request in failed table for future investigation
+        dosomething_rogue_handle_migration_failure($data, $post->sid, $post->rbid, $post->fid, $response, $e);
+      }
+  }
+  else {
+    echo 'No northstar id, that is terrible ' . $post->fid . PHP_EOL;
+
+    // Put request in failed table for future investigation
+    dosomething_rogue_handle_migration_failure($data, $post->sid, $post->rbid, $post->fid);
+  }
+}
+
+echo 'Nothing else to migrate!' . PHP_EOL;

--- a/scripts/rogue-keeper-upper.php
+++ b/scripts/rogue-keeper-upper.php
@@ -81,9 +81,8 @@ foreach ($signups as $signup) {
           stathat_send_ez_count('drupal - Rogue - signup migrated - count', 1);
         }
       }
-
       // Handle getting a 404
-      if (!$response) {
+      else {
         // Put request in failed table for future investigation
         dosomething_rogue_handle_migration_failure($data, $signup->sid, $signup->rbid, $fids);
 
@@ -165,9 +164,8 @@ foreach ($postless_updates as $update) {
             stathat_send_ez_count('drupal - Rogue - post migrated - count', 1);
           }
         }
-
         // Handle getting a 404
-        if (!$response) {
+        else {
           echo '404' . PHP_EOL;
 
           // Put request in failed table for future investigation
@@ -268,9 +266,8 @@ foreach ($posts as $post) {
 
         echo 'Migrated file ' . $post->fid . ' to Rogue.' . PHP_EOL;
       }
-
       // Handle getting a 404
-      if (!$response) {
+      else {
         echo '404' . PHP_EOL;
 
         // Put request in failed table for future investigation


### PR DESCRIPTION
#### What's this PR do?
This is the keeper upper script. This script will be run regularly to keep Rogue up to date with the latest Phoenix data. There are 3 types of updates sent:
1. New signup
2. New reportback/signup update
    - at least one new post
    - updating the `quantity` on the signup
    - updating the `why_participated` on the signup
3. Quantity or why update
    - In Phoenix, this would be an update on just the reportback without adding a new image
    - In Rogue, this would be a signup update

There are also three parts to the migration that do those 3 things in that order. We can see if signups or posts are in Rogue by using the reference tables, but for type 3 we have to check on timestamps. This is done by logging the timestamp of the most recent item (in this category) we sent. This is the timestamp on the item, not when we sent it. Then we use that information to see if there are any new quantity or why updates that we need to send over.

#### How should this be reviewed?
I suggest looking through each piece of the script as its own unit because they don't really interact. 

#### Any background context you want to provide?
Do it for the data 📈 

#### Relevant tickets
Fixes #7367

#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
