### PR TITLE
Adding age to opt in data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "dosomething/gateway": "^1.0.0-rc14",
     "stripe/stripe-php": "^1.18.0",
     "tightenco/collect": "^5.4",
-    "zendesk/zendesk_api_client_php": "^1.2.0"
+    "zendesk/zendesk_api_client_php": "^1.2.0",
+    "nesbot/carbon": "^1.22"
   },
   "require-dev": {
     "symfony/var-dumper": "^3.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "71716a478a83f648503e5cdf5a6f4d03",
-    "content-hash": "3fcf86a2f9762dfd3cab874df8dd0535",
+    "hash": "69a75a1b203587a0c5bd3082ce60e3e4",
+    "content-hash": "6fad5f3cef115a7b880d8f06b3982aeb",
     "packages": [
         {
             "name": "dosomething/gateway",
@@ -562,26 +562,32 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "1.21.0",
+            "version": "1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "7b08ec6f75791e130012f206e3f7b0e76e18e3d7"
+                "reference": "7cdf42c0b1cc763ab7e4c33c47a24e27c66bfccc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/7b08ec6f75791e130012f206e3f7b0e76e18e3d7",
-                "reference": "7b08ec6f75791e130012f206e3f7b0e76e18e3d7",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/7cdf42c0b1cc763ab7e4c33c47a24e27c66bfccc",
+                "reference": "7cdf42c0b1cc763ab7e4c33c47a24e27c66bfccc",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0",
-                "symfony/translation": "~2.6|~3.0"
+                "symfony/translation": "~2.6 || ~3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0|~5.0"
+                "friendsofphp/php-cs-fixer": "~2",
+                "phpunit/phpunit": "~4.0 || ~5.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.23-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Carbon\\": "src/Carbon/"
@@ -605,7 +611,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2015-11-04 20:07:17"
+            "time": "2017-01-16 07:55:07"
         },
         {
             "name": "psr/http-message",

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -1,4 +1,7 @@
 <?php
+
+use Carbon\Carbon;
+
 /**
  * @file
  * Helper functions for dosomething_campaign functionality.
@@ -389,6 +392,7 @@ function dosomething_campaign_create_affiliate_messaging_opt_in($user, $campaign
       'first_name' => $northstar_user->first_name,
       'email' => $northstar_user->email,
       'mobile' => $northstar_user->mobile,
+      'age' => dosomething_user_get_age($northstar_user->birthdate)->y,
     ])->execute();
 
   drupal_set_message('And thanks for signing up for messaging from our affiliate!');

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.helpers.inc
@@ -1,7 +1,5 @@
 <?php
 
-use Carbon\Carbon;
-
 /**
  * @file
  * Helper functions for dosomething_campaign functionality.

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
@@ -52,6 +52,11 @@ function dosomething_campaign_schema() {
         'not null' => FALSE,
         'length' => '255',
       ],
+      'age' => [
+        'description' => 'The ae for the user that opted-in.',
+        'type' => 'int',
+        'not null' => FALSE,
+      ],
     ],
     'primary key' => ['id'],
     'indexes' => [
@@ -220,5 +225,18 @@ function dosomething_campaign_update_7014() {
     $schema = dosomething_campaign_schema();
 
     db_create_table($table_name, $schema[$table_name]);
+  }
+}
+
+/**
+ * Add the age field to the dosomething_campaign_affiliate_opt_ins table.
+ */
+function dosomething_campaign_update_7015() {
+  $field_name = 'age';
+  $table = 'dosomething_campaign_affiliate_opt_ins';
+  $schema = dosomething_campaign_schema();
+
+  if (!db_field_exists($table, $field_name)) {
+    db_add_field($table, $field_name, $schema[$table]['fields'][$field_name]);
   }
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.install
@@ -53,7 +53,7 @@ function dosomething_campaign_schema() {
         'length' => '255',
       ],
       'age' => [
-        'description' => 'The ae for the user that opted-in.',
+        'description' => 'The age for the user that opted-in.',
         'type' => 'int',
         'not null' => FALSE,
       ],

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -521,7 +521,7 @@ function dosomething_helpers_exports_form_submit(&$form, &$form_state) {
   $values = $form_state['values'];
 
   if ($values['export_affiliate_messaging_optins']) {
-    $fields = ['campaign_id', 'campaign_run_id', 'northstar_id', 'first_name', 'email', 'mobile'];
+    $fields = ['campaign_id', 'campaign_run_id', 'northstar_id', 'first_name', 'email', 'mobile', 'age'];
 
     $data['affiliate_messaging_optins']['filename'] = 'Messaging Optins For '.$values['campaign_title'].'.csv';
 

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1,4 +1,7 @@
 <?php
+
+use Carbon\Carbon;
+
 /**
  * @file
  * Code for the DoSomething User feature.
@@ -1335,19 +1338,17 @@ function dosomething_user_format_string($string, $format) {
         return strtolower($string);
     }
 }
+
 /**
- * Returns given user's age.
+ * Returns object containing age related data.
  *
- * @param string $birthdate
- *   The value returned from `dosomething_user_get_field_birthdate`.
+ * @param  string $birthdate
+ * @return DateInterval
  *
- * @return string
- *   Returns the age (in years) of the user.
+ * @see http://php.net/manual/en/class.dateinterval.php
  */
 function dosomething_user_get_age($birthdate) {
-  $today = new DateTime('now');
-  $birthday = new DateTime($birthdate);
-  return $birthday->diff($today)->y;
+  return Carbon::parse($birthdate)->diff(Carbon::now());
 }
 
 /**
@@ -1460,7 +1461,7 @@ function dosomething_user_info_form($form, &$form_state, $account) {
     '#default_value' => $zipcode,
   );
   $birthday = dosomething_user_get_field_birthdate(dosomething_user_get_field('field_birthdate', $account), 'm/d/Y');
-  $age = dosomething_user_get_age($birthday);
+  $age = dosomething_user_get_age($birthday)->y;
   $form['info']['birthdate'] = array(
     '#title' => "Birthdate",
     '#type' => 'textfield',


### PR DESCRIPTION
#### What's this PR do?
This PR updates the opt-out/in data collection to include the age of the user that decides not to opt-out and also adds the data to the exported CSV.

#### How should this be reviewed?
👁 

#### Any background context you want to provide?
This PR does _not_ backfill the user's age in the current data in the affiliate opt-in data that has already been collected. That may potentially happen in another PR update.

#### Relevant tickets
https://trello.com/c/akkAiFZq/678-3-as-a-campaign-lead-for-who-has-their-eye-on-you-i-want-age-added-to-the-opt-out-export-file

#### Checklist
- [ ] Tested on staging.
