### PR TITLE
Address form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Gemfile.lock
 lib/themes/dosomething/paraneue_dosomething/dist/
 tmp/
 vendor/
+package-lock.json

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -229,3 +229,27 @@ POST /api/v1/users/{uid}/magic_login_url
 }
 ```
 
+## Update User Profile
+
+Users may only update their own profile. Must include Northstar ID in the URL.
+
+Currently the only fields supported are for location fields.
+
+```
+POST /api/v1/users/{northstar_id}/update
+```
+
+**Example Response:**
+
+```js
+// 200 Okay
+
+{
+    "data": {
+        "id": "559442c4a59dbfc9578b4b6a",
+        "_id": "559442c4a59dbfc9578b4b6a",
+        "first_name": "Joe",
+        ...
+    }
+}
+```

--- a/documentation/endpoints/users.md
+++ b/documentation/endpoints/users.md
@@ -231,7 +231,7 @@ POST /api/v1/users/{uid}/magic_login_url
 
 ## Update User Profile
 
-Users may only update their own profile. Must include Northstar ID in the URL.
+Users may only update their own profile for now. Must include Northstar ID in the URL.
 
 Currently the only fields supported are for location fields.
 

--- a/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
+++ b/lib/modules/dosomething/dosomething_api/dosomething_api.services.inc
@@ -222,6 +222,9 @@ function dosomething_api_default_services_endpoint() {
         ),
       ),
       'targeted_actions' => array(
+        'update' => array(
+          'enabled' => '1',
+        ),
         'password_reset_url' => array(
           'enabled' => '1',
         ),

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -177,7 +177,7 @@ function _member_resource_access($op) {
 /**
  * Access calback for the user update resource.
  *
- * Only allow users to edit their own profile.
+ * Only allow users to edit their own profile for now.
  */
 function _member_update_access($id) {
   global $user;

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -287,7 +287,7 @@ function _member_resource_create($request) {
  * @return mixed Object of the newly created user if successful. String if errors.
  */
 function _member_resource_update($id, $request) {
-  $keys = ['addr_street1', 'addr_street2', 'addr_city', 'addr_state'];
+  $keys = ['addr_street1', 'addr_street2', 'addr_city', 'addr_state', 'addr_zip'];
   $fields = [];
   $account = $request['account'];
 

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -300,6 +300,7 @@ function _member_resource_update($id, $request) {
     }
   }
 
+  dosomething_northstar_clear_user_cache($id);
   $response = dosomething_northstar_client()->asClient()->put('v1/users/id/' . $id, $fields);
 
   return $response;

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -53,7 +53,7 @@ function _member_resource_definition() {
           'module' => 'dosomething_api',
           'name' => 'resources/member_resource',
         ),
-        'help'   => 'Returns Current User Activity. GET from users/current/activity, users/23423/activity',
+        'help' => 'Returns Current User Activity. GET from users/current/activity, users/23423/activity',
         'access callback' => '_member_resource_access',
         'access arguments' => array('activity'),
         'access arguments append' => TRUE,
@@ -90,6 +90,33 @@ function _member_resource_definition() {
       ),
     ),
     'targeted_actions' => array(
+      'update' => [
+        'file' => [
+          'type' => 'inc',
+          'module' => 'dosomething_api',
+          'name' => 'resources/member_resource',
+        ],
+        'help' => 'Update the users profile',
+        'args' => [
+          [
+            'name' => 'id',
+            'optional' => FALSE,
+            'source' => array('path' => 0),
+            'type' => 'string',
+            'description' => 'The Northstar ID of the user we\'re updating.',
+          ],
+          [
+            'name' => 'account',
+            'type' => 'array',
+            'description' => 'The user object',
+            'source' => 'data',
+            'optional' => FALSE,
+          ],
+        ],
+        'callback' => '_member_resource_update',
+        'access callback' => '_member_update_access',
+        'access arguments append' => TRUE,
+      ],
       'password_reset_url' => array(
         'help' => 'Gets the user password reset URL.',
         'file' => array(
@@ -145,6 +172,18 @@ function _member_resource_access($op) {
   global $user;
   // For now, only admins can access any other User resources.
   return in_array('administrator', $user->roles);
+}
+
+/**
+ * Access calback for the user update resource.
+ *
+ * Only allow users to edit their own profile.
+ */
+function _member_update_access($id) {
+  global $user;
+
+  $request_user = dosomething_user_get_user_by_northstar_id($id);
+  return $user->uid === $request_user->uid;
 }
 
 /**
@@ -234,6 +273,37 @@ function _member_resource_create($request) {
   catch (Exception $e) {
     services_error($e);
   }
+}
+
+/**
+ * Callback for User create.
+ *
+ * @param $request Array passed to the endpoint.
+ *   Possible keys:
+ *   - addr_street1
+ *   - addr_street2
+ *   - addr_city
+ *   - addr_state
+ * @return mixed Object of the newly created user if successful. String if errors.
+ */
+function _member_resource_update($id, $request) {
+  $keys = ['addr_street1', 'addr_street2', 'addr_city', 'addr_state'];
+  $fields = [];
+  $account = $request['account'];
+
+  if ($account) {
+    foreach ($keys as $key) {
+      $value = $account[$key];
+
+      if (isset($value)) {
+        $fields[$key] = $value;
+      }
+    }
+  }
+
+  $response = dosomething_northstar_client()->asClient()->put('v1/users/id/' . $id, $fields);
+
+  return $response;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -301,7 +301,7 @@ function _member_resource_update($id, $request) {
   }
 
   dosomething_northstar_clear_user_cache($id);
-  $response = dosomething_northstar_client()->asClient()->put('v1/users/id/' . $id, $fields);
+  $response = dosomething_northstar_client()->asUser()->post('v1/profile', $fields);
 
   return $response;
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -138,6 +138,8 @@ function dosomething_campaign_preprocess_common_vars(&$vars, &$wrapper) {
   $vars['show_problem_shares'] = theme_get_setting('show_problem_shares');
   $campaign = $vars['campaign'];
 
+  $vars['enable_address_form'] = dosomething_helpers_get_variable('node', $campaign->nid, 'enable_address_form');
+
   if ($vars['show_problem_shares']) {
     $problem_share_prompt = t(variable_get('dosomething_campaign_problem_share_prompt'));
     if ($problem_share_prompt) {
@@ -605,5 +607,3 @@ function dosomething_campaign_preprocess_closed_reportback_gallery(&$vars, $styl
     $vars['reportback_gallery'][$delta]['first_name'] = dosomething_user_get_field('field_first_name', $account);
   }
 }
-
-

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -135,8 +135,8 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
   if (module_exists('dosomething_shipment')) {
     $form['shipment'] = array(
       '#type' => 'fieldset',
-      '#title' => t('Shipment Form'),
-      '#description' => t('Legacy system, use the Signup Data Form instead.'),
+      '#title' => t('Shipment Form (Legacy)'),
+      '#description' => t('Legacy system, use the address form below.'),
       '#collapsible' => TRUE,
       '#collapsed' => TRUE,
     );
@@ -245,6 +245,20 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
     '#title' => t('Enable auto competition opt-in'),
     '#description' => t('Users who signup will automatically join a competition'),
     '#default_value' => $vars['enable_auto_competition_opt_in']
+  ];
+
+  // Address form V2
+  $form['address_form'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Address form'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  ];
+  $form['address_form']['enable_address_form'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Enable address form'),
+    '#description' => t('Users will be presented a form within the campaign template to update there address'),
+    '#default_value' => $vars['enable_address_form']
   ];
 
   $form['actions'] = array(

--- a/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
+++ b/lib/modules/dosomething/dosomething_helpers/dosomething_helpers.variable.inc
@@ -257,7 +257,7 @@ function dosomething_helpers_variable_form($form, &$form_state, $node) {
   $form['address_form']['enable_address_form'] = [
     '#type' => 'checkbox',
     '#title' => t('Enable address form'),
-    '#description' => t('Users will be presented a form within the campaign template to update there address'),
+    '#description' => t('Users will be presented a form within the campaign template to update their address'),
     '#default_value' => $vars['enable_address_form']
   ];
 

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -123,9 +123,9 @@ function dosomething_northstar_get_user($id, $type = 'id') {
   $northstar_user = cache_get($cache_key, $cache_bin);
 
   // Return cached northstar user data.
-  if ($northstar_user) {
-    return $northstar_user->data;
-  }
+  // if ($northstar_user) {
+  //   return $northstar_user->data;
+  // }
 
   $northstar_user = dosomething_northstar_client()->asClient()->getUser($type, $id);
 

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -123,9 +123,9 @@ function dosomething_northstar_get_user($id, $type = 'id') {
   $northstar_user = cache_get($cache_key, $cache_bin);
 
   // Return cached northstar user data.
-  // if ($northstar_user) {
-  //   return $northstar_user->data;
-  // }
+  if ($northstar_user) {
+    return $northstar_user->data;
+  }
 
   $northstar_user = dosomething_northstar_client()->asClient()->getUser($type, $id);
 
@@ -140,6 +140,18 @@ function dosomething_northstar_get_user($id, $type = 'id') {
   watchdog_exception('northstar', new Exception($error));
 
   return NULL;
+}
+
+/**
+ * Clear the Northstar cache for the given Northstar id.
+ *
+ * @param  $northstar_id - Northstar id
+ */
+function dosomething_northstar_clear_user_cache($northstar_id) {
+  $cache_bin = 'cache_dosomething_northstar';
+  $cache_key = 'northstar_user_id' . '=' . $northstar_id;
+
+  cache_clear_all($cache_key, $cache_bin);
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/js/address/index.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/address/index.js
@@ -47,12 +47,12 @@ function init($addressForm = $('#dosomething-address-form')) {
   prefillForm($form);
   handleFormSubmit($form, (res) => {
     if (! res || ! res.data || ! res.data.id) {
-      $addressForm.find('[role=error]').text('Looks like we had an error. Try again?');
+      $addressForm.find('[role=error]').text('Uh-oh, something went wrong. Please check your information and try again.');
       return;
     }
 
     $addressForm.toggleClass('js-reveal');
-    $addressForm.find('[role=success]').text('Done!');
+    $addressForm.find('[role=success]').text('Thanks! You should be receiving your thumb socks in the next 2-3 weeks.');
   });
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/address/index.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/address/index.js
@@ -46,7 +46,6 @@ function init($addressForm = $('#dosomething-address-form')) {
 
   prefillForm($form);
   handleFormSubmit($form, (res) => {
-    console.log(res);
     if (! res || ! res.data || ! res.data.id) {
       $addressForm.find('[role=error]').text('Looks like we had an error. Try again?');
       return;

--- a/lib/themes/dosomething/paraneue_dosomething/js/address/index.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/address/index.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import setting from '../utilities/Setting';
+import ApiClient from '../utilities/ApiClient';
 
 function prefillForm($form) {
   $form.find('#addr-street1').val(setting('dsUser.info.addr_street1'));
@@ -10,7 +11,9 @@ function prefillForm($form) {
 }
 
 function handleFormSubmit($form, callback) {
-  $form.on('submit', () => {
+  $form.on('submit', (event) => {
+    event.preventDefault();
+
     const payload = {
       'addr-street1': $form.find('#addr-street1').val(),
       'addr-street2': $form.find('#addr-street2').val(),

--- a/lib/themes/dosomething/paraneue_dosomething/js/address/index.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/address/index.js
@@ -14,17 +14,17 @@ function handleFormSubmit($form, callback) {
   $form.on('submit', (event) => {
     event.preventDefault();
 
-    const payload = {
-      'addr-street1': $form.find('#addr-street1').val(),
-      'addr-street2': $form.find('#addr-street2').val(),
-      'addr-city': $form.find('#addr-city').val(),
-      'addr-state': $form.find('#addr-state').val(),
-      'addr-zip': $form.find('#addr-zip').val(),
+    const account = {
+      'addr_street1': $form.find('#addr-street1').val(),
+      'addr_street2': $form.find('#addr-street2').val(),
+      'addr_city': $form.find('#addr-city').val(),
+      'addr_state': $form.find('#addr-state').val(),
+      'addr_zip': $form.find('#addr-zip').val(),
     };
 
     const client = new ApiClient('v1');
     const uri = `users/${setting('dsUser.info.id')}/update`;
-    client.post(uri, payload).then(callback);
+    client.post(uri, { account }).then(callback);
 
     return false;
   });
@@ -46,6 +46,7 @@ function init($addressForm = $('#dosomething-address-form')) {
 
   prefillForm($form);
   handleFormSubmit($form, (res) => {
+    console.log(res);
     if (! res || ! res.data || ! res.data.id) {
       $addressForm.find('[role=error]').text('Looks like we had an error. Try again?');
       return;

--- a/lib/themes/dosomething/paraneue_dosomething/js/address/index.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/address/index.js
@@ -1,0 +1,56 @@
+import $ from 'jquery';
+import setting from '../utilities/Setting';
+
+function prefillForm($form) {
+  $form.find('#addr-street1').val(setting('dsUser.info.addr_street1'));
+  $form.find('#addr-street2').val(setting('dsUser.info.addr_street2'));
+  $form.find('#addr-city').val(setting('dsUser.info.addr_city'));
+  $form.find('#addr-state').val(setting('dsUser.info.addr_state'));
+  $form.find('#addr-zip').val(setting('dsUser.info.addr_zip'));
+}
+
+function handleFormSubmit($form, callback) {
+  $form.on('submit', () => {
+    const payload = {
+      'addr-street1': $form.find('#addr-street1').val(),
+      'addr-street2': $form.find('#addr-street2').val(),
+      'addr-city': $form.find('#addr-city').val(),
+      'addr-state': $form.find('#addr-state').val(),
+      'addr-zip': $form.find('#addr-zip').val(),
+    };
+
+    const client = new ApiClient('v1');
+    const uri = `users/${setting('dsUser.info.id')}/update`;
+    client.post(uri, payload).then(callback);
+
+    return false;
+  });
+}
+
+/**
+ * Initialize the Stripe donation form.
+ * @param {jQuery} $donateForm - Donation form element
+ */
+function init($addressForm = $('#dosomething-address-form')) {
+  if (!$addressForm.length) return;
+
+  const $revealButton = $addressForm.find('[role=revealer]');
+  const $submitForm = $addressForm.find('[role=submit]');
+
+  const $form = $addressForm.find('form');
+
+  $revealButton.on('click', () => $addressForm.toggleClass('js-reveal'));
+
+  prefillForm($form);
+  handleFormSubmit($form, (res) => {
+    if (! res || ! res.data || ! res.data.id) {
+      $addressForm.find('[role=error]').text('Looks like we had an error. Try again?');
+      return;
+    }
+
+    $addressForm.toggleClass('js-reveal');
+    $addressForm.find('[role=success]').text('Done!');
+  });
+}
+
+export default { init };

--- a/lib/themes/dosomething/paraneue_dosomething/js/app.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/app.js
@@ -21,6 +21,7 @@ import Donate from 'donate/Donate';
 import Finder from 'finder/Finder';
 import Reportback from 'reportback/Reportback';
 import SchoolFinder from 'campaign/SchoolFinder';
+import Address from 'address';
 
 // Patterns
 import Gallery from 'patterns/Gallery';
@@ -83,6 +84,8 @@ $(document).ready(function() {
   // Add fallback for HTML5 video on mobile tiles
   Tile.init();
 
+  // Initialize the custom address form.
+  Address.init();
 
   /**
    * We use the Filament Group's fixed-sticky library to polyfill the

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -34,6 +34,7 @@ $asset-path: "";
 @import "patterns/tile";
 
 // Content styles by section
+@import "content/address-form";
 @import "content/campaign";
 @import "content/campaign-sms";
 @import "content/campaign-closed";

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_address-form.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_address-form.scss
@@ -1,0 +1,43 @@
+.address-form {
+  form {
+    display: none;
+  }
+
+  .address-form__message {
+    margin: $base-spacing / 2 0;
+  }
+
+  [role="revealer"] {
+    display: block;
+  }
+
+  [role="success"] {
+    color: #008000;
+  }
+
+  [role="error"] {
+    color: $error-color;
+  }
+
+  &.js-reveal {
+    form {
+      display: block;
+      margin-top: $base-spacing;
+      animation: reveal-form 250ms ease-in-out both;
+    }
+
+    [role="revealer"] {
+      display: none;
+    }
+  }
+}
+
+@keyframes reveal-form {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -181,6 +181,38 @@
       <?php endforeach; ?>
       <?php endif; ?>
 
+      <?php if (isset($enable_address_form)): ?>
+        <div id="dosomething-address-form" class="container__block -half address-form">
+          <h3 class="inline-sponsor-color">Tell us your address</h3>
+          <p>Some copy is going here, we'll put some actual stuff here later.</p>
+          <p class="address-form__message" role="error"></p>
+          <p class="address-form__message" role="success"></p>
+          <form>
+            <div class="form-item">
+              <label for="addr-street1" class="field-label">Address Street 1</label>
+              <input type="text" id="addr-street1" class="text-field" name="addr_street1" value="">
+            </div>
+            <div class="form-item">
+              <label for="addr-street2" class="field-label">Address Street 2</label>
+              <input type="text" id="addr-street2" class="text-field" name="addr_street2" value="">
+            </div>
+            <div class="form-item">
+              <label for="addr-city" class="field-label">City</label>
+              <input type="text" id="addr-city" class="text-field" name="addr_city" value="">
+            </div>
+            <div class="form-item">
+              <label for="addr-state" class="field-label">State</label>
+              <input type="text" id="addr-state" class="text-field" name="addr_state" value="">
+            </div>
+            <div class="form-item">
+              <label for="addr-zip" class="field-label">ZIP</label>
+              <input type="text" id="addr-zip" class="text-field" name="addr_zip" value="">
+            </div>
+            <button role="submit" class="button">Submit</button>
+          </form>
+          <button role="revealer" class="button -secondary">Show form</button>
+        </div>
+      <?php endif; ?>
 
       <?php if (isset($location_finder['url'])) : ?>
         <div class="container__block -narrow">

--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign.tpl.php
@@ -183,8 +183,8 @@
 
       <?php if (isset($enable_address_form)): ?>
         <div id="dosomething-address-form" class="container__block -half address-form">
-          <h3 class="inline-sponsor-color">Tell us your address</h3>
-          <p>Some copy is going here, we'll put some actual stuff here later.</p>
+          <h3 class="inline-sponsor-color">Want Free Thumb Socks?</h3>
+          <p>Fill out this information and we’ll send you two free pairs of Thumb Socks. One for you and one for a friend.</p>
           <p class="address-form__message" role="error"></p>
           <p class="address-form__message" role="success"></p>
           <form>


### PR DESCRIPTION
#### What's this PR do?
- Adds the `package-lock` to the .gitignore till we decide to use npm 5 here
- Adds a new endpoint to let users update Northstar profiles 
- Adds a new address form that inlines on the campaign template, toggled with custom setting
- Adds a new Northstar function to clear the user cache

STILL TO-DO in future PR
- Final copy
- Adding some form validation 

(I totally broke our smaller PR rule :man_facepalming: )

#### How should this be reviewed?
1. Enable the address form
2. Signup for the campaign
3. Fill in your deets
4. Submit (You should see a success message)
5. Check your Northstar profile, the fields should be there
6. Refresh the campaign page, open up the form. It should prefill those inputs.