### PR TITLE
Updates styles to account for scholarships when opt-out/in added to campaign.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -381,7 +381,7 @@ function paraneue_dosomething_preprocess_node_campaign_scholarship(&$vars) {
     // Pitch page classes:
     elseif (isset($campaign->is_pitch_page)) {
       // Values for pitch page:
-      $classes = array('-below', '-white',  '-dynamic-right');
+      $classes = array('-above', '-white',  '-dynamic-right');
     }
     // Else action page classes:
     else {

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -13,9 +13,9 @@
 .campaign--action .container--prove {
   .message-callout__copy {
     left: 12px;
-    &:before {
-      left: 250px;
-    }
+    // &:before {
+    //   left: 250px;
+    // }
   }
 }
 
@@ -25,23 +25,28 @@
     .message-callout {
       .message-callout__copy {
         &:before {
-          right: 35px;
-          top: -25px;
+          // right: 35px;
+          // top: -25px;
+          bottom: -30px;
+          right: 0;
+          transform: rotate(30deg);
         }
       }
 
       @include media($tablet) {
         position: absolute;
         left: 144px;
-        bottom: 0;
+        top: 0;
         width: 180px;
 
         .message-callout__copy {
           text-align: center;
 
           &:before {
+            bottom: auto;
             right: auto;
             top: 50%;
+            transform: none;
           }
         }
       }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_campaign.scss
@@ -13,9 +13,6 @@
 .campaign--action .container--prove {
   .message-callout__copy {
     left: 12px;
-    // &:before {
-    //   left: 250px;
-    // }
   }
 }
 
@@ -25,8 +22,6 @@
     .message-callout {
       .message-callout__copy {
         &:before {
-          // right: 35px;
-          // top: -25px;
           bottom: -30px;
           right: 0;
           transform: rotate(30deg);

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
@@ -24,15 +24,15 @@
 
       <?php if (isset($signup_button)): ?>
         <div class="header__signup">
-          <?php print render($signup_button); ?>
-
           <?php if (isset($presignup_callout)): ?>
-          <div class="message-callout -below -white -dynamic-right">
+          <div class="message-callout -above -white -dynamic-right">
             <div class="message-callout__copy">
               <p><?php print $presignup_callout; ?></p>
             </div>
           </div>
           <?php endif; ?>
+
+          <?php print render($signup_button); ?>
         </div>
       <?php endif; ?>
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--pitch.tpl.php
@@ -16,8 +16,8 @@
 
       <?php if (isset($signup_button_primary)): ?>
         <div class="header__signup">
-          <?php print render($signup_button_primary); ?>
           <?php print $campaign_scholarship; ?>
+          <?php print render($signup_button_primary); ?>
         </div>
       <?php endif; ?>
 

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign_group/node--campaign_group.tpl.php
@@ -26,14 +26,15 @@
 
       <?php if (isset($signup_button_primary)): ?>
         <div class="header__signup">
-          <?php print render($signup_button_primary); ?>
           <?php if (isset($scholarship)): ?>
-            <div class="message-callout -below -white -dynamic-right">
+            <div class="message-callout -above -white -dynamic-right">
               <div class="message-callout__copy">
                 <p><?php print $scholarship; ?></p>
               </div>
             </div>
           <?php endif; ?>
+
+          <?php print render($signup_button_primary); ?>
         </div>
       <?php endif; ?>
 


### PR DESCRIPTION
#### What's this PR do?
This PR updates the campaign header for pitch/closed/campaign-group to account for scholarship message callouts when affiliate opt-in/out messaging toggle is included. Prior to this fix, the message callout fell awkwardly on top of the affiliate messaging.


#### Any background context you want to provide?
![image](https://d2ppvlu71ri8gs.cloudfront.net/items/3X3g2i36452t3R3G2N1Y/Screen%20Recording%202017-05-03%20at%2001.49%20PM.gif?v=7e1e2d39)

#### Relevant tickets
Fixes #7296
Refs https://trello.com/c/X1BfgDFd/268-3-as-a-developer-i-want-to-do-the-final-things-for-the-opt-out-button-for-truth

#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
