### PR TITLE
Only prompt if user isn't in a competition.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -760,7 +760,15 @@ function dosomething_campaign_add_signup_data_form_vars(&$node, $langcode) {
   // Pass to the user signup data form.
   $node->content['signup_data_form'] = drupal_get_form('dosomething_signup_user_signup_data_form', $signup);
   // If the signup_data_form is required and user has not submitted form yet:
-  if ($config['required'] && !$signup->signup_data_form_timestamp) {
+  $hasCompetitionRecordedLocally = $signup->signup_data_form_timestamp;
+  $shouldShowCompetitionPrompt = $config['required'] && !$hasCompetitionRecordedLocally;
+
+  // If Gladiator is enabled, check there too!
+  if (module_exists('dosomething_gladiator')) {
+    $shouldShowCompetitionPrompt = $shouldShowCompetitionPrompt && ! dosomething_gladiator_in_a_competition($signup);
+  }
+
+  if ($shouldShowCompetitionPrompt) {
     // Store flag to indicate we need to prompt user (handled in theme).
     $node->required_signup_data_form = 1;
     // If form is configured to include a skip button:

--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
@@ -38,6 +38,41 @@ function _dosomething_gladiator_build_http_client() {
 }
 
 /**
+ * Check if the given user is already in a competition for this campaign.
+ * If they are in a competition or waiting room in Gladiator, update their
+ * local signup record to reflect that.
+ *
+ * @param $signup - signup entity
+ *
+ * @return bool
+ */
+function dosomething_gladiator_in_a_competition($signup) {
+  $client = _dosomething_gladiator_build_http_client();
+
+  $query = drupal_http_build_query([
+    'id' => dosomething_user_get_northstar_id($signup->uid),
+    'campaign_id' => $signup->nid,
+    'campaign_run_id' => $signup->run_nid,
+  ]);
+
+  $response = drupal_http_request($client['base_url'] . '/users?'.$query, [
+    'method' => 'GET',
+    'headers' => $client['headers'],
+  ]);
+
+  $json = json_decode($response->data, TRUE);
+  $already_in_gladiator = !empty($json['data']['waitingRoom']) || !empty($json['data']['competition']);
+
+  // If signup exists in Gladiator (from Phoenix Next, for example), set
+  // the "signup data form" timestamp so we know not to ask again.
+  if ($already_in_gladiator) {
+    dosomething_signup_update_signup_data(['sid' => $signup->sid], ['competition_signup' => $already_in_gladiator]);
+  }
+
+  return $already_in_gladiator;
+}
+
+/**
  * Sends a user to Gladiator (https://github.com/DoSomething/gladiator)
  *
  * @param object $user


### PR DESCRIPTION
#### What's this PR do?
This pull request updates Phoenix Ashes to check with Gladiator before displaying the "competition prompt" to a user. This will prevent users who originally joined a competition on Phoenix Next from being prompted again.

#### How should this be reviewed?
👀! Any error-checking I'm missing?

#### Any background context you want to provide?
This gives a better user experience for users who "start" in Phoenix Next but then return to the campaign in Phoenix Ashes.

#### Relevant tickets
Fixes 🏆.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  