### PR TITLE
Properly handle failing to find northstar user in Rogue keeper upper

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -607,7 +607,24 @@ function dosomething_rogue_store_rogue_signup_references($sid, $rogue_signup) {
  */
 function dosomething_rogue_handle_migration_failure($values, $sid, $rbid = NULL, $fids = NULL, $response = NULL, $e = NULL) {
   // one row for each photo, just the sid if no northstar id, or just the signup info
-  if (!isset($values)) {
+  // When trying to send a file but there is no northstar id
+  if (empty($values) && isset($fids)) {
+      db_insert('dosomething_rogue_failed_migrations')
+      ->fields([
+        // Signup
+        'sid' => $sid,
+
+        // Reportback
+        'rbid' => $rbid,
+
+        // Files
+        'fid' => $fids,
+
+        // Fail data
+        'timestamp' => REQUEST_TIME,
+      ])
+      ->execute();
+  } elseif (!isset($values)) {
       db_insert('dosomething_rogue_failed_migrations')
       ->fields([
         // Signup

--- a/scripts/rogue-keeper-upper.php
+++ b/scripts/rogue-keeper-upper.php
@@ -23,6 +23,7 @@ else {
                       FROM dosomething_signup signups
                       LEFT JOIN dosomething_reportback rb ON signups.uid = rb.uid AND signups.nid = rb.nid AND signups.run_nid = rb.run_nid
                       WHERE signups.sid NOT IN (SELECT sid FROM dosomething_rogue_signups)
+                        AND signups.sid NOT IN (SELECT sid FROM dosomething_rogue_failed_migrations)
                       ORDER BY signups.sid');
 }
 


### PR DESCRIPTION
#### What's this PR do?
When we got to a Post with no Northstar user, we weren't logging the information in the failed table, and now we are.

#### How should this be reviewed?
Compare what we send to `dosomething_rogue_handle_migration_failure` if we are dealing with a Post with no Northstar ID [here](https://github.com/DoSomething/phoenix/blob/dev/scripts/rogue-keeper-upper.php#L231) to the updates made to that function in this PR.

#### Any background context you want to provide?
Check out #7374 for more details about this bug.

#### Relevant tickets
Fixes #7374

#### Checklist
- [ ] Tested on staging.
