### PR TITLE
Another few keeper upper fixes

### DIFF
--- a/scripts/rogue-keeper-upper.php
+++ b/scripts/rogue-keeper-upper.php
@@ -113,9 +113,12 @@ foreach ($signups as $signup) {
 // 2. Quantity and why participated updates with no new file
 $last_timestamp = variable_get('dosomething_rogue_last_timestamp_sent', 0);
 
-$postless_updates = db_query("SELECT rblog.rbid, rblog.quantity, rblog.why_participated, rb.nid, rb.run_nid, rb.uid, rblog.timestamp
+$postless_updates = db_query("SELECT rblog.rbid, rblog.quantity, rblog.why_participated, rb.nid, rb.run_nid, rb.uid, rblog.timestamp, signup.sid
                               FROM dosomething_reportback_log rblog
                               JOIN dosomething_reportback rb on rb.rbid = rblog.rbid
+                              JOIN dosomething_signup signup ON signup.uid = rb.uid
+                                AND signup.nid = rb.nid
+                                AND signup.run_nid = rb.run_nid
                               WHERE rblog.timestamp>$last_timestamp
                               AND substring_index(rblog.files, ',',-1) IN (Select fid from dosomething_rogue_reportbacks)");
 

--- a/scripts/rogue-keeper-upper.php
+++ b/scripts/rogue-keeper-upper.php
@@ -91,17 +91,22 @@ foreach ($signups as $signup) {
     }
     // Handle getting a 404
     else {
+      echo '404' . PHP_EOL;
       // Put request in failed table for future investigation
       dosomething_rogue_handle_migration_failure($data, $signup->sid, $signup->rbid, $fids);
     }
   }
   catch (GuzzleHttp\Exception\ServerException $e) {
+    echo 'server exception' . PHP_EOL;
+
     // These aren't yet caught by Gateway
 
     // Put request in failed table for future investigation
     dosomething_rogue_handle_migration_failure($data, $signup->sid, $signup->rbid, $fids);
   }
   catch (DoSomething\Gateway\Exceptions\ApiException $e) {
+    echo 'api exception' . PHP_EOL;
+
     // Put request in failed table for future investigation
     dosomething_rogue_handle_migration_failure($data, $signup->sid, $signup->rbid, $fids);
   }


### PR DESCRIPTION
#### What's this PR do?
1. Include `sid` in in query to get `quantity` and `why_participated` updates so we can log failures the way we log all other failures.
2. Print out errors for the Signup section the way we do everywhere else.

#### How should this be reviewed?
:female_detective: 🕵️  

#### Any background context you want to provide?
I checked everything failing locally and it all works now!

#### Checklist
- [ ] Tested on staging.