### PR TITLE
Adding zendesk honeypot

### DIFF
--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -72,6 +72,11 @@ function dosomething_zendesk_form($form, &$form_state, $entity = NULL)  {
     $ip_address = ip_address();
   }
 
+  $form['honeypot'] = [
+    '#type' => 'textfield',
+    '#title' => 'honeypot',
+  ];
+
   $form['browser'] = array(
     '#type' => 'hidden',
     '#access' => FALSE,
@@ -191,6 +196,12 @@ function dosomething_zendesk_get_zendesk_group_id($entity = NULL) {
  * Validation callback for dosomething_zendesk_form().
  */
 function dosomething_zendesk_form_validate($form, &$form_state) {
+  // If a bot fell for the honeypot...
+  if (!empty($form_state['values']['honeypot'])) {
+    form_set_error('bot', 'Are you a bot?');
+    stathat_send_ez_count('drupal - Zendesk - honeypot', 1);
+  }
+
   // If an email field is present:
   if (isset($form_state['values']['email'])) {
     // Check if valid email.

--- a/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
+++ b/lib/modules/dosomething/dosomething_zendesk/dosomething_zendesk.module
@@ -72,7 +72,7 @@ function dosomething_zendesk_form($form, &$form_state, $entity = NULL)  {
     $ip_address = ip_address();
   }
 
-  $form['honeypot'] = [
+  $form['not_honeypot'] = [
     '#type' => 'textfield',
     '#title' => 'honeypot',
   ];
@@ -197,7 +197,7 @@ function dosomething_zendesk_get_zendesk_group_id($entity = NULL) {
  */
 function dosomething_zendesk_form_validate($form, &$form_state) {
   // If a bot fell for the honeypot...
-  if (!empty($form_state['values']['honeypot'])) {
+  if (!empty($form_state['values']['not_honeypot'])) {
     form_set_error('bot', 'Are you a bot?');
     stathat_send_ez_count('drupal - Zendesk - honeypot', 1);
   }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -44,6 +44,7 @@ $asset-path: "";
 @import "content/finder";
 @import "content/home";
 @import "content/modal-address";
+@import "content/modal-contact";
 @import "content/modal-creator";
 @import "content/modal-crop";
 @import "content/modal-schoolfinder";

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-contact.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-contact.scss
@@ -1,3 +1,3 @@
-.modal--contact .form-item-honeypot {
+.modal--contact .form-item-not-honeypot {
   display: none;
 }

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-contact.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_modal-contact.scss
@@ -1,0 +1,3 @@
+.modal--contact .form-item-honeypot {
+  display: none;
+}


### PR DESCRIPTION
#### What's this PR do?
This pr adds a simple honeypot for some dork that's spamming our Zendesk tickets. If they keep persisting after this we'll look into something more advanced like [this](https://developers.google.com/recaptcha/)

#### How should this be reviewed?
Submit the Zendesk form, everything should work normally. Then try again, but fill-out the value of the honeypot input. 

![honey](https://user-images.githubusercontent.com/897368/28033545-911c82b4-657c-11e7-8806-1720d11d2bfe.gif)

#### Any background context you want to provide?
I was originally going to implement our own shitty captcha, but this is a bit easier and doesn't impact the user at all. 