### PR TITLE
#6394: Boost current language results more to compensate for other field boosts

### DIFF
--- a/lib/modules/dosomething/dosomething_search/dosomething_search.module
+++ b/lib/modules/dosomething/dosomething_search/dosomething_search.module
@@ -135,7 +135,7 @@ function dosomething_search_apachesolr_query_alter(DrupalSolrQueryInterface $que
     // We also need to make sure that we give a small boost to the language
     // specific translation of the node so that we don't see en-global versions
     // of nodes that do have valid translations in the current language.
-    $params['bq'][] = "ss_language:{$language}^1.0";
+    $params['bq'][] = "ss_language:{$language}^10.0";
   }
 
   // There is a bug in the apachesolr allowed types export that


### PR DESCRIPTION
#### What's this PR do?

This ensures that the /campaigns page will show results in the current language when available, instead of showing en-global results even though a translated version is available. That was happening if the en-global had "Staff Pick" selected and the translated version didn't (along with a few other combinations of fields that made that possible).

#### How should this be reviewed?

1. Find a campaign that has an en-global translation and a br or mx translation
2. Edit the en-global translation and check "Staff Pick"
3. Edit the br or mx translation and UNcheck "Staff Pick"
4. Visit /br/campaigns or /mx/campaigns and ensure that you see the br or mx version of that campaign.

#### Relevant tickets
Fixes #6394