### PR TITLE
Fixing path alias for reportback prove it button

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc
@@ -17,13 +17,14 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
         'title' => htmlspecialchars_decode($value['link'], ENT_QUOTES),
         'image' => $image,
         'description' => $value['call_to_action'],
-        'url' => dosomething_global_node_url($value['nid'], $language, 'prove'),
+        'url' => '/' . $value['path_alias'] . '#prove',
         'button_text' => t("Prove It"),
       );
       $doing_items[$delta] = paraneue_dosomething_get_gallery_item($item, 'figure');
     }
     $vars['doing_gallery'] = paraneue_dosomething_get_gallery($doing_items, 'triad', array(), TRUE);
   }
+
   // Get an array of reportbacks.
   $reportbacks = $vars['reportbacks'];
   if (!empty($reportbacks)) {


### PR DESCRIPTION
#### What's this PR do?
Phoenix Next campaigns aren't redirected on the `node/*` urls, so users are getting the old template when they click `prove it` on their profile. This forces that button to always use the proper alias.

#### How should this be reviewed?
Click the prove it button

#### Any background context you want to provide?
This path_alias was already [_globalized_](https://github.com/DoSomething/phoenix/blob/4495792c1d7f300bbd6de9e7d73e5947cc51dd73/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module#L579) so it doesn't need the global url function anymore.