### PR TITLE
Update authentication documentation

### DIFF
--- a/documentation/endpoints/auth.md
+++ b/documentation/endpoints/auth.md
@@ -16,6 +16,11 @@ If login was successful, the response contains values to use when making subsequ
 - session_name: (string). The name of the Cookie header to post.
 - user: (object). The logged in user.
 
+**Important**
+
+Your autentication cookie is good for one month. Make sure you regenerate it before it expires. Otherwise you'll get an error "Must be logged in!" in response for all API calls that require autentication.
+
+
 Example request
 ```
 curl https://www.dosomething.org/api/v1/auth/login

--- a/documentation/endpoints/auth.md
+++ b/documentation/endpoints/auth.md
@@ -18,7 +18,7 @@ If login was successful, the response contains values to use when making subsequ
 
 **Important**
 
-Your autentication cookie is good for one month. Make sure you regenerate it before it expires. Otherwise you'll get an error "Must be logged in!" in response for all API calls that require autentication.
+Your authentication cookie is good for one month. Make sure you regenerate your session before the cookie expires. Otherwise, you'll get an error "Must be logged in!" in response to all API calls which require authentication.
 
 
 Example request


### PR DESCRIPTION
#### What's this PR do?
Notes that API auth cookie has the expiration date.

#### Any background context you want to provide?
All long-running daemons are affected. For example, today the user import script failed with:

```
        "message": "Can't signup user 7677543 to 3590: Must be logged in!",
```

