### PR TITLE
Drush command for backfilling age data for users that want affiliate messaging.

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.drush.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.drush.inc
@@ -4,9 +4,10 @@
  * Implementation of hook_drush_command().
  */
 function dosomething_campaign_drush_command() {
-  $items = array();
+  $items = [];
+
   // Name of the drush command.
-  $items['campaign-create'] = array(
+  $items['campaign-create'] = [
     'description' => 'Creates a campaign node from given JSON file.',
     'arguments' => array(
       'filename' => 'Name of the JSON file to read.',
@@ -16,7 +17,21 @@ function dosomething_campaign_drush_command() {
     'examples' => array(
       'drush campaign-create ../tests/campaign/campaign.json' => 'Creates a campaign node from contents of campaign.json.',
     ),
-  );
+  ];
+
+  // Name of the drush command.
+  $items['affiliate-opt-ins-age-backfill'] = [
+    'description' => 'Backfills the affiliate optins collected user data with their age.',
+    'callback' => 'dosomething_campaign_drush_affiliate_opt_ins_age_backfill',
+    'arguments' => [
+      'campaign_id' => 'The ID for the specified campaign.',
+      'campaign_run_id' => 'The ID for the specified campaign run.',
+    ],
+    'examples' => [
+      'drush affiliate-optins-age-backfill' => 'Backfills age data for opted-in users on specified campaign.',
+    ],
+  ];
+
   return $items;
 }
 
@@ -33,3 +48,33 @@ function dosomething_campaign_drush_campaign_create($filename) {
     return "Invalid filename.";
   }
 }
+
+/**
+ * Callback for affiliate-optins-age-backfill command.
+ */
+function dosomething_campaign_drush_affiliate_opt_ins_age_backfill() {
+  $results = db_select('dosomething_campaign_affiliate_opt_ins', 'optins')
+      ->fields('optins', ['northstar_id', 'age'])
+      ->execute()
+      ->fetchAll();
+
+  if ($results) {
+    foreach($results as $result) {
+      if (is_null($result->age)) {
+        $northstar_user = dosomething_northstar_get_user($result->northstar_id);
+        $northstar_user_age = dosomething_user_get_age($northstar_user->birthdate)->y;
+
+        db_update('dosomething_campaign_affiliate_opt_ins')
+          ->fields(['age' => $northstar_user_age])
+          ->condition('northstar_id', $northstar_user->id, '=')
+          ->execute();
+      }
+    }
+
+    drupal_set_message(dt('Completed executing affiliate optins age backfill.'), 'success');
+  } else {
+    drupal_set_message(dt('No affiliate optin data found.'), 'error');
+  }
+}
+
+


### PR DESCRIPTION
#### What's this PR do?
This PR adds a Drush command that can be run to update all the records in the `dosomething_campaign_affiliate_opt_ins` to add each user's age if we don't already have that information.

```
$ drush affiliate-opt-ins-age-backfill
```

#### How should this be reviewed?
👁 

#### Relevant tickets
https://trello.com/c/akkAiFZq/678-3-as-a-campaign-lead-for-who-has-their-eye-on-you-i-want-age-added-to-the-opt-out-export-file

#### Checklist
- [ ] Tested on staging.
