### PR TITLE
fixes permalink bug when Rogue is off

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -523,15 +523,14 @@ function dosomething_reportback_form_alter(&$form, &$form_state, $form_id) {
 /**
  * Callback for /rbf/FID page.
  */
-function dosomething_reportback_permalink_view($args) {
-  $rbid = $args[0];
+function dosomething_reportback_permalink_view($rbid) {
   $fid = $_GET['fid'];
 
   if (variable_get('rogue_collection', FALSE)) {
     return dosomething_reportback_view_rogue($rbid, $fid);
   }
 
-  return dosomething_reportback_view_entity(entity_load('reportback', $rbid));
+  return dosomething_reportback_view_entity(reportback_load($rbid));
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?
- Fixes bug that shows an error instead of permalink page after reporting back when Rogue is OFF (I thought I did this in #7428 but for some reason didn't make it!)

#### How should this be reviewed?
- Turn Rogue OFF.
- Reportback. 
- Permalink page should be hit. 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
