### PR TITLE
Fix for Signup Bug when Rogue is Turned On

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -810,7 +810,6 @@ function dosomething_campaign_add_shipment_form_vars($node) {
 function dosomething_campaign_is_pitch_page($node) {
   // Exclude all non campaign node types.
   if ($node->type != 'campaign') { return FALSE; }
-
   // If not a campaign campaign (e.g. SMS Game), no pitch page is needed.
   if (dosomething_campaign_get_campaign_type($node) != 'campaign') {
     return FALSE;
@@ -830,6 +829,7 @@ function dosomething_campaign_is_pitch_page($node) {
   elseif (dosomething_user_is_staff() || dosomething_global_is_regional_admin()) {
     return FALSE;
   }
+
   // The $node is a pitch page if you haven't signed up yet.
   return (!dosomething_signup_exists($node->nid));
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -49,9 +49,9 @@ function dosomething_campaign_preprocess_node(&$vars) {
       ],
     ]);
 
-    $response['data'] ? $signup_exists = TRUE : $signup_exists = FALSE;
+    $signup_exists = ! empty($response['data']);
   } else {
-    dosomething_campaign_is_pitch_page($node) ? $signup_exists = FALSE : $signup_exists = TRUE;
+    $signup_exists = ! dosomething_campaign_is_pitch_page($node);
   }
 
   if ($pitch_path == $current_path || ! $signup_exists) {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -40,9 +40,7 @@ function dosomething_campaign_preprocess_node(&$vars) {
     global $user;
     $northstar_user = dosomething_user_get_northstar_id($user->uid);
 
-    $rogue = new Rogue(ROGUE_API_URL . '/',
-      ['headers' => ['X-DS-Rogue-API-Key' => ROGUE_API_KEY]]
-    );
+    $rogue = dosomething_rogue_client();
 
     $response = $rogue->getActivity([
       'filter' => [

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -38,7 +38,7 @@ function dosomething_campaign_preprocess_node(&$vars) {
 
   if (variable_get('rogue_collection', FALSE)) {
     global $user;
-    $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
+    $northstar_user = dosomething_user_get_northstar_id($user->uid);
 
     $rogue = new Rogue(ROGUE_API_URL . '/',
       ['headers' => ['X-DS-Rogue-API-Key' => ROGUE_API_KEY]]

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -10,7 +10,6 @@
  */
 function dosomething_campaign_preprocess_node(&$vars) {
   if ($vars['type'] != 'campaign' || $vars['view_mode'] != 'full') return;
-
   $node = $vars['node'];
   $vars['campaign'] = dosomething_campaign_load($node);
 
@@ -36,8 +35,37 @@ function dosomething_campaign_preprocess_node(&$vars) {
   dosomething_campaign_preprocess_common_vars($vars, $wrapper);
 
   $pitch_path = 'node/' . $node->nid . '/pitch';
-  if ($pitch_path == $current_path || dosomething_campaign_is_pitch_page($node)) {
-    // Gather vars for pitch page.
+
+  // @TODO: pitch page is always rendered because Phoenix doesn't know about sign up in Rogue
+  // need to be able to check if Signup exists in Rogue here via API call?
+  // Gather vars for pitch page.
+  if (variable_get('rogue_collection', FALSE)) {
+    global $user;
+    $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
+
+    $rogue = new Rogue(ROGUE_API_URL . '/',
+      ['headers' => ['X-DS-Rogue-API-Key' => ROGUE_API_KEY]]
+    );
+
+    $response = $rogue->getActivity([
+      'filter' => [
+        'northstar_id' => $northstar_user->id,
+      ],
+    ]);
+
+    if ($response['data']) {
+      $signup_exists = TRUE;
+    } else {
+      $signup_exists = FALSE;
+    }
+  } else {
+    if (dosomething_campaign_is_pitch_page($node)) {
+      $signup_exists = FALSE;
+    } else {
+      $signup_exists = TRUE;
+    }
+  }
+  if ($pitch_path == $current_path || ! $signup_exists) {
     $vars['is_pitch_page'] = TRUE;
     dosomething_campaign_preprocess_pitch_page($vars, $wrapper);
     return;

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -36,9 +36,6 @@ function dosomething_campaign_preprocess_node(&$vars) {
 
   $pitch_path = 'node/' . $node->nid . '/pitch';
 
-  // @TODO: pitch page is always rendered because Phoenix doesn't know about sign up in Rogue
-  // need to be able to check if Signup exists in Rogue here via API call?
-  // Gather vars for pitch page.
   if (variable_get('rogue_collection', FALSE)) {
     global $user;
     $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
@@ -50,22 +47,17 @@ function dosomething_campaign_preprocess_node(&$vars) {
     $response = $rogue->getActivity([
       'filter' => [
         'northstar_id' => $northstar_user->id,
+        'campaign_id' => $vars['nid'],
       ],
     ]);
 
-    if ($response['data']) {
-      $signup_exists = TRUE;
-    } else {
-      $signup_exists = FALSE;
-    }
+    $response['data'] ? $signup_exists = TRUE : $signup_exists = FALSE;
   } else {
-    if (dosomething_campaign_is_pitch_page($node)) {
-      $signup_exists = FALSE;
-    } else {
-      $signup_exists = TRUE;
-    }
+    dosomething_campaign_is_pitch_page($node) ? $signup_exists = FALSE : $signup_exists = TRUE;
   }
+
   if ($pitch_path == $current_path || ! $signup_exists) {
+    // Gather vars for pitch page.
     $vars['is_pitch_page'] = TRUE;
     dosomething_campaign_preprocess_pitch_page($vars, $wrapper);
     return;

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -93,4 +93,18 @@ class Rogue extends RestApiClient {
 
     return $response;
   }
+
+  /**
+   * Send a GET request to return all reportbacks matching a given
+   * query from Rogue.
+   *
+   * @param array $inputs
+   * @return Rogue Reportbacks
+   */
+  public function getActivity($inputs = [])
+  {
+    $response = $this->get('v2/activity', $inputs);
+
+    return $response;
+  }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -98,6 +98,7 @@ function dosomething_signup_form_submit($form, &$form_state) {
   }
 
   if (variable_get('rogue_collection', FALSE)) {
+    $form_state['values']['source'] = 'phoenix-web';
     $rogue_signup = dosomething_rogue_send_signup_to_rogue($form_state['values']);
 
     // Make sure the signup exists before using it

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -98,7 +98,6 @@ function dosomething_signup_form_submit($form, &$form_state) {
   }
 
   if (variable_get('rogue_collection', FALSE)) {
-    $form_state['values']['source'] = 'phoenix-web';
     $rogue_signup = dosomething_rogue_send_signup_to_rogue($form_state['values']);
 
     // Make sure the signup exists before using it

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -103,6 +103,8 @@ function dosomething_signup_form_submit($form, &$form_state) {
     // Make sure the signup exists before using it
     if ($rogue_signup) {
       dosomething_rogue_check_sid_and_store_ref($rogue_signup);
+      $node = node_load($rogue_signup['data']['campaign_id']);
+      dosomething_signup_set_signup_message($node->title);
     }
   } else {
     // Create signup for logged in user.


### PR DESCRIPTION
#### What's this PR do?
- Fixes the signup bug when Rogue is turned on (where you can't get to regular campaign page after signing up) 

#### How should this be reviewed?
- Turn Rogue on.
- Try to sign up for a campaign. 
- Make sure you get re-directed to the campaign page instead of re-directed to the Signup page. 

#### Any background context you want to provide?
Reminder: when merged and deployed to Thor, make sure that competitions prompt/custom social share prompt still works if on.

#### Relevant tickets
Fixes https://trello.com/c/vsSBl0Xf/462-8-%F0%9F%90%9B-when-rogue-is-turned-on-youre-not-able-to-sign-up-for-a-campaign-%F0%9F%90%9B

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
