### PR TITLE
Northstar token fixes

### DIFF
--- a/lib/app/Auth/PhoenixOAuthUser.php
+++ b/lib/app/Auth/PhoenixOAuthUser.php
@@ -95,10 +95,15 @@ class PhoenixOAuthUser implements NorthstarUserContract {
    * @return void
    */
   public function setOAuthToken(AccessToken $token) {
-    $this->user->field_access_token[LANGUAGE_NONE][0]['value'] = $token->getToken();
-    $this->user->field_refresh_token[LANGUAGE_NONE][0]['value'] = $token->getRefreshToken();
-    $this->user->field_access_token_expiration[LANGUAGE_NONE][0]['value'] = $token->getExpires();
-    user_save($this->user);
+    $edit = [];
+
+    dosomething_user_set_fields($edit, [
+      'access_token' => $token->getToken(),
+      'refresh_token' => $token->getRefreshToken(),
+      'access_token_expiration' => $token->getExpires(),
+    ]);
+
+    user_save($this->user, $edit);
   }
 
   /**
@@ -107,9 +112,14 @@ class PhoenixOAuthUser implements NorthstarUserContract {
    * @return void
    */
   public function clearOAuthToken() {
-    unset($this->user->field_access_token);
-    unset($this->user->field_refresh_token);
-    unset($this->user->field_access_token_expiration);
+    $edit = [];
+
+    dosomething_user_set_fields($edit, [
+      'access_token' => null,
+      'refresh_token' => null,
+      'access_token_expiration' => null,
+    ]);
+
     user_save($this->user);
   }
 }

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -76,6 +76,12 @@ function dosomething_northstar_init() {
     $account = new PhoenixOAuthUser($user->uid);
     $token = $account->getOAuthToken();
 
+    // If the user doesn't have a token, log them out.
+    if (! $token) {
+      watchdog('dosomething_northstar', 'logged user `!uid` out because of missing token', ['!uid' => $user->uid]);
+      user_logout();
+    }
+
     if ($token->hasExpired()) {
       dosomething_northstar_client()->getTokenByRefreshTokenGrant($token);
     }

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -220,11 +220,11 @@ projects[token][version] = "1.5"
 projects[token][subdir] = "contrib"
 
 ; UUID
-projects[uuid][version] = "1.0-alpha5"
+projects[uuid][version] = "1.0"
 projects[uuid][subdir] = "contrib"
 
 ; UUID Features
-projects[uuid_features][version] = "1.0-alpha4"
+projects[uuid_features][version] = "1.0-rc1"
 projects[uuid_features][subdir] = "contrib"
 
 ; Variable


### PR DESCRIPTION
#### What's this PR do?
This pull request includes some fixes for #7438:

🆔 Updates the `uuid` and `uuid_features` modules, which were both pinned to alpha releases to their latest stable and release candidate versions. This was one of the [recommended fixes](https://drupal.stackexchange.com/questions/66045/im-suddenly-getting-the-error-entitymetadatawrapperexception) I found for inconsistent `EntityMetadataWrapperException` when loading fields. It seems very arbitrary, but it did immediately clear up the issue on my local once I ran `drush updb`.

✏️ Updates `PhoenixOAuthUser` to use our `dosomething_user_set_fields` helper.

👞 If the logged in user doesn't have a token, log them out rather than trying to call the "refresh" method on `null`. Hopefully this should not happen much anymore.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Full write-up on debugging this is in #7438.

#### Relevant tickets
References #7438.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  