### PR TITLE
Don't try to refresh access tokens for CLI or API requests.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -71,7 +71,8 @@ function dosomething_northstar_init() {
 
   // If a user is logged in, check their access token & ensure they
   // have a valid session by refreshing it if it's expired.
-  if (user_is_logged_in()) {
+  $is_web_request = !dosomething_helpers_is_api_request() && !drupal_is_cli();
+  if ($is_web_request && user_is_logged_in()) {
     $account = new PhoenixOAuthUser($user->uid);
     $token = $account->getOAuthToken();
 


### PR DESCRIPTION
#### What's this PR do?
The init hook to refresh a user's access token (added in #7351 yesterday) runs on non-web requests, and is unable to refresh a token since the API user doesn't log in via Northstar and so it wouldn't have one. This pull request excludes API & CLI requests from that hook.

#### How should this be reviewed?
I tested this on my local and it resolved the problem. Let's also test on Thor!

#### Any background context you want to provide?
🍃

#### Relevant tickets
Fixes a bug introduced in #7351. References DoSomething/quasar#361.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  