### PR TITLE
Move rogue signup logic into the single function that handles signups

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -766,12 +766,12 @@ function dosomething_rogue_transform_signup($values, $northstar_id, $user) {
 
   $run = dosomething_helpers_get_current_campaign_run_for_user($values['campaign_id'], $user);
 
- $data = [
-   'northstar_id' => $northstar_id,
-   'campaign_id' => $values['campaign_id'],
-   'campaign_run_id' => $run->nid,
-   'source' => $values['source'],
- ];
+  $data = [
+    'northstar_id' => $northstar_id,
+    'campaign_id' => $values['campaign_id'],
+    'campaign_run_id' => $run->nid,
+    'source' => $values['source'],
+  ];
 
  return $data;
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -97,18 +97,21 @@ function dosomething_signup_form_submit($form, &$form_state) {
     $params['affiliate_messaging_opt_in'] = (bool) $form_state['values']['affiliate_messaging_opt_in'];
   }
 
-  if (variable_get('rogue_collection', FALSE)) {
-    $rogue_signup = dosomething_rogue_send_signup_to_rogue($form_state['values']);
+  // Create signup for logged in user.
+  dosomething_signup_user_signup($nid, NULL, $source, $params, $form_state['values']);
 
-    // Make sure the signup exists before using it
-    if ($rogue_signup) {
-      $node = node_load($rogue_signup['data']['campaign_id']);
-      dosomething_signup_set_signup_message($node->title);
-    }
-  } else {
-    // Create signup for logged in user.
-    dosomething_signup_user_signup($nid, NULL, $source, $params);
-  }
+  // if (variable_get('rogue_collection', FALSE)) {
+  //   $rogue_signup = dosomething_rogue_send_signup_to_rogue($form_state['values']);
+
+  //   // Make sure the signup exists before using it
+  //   if ($rogue_signup) {
+  //     $node = node_load($rogue_signup['data']['campaign_id']);
+  //     dosomething_signup_set_signup_message($node->title);
+  //   }
+  // } else {
+  //   // Create signup for logged in user.
+  //   dosomething_signup_user_signup($nid, NULL, $source, $params);
+  // }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -98,20 +98,7 @@ function dosomething_signup_form_submit($form, &$form_state) {
   }
 
   // Create signup for logged in user.
-  dosomething_signup_user_signup($nid, NULL, $source, $params, $form_state['values']);
-
-  // if (variable_get('rogue_collection', FALSE)) {
-  //   $rogue_signup = dosomething_rogue_send_signup_to_rogue($form_state['values']);
-
-  //   // Make sure the signup exists before using it
-  //   if ($rogue_signup) {
-  //     $node = node_load($rogue_signup['data']['campaign_id']);
-  //     dosomething_signup_set_signup_message($node->title);
-  //   }
-  // } else {
-  //   // Create signup for logged in user.
-  //   dosomething_signup_user_signup($nid, NULL, $source, $params);
-  // }
+  dosomething_signup_user_signup($nid, NULL, $source, $params);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -583,36 +583,31 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL, $
     $rogue_signup = dosomething_rogue_send_signup_to_rogue([
       'campaign_id' => $nid,
       'source' => $source,
-    ]);
-
-    // Make sure the signup exists before using it
-    if ($rogue_signup) {
-      $node = $node = node_load($nid);
-      dosomething_signup_set_signup_message($node->title);
-    }
+    ], $account);
   } else {
     // Insert signup.
-    if ($sid = dosomething_signup_create($nid, $account->uid, $source)) {
-      $node = node_load($nid);
+    $sid = dosomething_signup_create($nid, $account->uid, $source);
 
-      // Opt into competition if auto opt-in is enabled for this campaign.
-      $auto_opt_in = dosomething_helpers_get_variable('node', $nid, 'enable_auto_competition_opt_in');
-
-      if ($auto_opt_in) {
-        $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $account);
-
-        dosomething_gladiator_send_user_to_gladiator($account, ['nid' => $nid, 'run_nid' => $run->nid]);
-      }
-
-      // Set default signup message if we're still in this function.
-      dosomething_signup_set_signup_message($node->title);
-
-      if ($params) {
-        if (isset($params['affiliate_messaging_opt_in']) && $params['affiliate_messaging_opt_in']) {
-          dosomething_campaign_create_affiliate_messaging_opt_in($account, $nid, $node);
-        }
+    if ($sid && $params) {
+      if (isset($params['affiliate_messaging_opt_in']) && $params['affiliate_messaging_opt_in']) {
+        dosomething_campaign_create_affiliate_messaging_opt_in($account, $nid, $node);
       }
     }
+  }
+
+  // Opt into competition if auto opt-in is enabled for this campaign.
+  $auto_opt_in = dosomething_helpers_get_variable('node', $nid, 'enable_auto_competition_opt_in');
+
+  if ($auto_opt_in) {
+    $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $account);
+
+    dosomething_gladiator_send_user_to_gladiator($account, ['nid' => $nid, 'run_nid' => $run->nid]);
+  }
+
+  // Set default signup message if we're still in this function.
+  if (!empty($sid) || !empty($rogue_signup)) {
+    $node = node_load($nid);
+    dosomething_signup_set_signup_message($node->title);
   }
 }
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -579,25 +579,38 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL, $
     $account = $user;
   }
 
-  // Insert signup.
-  if ($sid = dosomething_signup_create($nid, $account->uid, $source)) {
-    $node = node_load($nid);
+  if (variable_get('rogue_collection', FALSE)) {
+    $rogue_signup = dosomething_rogue_send_signup_to_rogue([
+      'campaign_id' => $nid,
+      'source' => $source,
+    ]);
 
-    // Opt into competition if auto opt-in is enabled for this campaign.
-    $auto_opt_in = dosomething_helpers_get_variable('node', $nid, 'enable_auto_competition_opt_in');
-
-    if ($auto_opt_in) {
-      $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $account);
-
-      dosomething_gladiator_send_user_to_gladiator($account, ['nid' => $nid, 'run_nid' => $run->nid]);
+    // Make sure the signup exists before using it
+    if ($rogue_signup) {
+      $node = $node = node_load($nid);
+      dosomething_signup_set_signup_message($node->title);
     }
+  } else {
+    // Insert signup.
+    if ($sid = dosomething_signup_create($nid, $account->uid, $source)) {
+      $node = node_load($nid);
 
-    // Set default signup message if we're still in this function.
-    dosomething_signup_set_signup_message($node->title);
+      // Opt into competition if auto opt-in is enabled for this campaign.
+      $auto_opt_in = dosomething_helpers_get_variable('node', $nid, 'enable_auto_competition_opt_in');
 
-    if ($params) {
-      if (isset($params['affiliate_messaging_opt_in']) && $params['affiliate_messaging_opt_in']) {
-        dosomething_campaign_create_affiliate_messaging_opt_in($account, $nid, $node);
+      if ($auto_opt_in) {
+        $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $account);
+
+        dosomething_gladiator_send_user_to_gladiator($account, ['nid' => $nid, 'run_nid' => $run->nid]);
+      }
+
+      // Set default signup message if we're still in this function.
+      dosomething_signup_set_signup_message($node->title);
+
+      if ($params) {
+        if (isset($params['affiliate_messaging_opt_in']) && $params['affiliate_messaging_opt_in']) {
+          dosomething_campaign_create_affiliate_messaging_opt_in($account, $nid, $node);
+        }
       }
     }
   }


### PR DESCRIPTION
#### What's this PR do?

This moves the logic of checking if rogue is on and sending to rogue instead of storing in phoenix to the `dosomething_user_signup_user` function. It turns out this is called in a [few places](https://github.com/DoSomething/phoenix/search?utf8=%E2%9C%93&q=dosomething_signup_user_signup&type=). And we could have been missing some funnels where the user wasn't getting sent to rogue and still getting stored in phoenix. This should clean that up by moving all the logic into the same handler. 

#### Any background context you want to provide?

We were seeing and issue on thor where users were not being sent to the pitch page after signing up. This seemed to only occur on thor, but hoping this will clean up some of the logic so that the issue is either fixed, or allows for easier debugging. 

#### Relevant tickets
Addresses: https://trello.com/c/Jy2dPJoh/517-when-rogue-is-on-an-already-authenticated-user-is-not-being-redirected-to-the-pitch-page

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
