### PR TITLE
Reportback statuses count fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     "preferred-install": "dist"
   },
   "require": {
+    "dosomething/gateway": "^1.0.0-rc14",
     "stripe/stripe-php": "^1.18.0",
-    "zendesk/zendesk_api_client_php": "^1.2.0",
-    "tightenco/collect": "^5.2",
-    "dosomething/gateway": "^1.0.0-rc14"
+    "tightenco/collect": "^5.4",
+    "zendesk/zendesk_api_client_php": "^1.2.0"
   },
   "require-dev": {
     "symfony/var-dumper": "^3.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "950dee19f2cd86c9d11ce407a07efe84",
-    "content-hash": "5caf0890d5c68f86a5f721c42b9bbace",
+    "hash": "71716a478a83f648503e5cdf5a6f4d03",
+    "content-hash": "3fcf86a2f9762dfd3cab874df8dd0535",
     "packages": [
         {
             "name": "dosomething/gateway",
@@ -943,24 +943,24 @@
         },
         {
             "name": "tightenco/collect",
-            "version": "v5.3.20",
+            "version": "v5.4.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tightenco/collect.git",
-                "reference": "07547aa6191f6d05b459ecea7c62526e18f33851"
+                "reference": "884ee096c8c5501f3ea87e97314b4373991b04a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tightenco/collect/zipball/07547aa6191f6d05b459ecea7c62526e18f33851",
-                "reference": "07547aa6191f6d05b459ecea7c62526e18f33851",
+                "url": "https://api.github.com/repos/tightenco/collect/zipball/884ee096c8c5501f3ea87e97314b4373991b04a7",
+                "reference": "884ee096c8c5501f3ea87e97314b4373991b04a7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": ">=5.6.4"
             },
             "require-dev": {
-                "mockery/mockery": "~0.9.4",
-                "phpunit/phpunit": "~4.1"
+                "mockery/mockery": "^0.9.7",
+                "phpunit/phpunit": "^5.7"
             },
             "type": "library",
             "autoload": {
@@ -986,7 +986,7 @@
                 "collection",
                 "laravel"
             ],
-            "time": "2016-10-25 18:10:45"
+            "time": "2017-04-27 15:27:15"
         },
         {
             "name": "zendesk/zendesk_api_client_php",

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -81,6 +81,55 @@ function dosomething_reportback_admin_generate_form_submit($form, &$form_state) 
 }
 
 /**
+ * Form constructor for refreshing Reportback counts.
+ */
+function dosomething_reportback_admin_refresh_counts_form($form, &$form_state) {
+  $collection = collect(dosomething_campaign_get_campaigns_query_result(['type' => 'campaign'], 'all'));
+
+  $campaigns = $collection->mapWithKeys(function ($item) {
+    return [$item->nid => $item->title];
+  });
+
+  $form['help'] = array(
+    '#markup' => t("Use this form to refresh the Reportback counts for all statuses on the specified campaign, if the numbers don't see to be adding up."),
+  );
+
+  $form['campaign'] = array(
+   '#type' => 'select',
+   '#title' => t('Select a campaign to refresh the reportback counts for it:'),
+   '#required' => TRUE,
+   '#empty_option' => '- Select a campaign -',
+   '#empty_value' => 'none',
+   '#options' => $campaigns->toArray(),
+ );
+
+  $form['actions'] = array(
+    '#type' => 'actions',
+    'submit' => [
+      '#type' => 'submit',
+      '#value' => t("Refresh Count"),
+    ],
+  );
+
+  return $form;
+}
+
+/**
+ * Form submit callback for dosomething_reportback_admin_refresh_counts_form.
+ */
+function dosomething_reportback_admin_refresh_counts_form_submit($form, &$form_state) {
+  $campaign_id = (int) $form_state['values']['campaign'];
+
+  if ($campaign_id && is_int($campaign_id)) {
+    dosomething_reportback_reset_count('node', $campaign_id);
+    drupal_set_message(t("Great! Reportback count for all statuses for this campaign have been refreshed."));
+  } else {
+    drupal_set_message(t("Hmmm, looks like something went wrong when trying to refresh the reportback statuses count."), 'error');
+  }
+
+}
+
+/**
  * Form to set the status of Reportback Files.
  *
  * @param string $status
@@ -240,6 +289,7 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
   }
 
   $updates_to_send_to_rogue = [];
+
   foreach ($rb_files as $fid => $values) {
     $kudos = [
       'fid' => $fid,
@@ -407,26 +457,29 @@ function dosomething_reportback_count_page() {
   $status_values = dosomething_reportback_get_file_status_values();
   $params = ['type' => 'campaign'];
 
-  $header = array(t('Title'));
+  $header = [t('Title')];
   foreach ($status_values as $status) {
     $header[] = t($status);
   }
 
-  $tables = array();
+  $tables = [];
   $tables['node']['title'] = t("Campaigns");
   $tables['node']['url'] = 'node/';
   $tables['node']['results'] = dosomething_campaign_get_campaigns_query_result($params, 'all');
 
   $tables['taxonomy_term']['title'] = t("Cause");
   $tables['taxonomy_term']['url'] = 'taxonomy/term/';
-  $tables['taxonomy_term']['results'] = array();
+  $tables['taxonomy_term']['results'] = [];
+
   $cause = taxonomy_vocabulary_machine_name_load('cause');
+
   if ($cause) {
     $tables['taxonomy_term']['results'] = taxonomy_get_tree($cause->vid);
   }
 
   foreach ($tables as $entity_type => $table) {
-    $rows = array();
+    $rows = [];
+
     foreach ($table['results'] as $record) {
       if ($entity_type === 'node') {
         $id = $record->nid;
@@ -436,10 +489,12 @@ function dosomething_reportback_count_page() {
         $id = $record->tid;
         $title = $record->name;
       }
+
       $vars = dosomething_helpers_get_variables($entity_type, $id);
-      ;
+
       // First column is a link to the entity.
-      $row_values = array(l($title, $table['url'] . $id));
+      $row_values = [l($title, $table['url'] . $id)];
+
       // Loop through status values and set links for each.
       $i = 0;
       foreach ($status_values as $status) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -278,6 +278,16 @@ function dosomething_reportback_menu() {
     $items = array_merge($items, $rb_items);
   }
 
+  $items['admin/users/rb/refresh-counts'] = array(
+    'title' => 'Refresh Counts',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => ['dosomething_reportback_admin_refresh_counts_form'],
+    'access callback' => 'user_access',
+    'access arguments' => ['edit any reportback'],
+    'file' => 'dosomething_reportback.admin.inc',
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 100,
+  );
   $items['admin/users/rb/add'] = array(
     'title' => 'Add reportback',
     'page callback' => 'drupal_get_form',
@@ -285,7 +295,7 @@ function dosomething_reportback_menu() {
     'access callback' => 'user_access',
     'access arguments' => array('edit any reportback'),
     'type' => MENU_LOCAL_TASK,
-    'weight' => 100,
+    'weight' => 110,
   );
   $items['reportback/%reportback/edit'] = array(
     'title' => 'Edit',
@@ -1247,6 +1257,7 @@ function dosomething_reportback_get_reportback_files_query_count($params, $reset
   if ($entity_type && !$reset) {
     // Check if we have the count stored already.
     $count = dosomething_helpers_get_variable($entity_type, $entity_id, $var_name);
+
     if ($count === FALSE) {
       $reset = TRUE;
     }
@@ -1308,7 +1319,8 @@ function dosomething_reportback_mark_reportback_as_excluded($fid) {
  * Resets Reportback Count variables for given entity type and entity_id.
  */
 function dosomething_reportback_reset_count($entity_type, $entity_id, $status = NULL) {
-  $params = array();
+  $params = [];
+
   if ($entity_type == 'node') {
     $params['nid'] = $entity_id;
   }

--- a/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
+++ b/lib/modules/dosomething/dosomething_reportback/includes/ReportbackItem.php
@@ -160,19 +160,23 @@ class ReportbackItem extends Entity {
    */
   public function review($values) {
     global $user;
+
     if (!isset($values['status'])) {
       return FALSE;
     }
+
     $this->status = $values['status'];
     $this->reviewer = $user->uid;
     $this->reviewed = REQUEST_TIME;
     // Default source as the current URL path of page being viewed.
     $this->review_source = current_path();
+
     // If source was passed:
     if (isset($values['source'])) {
       // Store that instead.
       $this->review_source = $values['source'];
     }
+
     $reportback = reportback_load($this->rbid);
     $reason = NULL;
 
@@ -191,6 +195,9 @@ class ReportbackItem extends Entity {
     if (!empty($values['delete'])) {
       $this->deleteFile();
     }
+
+    // Reset the count to reflect reportback review update!
+    dosomething_reportback_reset_count('node', $reportback->nid, $values['status']);
 
     // Save the reviewed properties.
     return $updated_reportback_item;


### PR DESCRIPTION
#### What's this PR do?
This PR adds a fix to help more accurately display the correct counts of Reportbacks of different statuses per campaign on the `/admin/users/rb` page. It updates the `ReportbackItem` class so that after an item is reviewed then the cached count of items based on status is updated so that it will accurately display the correct count back on the index list page.

However, this will only fix the counts _after_ a new Reportback is reviewed. If there are no RBs waiting for review for a campaign, then the counts will not be fixed. So to remedy this, this PR also adds a new page tab called "Refresh Counts" on the `/admin/users/rb` page. This new page provides a form to select a campaign and force refresh the Reportback statuses counts:

![image](https://d2ppvlu71ri8gs.cloudfront.net/items/3T1p0n343W2D2L0i2E1o/Screen%20Recording%202017-05-09%20at%2001.35%20PM.gif?v=7add44f1)

This PR also does some general code cleanup like switching to literal array syntax and adding some carriage returns, cause _why_ did we insist on mushing all our code together without some breathing room! It was hurting my poor 👀  😖 

#### How should this be reviewed?
👁 

#### Relevant tickets
Refs https://trello.com/c/52cHXmq3/566-2-drupal-inbox-overview-showing-zero-even-though-there-are-rbs-with-that-status-time-box-1-2-hours

#### Checklist
- [x] Tested on staging.
- [x] Pinged a PM if this is a larger PR that would benefit from some additional testing love
