### PR TITLE
Remove usage of EntityMetadataWrapper.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1107,19 +1107,8 @@ function dosomething_user_get_field($field_name, $account = NULL, $format = NULL
     $account = $user;
   }
 
-  $wrapper = entity_metadata_wrapper('user', $account);
-  try {
-    $field_value =  $wrapper->{$field_name}->value();
-  } catch (EntityMetadataWrapperException $e) {
-    // Don't fall into error 500 when the field is not accessible.
-    watchdog(
-      'dosomething_user',
-      'Can\'t load field `!field_name` for user `!email`.',
-      ['!field_name' => $field_name, '!email' => $account->mail],
-      WATCHDOG_NOTICE
-    );
-    return NULL;
-  }
+  // Load the requested field from the provided user.
+  $field_value = $account->{$field_name}[LANGUAGE_NONE][0]['value'];
 
   // Check if there is a specifc function handler for that field, use that first.
   $handler = 'dosomething_user_get_' . $field_name;


### PR DESCRIPTION
#### What's this PR do?
This pull request removes `EntityMetadataWrapper` from `dosomething_user_get_field`. I still can't figure out the root problem, but we're seeing a ton of strange exceptions when using it on staging that seem to disappear when just grabbing the fields by hand.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
🔥 🔥 🔥 

#### Relevant tickets
References #7438.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  