### PR TITLE
Removes default images from gallery when Rogue is on

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -250,6 +250,12 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars, $count = 6) 
 
     $promotedReportbackItems = $promotedReportbackItemsResponse['data'];
 
+    foreach ($promotedReportbackItems as $key => $promotedReportbackItem) {
+      if ($promotedReportbackItem['media']['uri'] === 'default') {
+        unset($promotedReportbackItems[$key]);
+      }
+    }
+
     $gallery['initial_promoted_count'] = count($promotedReportbackItems);
 
     // Since Rogue only sends back approved reportbacks, we can just set total_approved to total_promoted.

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -284,7 +284,7 @@ const Reportback = {
         }
       },
     }).done(function(response) {
-      // Check to see if the response if from Rogue.
+      // Check to see if the response is from Rogue.
       if (setting('dsRogue.poweringGallery')) {
         if (response.meta.pagination.links.next_uri) {
           var splitResponseUrl = response.meta.pagination.links.next_uri.split("&");
@@ -333,9 +333,14 @@ const Reportback = {
    * @param {array} collection JSON object containing reportback items and other meta data.
    */
   templatize: function(collection) {
+    console.log(9);
     const items = collection.data;
 
     for (let i = 0, count = items.length; i < count; i++) {
+      if (items[i].media.uri === 'default') {
+        continue;
+      }
+
       const data = {
         'id': items[i].id,
         'reportbackId': items[i].reportback.id,

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -333,11 +333,10 @@ const Reportback = {
    * @param {array} collection JSON object containing reportback items and other meta data.
    */
   templatize: function(collection) {
-    console.log(9);
     const items = collection.data;
 
     for (let i = 0, count = items.length; i < count; i++) {
-      if (items[i].media.uri === 'default') {
+      if (items[i].media.uri == 'default') {
         continue;
       }
 


### PR DESCRIPTION
#### What's this PR do?
If a post has a `default` image, do not show in gallery when Rogue is powering the gallery. 

#### How should this be reviewed?
- Set some posts' image URL to `default` in your local Rogue database. 
- Turn Rogue on.
- Go to a campaign page and view the gallery. The posts with `default` images shouldn't be included in the gallery. 
- If you click `view more`, they should also be omitted from this part of the gallery. 

#### Relevant tickets
Fixes https://trello.com/c/mf6bRBgJ/465-5-as-a-campaign-lead-i-dont-want-the-broken-images-to-show-up-in-the-gallery-when-rogue-is-turned-on

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
