### PR TITLE
A few keeper upper fixes

### DIFF
--- a/scripts/rogue-keeper-upper.php
+++ b/scripts/rogue-keeper-upper.php
@@ -121,7 +121,7 @@ foreach ($signups as $signup) {
 }
 
 // 2. Quantity and why participated updates with no new file
-$last_timestamp = variable_get('dosomething_rogue_last_timestamp_sent', NULL);
+$last_timestamp = variable_get('dosomething_rogue_last_timestamp_sent', 0);
 
 $postless_updates = db_query("SELECT rblog.rbid, rblog.quantity, rblog.why_participated, rb.nid, rb.run_nid, rb.uid, rblog.timestamp
                               FROM dosomething_reportback_log rblog
@@ -141,6 +141,8 @@ foreach ($postless_updates as $update) {
 
     // Put request in failed table for future investigation
     dosomething_rogue_handle_migration_failure($data, $post->sid, $post->rbid, $post->fid);
+
+    continue;
   }
 
   $updated_at = date('Y-m-d H:i:s', $update->timestamp);
@@ -161,6 +163,8 @@ foreach ($postless_updates as $update) {
 
       // Make sure we get a successful response
       if ($response) {
+        echo 'Updated rbid ' . $update->rbid . '...' . PHP_EOL;
+
         // Update the timestamp so we only check for updates after where we left off
         variable_set('dosomething_rogue_last_timestamp_sent', $update->timestamp);
 


### PR DESCRIPTION
#### What's this PR do?
1. Phoenix didn't like when the default timestamp variable was `null`. Making it `0` fixes the complaints. Also, setting it at 0 means that the first time the keeper upper is run, it will run through a lot of data that is already in Rogue. However, these updates only send the `why_participated` and `quantity` to Rogue and do not cause anything to be duplicated or any timestamps to be altered. Additionally, we are sure that we are capturing the latest `quantity` and `why_participated` for each signup. 

2. A `continue` was missing!

3. Added more helpful outputs.

#### How should this be reviewed?
👀  is probably sufficient!

#### Any background context you want to provide?
I think everything is explained above, ping me about any context I didn't cover 🏓 

#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
