### PR TITLE
No-Ticket: Remove user entities from metatag table prior to running metatag updates

### DIFF
--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.features.metatag.inc
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.features.metatag.inc
@@ -101,9 +101,6 @@ function dosomething_metatag_metatag_export_default() {
       'twitter:description' => array(
         'value' => '',
       ),
-      'twitter:image:src' => array(
-        'value' => '',
-      ),
       'twitter:image:width' => array(
         'value' => '',
       ),
@@ -177,6 +174,9 @@ function dosomething_metatag_metatag_export_default() {
         'value' => '',
       ),
       'twitter:data2' => array(
+        'value' => '',
+      ),
+      'twitter:image' => array(
         'value' => '',
       ),
     ),

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.install
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.install
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @file
+ * Installation and schema hooks for dosomething_metatag.module
+ */
+
+/**
+ * Ensure this module's 7000 update runs before the 7040 & 7041 metatag updates.
+ *
+ * We do not need to update the metatag entries for user entities.
+ * In fact, we don't even need the entries. We remove the entries prior to doing
+ * the time-consuming work of updating them.
+ */
+function dosomething_metatag_update_dependencies() {
+  $dependencies['dosomething_metatag'][7000] = array(
+    'metatag' => 7039,
+  );
+
+  return $dependencies;
+}
+
+/**
+ * Remove metatag entries for user entities.
+ */
+function dosomething_metatag_update_7000() {
+  db_delete('metatag')
+  ->condition('entity_type', 'user')
+  ->execute();
+}

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.strongarm.inc
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.strongarm.inc
@@ -196,7 +196,7 @@ function dosomething_metatag_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'metatag_enable_user';
-  $strongarm->value = 1;
+  $strongarm->value = 0;
   $export['metatag_enable_user'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
#### What's this PR do?
This is related to work done for issue #7392  - Upgrade Metatag module from 7.x-1.4 to 7.x-1.21

On Thor, with the larger dataset, the upgrade process took 1 day and 21 hours. The reason for this appears to be that metatags is updating all of the user entities (there's a lot of them). This is completely unnecessary because user profiles are not exposed to the public and thus having metatags on them is also unnecessary.

This PR does:

- Removes User from metatag configuration. 
- Also includes a re-export (minor change) of the twitter image metatag.
- Implements update hook for dosomething_metatag.
- Implements hook_update_dependencies() to ensure that the dosomething_metatag hook runs prior to the time-consuming metatag updates.

#### How should this be reviewed?
1. Refresh Thor with Prod db prior to deploying to Thor
2. We should have less than the original 974,944 records to update (for update # 7041 / the update for 7040 ran quicker and covered a smaller subset of records).

If reviewing locally, you will have to update the systems table for the metatag entry to roll back to the schema version of 7035 to match the state of version 1.4 (reference =  http://cgit.drupalcode.org/metatag/tree/metatag.install?h=7.x-1.4&id=4ea7c8dabbc2e4eca0d83774e35caeb08c03eba7)

@mikecrittenden: Couldn't add you as a reviewer, but could you take a look?

#### Any background context you want to provide?
N/A

#### Relevant tickets
Related to problem reported when run on Thor: #7392 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
