### PR TITLE
Bug fix: when Rogue is on and user is logged out, action page is shown. 

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -805,9 +805,12 @@ function dosomething_campaign_add_shipment_form_vars($node) {
  * @param obj $node
  *   A loaded node.
  *
+ * @param bool $rogue_signup_exists
+ *   Boolean if a signup exists in Rogue. Optional param.
+ *
  * @return bool
  */
-function dosomething_campaign_is_pitch_page($node) {
+function dosomething_campaign_is_pitch_page($node, $rogue_signup_exists = NULL) {
   // Exclude all non campaign node types.
   if ($node->type != 'campaign') { return FALSE; }
   // If not a campaign campaign (e.g. SMS Game), no pitch page is needed.
@@ -823,6 +826,7 @@ function dosomething_campaign_is_pitch_page($node) {
 
   // Anonymous users are always shown pitch page.
   if (!user_is_logged_in()) {
+
     return TRUE;
   }
   // Staff can always bypass pitch page to view full action page.
@@ -831,7 +835,11 @@ function dosomething_campaign_is_pitch_page($node) {
   }
 
   // The $node is a pitch page if you haven't signed up yet.
-  return (!dosomething_signup_exists($node->nid));
+  if ($rogue_signup_exists) {
+    return FALSE;
+  } else {
+    return (!dosomething_signup_exists($node->nid));
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -49,7 +49,7 @@ function dosomething_campaign_preprocess_node(&$vars) {
       ],
     ]);
 
-    $signup_exists = ! empty($response['data']);
+    $signup_exists = ! dosomething_campaign_is_pitch_page($node, ! empty($response['data']));
   } else {
     $signup_exists = ! dosomething_campaign_is_pitch_page($node);
   }


### PR DESCRIPTION
#### What's this PR do?
Fixes the bug when Rogue is on and the user is logged out, action page is shown. Now, when Rogue is on and user is logged out, only sign up page is shown. 
- Sends to `dosomething_campaign_is_pitch_page` to do all checks instead of just checking if a signup exists in Rogue when Rogue is on. 

#### How should this be reviewed?
- Turn Rogue on.
- Try to sign up for a campaign.
- Make sure you get re-directed to the campaign page instead of re-directed to the Signup page.
- Log out. 
- Make sure you are on the signup page.
- Make sure everything is still working as expected when Rogue is turned off.

#### Any background context you want to provide?
Fixes bug created from [this PR](https://github.com/DoSomething/phoenix/pull/7404).

#### Relevant tickets
Fixes https://trello.com/c/vQ9r8Epe/483-%F0%9F%90%9Bwhen-rogue-is-turned-on-you-seem-to-be-getting-the-action-page-and-youre-getting-onboarding-%F0%9F%90%9B

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
