### PR TITLE
Fix issue with `as_user` on reportback items endpoint.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -166,7 +166,7 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
         'exclude' => $exclude,
       ],
       // If `?as_user` provided with UID or Northstar ID, use that. Otherwise, send logged-in user's NS ID.
-      'as_user' => dosomething_user_get_northstar_id($as_user ? $as_user : $user->uid),
+      'as_user' => dosomething_user_convert_to_northstar_id($as_user ? $as_user : $user->uid),
       'limit' => $count,
       'page' => $page,
     ]);

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -1066,10 +1066,11 @@ function dosomething_user_create_user_by_mobile($number) {
 
   return FALSE;
 }
+
 /**
  * Convert a supplied ID into a legacy Drupal ID.
  *
- * @param  string $id
+ * @param  string $id - Northstar or Drupal ID
  * @return string
  */
 function dosomething_user_convert_to_legacy_id($id) {
@@ -1084,6 +1085,24 @@ function dosomething_user_convert_to_legacy_id($id) {
   $user = dosomething_user_get_user_by_northstar_id($id);
 
   return $user->uid;
+}
+
+/**
+ * Convert a supplied ID into a Northstar ID.
+ *
+ * @param  string $id - Northstar or Drupal ID
+ * @return string
+ */
+function dosomething_user_convert_to_northstar_id($id) {
+  if (!$id) {
+    return NULL;
+  }
+
+  if (is_numeric($id)) {
+    return dosomething_user_get_northstar_id($id);
+  }
+
+  return $id;
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?
I made a boo-boo in the `reportback-items` endpoint: `dosomething_user_get_northstar_id` would be upset if you sent a Northstar ID through it. This should work the way we want it to (accept either a Northstar ID or Drupal ID for that parameter, and always send Rogue a Northstar ID).

#### How should this be reviewed?
👀

#### Any background context you want to provide?
🎲 

#### Relevant tickets
Fixes 🐛!

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  