### PR TITLE
Fix for Counter Bug in Gallery 

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -364,6 +364,7 @@ function paraneue_dosomething_get_themed_reportback_item($data, $rogue_rb_item =
   if ($data->id && !dosomething_kudos_disable_reactions($data->campaign->id)) {
       if ($rogue_rb_item) {
         $total_rogue_kudos = $data->kudos['total'];
+
         $liked_by_current_user = $data->kudos['data']['current_user']['reacted'] ? true : false;
 
         // Let the front end know that Rogue is powering the gallery.
@@ -377,7 +378,7 @@ function paraneue_dosomething_get_themed_reportback_item($data, $rogue_rb_item =
         );
       }
 
-      $data->kudos = dosomething_kudos_get_kudos_data_for_fid($data->id, $total_rogue_kudos ? $total_rogue_kudos : null, $liked_by_current_user ? $liked_by_current_user : null);
+      $data->kudos = dosomething_kudos_get_kudos_data_for_fid($data->id, $total_rogue_kudos ? $total_rogue_kudos : 0, $liked_by_current_user ? $liked_by_current_user : null);
   }
 
   if ($data instanceof ReportbackItem && user_access('view any reportback')) {


### PR DESCRIPTION
#### What's this PR do?
- Fixes the counter bug that is grabbing the total number of reactions in P-A if there are no reactions in Rogue. 
- If there is no `$total_rogue_kudos` , set to `0` instead of `null`. 

#### How should this be reviewed?
- Instead of setting to `null` if there are no reactions in Rogue, set to `0` so we don't grab reactions from P-A database [here](https://github.com/DoSomething/phoenix/blob/dev/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module#L332).

#### Any background context you want to provide?
The only thing that is a little strange to me is that even if there are no reactions in Rogue, the `$data->kudos['total']` should return `0` so I'm not sure why it sets it as null? Here is the response for a post from Rogue: 
```
    {
      "id": 1,
      "status": "accepted",
      "caption": "post 1",
      "media": {
        "uri": "https://s3.amazonaws.com/ds-rogue-test/uploads/reportback-items/12-1484929292.jpeg",
        "type": "image"
      },
      "created_at": "2017-04-28T20:14:49+00:00",
      "reportback": {
        "id": 1,
        "created_at": "2017-04-28T20:14:48+00:00",
        "updated_at": "2017-04-28T20:14:48+00:00",
        "quantity": null,
        "why_participated": "Voluptatem itaque quod et non accusantium id aut.",
        "flagged": "false"
      },
      "kudos": {
        "total": 0,
        "data": {
          "current_user": {
            "kudos_id": 1,
            "reacted": false
          },
          "term": {
            "name": "heart",
            "id": 641,
            "total": 0
          }
        }
      },
      "user": "5589c991a59dbfa93d8b45ae"
    },
``` 
Found out why! If it is `0`, it doesn't think it is sending anything in as `$total_rogue_kudos` to `dosomething_kudos_get_kudos_data_for_fid` and when I `print_r($total_rogue_kudos)` in that function, nothing is returned which is why it gets P-A total reaction count.

#### Relevant tickets
Fixes #7379 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
