### PR TITLE
Fix issue where Rogue signups would appear as API user account.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -265,11 +265,17 @@ function _campaign_resource_index($ids, $staff_pick, $term_ids, $count, $random,
  *   - source (string).
  *   - transactionals (bool). Optional flag to disable sending transactional messages.
  *       Defaults to sending messages.
+ * @return mixed
  */
 function _campaign_resource_signup($nid, $values) {
+  // Include support for passing user ID as `northstar_id`.
   if (isset($values['northstar_id'])) {
-    $values['uid'] = dosomething_user_get_user_by_northstar_id($values['northstar_id'])->uid;
+    $values['uid'] = $values['northstar_id'];
+    unset($values['northstar_id']);
   }
+
+  // If we pass either a Northstar ID or Drupal UID to `uid`, convert it to a real UID.
+  $values['uid'] = dosomething_user_convert_to_legacy_id($values['northstar_id']);
 
   if (!isset($values['uid'])) {
     return services_error('Cannot create signup without a `northstar_id` or `uid`.');

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -283,7 +283,7 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
 
   // If Rogue is enabled, create the signup there.
   if (variable_get('rogue_collection', FALSE)) {
-    $response = dosomething_rogue_send_signup_to_rogue($values);
+    $response = dosomething_rogue_send_signup_to_rogue($values, $user);
 
     $sid = $response ? $response['data']['signup_id'] : NULL;
     _dosomething_signup_log_signup($sid, $source);


### PR DESCRIPTION
#### What's this PR do?
This pull request should fix the issue where signups were being saved as the API user, rather than the provided `northstar_id` or `user_id`. It also allows us to pass a Northstar ID to `uid` field like in other API endpoints as well.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
🇫🇰 

#### Relevant tickets
Fixes 👺

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  