### PR TITLE
Move Rogue feature flag check into signup module.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -286,17 +286,6 @@ function _campaign_resource_signup($nid, $values) {
     watchdog('dosomething_api', '_campaign_resource_signup values:' . json_encode($values));
   }
 
-  // Check to see if we should be sending requests to Rogue instead:
-  if (variable_get('rogue_collection', FALSE)) {
-    $rogue_signup = dosomething_rogue_send_signup_to_rogue(array_merge($values, [
-      'campaign_id' => $nid,
-    ]));
-
-    if ($rogue_signup) {
-      return $rogue_signup['data']['signup_id'];
-    }
-  }
-
   return dosomething_signup_create($nid, $values['uid'], $values['source'], NULL, $values['transactionals']);
 }
 

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -191,7 +191,16 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
 
   // Return data from Rogue if Rogue is turned on
   if (variable_get('rogue_collection', FALSE)) {
-    $rogue_response = dosomething_rogue_get_activity($parameters);
+    $rogue_response = dosomething_rogue_get_activity([
+      'filter' => [
+        'campaign_id' => data_get($parameters, 'campaigns'),
+        'campaign_run_id' => data_get($parameters, 'runs'),
+        'northstar_id' => data_get($parameters, 'user'),
+        'id' => data_get($parameters, 'id'),
+      ],
+      'limit' => data_get($parameters, 'count'),
+      'page' => data_get($parameters, 'page'),
+    ]);
 
     return json_decode(dosomething_rogue_format_activity($rogue_response));
   }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -802,15 +802,12 @@ function dosomething_campaign_add_shipment_form_vars($node) {
  * @todo: Assumes the campaign is in a live state, for now.
  * This logic will need to change when a campaign is in a closed state.
  *
- * @param obj $node
+ * @param stdClass $node
  *   A loaded node.
- *
- * @param bool $rogue_signup_exists
- *   Boolean if a signup exists in Rogue. Optional param.
  *
  * @return bool
  */
-function dosomething_campaign_is_pitch_page($node, $rogue_signup_exists = NULL) {
+function dosomething_campaign_is_pitch_page($node) {
   // Exclude all non campaign node types.
   if ($node->type != 'campaign') { return FALSE; }
   // If not a campaign campaign (e.g. SMS Game), no pitch page is needed.
@@ -835,17 +832,13 @@ function dosomething_campaign_is_pitch_page($node, $rogue_signup_exists = NULL) 
   }
 
   // The $node is a pitch page if you haven't signed up yet.
-  if ($rogue_signup_exists) {
-    return FALSE;
-  } else {
-    return (!dosomething_signup_exists($node->nid));
-  }
+  return ! dosomething_signup_exists($node->nid);
 }
 
 /**
  * For given campaign $node, determines if the closed page should be displayed.
  *
- * @param obj $node
+ * @param stdClass $node
  *   A loaded node.
  *
  * @return bool

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -35,24 +35,7 @@ function dosomething_campaign_preprocess_node(&$vars) {
   dosomething_campaign_preprocess_common_vars($vars, $wrapper);
 
   $pitch_path = 'node/' . $node->nid . '/pitch';
-
-  if (variable_get('rogue_collection', FALSE)) {
-    global $user;
-    $northstar_user_id = dosomething_user_get_northstar_id($user->uid);
-
-    $rogue = dosomething_rogue_client();
-
-    $response = $rogue->getActivity([
-      'filter' => [
-        'northstar_id' => $northstar_user_id,
-        'campaign_id' => $vars['nid'],
-      ],
-    ]);
-
-    $signup_exists = ! dosomething_campaign_is_pitch_page($node, ! empty($response['data']));
-  } else {
-    $signup_exists = ! dosomething_campaign_is_pitch_page($node);
-  }
+  $signup_exists = ! dosomething_campaign_is_pitch_page($node);
 
   if ($pitch_path == $current_path || ! $signup_exists) {
     // Gather vars for pitch page.

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -705,6 +705,7 @@ function dosomething_rogue_send_signup_to_rogue($values, $user = NULL, $failed_t
   // Band-aid fix for an issue we are seeing with phoenix not being
   // aware of a user's northstar id. If it doesn't find one, we just grab it
   // from northstar directly.
+  // @TODO: Investigate why this is happening.
   if (!$northstar_id) {
     $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
     $northstar_id = $northstar_user->id;

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -61,29 +61,15 @@ function dosomething_rogue_get_reportback_items($inputs)
 }
 
 /**
-  * Send a GET request to return all activiy matching a given
-  * query from Rogue.
-  *
-  * @param array $inputs
-  */
-function dosomething_rogue_get_activity($inputs)
+ * Send a GET request to return all activity matching a given
+ * query from Rogue.
+ *
+ * @param array $query
+ * @return array
+ */
+function dosomething_rogue_get_activity($query)
 {
-  $client = dosomething_rogue_client();
-
-  $rogue_inputs = [
-    'filter' => [
-      'campaign_id' => dosomething_helpers_isset($inputs, 'campaigns'),
-      'campaign_run_id' => dosomething_helpers_isset($inputs, 'runs'),
-      'northstar_id' => dosomething_helpers_isset($inputs, 'user'),
-      'id' => dosomething_helpers_isset($inputs, 'id'),
-    ],
-    'limit' => dosomething_helpers_isset($inputs, 'count'),
-    'page' => dosomething_helpers_isset($inputs, 'page'),
-  ];
-
-  $response = $client->getActivity($rogue_inputs);
-
-  return $response;
+  return dosomething_rogue_client()->getActivity($query);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -99,7 +99,7 @@ class Rogue extends RestApiClient {
    * query from Rogue.
    *
    * @param array $inputs
-   * @return Rogue Reportbacks
+   * @return array - JSON response
    */
   public function getActivity($inputs = [])
   {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -270,11 +270,6 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
 
   // If Rogue is enabled, create the signup there.
   if (variable_get('rogue_collection', FALSE)) {
-
-    // Reformat the `$values` array for Rogue.
-    // @TODO: Clean this up so it happens in Rogue method.
-    $values['campaign_id'] = $nid;
-
     $response = dosomething_rogue_send_signup_to_rogue($values);
 
     $sid = $response ? $response['data']['signup_id'] : NULL;

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -254,11 +254,6 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
   $campaign = Campaign::get($nid);
   $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $user, $campaign);
 
-  // If a signup already exists, return the signup ID.
-  if ($existing_id = dosomething_signup_exists($nid, $run->nid, $uid)) {
-    return $existing_id;
-  }
-
   $values = array(
     'nid' => $nid,
     'uid' => $uid,
@@ -268,30 +263,64 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
     'transactionals' => $transactionals,
   );
 
+  // If a signup already exists, return the signup ID.
+  if ($existing_id = dosomething_signup_exists($nid, $run->nid, $uid)) {
+    return $existing_id;
+  }
+
+  // If Rogue is enabled, create the signup there.
+  if (variable_get('rogue_collection', FALSE)) {
+    $rogue_signup = dosomething_rogue_send_signup_to_rogue(array_merge($values, [
+      'campaign_id' => $values['nid'],
+    ]));
+
+    $sid = $rogue_signup ? $rogue_signup['data']['signup_id'] : NULL;
+    _dosomething_signup_log_signup($sid, $source);
+
+    return $sid ? $sid : FALSE;
+  }
+
+  // Otherwise, create a local Phoenix entity.
+  // @TODO: Remove this once Rogue is shipped.
   try {
     // Create a signup entity.
     // @see: SignupsController.php save()
     $entity = entity_create('signup', $values);
     $entity->save();
 
-    if (isset($entity->sid)) {
-      if (module_exists('stathat')) {
-        // The source is often a string longer than just "reportback", but always starts with it if the page is a permalink
-        if (strpos($source, 'reportback') === 0) {
-          stathat_send_ez_count('drupal - Signup - permalink signup', 1);
-        }
-      }
+    _dosomething_signup_log_signup($entity->sid, $source);
 
-      return $entity->sid;
-    }
-    return FALSE;
+    return isset($entity->sid) ? $entity->sid : FALSE;
   }
   catch (Exception $e) {
+    _dosomething_signup_log_signup(NULL);
+
+    return FALSE;
+  }
+}
+
+/**
+ * Log details when creating a signup.
+ *
+ * @param $sid
+ * @param $source
+ */
+function _dosomething_signup_log_signup($sid, $source = '') {
+  if (! module_exists('stathat')) {
+    return;
+  }
+
+  if (is_null($sid)) {
     // Keep message general in case a user ever sees it.
     drupal_set_message(t("There was an error processing your request."));
+
     // Log the error.
     watchdog('dosomething_signup', $e, array(), WATCHDOG_ERROR);
-    return FALSE;
+  }
+
+  // The source is often a string longer than just "reportback", but always starts with it if the page is a permalink
+  if (strpos($source, 'reportback') === 0) {
+    stathat_send_ez_count('drupal - Signup - permalink signup', 1);
   }
 }
 
@@ -346,6 +375,17 @@ function dosomething_signup_exists($nid, $run_nid = NULL, $uid = NULL, $presignu
   if (!isset($run_nid)) {
     $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $user);
     $run_nid = $run->nid;
+  }
+
+  if (variable_get('rogue_collection', FALSE)) {
+    $response = dosomething_rogue_get_activity([
+      'northstar_id' => dosomething_user_get_northstar_id($uid),
+      'campaign_id' => $nid,
+      'campaign_run_id' => $run_nid,
+    ]);
+
+    $has_signup = isset($response['data']) && count($response['data']) === 1;
+    return $has_signup ? $response['data'][0]['signup_id'] : FALSE;
   }
 
   if ($presignup) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -254,14 +254,14 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
   $campaign = Campaign::get($nid);
   $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $user, $campaign);
 
-  $values = array(
+  $values = [
     'nid' => $nid,
     'uid' => $uid,
     'run_nid' => $run->nid,
     'source'=> $source,
     'timestamp' => $timestamp,
     'transactionals' => $transactionals,
-  );
+  ];
 
   // If a signup already exists, return the signup ID.
   if ($existing_id = dosomething_signup_exists($nid, $run->nid, $uid)) {

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -379,9 +379,11 @@ function dosomething_signup_exists($nid, $run_nid = NULL, $uid = NULL, $presignu
 
   if (variable_get('rogue_collection', FALSE)) {
     $response = dosomething_rogue_get_activity([
-      'northstar_id' => dosomething_user_get_northstar_id($uid),
-      'campaign_id' => $nid,
-      'campaign_run_id' => $run_nid,
+      'filter' => [
+        'northstar_id' => dosomething_user_get_northstar_id($uid),
+        'campaign_id' => $nid,
+        'campaign_run_id' => $run_nid,
+      ],
     ]);
 
     $has_signup = isset($response['data']) && count($response['data']) === 1;

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -270,11 +270,14 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
 
   // If Rogue is enabled, create the signup there.
   if (variable_get('rogue_collection', FALSE)) {
-    $rogue_signup = dosomething_rogue_send_signup_to_rogue(array_merge($values, [
-      'campaign_id' => $values['nid'],
-    ]));
 
-    $sid = $rogue_signup ? $rogue_signup['data']['signup_id'] : NULL;
+    // Reformat the `$values` array for Rogue.
+    // @TODO: Clean this up so it happens in Rogue method.
+    $values['campaign_id'] = $nid;
+
+    $response = dosomething_rogue_send_signup_to_rogue($values);
+
+    $sid = $response ? $response['data']['signup_id'] : NULL;
     _dosomething_signup_log_signup($sid, $source);
 
     return $sid ? $sid : FALSE;
@@ -621,19 +624,12 @@ function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL, $
     $account = $user;
   }
 
-  if (variable_get('rogue_collection', FALSE)) {
-    $rogue_signup = dosomething_rogue_send_signup_to_rogue([
-      'campaign_id' => $nid,
-      'source' => $source,
-    ], $account);
-  } else {
-    // Insert signup.
-    $sid = dosomething_signup_create($nid, $account->uid, $source);
+  // Insert signup.
+  $sid = dosomething_signup_create($nid, $account->uid, $source);
 
-    if ($sid && $params) {
-      if (isset($params['affiliate_messaging_opt_in']) && $params['affiliate_messaging_opt_in']) {
-        dosomething_campaign_create_affiliate_messaging_opt_in($account, $nid, $node);
-      }
+  if ($sid && $params) {
+    if (isset($params['affiliate_messaging_opt_in']) && $params['affiliate_messaging_opt_in']) {
+      dosomething_campaign_create_affiliate_messaging_opt_in($account, $nid);
     }
   }
 


### PR DESCRIPTION
#### What's this PR do?
This pull request moves the Rogue feature flags into the `dosomething_signup_create` and `dosomething_signup_exists` methods, since otherwise we had to check the feature flag in multiple places around the codebase which let some things fall through the cracks!

#### How should this be reviewed?
I roughly broke it into commits, but it's a lil' messy. Sorry in advance. 😬

#### Any background context you want to provide?
This should mean we don't end up with surprise Phoenix signup records anymore.

#### Relevant tickets
Fixes 🐛.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
