### PR TITLE
#7389: Upgrade Views Data Export from 7.x-3.0-beta8 to 7.x-3.2

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -244,7 +244,7 @@ projects[views][version] = "3.14"
 projects[views][subdir] = "contrib"
 
 ; Views Data Export
-projects[views_data_export][version] = "3.0-beta8"
+projects[views_data_export][version] = "3.2"
 projects[views_data_export][subdir] = "contrib"
 
 ; Views Grouping Row Limit


### PR DESCRIPTION
#### What's this PR do?

Upgrades the Views Data Export module from 7.x-3.0-beta8 to 7.x-3.2.

#### How should this be reviewed?

Clone it and run `ds build` basically. As far as I can tell this isn't actually being used anywhere though...? The `views_data_export` DB table is empty (at least on my DB dump) and I don't see any exported views using that type of display in the codebase. 

If that's the case, maybe this should just be disabled? I feel like I must be missing something.

#### Relevant tickets
Fixes #7389.
