### PR TITLE
Fix silly error to use the right index

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -275,7 +275,7 @@ function _campaign_resource_signup($nid, $values) {
   }
 
   // If we pass either a Northstar ID or Drupal UID to `uid`, convert it to a real UID.
-  $values['uid'] = dosomething_user_convert_to_legacy_id($values['northstar_id']);
+  $values['uid'] = dosomething_user_convert_to_legacy_id($values['uid']);
 
   if (!isset($values['uid'])) {
     return services_error('Cannot create signup without a `northstar_id` or `uid`.');


### PR DESCRIPTION
#### What's this PR do?
If given a `northstar_id` we reset it to live at `$values['uid']` and not ``$values['northstar_id']`, so use `$values['uid']` going forward. This fixes [this endpoint](https://github.com/DoSomething/phoenix/blob/dev/documentation/endpoints/campaigns.md#campaign-signup).

#### How should this be reviewed?
:eyes:

#### Any background context you want to provide?
I think we made this error somewhere along the way (sing that part like [the Dawes song](https://open.spotify.com/track/01HHVuCx2hBQLl2aZExNAc)) yesterday.

#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love