### PR TITLE
Fix for Counter Bug in Gallery Take Two

### DIFF
--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -324,15 +324,23 @@ function dosomething_kudos_get_kudos_data_for_fid($fid = NULL, $total_rogue_kudo
   if (! $fid) {
     return [];
   }
+
+  if ($total_rogue_kudos === 0) {
+    $total_kudos = 0;
+  } elseif ($total_rogue_kudos) {
+    $total_kudos = $total_rogue_kudos;
+  } else {
+    $total_kudos = dosomething_kudos_get_total_for_file_by_term_name($fid, 'heart');
+  }
+
   $kudos = [];
   $kudos['fid'] = $fid;
   $kudos['existing_kids'] = dosomething_kudos_get_kudos_for_user_by_file($fid);
   $kudos['reaction_totals'] = [
     'heart' =>
-        $total_rogue_kudos ? $total_rogue_kudos : dosomething_kudos_get_total_for_file_by_term_name($fid, 'heart')
+        $total_kudos,
   ];
   $kudos['allowed_reactions'] = [dosomething_kudos_get_term_id_by_name('heart')];
-
   // Use this in photo.tpl.php for the logged in user's reaction. If the user has reacted to the post, make the reaction button active.
   $kudos['liked_in_rogue'] = $liked_by_current_user;
 


### PR DESCRIPTION
#### What's this PR do?
- Similar to #7381 , the ternary check doesn't pass because `0` is not truthy. 
- Makes sure if `$total_rogue_kudos` is `0`, it doesn't go to `dosomething_kudos_get_total_for_file_by_term_name()`.

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Finishes work for #7381 

#### Relevant tickets
Refs #7379 (bug)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
