### PR TITLE
Starting on competition auto-opt in

### DIFF
--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -233,6 +233,20 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     '#default_value' => $vars['disable_onboarding']
   ];
 
+  // Auto Competition-Opt-In
+  $form['auto_competition'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Auto Competition Opt-In'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  ];
+  $form['auto_competition']['enable_auto_competition_opt_in'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Enable auto competition opt-in'),
+    '#description' => t('Users who signup will automatically join a competition'),
+    '#default_value' => $vars['enable_auto_competition_opt_in']
+  ];
+
   $form['actions'] = array(
     '#type' => 'actions',
     'submit' => array(

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -583,6 +583,12 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL, $
   if ($sid = dosomething_signup_create($nid, $account->uid, $source)) {
     $node = node_load($nid);
 
+    // Opt into competition if auto opt-in is enabled for this campaign.
+    $auto_opt_in = dosomething_helpers_get_variable('node', $nid, 'enable_auto_competition_opt_in');
+    if ($auto_opt_in) {
+      dosomething_gladiator_send_user_to_gladiator($account, ['nid' => $nid, 'run_nid' => ]);
+    }
+
     // Set default signup message if we're still in this function.
     dosomething_signup_set_signup_message($node->title);
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -585,8 +585,11 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL, $
 
     // Opt into competition if auto opt-in is enabled for this campaign.
     $auto_opt_in = dosomething_helpers_get_variable('node', $nid, 'enable_auto_competition_opt_in');
+
     if ($auto_opt_in) {
-      dosomething_gladiator_send_user_to_gladiator($account, ['nid' => $nid, 'run_nid' => ]);
+      $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $account);
+
+      dosomething_gladiator_send_user_to_gladiator($account, ['nid' => $nid, 'run_nid' => $run->nid]);
     }
 
     // Set default signup message if we're still in this function.


### PR DESCRIPTION
#### What's this PR do?
This PR lets admins automatically opt users into a competition when they signup. This is useful is the signup data form is being used for something other than competitions. 

Keep this feature on the _down low_, wink wink.

#### How should this be reviewed?
Signup for a campaign with this feature toggled on, check you are sent to Gladiator.