### PR TITLE
Return Post ID from Rogue when Creating an RB

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -378,10 +378,7 @@ function _campaign_resource_reportback($nid, $values) {
   if (variable_get('rogue_collection', FALSE) && ! isset($headers['X-Request-Id'])) {
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
-    // Make sure reportback made it back to Phoenix and store reference to the Rogue item if one was added.
-    $rb_info = dosomething_rogue_check_rbid_and_store_ref($rogue_reportback);
-
-    return $rb_info['rbid'];
+    return $rogue_reportback['data']['id']
   }
   else {
     if (isset($headers['X-Request-Id'])) {

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -378,7 +378,7 @@ function _campaign_resource_reportback($nid, $values) {
   if (variable_get('rogue_collection', FALSE) && ! isset($headers['X-Request-Id'])) {
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
-    return $rogue_reportback['data']['id']
+    return isset($rogue_reportback['data']['id']) ? $rogue_reportback['data']['id'] : FALSE;
   }
   else {
     if (isset($headers['X-Request-Id'])) {


### PR DESCRIPTION
#### What's this PR do?

Updates the return logic for the `/api/v1/campaigns/[nid]/reportback` Rogue proxy to return the `post_id` from rogue instead of storing anything in the reference table (which we don't use).

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

Reportbacks were successfully getting into rogue, but we were returning null because we don't use the reference table anymore. 
