### PR TITLE
Make sure we can call user_logout in the init hook.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -79,6 +79,7 @@ function dosomething_northstar_init() {
     // If the user doesn't have a token, log them out.
     if (! $token) {
       watchdog('dosomething_northstar', 'logged user `!uid` out because of missing token', ['!uid' => $user->uid]);
+      module_load_include('pages.inc', 'user'); // @see: https://drupal.stackexchange.com/a/188886
       user_logout();
     }
 


### PR DESCRIPTION
#### What's this PR do?
This should fix the issue that a few people mentioned where `user_logout` was undefined. It turns out you need to "include" the user module before you're able to call it in the init hook, okay.

![screen shot 2017-07-11 at 3 09 13 pm](https://user-images.githubusercontent.com/583202/28088119-aed03ca2-6652-11e7-9e12-3223f2c89f3f.png)

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Here's the linked [StackOverflow post](https://drupal.stackexchange.com/a/188886).

#### Relevant tickets
Fixes 🐛.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  