### PR TITLE
Competitions prompt

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -762,8 +762,12 @@ function dosomething_campaign_add_signup_data_form_vars(&$node, $langcode) {
   $node->content['signup_data_form'] = drupal_get_form('dosomething_signup_user_signup_data_form', $signup);
 
   // If the signup_data_form is required and user has not submitted form yet:
-  $hasCompetitionRecordedLocally = $signup->signup_data_form_timestamp;
-  $shouldShowCompetitionPrompt = $config['required'] && !$hasCompetitionRecordedLocally;
+  if (!variable_get('rogue_collection', FALSE)) {
+    $hasCompetitionRecordedLocally = $signup->signup_data_form_timestamp;
+    $shouldShowCompetitionPrompt = $config['required'] && !$hasCompetitionRecordedLocally;
+  } else {
+    $shouldShowCompetitionPrompt = $config['required'];
+  }
 
   // If Gladiator is enabled, check there too!
   if (module_exists('dosomething_gladiator')) {

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -757,8 +757,10 @@ function dosomething_campaign_add_signup_data_form_vars(&$node, $langcode) {
 
   // Load the signup entity.
   $signup = signup_load($sid);
+
   // Pass to the user signup data form.
   $node->content['signup_data_form'] = drupal_get_form('dosomething_signup_user_signup_data_form', $signup);
+
   // If the signup_data_form is required and user has not submitted form yet:
   $hasCompetitionRecordedLocally = $signup->signup_data_form_timestamp;
   $shouldShowCompetitionPrompt = $config['required'] && !$hasCompetitionRecordedLocally;

--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
@@ -70,7 +70,7 @@ function dosomething_gladiator_in_a_competition($signup) {
 
   // If signup exists in Gladiator (from Phoenix Next, for example), set
   // the "signup data form" timestamp so we know not to ask again.
-  if ($already_in_gladiator) {
+  if ($already_in_gladiator && !variable_get('rogue_collection', FALSE)) {
     dosomething_signup_update_signup_data(['sid' => $sid], ['competition_signup' => $already_in_gladiator]);
   }
 

--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
@@ -49,10 +49,15 @@ function _dosomething_gladiator_build_http_client() {
 function dosomething_gladiator_in_a_competition($signup) {
   $client = _dosomething_gladiator_build_http_client();
 
+  $nid = isset($signup->nid) ? $signup->nid : $signup['campaign_id'];
+  $sid = isset($signup->sid) ? $signup->sid : $signup['signup_id'];
+  $run_nid = isset($signup->run_nid) ? $signup->run_nid : $signup['campaign_run_id'];
+  $user_id = isset($signup->uid) ? dosomething_user_get_northstar_id($signup->uid) : $signup['northstar_id'];
+
   $query = drupal_http_build_query([
-    'id' => dosomething_user_get_northstar_id($signup->uid),
-    'campaign_id' => $signup->nid,
-    'campaign_run_id' => $signup->run_nid,
+    'id' => $user_id,
+    'campaign_id' => $nid,
+    'campaign_run_id' => $run_nid,
   ]);
 
   $response = drupal_http_request($client['base_url'] . '/users?'.$query, [
@@ -66,7 +71,7 @@ function dosomething_gladiator_in_a_competition($signup) {
   // If signup exists in Gladiator (from Phoenix Next, for example), set
   // the "signup data form" timestamp so we know not to ask again.
   if ($already_in_gladiator) {
-    dosomething_signup_update_signup_data(['sid' => $signup->sid], ['competition_signup' => $already_in_gladiator]);
+    dosomething_signup_update_signup_data(['sid' => $sid], ['competition_signup' => $already_in_gladiator]);
   }
 
   return $already_in_gladiator;

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -186,7 +186,18 @@ function dosomething_signup_permission() {
  * Menu autoloader for /signup.
  */
 function signup_load($id) {
-  return entity_load_single('signup', $id);
+  // If rogue is on load signup from rogue.
+  if (variable_get('rogue_collection', FALSE)) {
+    $response = dosomething_rogue_get_activity([
+      'filter' => [
+        'id' => $id
+      ],
+    ]);
+
+    return isset($response['data']) && count($response['data']) === 1 ? $response['data'][0] : FALSE;
+  } else {
+    return entity_load_single('signup', $id);
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -362,19 +362,20 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
   }
 
   // If the user has submitted form already:
-  if (($timestamp = $signup->signup_data_form_timestamp) && $signup->signup_data_form_response == 1) {
-    // Get filtered form_submitted_copy.
-    $copy = dosomething_signup_filter_form_submitted_copy($config['form_submitted_copy'], $timestamp);
-    // Display the form submitted copy:
-    $form['submitted_copy'] = array(
-      '#prefix' => '<div class="modal__block"><p>',
-      '#markup' => $copy,
-      '#suffix' => '</p></div>',
-    );
-    // Return form as is (without a submit button).
-    return $form;
+  if (!variable_get('rogue_collection', FALSE)) {
+    if (($timestamp = $signup->signup_data_form_timestamp) && $signup->signup_data_form_response == 1) {
+      // Get filtered form_submitted_copy.
+      $copy = dosomething_signup_filter_form_submitted_copy($config['form_submitted_copy'], $timestamp);
+      // Display the form submitted copy:
+      $form['submitted_copy'] = array(
+        '#prefix' => '<div class="modal__block"><p>',
+        '#markup' => $copy,
+        '#suffix' => '</p></div>',
+      );
+      // Return form as is (without a submit button).
+      return $form;
+    }
   }
-
 
   // Container for form elements
   $form['elements'] = array(
@@ -558,9 +559,11 @@ function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
   }
 
   // Update signup record.
-  dosomething_signup_update_signup_data($values, $config);
+  if (!variable_get('rogue_collection', FALSE)) {
+    dosomething_signup_update_signup_data($values, $config);
+  }
+
   // If this is a competition sign up, send it to gladiator.
-  //
   if ($config['competition_signup'] && module_exists('dosomething_gladiator')) {
     dosomething_gladiator_send_user_to_gladiator($user, $values);
   }
@@ -590,13 +593,17 @@ function dosomething_signup_user_signup_data_form_validate_school($form, &$form_
  *   The signup entity to save additional data to.
  */
 function dosomething_signup_user_skip_signup_data_form($form, &$form_state, $signup) {
-  $config = dosomething_signup_get_signup_data_form_info($signup->nid);
+  $nid = isset($signup->nid) ? $signup->nid : $signup['campaign_id'];
+  $sid = isset($signup->sid) ? $signup->sid : $signup['signup_id'];
+  $run_nid = isset($signup->run_nid) ? $signup->run_nid : $signup['campaign_run_id'];
+
+  $config = dosomething_signup_get_signup_data_form_info($nid);
   $skip_label = ($config['skip_text']) ? t($config['skip_text']) : t('Skip');
 
   $form['#attributes']['class'] = ['modal__block', 'form-actions'];
   $form['sid'] = [
     '#type' => 'hidden',
-    '#value' => $signup->sid,
+    '#value' => $sid,
     '#access' => FALSE,
   ];
   $form['submit'] = [
@@ -617,7 +624,9 @@ function dosomething_signup_user_skip_signup_data_form($form, &$form_state, $sig
  */
 function dosomething_signup_user_skip_signup_data_form_submit($form, &$form_state) {
   // Update signup record with response = 0.
-  dosomething_signup_update_signup_data($form_state['values'], NULL, 0);
+  if (!variable_get('rogue_collection', FALSE)) {
+    dosomething_signup_update_signup_data($form_state['values'], NULL, 0);
+  }
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -284,21 +284,26 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
  *   The signup entity to save additional data to.
  */
 function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) {
+  // Get the nid from the signup (either rogue signup or phoenix signup)
+  $nid = isset($signup->nid) ? $signup->nid : $signup['campaign_id'];
+  $sid = isset($signup->sid) ? $signup->sid : $signup['signup_id'];
+  $run_nid = isset($signup->run_nid) ? $signup->run_nid : $signup['campaign_run_id'];
   // Load signup data form config to determine what form elements we need.
-  $config = dosomething_signup_get_signup_data_form_info($signup->nid);
+  $config = dosomething_signup_get_signup_data_form_info($nid);
+
   $form['sid'] = array(
     '#type' => 'hidden',
-    '#value' => $signup->sid,
+    '#value' => $sid,
     '#access' => FALSE,
   );
   $form['nid'] = array(
     '#type' => 'hidden',
-    '#value' => $signup->nid,
+    '#value' => $nid,
     '#access' => FALSE,
   );
   $form['run_nid'] = array(
     '#type' => 'hidden',
-    '#value' => $signup->run_nid,
+    '#value' => $run_nid,
     '#access' => FALSE,
   );
 
@@ -306,23 +311,23 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
   if ($config['custom_social_share_signup']) {
     $form['header'] = array(
       '#prefix' => '<div class="modal__block"><h2 class="heading">',
-      '#markup' => dosomething_helpers_get_variable('node', $signup->nid, 'social_share_custom_text'),
+      '#markup' => dosomething_helpers_get_variable('node', $nid, 'social_share_custom_text'),
       '#suffix' => '</h2></div>',
     );
 
     $form['copy'] = array(
       '#prefix' => '<div class="modal__block"><p>',
-      '#markup' => dosomething_helpers_get_variable('node', $signup->nid, 'social_share_custom_description'),
+      '#markup' => dosomething_helpers_get_variable('node', $nid, 'social_share_custom_description'),
       '#suffix' => '</p></div>',
     );
 
     $form['custom_social_share_signup_img'] = array(
       '#prefix' => '<img src="',
-      '#markup' => dosomething_image_get_themed_image_url(dosomething_helpers_get_variable('node', $signup->nid, 'share_image_nid'), 'landscape'),
+      '#markup' => dosomething_image_get_themed_image_url(dosomething_helpers_get_variable('node', $nid, 'share_image_nid'), 'landscape'),
       '#suffix' => '">',
     );
 
-    $campaign = dosomething_campaign_load(node_load($signup->nid));
+    $campaign = dosomething_campaign_load(node_load($nid));
 
     $social_share_types = dosomething_helpers_campaign_page_social_share_types($campaign);
 


### PR DESCRIPTION
#### What's this PR do?

This PR fixes the competitions prompt when rogue is turned on. 

* The `$config` variable that pulls the signup data form configuration variables (i.e. submit button text, form copy) was dependent on a phoenix `$signup` object. When rogue is on, the `$signup` object is different so this PR updates the logic to work with phoenix or rogue signup objects. 

* The decision to show the modal or not was tied to a `signup_data_form_timestamp` and a `signup_data_form_response` column on the signup. When rogue is on, we do not store these columns on the signup. The PR removes any dependencies on these columns when rogue is on. Instead we always show the competitions prompt unless we find the user in gladiator directly.

* This PR also updates the `signup_load()` function to return a `$signup` from rogue if rogue is on.

#### Any background context you want to provide?

We made a decision to only support the competition prompt for Rogue's launch on 7/20/17. The signup data form supports the competition prompt, address collection, and the social share prompt. As a result, the code is pretty entangled and we need to do some work to separate some of the dependencies on the signup data form properties that we were stored on the signup. We will do this work after launch

#### Relevant tickets
https://trello.com/c/vGmYYcDa/511-%F0%9F%90%9B-competitions-prompt-not-working-when-rogue-is-turned-on%F0%9F%90%9B

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
