### PR TITLE
7389 uninstall modules

### DIFF
--- a/lib/modules/dosomething/dosomething_global/dosomething_global.install
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.install
@@ -65,6 +65,12 @@ function dosomething_global_update_7003(&$sandbox) {
 }
 
 /**
+ * Empty update function.
+ */
+function dosomething_global_update_7004() {
+}
+
+/**
  * Uninstall some unused modules.
  */
 function dosomething_global_update_7005() {

--- a/lib/modules/dosomething/dosomething_global/dosomething_global.install
+++ b/lib/modules/dosomething/dosomething_global/dosomething_global.install
@@ -67,7 +67,7 @@ function dosomething_global_update_7003(&$sandbox) {
 /**
  * Uninstall some unused modules.
  */
-function dosomething_global_update_7004() {
+function dosomething_global_update_7005() {
   // Disable and uninstall Views Data Export
   if (module_exists('views_data_export')) {
     module_disable(array('views_data_export'));

--- a/lib/profiles/dosomething/dosomething.info
+++ b/lib/profiles/dosomething/dosomething.info
@@ -68,7 +68,6 @@ dependencies[] = variable
 dependencies[] = varnish
 dependencies[] = view_unpublished
 dependencies[] = views
-dependencies[] = views_data_export
 dependencies[] = views_limit_grouping
 dependencies[] = views_ui
 dependencies[] = xmlsitemap


### PR DESCRIPTION
#### What's this PR do?

Removes views_data_export as a dependency so it won't re-enable itself at build time.

#### How should this be reviewed?

Run a full `ds build` to ensure that the module is disabled and stays disabled after the build is complete. 

#### Any background context you want to provide?

Nope.

#### Relevant tickets
Fixes #7389 