### PR TITLE
When Rogue is on, user can now signup via SMS for a campaign 

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -292,9 +292,8 @@ function _campaign_resource_signup($nid, $values) {
       'campaign_id' => $nid,
     ]));
 
-    // Store the reference to the Rogue signup
     if ($rogue_signup) {
-      return dosomething_rogue_check_sid_and_store_ref($rogue_signup);
+      return $rogue_signup['data']['signup_id'];
     }
   }
 

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -224,7 +224,21 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
             $formatted_post['media']['uri'] = $post['media']['url'];
             $formatted_post['media']['type'] = 'image';
             $formatted_post['created_at'] = (new Carbon($post['created_at']))->timestamp;
-            // $formatted_post['kudos'] =
+
+            if ($post['reactions']) {
+              $reactions = [];
+              foreach ($post['reactions'] as $reaction) {
+                $formatted_reaction = [];
+                $formatted_reaction['id'] = $reaction['id'];
+                $formatted_reaction['term'] = 'heart';
+                $formatted_reaction['reportback_item'] = $reaction['post_id'];
+                $formatted_reaction['user'] = $reaction['northstar_id'];
+                $formatted_reaction['uri'] = null;
+                array_push($reactions, $formatted_reaction);
+              }
+            }
+
+            $formatted_post['kudos'] = $reactions ? $reactions : null;
             array_push($posts, $formatted_post);
 
             if ($post['status'] === 'rejected') {
@@ -274,7 +288,20 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
   }
 
   if ($transformed_response) {
-    return $transformed_response;
+    $final_response = [];
+
+    // Mimic meta data response
+    $final_response['meta'] = $response['meta'];
+
+    $final_response['meta']['pagination']['links']['next_uri'] = $response['meta']['pagination']['links']['next'];
+    $final_response['meta']['pagination']['links']['prev_uri'] = $response['meta']['pagination']['links']['prev'];
+    unset($final_response['meta']['pagination']['links']['next']);
+    unset($final_response['meta']['pagination']['links']['prev']);
+
+    // Add data to the response
+    $final_response['data'] = $transformed_response;
+
+    return $final_response;
   } else {
     return (new SignupTransformer)->index($parameters);
   }

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -203,7 +203,6 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
         }
 
         $northstar_user_id = implode(',', $northstar_user_ids_array);
-        // 5589c991a59dbfa93d8b45ae,559442aba59dbfca578b49cb
       } else {
         $northstar_user_id = dosomething_user_get_northstar_id($user);
         $user_object = user_load($user);
@@ -302,8 +301,22 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
     // Mimic meta data response
     $final_response['meta'] = $response['meta'];
 
-    $final_response['meta']['pagination']['links']['next_uri'] = $response['meta']['pagination']['links']['next'];
-    $final_response['meta']['pagination']['links']['prev_uri'] = $response['meta']['pagination']['links']['prev'];
+    if ($response['meta']['pagination']['links']['next']) {
+      $query = drupal_get_query_parameters();
+      $query['page'] = $response['meta']['pagination']['current_page'] + 1;
+      $final_response['meta']['pagination']['links']['next_uri'] = url(current_path(), ['absolute' => TRUE, 'query' => $query]);
+    } else {
+      $final_response['meta']['pagination']['links']['next_uri'] = null;
+    }
+
+    if ($response['meta']['pagination']['links']['prev']) {
+      $query = drupal_get_query_parameters();
+      $query['page'] = $response['meta']['pagination']['current_page'] - 1;
+      $final_response['meta']['pagination']['links']['prev_uri'] = url(current_path(), ['absolute' => TRUE, 'query' => $query]);
+    } else {
+      $final_response['meta']['pagination']['links']['prev_uri'] = null;
+    }
+
     unset($final_response['meta']['pagination']['links']['next']);
     unset($final_response['meta']['pagination']['links']['prev']);
 

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -285,9 +285,6 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
         ];
       });
     }
-  }
-
-  if ($transformed_response) {
     $final_response = [];
 
     // Mimic meta data response
@@ -302,9 +299,9 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
     $final_response['data'] = $transformed_response;
 
     return $final_response;
-  } else {
-    return (new SignupTransformer)->index($parameters);
   }
+
+    return (new SignupTransformer)->index($parameters);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -1,5 +1,7 @@
 <?php
 
+use Carbon\Carbon;
+
 function _signup_resource_definition() {
   $signup_resource = [];
   $signup_resource['signups'] = [
@@ -191,7 +193,10 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
 
   if (variable_get('rogue_collection', FALSE)) {
     if ($user) {
-      $northstar_user_id = dosomething_user_get_northstar_id($user->uid);
+      $northstar_user_id = dosomething_user_get_northstar_id($user);
+      $user_object = user_load($user);
+      // print_r($user_object->language);
+      // die();
     }
 
      $rogue = dosomething_rogue_client();
@@ -199,22 +204,71 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
      $response = $rogue->getActivity([
        'filter' => [
          'northstar_id' => $northstar_user_id,
-         'campaign_id' => $campaigns[0],
+         'campaign_id' => $campaigns,
        ],
      ]);
 
     if ($response) {
-      $transformed_response = collect($response['data'])->map(function($signup) {
-      print_r((dosomething_helpers_get_current_campaign_run_for_user($signup['campaign_id'], $user)->nid == $signup['campaign_run_id']) ? TRUE : FALSE);
-        // print_r($signup['campaign_run_id']);
-      die();
+      collect($response['data'])->map(function($signup) {
+        $campaign = node_load($signup['campaign_id']);
+        print_r($campaign->field_campaign_status);
+        die();
         return [
           'id' => $signup['signup_id'],
-          // @TODO: come back to this
-          // 'created_at' => new Carbon($signup['created_at'])->timestamp,
+          'created_at' => (new Carbon($signup['created_at']))->timestamp,
           'campaign_run' => [
             'id' => $signup['campaign_run_id'],
-            'current' => (dosomething_helpers_get_current_campaign_run_for_user($signup['campaign_id'], $user)->nid == $signup['campaign_run_id']) ? TRUE : FALSE);
+            'current' => (dosomething_helpers_get_current_campaign_run_for_user($signup['campaign_id'], $user_object)->nid == $signup['campaign_run_id']) ? TRUE : FALSE,
+          ],
+          // @TODO: come back to this
+          // 'uri' =>
+          'campaign' => [
+            'id' => $signup['campaign_id'],
+            'title' => $campaign->title,
+            // 'campaign_runs' => [
+              // 'current' => [
+              // ],
+              // 'past' => [
+
+              // ],
+            // ],
+            'language' => [
+              // 'language_code' => ,
+              // 'prefix' => ,
+            ],
+            'translations' => [
+              // 'original' => ,
+              // ''
+            ],
+            'tagline' => [
+
+            ],
+            'status' => [
+
+            ],
+            'type' => [
+            ],
+            // 'reportback_info' => [
+            //   'copy' => ,
+            //   'confirmation_message' => ,
+            //   'noun' => ,
+            //   'verb' => ,
+            // ],
+            'reportback' => [
+              'id' => $signup['signup_id'],
+              'created_at' => (new Carbon($signup['created_at']))->timestamp,
+              'updated_at' => (new Carbon($signup['updated_at']))->timestamp,
+              'quantity' => $signup['quantity'],
+              // 'uri' => ,
+              'why_participated' => $signup['why_participated'],
+              // 'flagged' => ,
+              'reportback_items' => [
+                'total' => count($signup['posts']['data']),
+                'data' => [
+                  // iterate through each here.
+                ],
+              ],
+            ],
           ],
         ];
       });

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -1,7 +1,5 @@
 <?php
 
-use Carbon\Carbon;
-
 function _signup_resource_definition() {
   $signup_resource = [];
   $signup_resource['signups'] = [
@@ -191,142 +189,14 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
     'runs' => $runs,
   ];
 
+  // Return data from Rogue if Rogue is turned on
   if (variable_get('rogue_collection', FALSE)) {
-    if ($user) {
-      if( strpos($user, ',') !== false ) {
-        $users = explode(',', $user);
-        $northstar_user_ids_array = [];
+    $rogue_response = dosomething_rogue_get_activity($parameters);
 
-        foreach ($users as $user) {
-          $northstar_user_id = dosomething_user_get_northstar_id($user);
-          array_push($northstar_user_ids_array, $northstar_user_id);
-        }
-
-        $northstar_user_id = implode(',', $northstar_user_ids_array);
-      } else {
-        $northstar_user_id = dosomething_user_get_northstar_id($user);
-        $user_object = user_load($user);
-      }
-    }
-
-     $rogue = dosomething_rogue_client();
-
-     $response = $rogue->getActivity([
-       'filter' => [
-         'northstar_id' => $northstar_user_id,
-         'campaign_id' => $campaigns,
-       ],
-     ]);
-
-    if ($response) {
-      $transformed_response = collect($response['data'])->map(function($signup) {
-        $campaign = Campaign::get($signup['campaign_id']);
-
-        if ($signup['posts']['data']) {
-          $posts = [];
-          $flagged = FALSE;
-
-          foreach ($signup['posts']['data'] as $post) {
-            $formatted_post = [];
-            $formatted_post['id'] = $post['id'];
-            $formatted_post['status'] = $post['status'];
-            $formatted_post['caption'] = $post['media']['caption'];
-            $formatted_post['uri'] = null;
-            $formatted_post['media']['uri'] = $post['media']['url'];
-            $formatted_post['media']['type'] = 'image';
-            $formatted_post['created_at'] = (new Carbon($post['created_at']))->timestamp;
-
-            if ($post['reactions']) {
-              $reactions = [];
-              foreach ($post['reactions'] as $reaction) {
-                $formatted_reaction = [];
-                $formatted_reaction['id'] = $reaction['id'];
-                $formatted_reaction['term'] = 'heart';
-                $formatted_reaction['reportback_item'] = $reaction['post_id'];
-                $formatted_reaction['user'] = $reaction['northstar_id'];
-                $formatted_reaction['uri'] = null;
-                array_push($reactions, $formatted_reaction);
-              }
-            }
-
-            $formatted_post['kudos'] = $reactions ? $reactions : null;
-            array_push($posts, $formatted_post);
-
-            if ($post['status'] === 'rejected') {
-              $flagged = TRUE;
-            }
-          }
-        }
-
-        return [
-          'id' => $signup['signup_id'],
-          'created_at' => (new Carbon($signup['created_at']))->timestamp,
-          'campaign_run' => [
-            'id' => $signup['campaign_run_id'],
-            'current' => (dosomething_helpers_get_current_campaign_run_for_user($signup['campaign_id'], $user_object)->nid == $signup['campaign_run_id']) ? TRUE : FALSE,
-          ],
-          'uri' => null,
-          'campaign' => [
-            'id' => $signup['campaign_id'],
-            'title' => $campaign->title,
-            'campaign_runs' => $campaign->campaign_runs,
-            'language' => [
-              'language_code' => $campaign->language['language_code'],
-              'prefix' => $campaign->language['prefix'],
-            ],
-            'translations' => $campaign->translations,
-            'tagline' => $campaign->tagline,
-            'status' => $campaign->status,
-            'type' => $campaign->type,
-            'reportback_info' => $campaign->reportback_info,
-          ],
-          'reportback' => [
-            'id' => $signup['signup_id'],
-            'created_at' => (new Carbon($signup['created_at']))->timestamp,
-            'updated_at' => (new Carbon($signup['updated_at']))->timestamp,
-            'quantity' => $signup['quantity'],
-            'uri' => null,
-            'why_participated' => $signup['why_participated'],
-            'flagged' => $flagged,
-            'reportback_items' => [
-              'total' => count($signup['posts']['data']),
-              'data' => $posts,
-            ],
-          ],
-        ];
-      });
-    }
-    $final_response = [];
-
-    // Mimic meta data response
-    $final_response['meta'] = $response['meta'];
-
-    if ($response['meta']['pagination']['links']['next']) {
-      $query = drupal_get_query_parameters();
-      $query['page'] = $response['meta']['pagination']['current_page'] + 1;
-      $final_response['meta']['pagination']['links']['next_uri'] = url(current_path(), ['absolute' => TRUE, 'query' => $query]);
-    } else {
-      $final_response['meta']['pagination']['links']['next_uri'] = null;
-    }
-
-    if ($response['meta']['pagination']['links']['prev']) {
-      $query = drupal_get_query_parameters();
-      $query['page'] = $response['meta']['pagination']['current_page'] - 1;
-      $final_response['meta']['pagination']['links']['prev_uri'] = url(current_path(), ['absolute' => TRUE, 'query' => $query]);
-    } else {
-      $final_response['meta']['pagination']['links']['prev_uri'] = null;
-    }
-
-    unset($final_response['meta']['pagination']['links']['next']);
-    unset($final_response['meta']['pagination']['links']['prev']);
-
-    // Add data to the response
-    $final_response['data'] = $transformed_response;
-
-    return $final_response;
+    return json_decode(dosomething_rogue_format_activity($rogue_response));
   }
 
-    return (new SignupTransformer)->index($parameters);
+  return (new SignupTransformer)->index($parameters);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -195,8 +195,6 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
     if ($user) {
       $northstar_user_id = dosomething_user_get_northstar_id($user);
       $user_object = user_load($user);
-      // print_r($user_object->language);
-      // die();
     }
 
      $rogue = dosomething_rogue_client();
@@ -212,46 +210,57 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
       collect($response['data'])->map(function($signup) {
         $campaign = node_load($signup['campaign_id']);
         $campaign = Campaign::get($signup['campaign_id']);
-        print_r($campaign->reportback_info);
-        die();
+        if ($signup['posts']['data']) {
+          $posts = [];
+          foreach ($signup['posts']['data'] as $post) {
+            $formatted_post = [];
+            $formatted_post['id'] = $post['id'];
+            $formatted_post['status'] = $post['status'];
+            $formatted_post['caption'] = $post['media']['caption'];
+            // $formatted_post['uri']
+            $formatted_post['media']['uri'] = $post['media']['url'];
+            $formatted_post['media']['type'] = 'image';
+            $formatted_post['created_at'] = (new Carbon($post['created_at']))->timestamp;
+            // $formatted_post['kudos']
+            array_push($posts, $formatted_post);
+          };
+        };
         return [
-          'id' => $signup['signup_id'],
-          'created_at' => (new Carbon($signup['created_at']))->timestamp,
-          'campaign_run' => [
-            'id' => $signup['campaign_run_id'],
-            'current' => (dosomething_helpers_get_current_campaign_run_for_user($signup['campaign_id'], $user_object)->nid == $signup['campaign_run_id']) ? TRUE : FALSE,
-          ],
-          // @TODO: come back to this
-          // 'uri' =>
-          'campaign' => [
-            'id' => $signup['campaign_id'],
-            'title' => $campaign->title,
-            'campaign_runs' => $campaign->campaign_runs,
-            'language' => [
-              'language_code' => $campaign->language['language_code'],
-              'prefix' => $campaign->language['prefix'],
-            ],
-            'translations' => $campaign->translations,
-            'tagline' => $campaign->tagline,
-            'status' => $campaign->status,
-            'type' => $campaign->type,
-            'reportback_info' => $campaign->reportback_info,
-            'reportback' => [
-              'id' => $signup['signup_id'],
-              'created_at' => (new Carbon($signup['created_at']))->timestamp,
-              'updated_at' => (new Carbon($signup['updated_at']))->timestamp,
-              'quantity' => $signup['quantity'],
-              // 'uri' => ,
-              'why_participated' => $signup['why_participated'],
-              // 'flagged' => ,
-              'reportback_items' => [
-                'total' => count($signup['posts']['data']),
-                'data' => [
-                  // iterate through each here.
-                ],
-              ],
-            ],
-          ],
+          // 'id' => $signup['signup_id'],
+          // 'created_at' => (new Carbon($signup['created_at']))->timestamp,
+          // 'campaign_run' => [
+          //   'id' => $signup['campaign_run_id'],
+          //   'current' => (dosomething_helpers_get_current_campaign_run_for_user($signup['campaign_id'], $user_object)->nid == $signup['campaign_run_id']) ? TRUE : FALSE,
+          // ],
+          // // @TODO: come back to this
+          // // 'uri' =>
+          // 'campaign' => [
+          //   'id' => $signup['campaign_id'],
+          //   'title' => $campaign->title,
+          //   'campaign_runs' => $campaign->campaign_runs,
+          //   'language' => [
+          //     'language_code' => $campaign->language['language_code'],
+          //     'prefix' => $campaign->language['prefix'],
+          //   ],
+          //   'translations' => $campaign->translations,
+          //   'tagline' => $campaign->tagline,
+          //   'status' => $campaign->status,
+          //   'type' => $campaign->type,
+          //   'reportback_info' => $campaign->reportback_info,
+          //   'reportback' => [
+          //     'id' => $signup['signup_id'],
+          //     'created_at' => (new Carbon($signup['created_at']))->timestamp,
+          //     'updated_at' => (new Carbon($signup['updated_at']))->timestamp,
+          //     'quantity' => $signup['quantity'],
+          //     // 'uri' => ,
+          //     'why_participated' => $signup['why_participated'],
+          //     // 'flagged' => ,
+          //     'reportback_items' => [
+          //       'total' => count($signup['posts']['data']),
+          //       'data' => $posts,
+          //     ],
+          //   ],
+          // ],
         ];
       });
     }

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -203,7 +203,9 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
        ],
      ]);
 
-     return
+     if ($response) {
+      return $response;
+     }
   }
 
   return (new SignupTransformer)->index($parameters);

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -211,7 +211,8 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
     if ($response) {
       collect($response['data'])->map(function($signup) {
         $campaign = node_load($signup['campaign_id']);
-        print_r($campaign->field_campaign_status);
+        $campaign = Campaign::get($signup['campaign_id']);
+        print_r($campaign->reportback_info);
         die();
         return [
           'id' => $signup['signup_id'],
@@ -225,35 +226,16 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
           'campaign' => [
             'id' => $signup['campaign_id'],
             'title' => $campaign->title,
-            // 'campaign_runs' => [
-              // 'current' => [
-              // ],
-              // 'past' => [
-
-              // ],
-            // ],
+            'campaign_runs' => $campaign->campaign_runs,
             'language' => [
-              // 'language_code' => ,
-              // 'prefix' => ,
+              'language_code' => $campaign->language['language_code'],
+              'prefix' => $campaign->language['prefix'],
             ],
-            'translations' => [
-              // 'original' => ,
-              // ''
-            ],
-            'tagline' => [
-
-            ],
-            'status' => [
-
-            ],
-            'type' => [
-            ],
-            // 'reportback_info' => [
-            //   'copy' => ,
-            //   'confirmation_message' => ,
-            //   'noun' => ,
-            //   'verb' => ,
-            // ],
+            'translations' => $campaign->translations,
+            'tagline' => $campaign->tagline,
+            'status' => $campaign->status,
+            'type' => $campaign->type,
+            'reportback_info' => $campaign->reportback_info,
             'reportback' => [
               'id' => $signup['signup_id'],
               'created_at' => (new Carbon($signup['created_at']))->timestamp,

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -207,66 +207,77 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
      ]);
 
     if ($response) {
-      collect($response['data'])->map(function($signup) {
+      $transformed_response = collect($response['data'])->map(function($signup) {
         $campaign = node_load($signup['campaign_id']);
         $campaign = Campaign::get($signup['campaign_id']);
+
         if ($signup['posts']['data']) {
           $posts = [];
+          $flagged = FALSE;
+
           foreach ($signup['posts']['data'] as $post) {
             $formatted_post = [];
             $formatted_post['id'] = $post['id'];
             $formatted_post['status'] = $post['status'];
             $formatted_post['caption'] = $post['media']['caption'];
-            // $formatted_post['uri']
+            $formatted_post['uri'] = null;
             $formatted_post['media']['uri'] = $post['media']['url'];
             $formatted_post['media']['type'] = 'image';
             $formatted_post['created_at'] = (new Carbon($post['created_at']))->timestamp;
-            // $formatted_post['kudos']
+            // $formatted_post['kudos'] =
             array_push($posts, $formatted_post);
-          };
-        };
+
+            if ($post['status'] === 'rejected') {
+              $flagged = TRUE;
+            }
+          }
+        }
+
         return [
-          // 'id' => $signup['signup_id'],
-          // 'created_at' => (new Carbon($signup['created_at']))->timestamp,
-          // 'campaign_run' => [
-          //   'id' => $signup['campaign_run_id'],
-          //   'current' => (dosomething_helpers_get_current_campaign_run_for_user($signup['campaign_id'], $user_object)->nid == $signup['campaign_run_id']) ? TRUE : FALSE,
-          // ],
-          // // @TODO: come back to this
-          // // 'uri' =>
-          // 'campaign' => [
-          //   'id' => $signup['campaign_id'],
-          //   'title' => $campaign->title,
-          //   'campaign_runs' => $campaign->campaign_runs,
-          //   'language' => [
-          //     'language_code' => $campaign->language['language_code'],
-          //     'prefix' => $campaign->language['prefix'],
-          //   ],
-          //   'translations' => $campaign->translations,
-          //   'tagline' => $campaign->tagline,
-          //   'status' => $campaign->status,
-          //   'type' => $campaign->type,
-          //   'reportback_info' => $campaign->reportback_info,
-          //   'reportback' => [
-          //     'id' => $signup['signup_id'],
-          //     'created_at' => (new Carbon($signup['created_at']))->timestamp,
-          //     'updated_at' => (new Carbon($signup['updated_at']))->timestamp,
-          //     'quantity' => $signup['quantity'],
-          //     // 'uri' => ,
-          //     'why_participated' => $signup['why_participated'],
-          //     // 'flagged' => ,
-          //     'reportback_items' => [
-          //       'total' => count($signup['posts']['data']),
-          //       'data' => $posts,
-          //     ],
-          //   ],
-          // ],
+          'id' => $signup['signup_id'],
+          'created_at' => (new Carbon($signup['created_at']))->timestamp,
+          'campaign_run' => [
+            'id' => $signup['campaign_run_id'],
+            'current' => (dosomething_helpers_get_current_campaign_run_for_user($signup['campaign_id'], $user_object)->nid == $signup['campaign_run_id']) ? TRUE : FALSE,
+          ],
+          'uri' => null,
+          'campaign' => [
+            'id' => $signup['campaign_id'],
+            'title' => $campaign->title,
+            'campaign_runs' => $campaign->campaign_runs,
+            'language' => [
+              'language_code' => $campaign->language['language_code'],
+              'prefix' => $campaign->language['prefix'],
+            ],
+            'translations' => $campaign->translations,
+            'tagline' => $campaign->tagline,
+            'status' => $campaign->status,
+            'type' => $campaign->type,
+            'reportback_info' => $campaign->reportback_info,
+          ],
+          'reportback' => [
+            'id' => $signup['signup_id'],
+            'created_at' => (new Carbon($signup['created_at']))->timestamp,
+            'updated_at' => (new Carbon($signup['updated_at']))->timestamp,
+            'quantity' => $signup['quantity'],
+            'uri' => null,
+            'why_participated' => $signup['why_participated'],
+            'flagged' => $flagged,
+            'reportback_items' => [
+              'total' => count($signup['posts']['data']),
+              'data' => $posts,
+            ],
+          ],
         ];
       });
     }
   }
 
-  return (new SignupTransformer)->index($parameters);
+  if ($transformed_response) {
+    return $transformed_response;
+  } else {
+    return (new SignupTransformer)->index($parameters);
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -208,7 +208,6 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
 
     if ($response) {
       $transformed_response = collect($response['data'])->map(function($signup) {
-        $campaign = node_load($signup['campaign_id']);
         $campaign = Campaign::get($signup['campaign_id']);
 
         if ($signup['posts']['data']) {

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -203,9 +203,22 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
        ],
      ]);
 
-     if ($response) {
-      return $response;
-     }
+    if ($response) {
+      $transformed_response = collect($response['data'])->map(function($signup) {
+      print_r((dosomething_helpers_get_current_campaign_run_for_user($signup['campaign_id'], $user)->nid == $signup['campaign_run_id']) ? TRUE : FALSE);
+        // print_r($signup['campaign_run_id']);
+      die();
+        return [
+          'id' => $signup['signup_id'],
+          // @TODO: come back to this
+          // 'created_at' => new Carbon($signup['created_at'])->timestamp,
+          'campaign_run' => [
+            'id' => $signup['campaign_run_id'],
+            'current' => (dosomething_helpers_get_current_campaign_run_for_user($signup['campaign_id'], $user)->nid == $signup['campaign_run_id']) ? TRUE : FALSE);
+          ],
+        ];
+      });
+    }
   }
 
   return (new SignupTransformer)->index($parameters);

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -189,6 +189,23 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
     'runs' => $runs,
   ];
 
+  if (variable_get('rogue_collection', FALSE)) {
+    if ($user) {
+      $northstar_user_id = dosomething_user_get_northstar_id($user->uid);
+    }
+
+     $rogue = dosomething_rogue_client();
+
+     $response = $rogue->getActivity([
+       'filter' => [
+         'northstar_id' => $northstar_user_id,
+         'campaign_id' => $campaigns[0],
+       ],
+     ]);
+
+     return
+  }
+
   return (new SignupTransformer)->index($parameters);
 }
 

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -193,8 +193,21 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
 
   if (variable_get('rogue_collection', FALSE)) {
     if ($user) {
-      $northstar_user_id = dosomething_user_get_northstar_id($user);
-      $user_object = user_load($user);
+      if( strpos($user, ',') !== false ) {
+        $users = explode(',', $user);
+        $northstar_user_ids_array = [];
+
+        foreach ($users as $user) {
+          $northstar_user_id = dosomething_user_get_northstar_id($user);
+          array_push($northstar_user_ids_array, $northstar_user_id);
+        }
+
+        $northstar_user_id = implode(',', $northstar_user_ids_array);
+        // 5589c991a59dbfa93d8b45ae,559442aba59dbfca578b49cb
+      } else {
+        $northstar_user_id = dosomething_user_get_northstar_id($user);
+        $user_object = user_load($user);
+      }
     }
 
      $rogue = dosomething_rogue_client();

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.cron.inc
@@ -61,8 +61,6 @@ function dosomething_rogue_retry_failed_reportbacks() {
         $rogue_signup = dosomething_rogue_send_signup_to_rogue((array)$task, $user, $task->id);
 
         if ($rogue_signup) {
-          dosomething_rogue_check_sid_and_store_ref($rogue_signup);
-
           // Remove signup from failed log once it has been send successfully
           db_delete('dosomething_rogue_failed_task_log')
             ->condition('id', $task->id)

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -546,35 +546,6 @@ function dosomething_rogue_transform_signup($values, $northstar_id, $user) {
 }
 
 /**
- * Checks to see if the given signup data exists in Phoenix and if so stores in Rogue reference table.
- *
- * @param array $rogue_signup
- * The response from dosomething_rogue_send_signup_to_rogue().
- *
- */
-function dosomething_rogue_check_sid_and_store_ref($rogue_signup) {
-  // Get user from Northstar ID
-  $northstar_user = dosomething_northstar_get_user($rogue_signup['data']['northstar_id']);
-  $user = user_load($northstar_user->drupal_id);
-
-  // Get the signup
-  $sid = dosomething_signup_exists($rogue_signup['data']['campaign_id'], $rogue_signup['data']['campaign_run_id'], $user->uid);
-
-  // Make sure the signup exists before we try to use it
-  if ($sid) {
-    // Make sure that signup is not in the Rogue reference table yet
-    if (!dosomething_rogue_get_signup_by_sid($sid)) {
-      // Store reference to the signup in rogue
-      dosomething_rogue_store_rogue_signup_references($sid, $rogue_signup);
-    }
-
-    return $sid;
-  }
-
-  return false;
-}
-
-/**
  * Insert record that stores reference to the signup in
  * phoenix and corresponding signup id in Rogue
  *

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -102,7 +102,6 @@ function dosomething_signup_form_submit($form, &$form_state) {
 
     // Make sure the signup exists before using it
     if ($rogue_signup) {
-      dosomething_rogue_check_sid_and_store_ref($rogue_signup);
       $node = node_load($rogue_signup['data']['campaign_id']);
       dosomething_signup_set_signup_message($node->title);
     }


### PR DESCRIPTION
#### What's this PR do?
- Fixes bug so now when Rogue is on, user can go through SMS flow when texting in keyword to 38383. 
  - When user texts keyword, first check if signup exists in Rogue and if not, create a new signup. 
    - Returns Rogue signup object when Phoenix's `GET /signups` endpoint is hit. 
    - Returns Rogue `signup_id` when Phoenix's `/campaigns/[nid]/signup` is hit.
- Removes `dosomething_rogue_check_sid_and_store_ref` and anywhere that uses this since we no longer post info back to Phoenix from Rogue.

#### How should this be reviewed?
- Turn Rogue on. 
- Signup for a new campaign.
- Make sure signup makes it to Rogue. 
- Hit `/campaigns/[nid]/signup` and make sure Rogue signup id is returned. 
- Make sure signing up via SMS works (both for a new and existing signup). 

#### Any background context you want to provide?
Just want to flag for @aaronschachter in case you see any issues because of this PR! 

#### Relevant tickets
Fixes https://trello.com/c/S7cjnFL1/482-3-when-rogue-is-turned-on-user-cannot-sign-up-via-sms

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
