### PR TITLE
Fixes bug to allow reportback after signup when Rogue is on.

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -107,11 +107,9 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     unset($form['reportback_submissions']['reportback_item']['#attributes']['data-validate']);
 
     $reportback_submissions_data = array();
-
     // Specify number of prior reportbacks to retrieve, including the latest one to show prominently.
     $reportback__submissions_count = 5;
 
-    // @TODO come back to this
     foreach ($entity->fids as $index => $fid) {
       $reportback_submissions_data[$index] = reportback_file_load($fid);
       $reportback_submissions_data[$index]->image = dosomething_image_get_themed_image_by_fid($fid, '400x400');
@@ -342,7 +340,7 @@ function dosomething_reportback_form_validate($form, &$form_state) {
     $response = $rogue->getActivity([
       'filter' => [
         'northstar_id' => $northstar_user_id,
-        'campaign_id' => menu_get_object()->nid,
+        'campaign_id' => $campaign_id,
       ],
     ]);
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -15,6 +15,30 @@
  * @ingroup forms
  */
 function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
+  if (variable_get('rogue_collection', FALSE)) {
+    global $user;
+    $northstar_user_id = dosomething_user_get_northstar_id($user->uid);
+
+    $rogue = dosomething_rogue_client();
+
+    $response = $rogue->getActivity([
+      'filter' => [
+        'northstar_id' => $northstar_user_id,
+        'campaign_id' => menu_get_object()->nid,
+      ],
+    ]);
+
+    if ($response['data'][0]['quantity']) {
+      $entity = new stdClass();
+      $entity->nid = $response['data'][0]['campaign_id'];
+      $entity->why_participated = $response['data'][0]['why_participated'];
+      $entity->quantity = $response['data'][0]['quantity'];
+      // @TODO: is the below ok??
+      $entity->rbid = $response['data'][0]['posts']['data'][0]['id'];
+      // @TODO: figure out how to populate the post picture in the template
+    }
+  }
+
   if (!$entity) {
     $entity = entity_create('reportback', array(
       'uid' => NULL,
@@ -99,8 +123,6 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     $entity->rbid = 0;
 
     $submit_label = t("Submit your pic");
-
-
   }
 
   // Else, it's an update form.
@@ -109,9 +131,11 @@ function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
     unset($form['reportback_submissions']['reportback_item']['#attributes']['data-validate']);
 
     $reportback_submissions_data = array();
+
     // Specify number of prior reportbacks to retrieve, including the latest one to show prominently.
     $reportback__submissions_count = 5;
 
+    // @TODO come back to this
     foreach ($entity->fids as $index => $fid) {
       $reportback_submissions_data[$index] = reportback_file_load($fid);
       $reportback_submissions_data[$index]->image = dosomething_image_get_themed_image_by_fid($fid, '400x400');

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -357,8 +357,26 @@ function dosomething_reportback_form_validate($form, &$form_state) {
     drupal_goto('node/' . $campaign_id);
   }
 
+  if (variable_get('rogue_collection', FALSE)) {
+    global $user;
+    $northstar_user_id = dosomething_user_get_northstar_id($user->uid);
+
+    $rogue = dosomething_rogue_client();
+
+    $response = $rogue->getActivity([
+      'filter' => [
+        'northstar_id' => $northstar_user_id,
+        'campaign_id' => menu_get_object()->nid,
+      ],
+    ]);
+
+    $signup_exists = $response['data'][0]['signup_id'] ? TRUE : FALSE;
+  } else {
+    $signup_exists = dosomething_signup_exists($campaign_id);
+  }
+
   // If user isn't signed up for the campaign.
-  if (!dosomething_user_is_staff() && !dosomething_signup_exists($campaign_id)) {
+  if (!dosomething_user_is_staff() && !$signup_exists) {
     drupal_set_message(t("You must be signed up for this campaign first."), 'error');
     drupal_goto('node/' . $campaign_id);
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -15,30 +15,6 @@
  * @ingroup forms
  */
 function dosomething_reportback_form($form, &$form_state, $entity = NULL) {
-  if (variable_get('rogue_collection', FALSE)) {
-    global $user;
-    $northstar_user_id = dosomething_user_get_northstar_id($user->uid);
-
-    $rogue = dosomething_rogue_client();
-
-    $response = $rogue->getActivity([
-      'filter' => [
-        'northstar_id' => $northstar_user_id,
-        'campaign_id' => menu_get_object()->nid,
-      ],
-    ]);
-
-    if ($response['data'][0]['quantity']) {
-      $entity = new stdClass();
-      $entity->nid = $response['data'][0]['campaign_id'];
-      $entity->why_participated = $response['data'][0]['why_participated'];
-      $entity->quantity = $response['data'][0]['quantity'];
-      // @TODO: is the below ok??
-      $entity->rbid = $response['data'][0]['posts']['data'][0]['id'];
-      // @TODO: figure out how to populate the post picture in the template
-    }
-  }
-
   if (!$entity) {
     $entity = entity_create('reportback', array(
       'uid' => NULL,


### PR DESCRIPTION
#### What's this PR do?
Fixes bug to allow reportback after signup when Rogue is on.

#### How should this be reviewed?
- Turn Rogue on. 
- Signup for a new campaign. 
- Reportback for a campaign. 
- Reportback should be in Rogue database. 

#### Relevant tickets
Fixes https://trello.com/c/35FIObWf/481-5-when-rogue-is-turned-on-and-after-signup-user-cannot-reportback

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
