### PR TITLE
#7389: Disable some unused modules

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.install
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.install
@@ -69,8 +69,10 @@ function dosomething_global_update_7003(&$sandbox) {
  */
 function dosomething_global_update_7004() {
   // Disable and uninstall Views Data Export
-  module_disable(array('views_data_export'));
-  drupal_uninstall_modules(array('views_data_export'));
+  if (module_exists('views_data_export')) {
+    module_disable(array('views_data_export'));
+    drupal_uninstall_modules(array('views_data_export'));
+  }
 
   // Remove some lingering previously removed modules from the System table.
   $modules = array(

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.install
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.install
@@ -63,3 +63,25 @@ function dosomething_global_update_7003(&$sandbox) {
                         WHERE u.language = 'en-global'
                         AND a.field_address_country = 'XR';");
 }
+
+/**
+ * Uninstall some unused modules.
+ */
+function dosomething_global_update_7004() {
+  // Disable and uninstall Views Data Export
+  module_disable(array('views_data_export'));
+  drupal_uninstall_modules(array('views_data_export'));
+
+  // Remove some lingering previously removed modules from the System table.
+  $modules = array(
+    'flag',
+    'restful',
+    'wysiwyg',
+    'dosomething_campaign_hot_shares',
+    'securepages',
+  );
+  db_delete('system')
+    ->condition('name', $modules, 'IN')
+    ->condition('type', 'module')
+    ->execute();
+}


### PR DESCRIPTION
#### What's this PR do?

Disables and uninstalls views_data_export, and then removes some lingering modules from the System table so that we don't get warnings about then when running `drush updb`:

- flag
- restful
- wysiwyg
- dosomething_campaign_hot_shares
- securepages

#### How should this be reviewed?

Clone the code, run `drush updb`, and make sure the site hasn't exploded and that subsequent runs of `drush updb` don't show warnings about modules missing from the filesystem.

#### Any background context you want to provide?

We originally planned to upgrade views_data_export but realized that it wasn't in use, hence why it's being uninstalled.

#### Relevant tickets

Fixes #7389 