### PR TITLE
fixes bug to try to get id from northstar_id

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -38,13 +38,13 @@ function dosomething_campaign_preprocess_node(&$vars) {
 
   if (variable_get('rogue_collection', FALSE)) {
     global $user;
-    $northstar_user = dosomething_user_get_northstar_id($user->uid);
+    $northstar_user_id = dosomething_user_get_northstar_id($user->uid);
 
     $rogue = dosomething_rogue_client();
 
     $response = $rogue->getActivity([
       'filter' => [
-        'northstar_id' => $northstar_user->id,
+        'northstar_id' => $northstar_user_id,
         'campaign_id' => $vars['nid'],
       ],
     ]);


### PR DESCRIPTION
#### What's this PR do?
Fixes bug to try to get the `id` from the `$northstar_user` variable (which is just the northstar id, not the northstar user object). Also changes variable name to make it more clear.

#### How should this be reviewed?
👀 

#### Any background context you want to provide?
Typo from PR #7404 

#### Relevant tickets
https://trello.com/c/vsSBl0Xf/462-8-%F0%9F%90%9B-when-rogue-is-turned-on-youre-not-able-to-sign-up-for-a-campaign-%F0%9F%90%9B-5

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
