### PR TITLE
Fill in campaign & user profile in Phoenix.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -168,6 +168,32 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
       'page' => $page,
     ]);
 
+    $response['data'] = collect($response['data'])->map(function ($item) use ($load_user) {
+      // Add campaign to each item:
+      try {
+        $campaign = Campaign::get($item['campaign']['id']);
+        $item['campaign'] = $campaign;
+      } catch (Exception $e) {
+        // Oh well!
+      }
+
+      // If requested, add full user to each item:
+      if ($load_user) {
+        $profile = dosomething_northstar_get_user($item['user']['id']);
+
+        $item['user'] = [
+          'id' => $profile->id,
+          'drupal_id' => $profile->drupal_id,
+          'first_name' => $profile->first_name,
+          'last_initial' => $profile->last_initial,
+          'photo' => $profile->photo,
+          'country' => $profile->country,
+        ];
+      }
+
+      return $item;
+    });
+
     return $response;
   }
 


### PR DESCRIPTION
#### What's this PR do?
This pull request finishes the bug fixes to the `/api/v1/reportback-items` endpoint – it adds the `campaign` property from Phoenix and the `user` property from Northstar (only if the `load_user` query string is specified).

#### How should this be reviewed?
👀

#### Any background context you want to provide?
This relies on one tiny change in DoSomething/rogue#312.

#### Relevant tickets
Fixes #7456.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  