### PR TITLE
Always send Rogue northstar ids and not drupal ones

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -191,6 +191,18 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
 
   // Return data from Rogue if Rogue is turned on
   if (variable_get('rogue_collection', FALSE)) {
+    // Replace all drupal ids with northstar ids
+    $user = explode(',', $user);
+
+    foreach ($user as $key=>$current_user) {
+      if (is_numeric($current_user)) {
+        $user[$key] = dosomething_user_get_northstar_id($current_user);
+      }
+    }
+
+    $user = implode(',', $user);
+    $parameters['user'] = $user;
+
     $rogue_response = dosomething_rogue_get_activity([
       'filter' => [
         'campaign_id' => data_get($parameters, 'campaigns'),


### PR DESCRIPTION
#### What's this PR do?
When Rogue is on and you hit `GET /api/v1/signups`, requests can now include drupal ids or northstar ids or both! We go through all the ids given, swap out northstar for drupal where needed, and then put it all back together to pass over to Rogue.

#### How should this be reviewed?
Try a request like this `http://dev.dosomething.org:8888/api/v1/signups?users=1707996,1705523`

#### Any background context you want to provide?
Want to make sure all of this is supported when we turn Rogue on.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
