### PR TITLE
Allowing anonymous users to hit /northstar

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -106,8 +106,7 @@ function dosomething_user_menu() {
   $items['northstar/%'] = array(
     'page callback' => 'dosomething_user_get_view',
     'page arguments' => array(1),
-    'access callback' => 'user_view_access',
-    'access arguments' => array(1),
+    'access callback' => TRUE,
   );
   $items['user/magic/%'] = array(
     'page callback' => 'dosomething_user_magic_session',
@@ -122,7 +121,12 @@ function dosomething_user_get_view($id) {
   if (!$phoenix_user) {
     drupal_not_found();
   }
-  drupal_goto('user/' . $phoenix_user->uid);
+
+  if (user_is_anonymous()) {
+    drupal_goto('user/authorize');
+  } else {
+    drupal_goto('user/' . $phoenix_user->uid);
+  }
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?
This PR allows anonymous users to use the /northstar endpoint if they login, or continues redirecting authenticated users

![1](https://cloud.githubusercontent.com/assets/897368/25635280/947731b4-2f4b-11e7-81d0-b9d80956d338.gif)

![2](https://cloud.githubusercontent.com/assets/897368/25635279/94768174-2f4b-11e7-8959-400adea14f0f.gif)

#### How should this be reviewed?
Replicate the gifs!

#### Any background context you want to provide?
Needed for phoenix next so users can access profile. We know this flow isn't perfect but we are going to overhaul session management in the future
