### PR TITLE
fixes NaN bug for first 6 photos of the gallery

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -380,7 +380,7 @@ function paraneue_dosomething_get_themed_reportback_item($data, $rogue_rb_item =
         );
       }
 
-      $data->kudos = dosomething_kudos_get_kudos_data_for_fid($data->id, $rogue_rb_item ? $data->kudos['total'] : null, $rogue_rb_item ? $liked_by_current_user : null);
+      $data->kudos = dosomething_kudos_get_kudos_data_for_fid($data->id, $rogue_rb_item ? $data->kudos['data'][0]['term']['total'] : null, $rogue_rb_item ? $liked_by_current_user : null);
   }
 
   if ($data instanceof ReportbackItem && user_access('view any reportback')) {


### PR DESCRIPTION
#### What's this PR do?
Fixes reaction counter bug for first 6 photos of the gallery that should `NaN` in the counter.

#### How should this be reviewed?
Counter should show accurate number of reactions instead of `NaN` for first 6 photos in the gallery.

#### Any background context you want to provide?
My local is a little borked and won't let me do view more. I'll double check that this doesn't break anything for the rest of the gallery but @ngjo mentioned she only saw this for the first 6 so hoping it doesn't!

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
