### PR TITLE
Actually delete the unused fields.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.install
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.install
@@ -92,6 +92,16 @@ function dosomething_user_update_7010() {
 }
 
 /**
+ * Remove database tables for unused fields.
+ */
+function dosomething_user_update_7011() {
+  field_delete_field('field_under_thirteen');
+  field_delete_field('field_opt_in_sms');
+  field_delete_field('field_opt_in_email');
+  field_delete_field('field_created_by_openid_connect');
+}
+
+/**
  * Implements hook_uninstall().
  */
 function dosomething_user_uninstall() {


### PR DESCRIPTION
#### What's this PR do?
This pull request _actually_ deletes the fields I meant to remove in #7424. Turns out Drupal will remove the database tables when you delete the field in the GUI, but not when doing the same thing via `drush fra -y`. ¯\_(ツ)_/¯

#### How should this be reviewed?
🥞 👀

#### Any background context you want to provide?
[`field_delete_field` docs](https://api.drupal.org/api/drupal/modules!field!field.crud.inc/function/field_delete_field/7.x)

#### Relevant tickets
References #7424.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  