### PR TITLE
Return expected error when Rogue doesn't have a signup.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -245,6 +245,15 @@ function _signup_resource_retrieve($sid) {
       ],
     ]);
 
+    // If Rogue response is empty, return expected error.
+    if (empty($rogue_response['data'])) {
+      return [
+        'error' => [
+          'message' => 'No signup data found.',
+        ],
+      ];
+    }
+
     $formatted_signup = (object) dosomething_rogue_format_signup($rogue_response['data'][0]);
 
     $data['data'] = $formatted_signup;


### PR DESCRIPTION
#### What's this PR do?
This is a quick fix so that the `/api/v1/signups/:signup` endpoint returns a good error message instead of `Unexpected ''"` like a real doofus.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
💣

#### Relevant tickets
[Rogue Launch test cases](https://docs.google.com/spreadsheets/d/1Os1pFtuv5gT4C5UoVcbreMqGJ5i0-mS7e-xafmCOC1M/edit#gid=2123748242)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  