### PR TITLE
Adds a signup filter to the rogue activity get method

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -75,6 +75,7 @@ function dosomething_rogue_get_activity($inputs)
       'campaign_id' => dosomething_helpers_isset($inputs, 'campaigns'),
       'campaign_run_id' => dosomething_helpers_isset($inputs, 'runs'),
       'northstar_id' => dosomething_helpers_isset($inputs, 'user'),
+      'id' => dosomething_helpers_isset($inputs, 'id'),
     ],
     'limit' => dosomething_helpers_isset($inputs, 'count'),
     'page' => dosomething_helpers_isset($inputs, 'page'),


### PR DESCRIPTION
#### What's this PR do?

With the introduction of a [signup id filter](https://github.com/DoSomething/rogue/pull/300) on the Rogue `/activity` endpoint, this PR adds support for that filter in the `dosomething_rogue.module` so phoenix can easily request specific signup information. 

#### Relevant tickets

This will help work related to the signup proxy endpoints we are adding, the permalink page, and the RB received email. 
