### PR TITLE
Send new reviews to Rogue with the keeper upper script

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -697,6 +697,23 @@ function dosomething_rogue_handle_migration_failure($values, $sid, $rbid = NULL,
         ])
         ->execute();
       }
+    } elseif (array_key_exists('admin_northstar_id', $values)) {
+       // Store review
+       db_insert('dosomething_rogue_failed_migrations')
+        ->fields([
+          // Signup
+          'sid' => $sid,
+          'northstar_id' => $values['admin_northstar_id'],
+          'status' => $values['status'],
+          'fid' => $fids,
+          'rbid' => $rbid,
+
+          // Fail data
+          'timestamp' => REQUEST_TIME,
+          'response_code' => (isset($response->code)) ? $response->code : NULL, // @TODO: this is currently null until there a better way to get it from Gateway
+          'response_values' => (isset($e)) ? $e->getMessage() : NULL,
+        ])
+        ->execute();
     } else {
      db_insert('dosomething_rogue_failed_migrations')
       ->fields([

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -80,4 +80,17 @@ class Rogue extends RestApiClient {
 
     return $response;
   }
+
+  /**
+   * Send a POST request of the signup to be saved in Rogue.
+   *
+   * @param array $data
+   * @return object|false
+   */
+  public function postReview($data)
+  {
+    $response = $this->post('v2/reviews', $data);
+
+    return $response;
+  }
 }

--- a/scripts/rogue-keeper-upper.php
+++ b/scripts/rogue-keeper-upper.php
@@ -302,5 +302,86 @@ foreach ($posts as $post) {
   }
 }
 
+// 4. Get fresh reviews and send them over
+$last_review_timestamp = variable_get('dosomething_rogue_last_review_sent', 0);
+
+$reviews = db_query("SELECT rbf.fid, rbf.status, rbf.reviewer
+                    FROM dosomething_reportback_file rbf
+                    WHERE rbf.reviewed>$last_review_timestamp
+                      AND rbf.fid IN (Select fid from dosomething_rogue_reportbacks)");
+
+foreach ($reviews as $review) {
+  echo 'Trying to send review of fid ' . $review->fid . '...' . PHP_EOL;
+
+  // Get admin user info
+  $northstar_user = dosomething_northstar_get_user($review->reviewer, 'drupal_id');
+
+  // Don't send if there is no admin northstar user
+  if (!isset($northstar_user)) {
+    echo 'No northstar id, that is terrible ' . $review->fid . PHP_EOL;
+
+    // TODO: handle this
+    // Put request in failed table for future investigation
+    dosomething_rogue_handle_migration_failure($data, $post->sid, $post->rbid, $post->fid);
+
+    continue;
+  }
+
+  // Convert status to Rogue status
+  $rogue_status = dosomething_rogue_transform_status($review->status);
+
+  // Get Rogue post_id
+  $rogue_post_id = dosomething_rogue_get_by_file_id($review->fid);
+
+  // Format the data
+  $data = [
+    'admin_northstar_id' => $northstar_user->id,
+    'status' => $rogue_status,
+    'post_id' => $rogue_post_id,
+  ];
+
+  // Send to Rogue and handle failure
+    // Send to Rogue
+  try {
+    $response = $client->postReview($data);
+
+    // Make sure we get a successful response
+    if ($response) {
+      // Send to StatHat
+      if (module_exists('stathat')) {
+        stathat_send_ez_count('drupal - Rogue - review migrated - count', 1);
+      }
+
+      echo 'Migrated review of  ' . $post->fid . ' to Rogue.' . PHP_EOL;
+    }
+    // Handle getting a 404
+    else {
+      echo '404' . PHP_EOL;
+
+      // @TODO: this
+      // Put request in failed table for future investigation
+      dosomething_rogue_handle_migration_failure($data, $post->sid, $post->rbid, $post->fid, $response);
+    }
+  }
+  catch (GuzzleHttp\Exception\ServerException $e) {
+      echo 'server exception' . PHP_EOL;
+
+    // These aren't yet caught by Gateway
+
+    // @TODO: this
+    // Put request in failed table for future investigation
+    // @TODO: only put in this table if it's not already there
+    dosomething_rogue_handle_migration_failure($data, $post->sid, $post->rbid, $post->fid, $response, $e);
+  }
+  catch (DoSomething\Gateway\Exceptions\ApiException $e) {
+    echo 'api exception' . PHP_EOL;
+
+    // @TODO: this
+    // Put request in failed table for future investigation
+    dosomething_rogue_handle_migration_failure($data, $post->sid, $post->rbid, $post->fid, $response, $e);
+  }
+
+}
+
 // Done for now!
 echo 'Nothing else to migrate!' . PHP_EOL;

--- a/scripts/rogue-keeper-upper.php
+++ b/scripts/rogue-keeper-upper.php
@@ -121,7 +121,7 @@ $last_timestamp = variable_get('dosomething_rogue_last_timestamp_sent', 0);
 
 $postless_updates = db_query("SELECT rblog.rbid, rblog.quantity, rblog.why_participated, rb.nid, rb.run_nid, rb.uid, rblog.timestamp, signup.sid
                               FROM dosomething_reportback_log rblog
-                              JOIN dosomething_reportback rb on rb.rbid = rblog.rbid
+                              JOIN dosomething_reportback rb ON rb.rbid = rblog.rbid
                               JOIN dosomething_signup signup ON signup.uid = rb.uid
                                 AND signup.nid = rb.nid
                                 AND signup.run_nid = rb.run_nid


### PR DESCRIPTION
#### What's this PR do?
1. Adds a function to `Rogue.php` to hit the [`/reviews` endpoint](https://github.com/DoSomething/rogue/blob/master/documentation/endpoints/reviews.md#reviews---api) in Rogue.
2. Adds Part 4 to the keeper upper! Now if a post that lives in Rogue gets reviewed in Phoenix, we send that review on over. We look for all new reviews after the timestamp of the last one sent.
3. Handles failure of reviews. We have to store the ones that failed so we don't lose them forever, which is what would happen if one failed and then the next one succeeded.

#### How should this be reviewed?
Maybe test out the query and make sure it is catching all new reviews. Otherwise walk through the new logic in the script and see if it makes sense.

#### Relevant tickets
[Trello card
](https://trello.com/c/YrAFkbGX/434-5-as-an-admin-i-don-t-want-to-have-to-re-review-posts-in-rogue-once-it-is-turned-on)
#### Checklist
- [ ] Tested on staging.
