### PR TITLE
Fix RB Emails when Rogue is on

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -433,12 +433,13 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     $rid = $rogue_reportback['data']['signup_id'];
     $fid = $rogue_reportback['data']['id'];
 
+    // Get signup associated with the post.
     $rogue_signup = dosomething_rogue_get_activity(['id' => $rid]);
-    $post_count = count($rogue_signup['data'][0]['posts']['data']);
 
-    if ($post_count === 1) {
+    // Send an email if it is the first post.
+    if (dosomething_rogue_get_post_count($rogue_signup['data'][0]) === 1) {
       if (module_exists('dosomething_mbp')) {
-        dosomething_reportback_rogue_mbp_request($rogue_reportback['data']);
+        dosomething_reportback_rogue_mbp_request($rogue_reportback['data'], rogue_signup['data'][0]);
       }
     }
   } else {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -433,11 +433,14 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     $rid = $rogue_reportback['data']['signup_id'];
     $fid = $rogue_reportback['data']['id'];
 
-    // @TODO - Is this only supposed to happen on the first submission?
-    if (module_exists('dosomething_mbp')) {
-      dosomething_reportback_rogue_mbp_request($rogue_reportback['data']);
-    }
+    $rogue_signup = dosomething_rogue_get_activity(['id' => $rid]);
+    $post_count = count($rogue_signup['data'][0]['posts']['data']);
 
+    if ($post_count === 1) {
+      if (module_exists('dosomething_mbp')) {
+        dosomething_reportback_rogue_mbp_request($rogue_reportback['data']);
+      }
+    }
   } else {
     // Save uploaded file.
     if ($file = dosomething_reportback_form_save_file($form_state)) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -432,6 +432,11 @@ function dosomething_reportback_form_submit($form, &$form_state) {
 
     $rid = $rogue_reportback['data']['signup_id'];
     $fid = $rogue_reportback['data']['id'];
+
+    if (module_exists('dosomething_mbp')) {
+      dosomething_reportback_mbp_request($entity);
+    }
+
   } else {
     // Save uploaded file.
     if ($file = dosomething_reportback_form_save_file($form_state)) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -433,6 +433,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     $rid = $rogue_reportback['data']['signup_id'];
     $fid = $rogue_reportback['data']['id'];
 
+    // @TODO - Is this only supposed to happen on the first submission?
     if (module_exists('dosomething_mbp')) {
       dosomething_reportback_rogue_mbp_request($rogue_reportback['data']);
     }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -434,7 +434,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     $fid = $rogue_reportback['data']['id'];
 
     if (module_exists('dosomething_mbp')) {
-      dosomething_reportback_mbp_request($entity);
+      dosomething_reportback_rogue_mbp_request($rogue_reportback['data']);
     }
 
   } else {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1068,64 +1068,59 @@ function dosomething_reportback_mbp_request($entity) {
  * Sends mbp request for a reportback stored in Rogue.
  */
 function dosomething_reportback_rogue_mbp_request($rb) {
-  // dump($rb);
-  // die();
-  // This fid is the last file uploaded to the reportback.
-  // @see Reportback->save().
-  // $fid = $rb['id'];
-
-  // @TODO - Figure this out.
-  // $image_markup = dosomething_image_get_themed_image(variable_get('dosomething_campaign_permalink_failure_image_nid'), 'square', '480x480');
-
-  // dump($image_markup);
-  // dump(dosomething_image_get_themed_image_by_fid(22, '300x300')) => returns <img src="http://dev.dosomething.org:8888/sites/default/files/styles/300x300/public/Girls%20laughing%20cyberbully.jpg?itok=pKphE1jo" width="300" height="300" alt="" />;
-  // die();
-  //dosomething_image_get_themed_image_by_fid(22, '300x300');
-
   $image_url = $rb['media']['url'];
   $image_markup = '<img src="' . $image_url . '" width="300" height="300" alt="" />';
 
   if (module_exists('dosomething_northstar')) {
-    $northstar_user = dosomething_northstar_get_user($rb['northstar_id']);//user_load($entity->uid);
-    // dump($account);
-    // die();
-  //   $node = node_load($entity->nid);
-  //   $language = dosomething_global_get_language($account, $node);
-  //   $campaign_language = !empty($node->language) ? $node->language : DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
-  //   $campaign_country = dosomething_global_get_current_country_code();
+    $northstar_user = dosomething_northstar_get_user($rb['northstar_id']);
+    $account = user_load($northstar_user->drupal_id);
+    $rogue_signup = dosomething_rogue_get_activity(['id' => $rb['signup_id']]);
+    $node = node_load($rogue_signup['data'][0]['campaign_id']);
+    $language = dosomething_global_get_language($account, $node);
+    $campaign_language = !empty($node->language) ? $node->language : DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
+    $campaign_country = dosomething_global_get_current_country_code();
 
-  //   $title = $entity->node_title;
-  //   if ($node) {
-  //     // Get node title, normal for collections, translatable for campaigns.
-  //     if (isset($node->title_field)) {
-  //       $wrapper = entity_metadata_wrapper('node', $node);
-  //       $title = $wrapper->language($language)->title_field->value();
-  //     } else {
-  //       $title = $node->title;
-  //     }
-  //   } else {
-  //     watchdog(
-  //       'dosomething_reportback',
-  //       'Node !nid !nid not found for reportback fid !fid.',
-  //       ['!nid' => $entity->nid, '!fid' => $entity->fid],
-  //       WATCHDOG_WARNING
-  //     );
-  //   }
+    // @TODO - figure out what this is in the other function an see if I can replicate it here.
+    // $title = $entity->node_title;
+
+    if ($node) {
+      $wrapper = entity_metadata_wrapper('node', $node);
+
+      $noun = $wrapper->language($language)->field_reportback_noun->value();
+      $verb = $wrapper->language($language)->field_reportback_verb->value();
+      // Get node title, normal for collections, translatable for campaigns.
+      if (isset($node->title_field)) {
+        $wrapper = entity_metadata_wrapper('node', $node);
+        $title = $wrapper->language($language)->title_field->value();
+      } else {
+        $title = $node->title;
+      }
+    } else {
+      watchdog(
+        'dosomething_reportback',
+        'Node !nid !nid not found for post id !post_id.',
+        ['!nid' => $rogue_signup['data'][0]['campaign_id'], '!post_id' => $rb['id']],
+        WATCHDOG_WARNING
+      );
+    }
 
     $params = array(
       'email' => $northstar_user->email,
       'uid' => $northstar_user->drupal_id,
       'first_name' => $northstar_user->first_name,
       'mobile' => $northstar_user->mobile,
-      // 'campaign_title' => $title,
-      // 'event_id' => $entity->nid,
-      // 'impact_verb' => $entity->verb,
-      // 'impact_number' => $entity->quantity,
-      // 'impact_noun' => $entity->noun,
+      'campaign_title' => $title,
+      'event_id' => $rogue_signup['data'][0]['campaign_id'],
+      'impact_verb' => $verb,
+      'impact_number' => $rogue_signup['data'][0]['quantity'],
+      'impact_noun' => $noun,
       'image_markup' => $image_markup,
-      // 'campaign_language' => $campaign_language,
-      // 'campaign_country' => $campaign_country,
+      'campaign_language' => $campaign_language,
+      'campaign_country' => $campaign_country,
     );
+
+    dump('params', $params);
+    die();
 
     // if (module_exists('dosomething_mbp')) {
     //   dosomething_mbp_request('campaign_reportback', $params);

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1026,6 +1026,7 @@ function dosomething_reportback_mbp_request($entity) {
     $campaign_country = dosomething_global_get_current_country_code();
 
     $title = $entity->node_title;
+
     if ($node) {
       // Get node title, normal for collections, translatable for campaigns.
       if (isset($node->title_field)) {
@@ -1080,9 +1081,6 @@ function dosomething_reportback_rogue_mbp_request($rb) {
     $campaign_language = !empty($node->language) ? $node->language : DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
     $campaign_country = dosomething_global_get_current_country_code();
 
-    // @TODO - figure out what this is in the other function an see if I can replicate it here.
-    // $title = $entity->node_title;
-
     if ($node) {
       $wrapper = entity_metadata_wrapper('node', $node);
 
@@ -1110,21 +1108,18 @@ function dosomething_reportback_rogue_mbp_request($rb) {
       'first_name' => $northstar_user->first_name,
       'mobile' => $northstar_user->mobile,
       'campaign_title' => $title,
-      'event_id' => $rogue_signup['data'][0]['campaign_id'],
+      'event_id' => (string) $rogue_signup['data'][0]['campaign_id'],
       'impact_verb' => $verb,
-      'impact_number' => $rogue_signup['data'][0]['quantity'],
+      'impact_number' => (string) $rogue_signup['data'][0]['quantity'],
       'impact_noun' => $noun,
       'image_markup' => $image_markup,
       'campaign_language' => $campaign_language,
       'campaign_country' => $campaign_country,
     );
 
-    dump('params', $params);
-    die();
-
-    // if (module_exists('dosomething_mbp')) {
-    //   dosomething_mbp_request('campaign_reportback', $params);
-    // }
+    if (module_exists('dosomething_mbp')) {
+      dosomething_mbp_request('campaign_reportback', $params);
+    }
   }
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1064,6 +1064,66 @@ function dosomething_reportback_mbp_request($entity) {
   }
 }
 
+/**
+ * Sends mbp request for a reportback stored in Rogue.
+ */
+function dosomething_reportback_rogue_mbp_request($rb) {
+  // dump($rb);
+  // die();
+  // This fid is the last file uploaded to the reportback.
+  // @see Reportback->save().
+  $fid = $rb['id'];
+
+  // @TODO - Figure this out.
+  // $image_markup = dosomething_image_get_themed_image_by_fid($fid, '300x300');
+
+  if (module_exists('dosomething_northstar')) {
+    $northstar_user = dosomething_northstar_get_user($rb['northstar_id']);//user_load($entity->uid);
+    // dump($account);
+    // die();
+  //   $node = node_load($entity->nid);
+  //   $language = dosomething_global_get_language($account, $node);
+  //   $campaign_language = !empty($node->language) ? $node->language : DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
+  //   $campaign_country = dosomething_global_get_current_country_code();
+
+  //   $title = $entity->node_title;
+  //   if ($node) {
+  //     // Get node title, normal for collections, translatable for campaigns.
+  //     if (isset($node->title_field)) {
+  //       $wrapper = entity_metadata_wrapper('node', $node);
+  //       $title = $wrapper->language($language)->title_field->value();
+  //     } else {
+  //       $title = $node->title;
+  //     }
+  //   } else {
+  //     watchdog(
+  //       'dosomething_reportback',
+  //       'Node !nid !nid not found for reportback fid !fid.',
+  //       ['!nid' => $entity->nid, '!fid' => $entity->fid],
+  //       WATCHDOG_WARNING
+  //     );
+  //   }
+
+    $params = array(
+      'email' => $northstar_user->email,
+      'uid' => $northstar_user->drupal_id,
+      'first_name' => $northstar_user->first_name,
+      'mobile' => $northstar_user->mobile,
+      // 'campaign_title' => $title,
+      // 'event_id' => $entity->nid,
+      // 'impact_verb' => $entity->verb,
+      // 'impact_number' => $entity->quantity,
+      // 'impact_noun' => $entity->noun,
+      // 'image_markup' => $image_markup,
+      // 'campaign_language' => $campaign_language,
+      // 'campaign_country' => $campaign_country,
+    );
+
+    // if (module_exists('dosomething_mbp')) {
+    //   dosomething_mbp_request('campaign_reportback', $params);
+    // }
+  }
+}
 
 /**
  * Returns array of Reportback rbid's for a given User $uid.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1068,15 +1068,14 @@ function dosomething_reportback_mbp_request($entity) {
 /**
  * Sends mbp request for a reportback stored in Rogue.
  */
-function dosomething_reportback_rogue_mbp_request($rb) {
+function dosomething_reportback_rogue_mbp_request($rb, $signup) {
   $image_url = $rb['media']['url'];
   $image_markup = '<img src="' . $image_url . '" width="300" height="300" alt="" />';
 
   if (module_exists('dosomething_northstar')) {
     $northstar_user = dosomething_northstar_get_user($rb['northstar_id']);
     $account = user_load($northstar_user->drupal_id);
-    $rogue_signup = dosomething_rogue_get_activity(['id' => $rb['signup_id']]);
-    $node = node_load($rogue_signup['data'][0]['campaign_id']);
+    $node = node_load($signup['campaign_id']);
     $language = dosomething_global_get_language($account, $node);
     $campaign_language = !empty($node->language) ? $node->language : DOSOMETHING_GLOBAL_DEFAULT_LANG_CODE;
     $campaign_country = dosomething_global_get_current_country_code();
@@ -1097,7 +1096,7 @@ function dosomething_reportback_rogue_mbp_request($rb) {
       watchdog(
         'dosomething_reportback',
         'Node !nid !nid not found for post id !post_id.',
-        ['!nid' => $rogue_signup['data'][0]['campaign_id'], '!post_id' => $rb['id']],
+        ['!nid' => $signup['campaign_id'], '!post_id' => $rb['id']],
         WATCHDOG_WARNING
       );
     }
@@ -1108,9 +1107,9 @@ function dosomething_reportback_rogue_mbp_request($rb) {
       'first_name' => $northstar_user->first_name,
       'mobile' => $northstar_user->mobile,
       'campaign_title' => $title,
-      'event_id' => (string) $rogue_signup['data'][0]['campaign_id'],
+      'event_id' => (string) $signup['campaign_id'],
       'impact_verb' => $verb,
-      'impact_number' => (string) $rogue_signup['data'][0]['quantity'],
+      'impact_number' => (string) $signup['quantity'],
       'impact_noun' => $noun,
       'image_markup' => $image_markup,
       'campaign_language' => $campaign_language,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1072,10 +1072,18 @@ function dosomething_reportback_rogue_mbp_request($rb) {
   // die();
   // This fid is the last file uploaded to the reportback.
   // @see Reportback->save().
-  $fid = $rb['id'];
+  // $fid = $rb['id'];
 
   // @TODO - Figure this out.
-  // $image_markup = dosomething_image_get_themed_image_by_fid($fid, '300x300');
+  // $image_markup = dosomething_image_get_themed_image(variable_get('dosomething_campaign_permalink_failure_image_nid'), 'square', '480x480');
+
+  // dump($image_markup);
+  // dump(dosomething_image_get_themed_image_by_fid(22, '300x300')) => returns <img src="http://dev.dosomething.org:8888/sites/default/files/styles/300x300/public/Girls%20laughing%20cyberbully.jpg?itok=pKphE1jo" width="300" height="300" alt="" />;
+  // die();
+  //dosomething_image_get_themed_image_by_fid(22, '300x300');
+
+  $image_url = $rb['media']['url'];
+  $image_markup = '<img src="' . $image_url . '" width="300" height="300" alt="" />';
 
   if (module_exists('dosomething_northstar')) {
     $northstar_user = dosomething_northstar_get_user($rb['northstar_id']);//user_load($entity->uid);
@@ -1114,7 +1122,7 @@ function dosomething_reportback_rogue_mbp_request($rb) {
       // 'impact_verb' => $entity->verb,
       // 'impact_number' => $entity->quantity,
       // 'impact_noun' => $entity->noun,
-      // 'image_markup' => $image_markup,
+      'image_markup' => $image_markup,
       // 'campaign_language' => $campaign_language,
       // 'campaign_country' => $campaign_country,
     );

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -4,11 +4,11 @@
  * @file
  * Code for the dosomething_rogue feature.
  */
+module_load_include('php', 'dosomething_signup', 'includes/SignupTransformer');
 
 include_once('dosomething_rogue.admin.inc');
 include_once('dosomething_rogue.cron.inc');
 include_once('includes/Rogue.php');
-include_once('../dosomething_signup/includes/SignupTransformer.php');
 
 define('ROGUE_API_URL', variable_get('dosomething_rogue_url', 'http://rogue.app/api'));
 define('ROGUE_API_VERSION', variable_get('dosomething_rogue_api_version', 'v1'));
@@ -918,5 +918,17 @@ function dosomething_rogue_handle_migration_failure($values, $sid, $rbid = NULL,
         'response_values' => (isset($e)) ? $e->getMessage() : NULL,
       ])
       ->execute();
+  }
+
+  /**
+   * Get count of posts under a signup.
+   *
+   * @param array $rogue_signup
+   * @param int $count|null
+   *
+   * @return
+   */
+  function dosomething_rogue_get_post_count($rogue_signup) {
+    return $rogue_signup['posts'] ? count($rogue_signup['posts']['data']) : null;
   }
 }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -8,8 +8,7 @@
 include_once('dosomething_rogue.admin.inc');
 include_once('dosomething_rogue.cron.inc');
 include_once('includes/Rogue.php');
-
-module_load_include('php', 'dosomething_signup', 'includes/SignupTransformer');
+include_once('../dosomething_signup/includes/SignupTransformer.php');
 
 define('ROGUE_API_URL', variable_get('dosomething_rogue_url', 'http://rogue.app/api'));
 define('ROGUE_API_VERSION', variable_get('dosomething_rogue_api_version', 'v1'));


### PR DESCRIPTION
#### What's this PR do?

This PR fixes a bug where the "We Received Your RB" Email was not being sent when rogue was turned on. This was because we were bypassing the `ReportbackController::save()` method when rogue was turned on and that method made the call to `dosomething_reportback_mbp_request()` that sent the message. 

However `dosomething_reportback_mbp_request()` took a reportback entity as a param and when we are working with Rogue posts the data is in a different format. So in this PR I created a new function, `dosomething_reportback_rogue_mbp_request()`, that accepts a Rogue post and signup object, formats the params, and makes the call to message broker. 

#### How should this be reviewed?

We will have to make sure we are getting the email on the first submission of a reportback and it is looking good. 

#### Relevant tickets
https://trello.com/c/WHWZhku8/492-5-%F0%9F%90%9B-when-rogue-is-turned-on-and-after-you-reportback-it-doesnt-seem-like-the-we-got-your-rb-email-triggers-%F0%9F%90%9B

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
