### PR TITLE
Ensure full user is loaded before attempting to grab fields.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1107,7 +1107,8 @@ function dosomething_user_get_field($field_name, $account = NULL, $format = NULL
     $account = $user;
   }
 
-  // Load the requested field from the provided user.
+  // Load the full user profile & grab the requested field.
+  $account = user_load($account->uid);
   $field_value = $account->{$field_name}[LANGUAGE_NONE][0]['value'];
 
   // Check if there is a specifc function handler for that field, use that first.


### PR DESCRIPTION
#### What's this PR do?
The global `$user` [does not include fields until `user_load` is called](https://drupal.stackexchange.com/a/70920), so depending on the `$account` parameter passed to this function, the field might not exist here. This pull request updates this function to always call `user_load` (which is statically cached, so should not incur an extra performance hit).

#### How should this be reviewed?
👀

#### Any background context you want to provide?
This resolves a [new bug](https://dosomething.slack.com/archives/C0YGXUE01/p1500305760446352) reported by @sbsmith86.

#### Relevant tickets
Fixes 🐛.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  