### PR TITLE
GET /signups/:sid proxy 

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -227,5 +227,13 @@ function _signup_resource_create($campaign_id, $campaign_run_id, $key, $user_id)
  * @return array
  */
 function _signup_resource_retrieve($sid) {
+  // Return data from Rogue if Rogue is turned on
+  if (variable_get('rogue_collection', FALSE)) {
+
+    $rogue_response = dosomething_rogue_get_activity(['id' => $sid]);
+
+    return dosomething_rogue_format_signup($rogue_response['data'][0]);
+  }
+
   return (new SignupTransformer)->show($sid);
 }

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -232,7 +232,11 @@ function _signup_resource_retrieve($sid) {
 
     $rogue_response = dosomething_rogue_get_activity(['id' => $sid]);
 
-    return dosomething_rogue_format_signup($rogue_response['data']);
+    $formatted_signup = (object) dosomething_rogue_format_signup($rogue_response['data'][0]);
+
+    $data['data'] = $formatted_signup;
+
+    return $data;
   }
 
   return (new SignupTransformer)->show($sid);

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -232,7 +232,7 @@ function _signup_resource_retrieve($sid) {
 
     $rogue_response = dosomething_rogue_get_activity(['id' => $sid]);
 
-    return dosomething_rogue_format_signup($rogue_response['data'][0]);
+    return dosomething_rogue_format_signup($rogue_response['data']);
   }
 
   return (new SignupTransformer)->show($sid);

--- a/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
+++ b/lib/modules/dosomething/dosomething_campaign/includes/Campaign.php
@@ -58,6 +58,7 @@ class Campaign {
       $single_campaign = TRUE;
       $ids = [$ids];
     }
+
     // Only load campaign types in this class.
     $results = node_load_multiple($ids, ['type' => 'campaign']);
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -180,7 +180,7 @@ function dosomething_rogue_format_signup($signup) {
     $current_run_end = NULL;
   }
 
-  $campaign = node_load($signup['campaign_id']);
+  $campaign = Campaign::get($signup['campaign_id']);
 
   $campaign_data = (new SignupTransformer)->transformCampaign((object) $campaign);
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -137,124 +137,132 @@ function dosomething_rogue_format_activity($response)
 
     // Format each signup
     foreach ($response['data'] as $signup) {
-      // Get campaign and run information for the signup data response
-        $northstar_user = dosomething_northstar_get_user($signup['northstar_id']);
-
-        // Get campaign information
-        $drupal_user = dosomething_user_get_user_by_northstar_id($signup['northstar_id']);
-
-        try {
-          $campaign_run = dosomething_helpers_get_current_campaign_run_for_user($signup['campaign_id'], $drupal_user); // get errors when calling this sometimes (500 - no campaign data found)
-        } catch(Exception $e) {
-          // the regular Phoenix endpoint doesn't seem to handle exceptions like these so we just set the run to null if there is an exception
-          $campaign_run = null;
-        }
-
-        $campaign_run_nid = $campaign_run->nid;
-
-        $current = ($signups['campaign_run_id'] == $campaign_run_nid) ? true : false;
-
-        if (isset($campaign_run->field_run_date['en'][0])) {
-          $current_run_start = $campaign_run->field_run_date['en'][0]['value'];
-          $current_run_end = $campaign_run->field_run_date['en'][0]['value2'];
-        }
-        else {
-          $current_run_start = NULL;
-          $current_run_end = NULL;
-        }
-
-        $campaign = node_load($signup['campaign_id']);
-
-        $campaign_data = (new SignupTransformer)->transformCampaign((object) $campaign);
-
-        $user_data = (new SignupTransformer)->transformUser((object) $northstar_user);
-
-      // Format the data for each signup
-        $signup_data = [
-          // SIGNUP
-          'id' => $signup['signup_id'],
-          'created_at' => strtotime($signup['created_at']),
-
-          // CAMPAIGN RUN
-          'campaign_run' => [
-            'id' => $campaign_run_nid,
-            'current' => $current,
-            'timing' => [
-              'start' => $current_run_start,
-              'end' => $current_run_end,
-            ],
-          ],
-          'uri' => null,
-
-          // CAMPAIGN - no changes
-          'campaign' => $campaign_data,
-
-          // USER - no changes
-          'user' => $user_data,
-        ];
-
-        // REPORTBACK IS CONDITIONAL
-        if (array_key_exists('posts', $signup)) {
-          $reportback_data = [
-              'id' => $signup['signup_id'],
-              'created_at' => strtotime($signup['created_at']),
-              'updated_at' => strtotime($signup['updated_at']),
-              'quantity' => $signup['quantity'],
-              'uri' => null,
-              'why_participated' => $signup['why_participated'],
-              'flagged' => null,
-          ];
-
-          // Add data for each reportback item
-          $reportback_item_array = [];
-          foreach ($signup['posts']['data'] as $post) {
-            $post_data = [
-              'id' => $post['id'],
-              'status' => dosomething_rogue_transform_rogue_status_to_phoenix_status($post['status']),
-              'caption' => $post['media']['caption'],
-              'uri' => null,
-              'media' => [
-                'uri' => $post['media']['url'],
-                'type' => 'image',
-              ],
-              'created_at' => strtotime($post['created_at']),
-              'kudos' => [
-                'data' => [],
-              ],
-            ];
-
-            // Include reaction data if there is any
-            if (count($post['reactions']) > 0) {
-              $post_data['kudos']['data'] = [
-                '641' => [
-                  'term' => [
-                    'id' => '641',
-                    'name' => 'heart',
-                    'total' => count($post['reactions']),
-                  ],
-                  'current_user' => null,
-                ]
-              ];
-            }
-
-            array_push($reportback_item_array, $post_data);
-          }
-
-          // Include total number of items in the response
-          $reportback_data['reportback_items']['total'] = count($reportback_item_array);
-
-          // Add reportback item data to reportback portion of response
-          $reportback_data['reportback_items']['data'] = $reportback_item_array;
-
-          // Add reportback data to the response for this signup
-          $signup_data['reportback'] = $reportback_data;
-        }
+      $signup_data = dosomething_rogue_format_signup($signup);
 
       // Add data to the overall response
       array_push($data['data'], $signup_data);
     }
 
     return json_encode($data);
+  }
+}
+
+/**
+*/
+function dosomething_rogue_format_signup($signup) {
+  // Get campaign and run information for the signup data response
+  $northstar_user = dosomething_northstar_get_user($signup['northstar_id']);
+
+  // Get campaign information
+  $drupal_user = dosomething_user_get_user_by_northstar_id($signup['northstar_id']);
+
+  try {
+    $campaign_run = dosomething_helpers_get_current_campaign_run_for_user($signup['campaign_id'], $drupal_user); // get errors when calling this sometimes (500 - no campaign data found)
+  } catch(Exception $e) {
+    // the regular Phoenix endpoint doesn't seem to handle exceptions like these so we just set the run to null if there is an exception
+    $campaign_run = null;
+  }
+
+  $campaign_run_nid = $campaign_run->nid;
+
+  $current = ($signups['campaign_run_id'] == $campaign_run_nid) ? true : false;
+
+  if (isset($campaign_run->field_run_date['en'][0])) {
+    $current_run_start = $campaign_run->field_run_date['en'][0]['value'];
+    $current_run_end = $campaign_run->field_run_date['en'][0]['value2'];
+  }
+  else {
+    $current_run_start = NULL;
+    $current_run_end = NULL;
+  }
+
+  $campaign = node_load($signup['campaign_id']);
+
+  $campaign_data = (new SignupTransformer)->transformCampaign((object) $campaign);
+
+  $user_data = (new SignupTransformer)->transformUser((object) $northstar_user);
+
+  // Format the data for each signup
+  $signup_data = [
+    // SIGNUP
+    'id' => $signup['signup_id'],
+    'created_at' => strtotime($signup['created_at']),
+
+    // CAMPAIGN RUN
+    'campaign_run' => [
+      'id' => $campaign_run_nid,
+      'current' => $current,
+      'timing' => [
+        'start' => $current_run_start,
+        'end' => $current_run_end,
+      ],
+    ],
+    'uri' => null,
+
+    // CAMPAIGN - no changes
+    'campaign' => $campaign_data,
+
+    // USER - no changes
+    'user' => $user_data,
+  ];
+
+  // REPORTBACK IS CONDITIONAL
+  if (array_key_exists('posts', $signup)) {
+    $reportback_data = [
+        'id' => $signup['signup_id'],
+        'created_at' => strtotime($signup['created_at']),
+        'updated_at' => strtotime($signup['updated_at']),
+        'quantity' => $signup['quantity'],
+        'uri' => null,
+        'why_participated' => $signup['why_participated'],
+        'flagged' => null,
+    ];
+
+    // Add data for each reportback item
+    $reportback_item_array = [];
+    foreach ($signup['posts']['data'] as $post) {
+      $post_data = [
+        'id' => $post['id'],
+        'status' => dosomething_rogue_transform_rogue_status_to_phoenix_status($post['status']),
+        'caption' => $post['media']['caption'],
+        'uri' => null,
+        'media' => [
+          'uri' => $post['media']['url'],
+          'type' => 'image',
+        ],
+        'created_at' => strtotime($post['created_at']),
+        'kudos' => [
+          'data' => [],
+        ],
+      ];
+
+      // Include reaction data if there is any
+      if (count($post['reactions']) > 0) {
+        $post_data['kudos']['data'] = [
+          '641' => [
+            'term' => [
+              'id' => '641',
+              'name' => 'heart',
+              'total' => count($post['reactions']),
+            ],
+            'current_user' => null,
+          ]
+        ];
+      }
+
+      array_push($reportback_item_array, $post_data);
+    }
+
+    // Include total number of items in the response
+    $reportback_data['reportback_items']['total'] = count($reportback_item_array);
+
+    // Add reportback item data to reportback portion of response
+    $reportback_data['reportback_items']['data'] = $reportback_item_array;
+
+    // Add reportback data to the response for this signup
+    $signup_data['reportback'] = $reportback_data;
+
+    return $signup_data;
   }
 }
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -180,7 +180,11 @@ function dosomething_rogue_format_signup($signup) {
     $current_run_end = NULL;
   }
 
-  $campaign = Campaign::get($signup['campaign_id']);
+  try {
+    $campaign = Campaign::get($signup['campaign_id']);
+  } catch (Exception $e) {
+    $campaign = node_load($signup['campaign_id']);
+  }
 
   $campaign_data = (new SignupTransformer)->transformCampaign((object) $campaign);
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -169,7 +169,7 @@ function dosomething_rogue_format_signup($signup) {
 
   $campaign_run_nid = $campaign_run->nid;
 
-  $current = ($signups['campaign_run_id'] == $campaign_run_nid) ? true : false;
+  $current = ($signup['campaign_run_id'] == $campaign_run_nid) ? true : false;
 
   if (isset($campaign_run->field_run_date['en'][0])) {
     $current_run_start = $campaign_run->field_run_date['en'][0]['value'];

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -148,7 +148,11 @@ function dosomething_rogue_format_activity($response)
 }
 
 /**
-*/
+  * Format a response from Rogue's GET /activity to match
+  * the response from Phoenix's GET /signups/:sid
+  *
+  * @param array $signup
+  */
 function dosomething_rogue_format_signup($signup) {
   // Get campaign and run information for the signup data response
   $northstar_user = dosomething_northstar_get_user($signup['northstar_id']);


### PR DESCRIPTION
#### What's this PR do?
- Creates a Rogue proxy for the `GET /signups/:sid` endpoint 

#### How should this be reviewed?
- Turn Rogue on.
- Hit the `GET /signups/:sid` endpoint and the response should look exactly the same as if data was coming from Phoenix (compared results below) 
- Make sure this doesn't break the `GET /signups` endpoint that @katiecrane worked on! 
  - @katiecrane I separated the signup formatting to a separate helper function. I don't think that this broke anything but would your eyes just to double check! 

An example when Rogue is OFF: 
```
{
    "data": {
        "id": "234",
        "created_at": "1400010537",
        "campaign_run": {
            "id": "1807",
            "current": true,
            "timing": {
                "start": "2015-08-26 00:00:00",
                "end": null
            }
        },
        "uri": "http://dev.dosomething.org:8888/api/v1/signups/234",
        "campaign": {
            "id": "886",
            "title": "Kickball for All",
            "campaign_runs": {
                "current": {
                    "en": {
                        "id": "1807"
                    }
                },
                "past": []
            },
            "language": {
                "language_code": "en",
                "prefix": "us"
            },
            "translations": {
                "original": "en",
                "en": {
                    "language_code": "en",
                    "prefix": "us"
                }
            },
            "tagline": "Start an inclusive kickball team in your neighborhood.",
            "status": "active",
            "type": "campaign",
            "reportback_info": {
                "copy": "Upload yours by August 31.",
                "confirmation_message": "Back, back, back, GONE! You knocked this one out of the park.",
                "noun": "Games",
                "verb": "Played"
            },
            "magic_link_copy": null
        },
        "reportback": null,
        "user": {
            "id": "***",
            "drupal_id": "***",
            "first_name": "Mike",
            "last_initial": "",
            "photo": null,
            "country": "US"
        }
    }
}
```

An example when Rogue is ON: 
```
{
    "data": {
        "id": 122,
        "created_at": 1498676480,
        "campaign_run": {
            "id": "1842",
            "current": false,
            "timing": {
                "start": "2014-07-30 00:00:00",
                "end": null
            }
        },
        "uri": null,
        "campaign": {
            "id": "1334",
            "title": "Can-Tribute",
            "campaign_runs": {
                "current": {
                    "en": {
                        "id": "1842"
                    },
                    "en-global": {
                        "id": "1842"
                    }
                },
                "past": []
            },
            "language": {
                "language_code": "en",
                "prefix": "us"
            },
            "translations": {
                "original": "en",
                "en": {
                    "language_code": "en",
                    "prefix": "us"
                },
                "en-global": {
                    "language_code": "en-global",
                    "prefix": null
                }
            },
            "tagline": "May the odds be ever in your favor in this competitive food drive.",
            "status": "active",
            "type": "campaign",
            "reportback_info": {
                "copy": "Show us your photo to win tickets to a local pre-screening of The Hunger Games: Mockingjay - Part 1 for you and your friends! Upload your photo by November 6.",
                "confirmation_message": "Thanks for helping stock food bank shelves. Now go parade around in a fiery dress.",
                "noun": "items",
                "verb": "donated"
            },
            "magic_link_copy": null
        },
        "user": {
            "id": "****",
            "drupal_id": "****",
            "first_name": "Chloe",
            "last_initial": "L",
            "photo": null,
            "country": "US"
        },
        "reportback": {
            "id": 122,
            "created_at": 1498676480,
            "updated_at": 1498679922,
            "quantity": 343,
            "uri": null,
            "why_participated": "test!",
            "flagged": null,
            "reportback_items": {
                "total": 3,
                "data": [
                    {
                        "id": 194,
                        "status": "pending",
                        "caption": "go to rouge",
                        "uri": null,
                        "media": {
                            "uri": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/122-482cab927f6529c7f5e5c4bfd2594186-1498676480.jpeg",
                            "type": "image"
                        },
                        "created_at": 1498676481,
                        "kudos": {
                            "data": []
                        }
                    },
                    {
                        "id": 195,
                        "status": "pending",
                        "caption": "go to rouge",
                        "uri": null,
                        "media": {
                            "uri": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/122-482cab927f6529c7f5e5c4bfd2594186-1498676518.jpeg",
                            "type": "image"
                        },
                        "created_at": 1498676520,
                        "kudos": {
                            "data": []
                        }
                    },
                    {
                        "id": 196,
                        "status": "pending",
                        "caption": "get out",
                        "uri": null,
                        "media": {
                            "uri": "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/122-482cab927f6529c7f5e5c4bfd2594186-1498679921.jpeg",
                            "type": "image"
                        },
                        "created_at": 1498679922,
                        "kudos": {
                            "data": []
                        }
                    }
                ]
            }
        }
    }
}
```

#### Relevant tickets
Needs https://github.com/DoSomething/rogue/pull/300 to be merged in order for this to work. 

Fixes https://trello.com/c/QYdM5vVN/485-as-a-developer-i-want-to-make-sure-phoenixs-signups-sid-endpoint-has-a-rogue-proxy-for-gladiator-to-still-work-when-rogue-is-tur

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
