### PR TITLE
Simple Permalink when Rogue is on

### DIFF
--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -81,7 +81,10 @@ function dosomething_metatag_preprocess_page(&$vars) {
   }
 
   // Add special share info to the permalink page.
-  if (in_array('page__reportback', $vars['theme_hook_suggestions']) && !in_array('page__reportback__failure', $vars['theme_hook_suggestions'])) {
+  $isReportbackFailure = in_array('page__reportback__failure', $vars['theme_hook_suggestions']);
+  $isRogueReportback = variable_get('rogue_collection', FALSE);
+
+  if (in_array('page__reportback', $vars['theme_hook_suggestions']) && !$isReportbackFailure && !$isRogueReportback) {
     dosomething_metatag_get_permalink_vars();
   }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -427,12 +427,13 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
     // Make sure reportback made it back to Phoenix and store reference to the Rogue item if one was added
-    $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
+    // $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
 
-    if ($rb_info) {
+    // if ($rb_info) {
       // Redirect to permalink page.
-      dosomething_reportback_permalink_page($rb_info['rbid']);
-    } elseif ($rogue_reportback['data']['id']) {
+      // dosomething_reportback_permalink_page($rb_info['rbid']);
+    // } elseif ($rogue_reportback['data']['id']) {
+    if ($rogue_reportback['data']['id']) {
       dosomething_reportback_permalink_page($rogue_reportback['data']['signup_id'], $rogue_reportback, $campaign, $values['uid'], $values['why_participated'], $values['quantity']);
     } else {
       // Send user to the failed permalink page

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -431,17 +431,9 @@ function dosomething_reportback_form_submit($form, &$form_state) {
 
     if ($rb_info) {
       // Redirect to permalink page.
-      $form_state['redirect'] = array(
-        'reportback/' . $rb_info['rbid'],
-        array(
-          'query' => array(
-            'fid' => $rb_info['fid'],
-          ),
-        ),
-      );
+      dosomething_reportback_permalink_page($rb_info['rbid']);
     } elseif ($rogue_reportback['data']['id']) {
-      // Redirect to permalink page, populated as /reportback/{rogue_signup_id}?fid={rogue_post_id}
-      $form_state['redirect'] = 'reportback/' . $rogue_reportback['data']['signup_id'] . '?fid=' . $rogue_reportback['data']['id'];
+      dosomething_reportback_view_rogue_permalink($rogue_reportback['data']['signup_id'];
     } else {
       // Send user to the failed permalink page
       $form_state['redirect'] = 'reportback/failure/' . $values['nid'];
@@ -457,14 +449,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     $rid = dosomething_reportback_save($values, $user);
 
     // Redirect to permalink page.
-    $form_state['redirect'] = array(
-      'reportback/' . $rid,
-      array(
-        'query' => array(
-          'fid' => $values['fid'],
-        ),
-      ),
-    );
+    dosomething_reportback_permalink_page($rid);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -426,19 +426,13 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     // Send the reportback to rogue.
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
-    // Make sure reportback made it back to Phoenix and store reference to the Rogue item if one was added
-    $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
-
-    if ($rb_info) {
-      // Redirect to permalink page.
-      dosomething_reportback_permalink_page($rb_info['rbid']);
-    } elseif ($rogue_reportback['data']['id']) {
-    // if ($rogue_reportback['data']['id']) {
-      dosomething_reportback_permalink_page($rogue_reportback['data']['signup_id'], $rogue_reportback, $campaign, $values['uid'], $values['why_participated'], $values['quantity']);
-    } else {
-      // Send user to the failed permalink page
+    // @TODO: Test that this covers all error scenarios. Might need try/catch instead.
+    if (! $rogue_reportback) {
       $form_state['redirect'] = 'reportback/failure/' . $values['nid'];
     }
+
+    $rid = $rogue_reportback['data']['signup_id'];
+    $fid = $rogue_reportback['data']['id'];
   } else {
     // Save uploaded file.
     if ($file = dosomething_reportback_form_save_file($form_state)) {
@@ -448,17 +442,17 @@ function dosomething_reportback_form_submit($form, &$form_state) {
 
     // Save values into reportback.
     $rid = dosomething_reportback_save($values, $user);
-    // @TODO: this is sending the whole object, not just the $id of the reportback
-    // Redirect to permalink page.
-    $form_state['redirect'] = array(
-      'reportback/' . $rid,
-      array(
-        'query' => array(
-          'fid' => $values['fid'],
-        ),
-      ),
-    );
+    $fid = $values['fid'];
   }
+
+  // Redirect to permalink page.
+  $form_state['redirect'] = [
+    'reportback/' . $rid, [
+      'query' => [
+        'fid' => $fid,
+      ],
+    ],
+  ];
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -433,7 +433,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
       // Redirect to permalink page.
       dosomething_reportback_permalink_page($rb_info['rbid']);
     } elseif ($rogue_reportback['data']['id']) {
-      dosomething_reportback_view_rogue_permalink($rogue_reportback['data']['signup_id'];
+      dosomething_reportback_permalink_page($rogue_reportback['data']['signup_id'], $rogue_reportback, $campaign, $values['uid']);
     } else {
       // Send user to the failed permalink page
       $form_state['redirect'] = 'reportback/failure/' . $values['nid'];

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -426,9 +426,8 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     // Send the reportback to rogue.
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
-    // @TODO: Test that this covers all error scenarios. Might need try/catch instead.
     if (! $rogue_reportback) {
-      $form_state['redirect'] = 'reportback/failure/' . $values['nid'];
+      return $form_state['redirect'] = 'reportback/failure/' . $values['nid'];
     }
 
     $rid = $rogue_reportback['data']['signup_id'];

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -439,6 +439,9 @@ function dosomething_reportback_form_submit($form, &$form_state) {
           ),
         ),
       );
+    } elseif ($rogue_reportback['data']['id']) {
+      // Redirect to permalink page, populated as /reportback/{rogue_signup_id}?fid={rogue_post_id}
+      $form_state['redirect'] = 'reportback/' . $rogue_reportback['data']['signup_id'] . '?fid=' . $rogue_reportback['data']['id'];
     } else {
       // Send user to the failed permalink page
       $form_state['redirect'] = 'reportback/failure/' . $values['nid'];

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -427,13 +427,13 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
     // Make sure reportback made it back to Phoenix and store reference to the Rogue item if one was added
-    // $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
+    $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
 
-    // if ($rb_info) {
+    if ($rb_info) {
       // Redirect to permalink page.
-      // dosomething_reportback_permalink_page($rb_info['rbid']);
-    // } elseif ($rogue_reportback['data']['id']) {
-    if ($rogue_reportback['data']['id']) {
+      dosomething_reportback_permalink_page($rb_info['rbid']);
+    } elseif ($rogue_reportback['data']['id']) {
+    // if ($rogue_reportback['data']['id']) {
       dosomething_reportback_permalink_page($rogue_reportback['data']['signup_id'], $rogue_reportback, $campaign, $values['uid'], $values['why_participated'], $values['quantity']);
     } else {
       // Send user to the failed permalink page
@@ -448,9 +448,16 @@ function dosomething_reportback_form_submit($form, &$form_state) {
 
     // Save values into reportback.
     $rid = dosomething_reportback_save($values, $user);
-
+    // @TODO: this is sending the whole object, not just the $id of the reportback
     // Redirect to permalink page.
-    dosomething_reportback_permalink_page($rid);
+    $form_state['redirect'] = array(
+      'reportback/' . $rid,
+      array(
+        'query' => array(
+          'fid' => $values['fid'],
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -433,7 +433,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
       // Redirect to permalink page.
       dosomething_reportback_permalink_page($rb_info['rbid']);
     } elseif ($rogue_reportback['data']['id']) {
-      dosomething_reportback_permalink_page($rogue_reportback['data']['signup_id'], $rogue_reportback, $campaign, $values['uid']);
+      dosomething_reportback_permalink_page($rogue_reportback['data']['signup_id'], $rogue_reportback, $campaign, $values['uid'], $values['why_participated'], $values['quantity']);
     } else {
       // Send user to the failed permalink page
       $form_state['redirect'] = 'reportback/failure/' . $values['nid'];

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -249,7 +249,7 @@ function dosomething_reportback_menu() {
   );
   $items['reportback/%reportback'] = array(
     'title' => 'Reportback',
-    'page callback' => 'dosomething_reportback_view_entity',
+    'page callback' => 'dosomething_reportback_permalink_page',
     'page arguments' => array(1),
     //'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('access content'),
@@ -522,17 +522,40 @@ function dosomething_reportback_form_alter(&$form, &$form_state, $form_id) {
   }
 }
 
+function dosomething_reportback_permalink_page($rbid) {
+  $fid = $_GET['fid'];
+  $vars = [];
+
+  if (variable_get('rogue_collection', FALSE)) {
+    $rogue = dosomething_rogue_client();
+    $response = $rogue->get('v1/reportbacks/' . $rbid);
+
+    $vars = [
+      // @TODO: Make this look the same as the one below, but using Rogue's response.
+      'rb' => $rb,
+      'reportback' => $entity,
+      'node' => $node,
+      'user' => $rb_simple_user,
+      'is_owner' => $is_owner,
+      'copy_vars' => $copy_vars,
+      'title' => $title,
+      'subtitle' => $subtitle,
+      'share_bar' => $share_bar,
+      'share_enabled' => $share_enabled,
+      'why_participated_short' => isset($why_participated_short) ? $why_participated_short : $participated_copy,
+    ];
+  } else {
+    $entity = entity_load('reportback', $rbid);
+    $vars = dosomething_reportback_permalink_vars_from_entity($entity);
+  }
+
+  return theme('reportback_permalink', $vars);
+}
 
 /**
  * Callback for /rbf/FID page.
  */
 function dosomething_reportback_view_entity($entity) {
-  if (!$entity) {
-    print_r(current_path());
-    die();
-    // redirect to custom function. but how do we get the data of the post to send to Rogue??
-  }
-
   $rb_simple_user = dosomething_user_get_simple_user($rb_user = user_load($entity->uid));
   global $user;
 
@@ -633,7 +656,7 @@ function dosomething_reportback_view_entity($entity) {
     $permalink_vars['kudos'] = dosomething_kudos_get_kudos_data_for_fid($fid);
   }
 
-  return theme('reportback_permalink', $permalink_vars);
+  return $permalink_vars;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -602,12 +602,14 @@ function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campa
       'why_participated_short' => isset($why_participated_short) ? $why_participated_short : $participated_copy,
     ];
   } else {
+    print_r($rbid);
+    die();
     $entity = entity_load('reportback', $rbid);
     $vars = dosomething_reportback_permalink_vars_from_entity($entity);
+    return theme('reportback_permalink', $vars);
   }
-  // print_r(theme('reportback_permalink', $vars));
-  // die();
-  return theme('reportback_permalink', $vars);
+
+  // return theme('reportback_permalink', $vars);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -522,19 +522,75 @@ function dosomething_reportback_form_alter(&$form, &$form_state, $form_id) {
   }
 }
 
-function dosomething_reportback_permalink_page($rbid) {
+function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campaign = null, $uid = null) {
   $fid = $_GET['fid'];
   $vars = [];
 
   if (variable_get('rogue_collection', FALSE)) {
-    $rogue = dosomething_rogue_client();
-    $response = $rogue->get('v1/reportbacks/' . $rbid);
+    // $rogue = dosomething_rogue_client();
+    // $response = $rogue->get('v1/reportbacks/' . $rbid); this isn't possible right now
+
+    $rb_simple_user = dosomething_user_get_simple_user($rb_user = user_load($uid));
+    global $user;
+
+    $is_owner = ($user->uid == $rb_simple_user->uid) ? 1 : 0;
+
+    $rb = [
+      // @TODO: might have to reformat the image
+      'image' => $rogue_post['data']['media']['url'],
+      'caption' => $rogue_post['data']['media']['caption'],
+    ];
+
+    $reportback = new stdClass();
+    // $reportback->quantity =
+    $reportback->quantity_label = 'TBD';
+    // $reportback->why_participated =
+
+    $copy_vars = _dosomething_reportback_get_permalink_copy_vars($rb_user);
+    $title = ($is_owner) ? $copy_vars['owners_title'] : $copy_vars['non_owners_title'];
+    $subtitle = ($is_owner) ? $copy_vars['owners_rb_subtitle'] . " " . $incentive : $node->call_to_action;
+
+    // @TODO: we'll have to do the below logic once we get the why_participated
+    // $character_limit = 250;
+    // $participated_copy = $entity->why_participated;
+
+    // if (strlen($participated_copy) > $character_limit) {
+    //   $why_participated_short = dosomething_helpers_text_truncate($participated_copy, $character_limit, '...', FALSE, FALSE);
+    // }
+
+    // @TODO: will the below work?
+    $reportback_url = url(current_path(), array('absolute' => TRUE, 'query' => array('fid' => $rogue_post['data']['id'])));
+
+    $share_text = token_replace(t(variable_get('dosomething_campaign_permalink_confirmation_owners_social_network_copy')), array('node' => $campaign));
+    $share_text = str_replace('[node:issue]', strtolower($campaign->issue['name']), $share_text);
+
+    $share_types = array(
+      'facebook' => array(
+        'type' => 'feed_dialog',
+        'parameters' => array(
+          'picture' => $rb['image'],
+          'caption' => $campaign->call_to_action,
+        ),
+      ),
+      'twitter' => array(
+        'tweet' => htmlspecialchars_decode($share_text, ENT_QUOTES) . " ",
+      ),
+      'tumblr' => array(
+        'posttype' => 'photo',
+        'content' => $rb['image'],
+        'caption' => $share_text . " ",
+      ),
+    );
+
+    $share_bar = dosomething_helpers_share_bar($reportback_url, $share_types, 'Confirmation Page', 'cta__actions');
+
+    $share_enabled = variable_get('dosomething_reportback_display_permalink_share', '');
 
     $vars = [
       // @TODO: Make this look the same as the one below, but using Rogue's response.
       'rb' => $rb,
-      'reportback' => $entity,
-      'node' => $node,
+      'reportback' => $entity, // @TODO: Revisit this.
+      'node' => $campaign,
       'user' => $rb_simple_user,
       'is_owner' => $is_owner,
       'copy_vars' => $copy_vars,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -538,8 +538,7 @@ function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campa
     $is_owner = ($user->uid == $rb_simple_user->uid) ? 1 : 0;
 
     $rb = [
-      // @TODO: might have to reformat the image
-      'image' => $rogue_post['data']['media']['url'],
+      'image' => '<img src="'.$rogue_post['data']['media']['url'].'" width="480" height="480">&nbsp;',
       'caption' => $rogue_post['data']['media']['caption'],
     ];
 
@@ -606,7 +605,8 @@ function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campa
     $entity = entity_load('reportback', $rbid);
     $vars = dosomething_reportback_permalink_vars_from_entity($entity);
   }
-
+  // print_r(theme('reportback_permalink', $vars));
+  // die();
   return theme('reportback_permalink', $vars);
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -523,8 +523,10 @@ function dosomething_reportback_form_alter(&$form, &$form_state, $form_id) {
 }
 
 function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campaign = null, $uid = null, $why_participated = null, $quantity = null) {
-  $fid = $_GET['fid'];
+  // $fid = $_GET['fid'];
   $vars = [];
+
+  $campaign = dosomething_campaign_load(node_load($campaign->nid));
 
   if (variable_get('rogue_collection', FALSE)) {
     // $rogue = dosomething_rogue_client();
@@ -547,6 +549,8 @@ function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campa
     $reportback->why_participated = $why_participated;
 
     $copy_vars = _dosomething_reportback_get_permalink_copy_vars($rb_user);
+
+    $incentive = ($campaign->scholarship) ? $copy_vars['owners_rb_scholarship'] : "";
     $title = ($is_owner) ? $copy_vars['owners_title'] : $copy_vars['non_owners_title'];
     $subtitle = ($is_owner) ? $copy_vars['owners_rb_subtitle'] . " " . $incentive : $node->call_to_action;
 
@@ -587,7 +591,7 @@ function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campa
 
     $vars = [
       'rb' => $rb,
-      'reportback' => $entity, // @TODO: Revisit this.
+      'reportback' => $reportback,
       'node' => $campaign,
       'user' => $rb_simple_user,
       'is_owner' => $is_owner,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -527,6 +527,12 @@ function dosomething_reportback_form_alter(&$form, &$form_state, $form_id) {
  * Callback for /rbf/FID page.
  */
 function dosomething_reportback_view_entity($entity) {
+  if (!$entity) {
+    print_r(current_path());
+    die();
+    // redirect to custom function. but how do we get the data of the post to send to Rogue??
+  }
+
   $rb_simple_user = dosomething_user_get_simple_user($rb_user = user_load($entity->uid));
   global $user;
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -522,7 +522,7 @@ function dosomething_reportback_form_alter(&$form, &$form_state, $form_id) {
   }
 }
 
-function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campaign = null, $uid = null) {
+function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campaign = null, $uid = null, $why_participated = null, $quantity = null) {
   $fid = $_GET['fid'];
   $vars = [];
 
@@ -542,21 +542,20 @@ function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campa
     ];
 
     $reportback = new stdClass();
-    // $reportback->quantity =
+    $reportback->quantity = $quantity;
     $reportback->quantity_label = 'TBD';
-    // $reportback->why_participated =
+    $reportback->why_participated = $why_participated;
 
     $copy_vars = _dosomething_reportback_get_permalink_copy_vars($rb_user);
     $title = ($is_owner) ? $copy_vars['owners_title'] : $copy_vars['non_owners_title'];
     $subtitle = ($is_owner) ? $copy_vars['owners_rb_subtitle'] . " " . $incentive : $node->call_to_action;
 
-    // @TODO: we'll have to do the below logic once we get the why_participated
-    // $character_limit = 250;
-    // $participated_copy = $entity->why_participated;
+    $character_limit = 250;
+    $participated_copy = $why_participated;
 
-    // if (strlen($participated_copy) > $character_limit) {
-    //   $why_participated_short = dosomething_helpers_text_truncate($participated_copy, $character_limit, '...', FALSE, FALSE);
-    // }
+    if (strlen($participated_copy) > $character_limit) {
+      $why_participated_short = dosomething_helpers_text_truncate($participated_copy, $character_limit, '...', FALSE, FALSE);
+    }
 
     // @TODO: will the below work?
     $reportback_url = url(current_path(), array('absolute' => TRUE, 'query' => array('fid' => $rogue_post['data']['id'])));
@@ -587,7 +586,6 @@ function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campa
     $share_enabled = variable_get('dosomething_reportback_display_permalink_share', '');
 
     $vars = [
-      // @TODO: Make this look the same as the one below, but using Rogue's response.
       'rb' => $rb,
       'reportback' => $entity, // @TODO: Revisit this.
       'node' => $campaign,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -533,6 +533,7 @@ function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campa
     // $response = $rogue->get('v1/reportbacks/' . $rbid); this isn't possible right now
 
     $rb_simple_user = dosomething_user_get_simple_user($rb_user = user_load($uid));
+
     global $user;
 
     $is_owner = ($user->uid == $rb_simple_user->uid) ? 1 : 0;
@@ -543,6 +544,8 @@ function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campa
     ];
 
     $reportback = new Reportback();
+    $reportback->rbid = $rogue_post['data']['signup_id'];
+    $reportback->fids = [$rogue_post['data']['id']];
     $reportback->quantity = $quantity;
     $reportback->quantity_label = 'TBD';
     $reportback->why_participated = $why_participated;
@@ -588,7 +591,7 @@ function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campa
 
     $share_enabled = variable_get('dosomething_reportback_display_permalink_share', '');
 
-    $vars = [
+    $permalink_vars = [
       'rb' => $rb,
       'reportback' => $reportback,
       'node' => $campaign,
@@ -602,7 +605,7 @@ function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campa
       'why_participated_short' => isset($why_participated_short) ? $why_participated_short : $participated_copy,
     ];
 
-    return theme('reportback_permalink', $vars);
+    theme('reportback_permalink', $permalink_vars);
   } else {
     dosomething_reportback_view_entity(entity_load('reportback', $rbid));
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -543,7 +543,7 @@ function dosomething_reportback_view_rogue($rbid, $fid) {
     // $campaign = dosomething_campaign_load(node_load($rogue_signup['data']['campaign_id']));
 
     return theme('reportback_simple_permalink', [
-      'image' => 'lol',
+      'image' => dosomething_image_get_themed_image(variable_get('dosomething_campaign_permalink_failure_image_nid'), 'square', '480x480'),
     ]);
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -542,7 +542,7 @@ function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campa
       'caption' => $rogue_post['data']['media']['caption'],
     ];
 
-    $reportback = new stdClass();
+    $reportback = new Reportback();
     $reportback->quantity = $quantity;
     $reportback->quantity_label = 'TBD';
     $reportback->why_participated = $why_participated;

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -601,15 +601,11 @@ function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campa
       'share_enabled' => $share_enabled,
       'why_participated_short' => isset($why_participated_short) ? $why_participated_short : $participated_copy,
     ];
-  } else {
-    print_r($rbid);
-    die();
-    $entity = entity_load('reportback', $rbid);
-    $vars = dosomething_reportback_permalink_vars_from_entity($entity);
-    return theme('reportback_permalink', $vars);
-  }
 
-  // return theme('reportback_permalink', $vars);
+    return theme('reportback_permalink', $vars);
+  } else {
+    dosomething_reportback_view_entity(entity_load('reportback', $rbid));
+  }
 }
 
 /**
@@ -716,7 +712,7 @@ function dosomething_reportback_view_entity($entity) {
     $permalink_vars['kudos'] = dosomething_kudos_get_kudos_data_for_fid($fid);
   }
 
-  return $permalink_vars;
+  return theme('reportback_permalink', $permalink_vars);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -528,12 +528,7 @@ function dosomething_reportback_permalink_view($args) {
   $fid = $_GET['fid'];
 
   if (variable_get('rogue_collection', FALSE)) {
-    $campaign = dosomething_campaign_load(node_load($campaign->nid));
-
-    // @TODO: Request signup from Rogue so we can display it on permalink page.
-    // $rogue_signup = dosomething_rogue_client()->get('v2/activity')
-
-    return dosomething_reportback_view_rogue($rbid, $rogue_signup, $campaign);
+    return dosomething_reportback_view_rogue($rbid, $fid);
   }
 
   return dosomething_reportback_view_entity(entity_load('reportback', $rbid));
@@ -542,85 +537,14 @@ function dosomething_reportback_permalink_view($args) {
 /**
  * Callback for /rbf/FID page, when Rogue is enabled.
  */
-function dosomething_reportback_view_rogue($rbid, $rogue_post, $campaign) {
-    $vars = [];
-    // $rogue = dosomething_rogue_client();
-    // $response = $rogue->get('v1/reportbacks/' . $rbid); this isn't possible right now
+function dosomething_reportback_view_rogue($rbid, $fid) {
+    // @TODO: Request signup from Rogue so we can display it on permalink page.
+    // $rogue_signup = dosomething_rogue_client()->get('v2/activity')
+    // $campaign = dosomething_campaign_load(node_load($rogue_signup['data']['campaign_id']));
 
-    $rb_simple_user = dosomething_user_get_simple_user($rb_user = user_load($uid));
-
-    global $user;
-
-    $is_owner = ($user->uid == $rb_simple_user->uid) ? 1 : 0;
-
-    $rb = [
-      'image' => '<img src="'.$rogue_post['data']['media']['url'].'" width="480" height="480">&nbsp;',
-      'caption' => $rogue_post['data']['media']['caption'],
-    ];
-
-    $reportback = new Reportback();
-    $reportback->rbid = $rogue_post['data']['signup_id'];
-    $reportback->fids = [$rogue_post['data']['id']];
-    $reportback->quantity = $quantity;
-    $reportback->quantity_label = 'TBD';
-    $reportback->why_participated = $why_participated;
-
-    $copy_vars = _dosomething_reportback_get_permalink_copy_vars($rb_user);
-
-    $incentive = ($campaign->scholarship) ? $copy_vars['owners_rb_scholarship'] : "";
-    $title = ($is_owner) ? $copy_vars['owners_title'] : $copy_vars['non_owners_title'];
-    $subtitle = ($is_owner) ? $copy_vars['owners_rb_subtitle'] . " " . $incentive : $node->call_to_action;
-
-    $character_limit = 250;
-    $participated_copy = $why_participated;
-
-    if (strlen($participated_copy) > $character_limit) {
-      $why_participated_short = dosomething_helpers_text_truncate($participated_copy, $character_limit, '...', FALSE, FALSE);
-    }
-
-    // @TODO: will the below work?
-    $reportback_url = url(current_path(), array('absolute' => TRUE, 'query' => array('fid' => $rogue_post['data']['id'])));
-
-    $share_text = token_replace(t(variable_get('dosomething_campaign_permalink_confirmation_owners_social_network_copy')), array('node' => $campaign));
-    $share_text = str_replace('[node:issue]', strtolower($campaign->issue['name']), $share_text);
-
-    $share_types = array(
-      'facebook' => array(
-        'type' => 'feed_dialog',
-        'parameters' => array(
-          'picture' => $rb['image'],
-          'caption' => $campaign->call_to_action,
-        ),
-      ),
-      'twitter' => array(
-        'tweet' => htmlspecialchars_decode($share_text, ENT_QUOTES) . " ",
-      ),
-      'tumblr' => array(
-        'posttype' => 'photo',
-        'content' => $rb['image'],
-        'caption' => $share_text . " ",
-      ),
-    );
-
-    $share_bar = dosomething_helpers_share_bar($reportback_url, $share_types, 'Confirmation Page', 'cta__actions');
-
-    $share_enabled = variable_get('dosomething_reportback_display_permalink_share', '');
-
-    $permalink_vars = [
-      'rb' => $rb,
-      'reportback' => $reportback,
-      'node' => $campaign,
-      'user' => $rb_simple_user,
-      'is_owner' => $is_owner,
-      'copy_vars' => $copy_vars,
-      'title' => $title,
-      'subtitle' => $subtitle,
-      'share_bar' => $share_bar,
-      'share_enabled' => $share_enabled,
-      'why_participated_short' => isset($why_participated_short) ? $why_participated_short : $participated_copy,
-    ];
-
-    return theme('reportback_permalink', $permalink_vars);
+    return theme('reportback_simple_permalink', [
+      'image' => 'lol',
+    ]);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -247,18 +247,16 @@ function dosomething_reportback_menu() {
     'page arguments' => array(2),
     'access arguments' => array('access content'),
   );
-  $items['reportback/%reportback'] = array(
+  $items['reportback/%'] = array(
     'title' => 'Reportback',
-    'page callback' => 'dosomething_reportback_permalink_page',
+    'page callback' => 'dosomething_reportback_permalink_view',
     'page arguments' => array(1),
-    //'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('access content'),
   );
   $items['admin/reportback/%reportback'] = array(
     'title' => 'Reportback',
     'page callback' => 'dosomething_reportback_admin_view_entity',
     'page arguments' => array(2),
-    // 'access callback' => 'dosomething_reportback_access',
     'access arguments' => array('view any reportback'),
   );
   $items['admin/users/rb'] = array(
@@ -522,13 +520,30 @@ function dosomething_reportback_form_alter(&$form, &$form_state, $form_id) {
   }
 }
 
-function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campaign = null, $uid = null, $why_participated = null, $quantity = null) {
-  // $fid = $_GET['fid'];
-  $vars = [];
-
-  $campaign = dosomething_campaign_load(node_load($campaign->nid));
+/**
+ * Callback for /rbf/FID page.
+ */
+function dosomething_reportback_permalink_view($args) {
+  $rbid = $args[0];
+  $fid = $_GET['fid'];
 
   if (variable_get('rogue_collection', FALSE)) {
+    $campaign = dosomething_campaign_load(node_load($campaign->nid));
+
+    // @TODO: Request signup from Rogue so we can display it on permalink page.
+    // $rogue_signup = dosomething_rogue_client()->get('v2/activity')
+
+    return dosomething_reportback_view_rogue($rbid, $rogue_signup, $campaign);
+  }
+
+  return dosomething_reportback_view_entity(entity_load('reportback', $rbid));
+}
+
+/**
+ * Callback for /rbf/FID page, when Rogue is enabled.
+ */
+function dosomething_reportback_view_rogue($rbid, $rogue_post, $campaign) {
+    $vars = [];
     // $rogue = dosomething_rogue_client();
     // $response = $rogue->get('v1/reportbacks/' . $rbid); this isn't possible right now
 
@@ -605,10 +620,7 @@ function dosomething_reportback_permalink_page($rbid, $rogue_post = null, $campa
       'why_participated_short' => isset($why_participated_short) ? $why_participated_short : $participated_copy,
     ];
 
-    theme('reportback_permalink', $permalink_vars);
-  } else {
-    dosomething_reportback_view_entity(entity_load('reportback', $rbid));
-  }
+    return theme('reportback_permalink', $permalink_vars);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.theme.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.theme.inc
@@ -32,6 +32,10 @@ function dosomething_reportback_theme($existing, $type, $theme, $path) {
       'template' => 'reportback-permalink',
       'path' => drupal_get_path('module', 'dosomething_reportback') . '/theme',
     ),
+    'reportback_simple_permalink' => array(
+      'template' => 'reportback-simple-permalink',
+      'path' => drupal_get_path('module', 'dosomething_reportback') . '/theme',
+    ),
     'reportback_rogue_fail_permalink' => array(
       'template' => 'reportback-rogue-fail-permalink',
       'path' => drupal_get_path('module', 'dosomething_reportback') . '/theme',

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-simple-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-simple-permalink.tpl.php
@@ -7,8 +7,8 @@
 <article class="reportback__permalink">
   <header role="banner" class="header ">
     <div class="wrapper">
-      <h1 class="header__title">Thanks for reporting back!</h1>
-      <p class="header__subtitle">We got your photo.</p>
+      <h1 class="header__title">Awesome! We got your photo.</h1>
+      <p class="header__subtitle">You've entered into the scholarship and your photo will show up in the gallery soon!</p>
     </div>
   </header>
 
@@ -16,14 +16,14 @@
     <div class="wrapper">
       <div class="card">
         <div class="card__column">
-          IMAGE HERE
+          <?php print $image; ?>
         </div>
         <div class="card__column">
           <div class="wrapper">
           <!--Show user the reportback confirmation page -->
             <div class="card__copy">
-              <h1>LUKE TEXT HERE</h1>
-              LUKE LOVES THIS PHOTO
+              <h1>What's next?</h1>
+              <p>The fun doesn't have to stop now. You can upload more photos, continue working on the campaign, or share it with your friends on social media.</p>
             </div>
           </div>
         </div>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-simple-permalink.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/reportback/reportback-simple-permalink.tpl.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @file
+ * Reportback confirmation/permalink page for Rogue.
+ */
+?>
+<article class="reportback__permalink">
+  <header role="banner" class="header ">
+    <div class="wrapper">
+      <h1 class="header__title">Thanks for reporting back!</h1>
+      <p class="header__subtitle">We got your photo.</p>
+    </div>
+  </header>
+
+  <div class="container -padded -dark">
+    <div class="wrapper">
+      <div class="card">
+        <div class="card__column">
+          IMAGE HERE
+        </div>
+        <div class="card__column">
+          <div class="wrapper">
+          <!--Show user the reportback confirmation page -->
+            <div class="card__copy">
+              <h1>LUKE TEXT HERE</h1>
+              LUKE LOVES THIS PHOTO
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</article>


### PR DESCRIPTION
#### What's this PR do?
- When Rogue is on, creates a simple permalink page that is standard for all users (doesn't include post photo, specific quantity/why, etc). 
  - Note that this can be done and most of the work to do so is in a commit in the branch but we first need to add another endpoint in Rogue to retrieve all information needed. 

Simple standard permalink page when Rogue is on: 
![screen shot 2017-06-28 at 3 58 50 pm](https://user-images.githubusercontent.com/9019452/27657497-da65d594-5c1a-11e7-9b74-306ca118de14.png)

Failed page still works when RB doesn't make it to Rogue:
![screen shot 2017-06-28 at 2 15 52 pm](https://user-images.githubusercontent.com/9019452/27653701-e9969b78-5c0d-11e7-979e-ed6afc911d7e.png)


#### How should this be reviewed?
- Turn Rogue on.
- Reportback and/or update a reportback. 
- You should see the same page as the screen shot above.
- Turn Rogue off. 
- Everything should work as it did before. 
- Change Rogue URL to incorrect URL. 
- You should hit failed page (like screen shot above). 

#### Any background context you want to provide?
The photo used in this simple permalink page is the same one that is set for the [failed permalink page](https://github.com/DoSomething/phoenix/pull/7152). cc @ngjo @lkpttn  

#### Relevant tickets
Fixes https://trello.com/c/ahKepTKN/476-5-as-a-phoenix-ashes-user-when-i-reportback-i-want-the-normal-permalink-page-to-be-shown-to-me-w-generic-text-that-indicates-the

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
