### PR TITLE
#7391: Upgrade Services from 3.12 to 3.19

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -187,7 +187,7 @@ projects[seckit][subdir] = "contrib"
 projects[seckit][version] = "1.9"
 
 ; Services
-projects[services][version] = "3.12"
+projects[services][version] = "3.19"
 projects[services][subdir] = "contrib"
 
 ; Stathat


### PR DESCRIPTION
#### What's this PR do?

Upgrades the Services module from 3.12 to 3.19.

#### How should this be reviewed?

1. Pull the code.
2. Run `ds build`
3. Test some services by hitting (for example) `api/v1/campaigns` or `api/v1/campaigns/1261` or `api/v1/kudos` and compare output to the same URLs on Staging.

#### Any background context you want to provide?

There is one update hook, and it looks slightly worrisome:

```php
<?php

/**
 * Add primary key to the services_user table, truncating it first
 */
function services_update_7403() {
  // We have to truncate the table because the table was wrongly
  // updating every single record
  db_truncate('services_user')->execute();
  db_add_primary_key('services_user', array('uid'));
}
```

That said, it didn't cause any problems that I'm able to find, and just judging from the description there, it seems like it wasn't working well to begin with, so it seems safe enough to me.

#### Relevant tickets
Fixes #7391 

cc @mirie 