### PR TITLE
Fix some inconsistencies in kudos proxy response.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -1,5 +1,7 @@
 <?php
 
+use Carbon\Carbon;
+
 function _kudos_resource_definition() {
   $kudos_resource = [];
   $kudos_resource['kudos'] = [
@@ -202,16 +204,21 @@ function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
 
     $response = dosomething_rogue_client()->postReaction($data);
 
-    if ($response['meta']['action'] === 'liked') {
-      return [
-        [
-          'kid' => $response['data']['post_id'],
-        ]
-      ];
+    // If Rogue doesn't acknowledge that we liked a post, return Phoenix-style failure.
+    if ($response['meta']['action'] !== 'liked') {
+      return [false];
     }
-    else {
-      return;
-    }
+
+    // Otherwise, return Phoenix-style success!
+    return [
+      [
+        'kid' => $response['data']['post_id'],
+        'fid' => $reportback_item_id,
+        'uid' => $northstar_id,
+        'tid' => $term_ids[0],
+        'created' => (new Carbon($response['data']['created_at']))->timestamp,
+      ]
+    ];
   }
 
   $parameters = [
@@ -228,7 +235,7 @@ function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
  *
  * @param $kudos_id
  *
- * @return string
+ * @return array
  */
 function _kudos_resource_delete($kudos_id) {
   global $user;
@@ -243,9 +250,21 @@ function _kudos_resource_delete($kudos_id) {
 
     $response = dosomething_rogue_client()->postReaction($data);
 
-    if ($response['meta']['action'] === 'unliked') {
-      return;
+    // If Rogue doesn't acknowledge that we unliked a post, return Phoenix-style failure.
+    if ($response['meta']['action'] !== 'unliked') {
+      return [
+        'error' => [
+          'message' => 'There was an error deleting the specified kudos record.',
+        ],
+      ];
     }
+
+    // Otherwise, return Phoenix-style success!
+    return [
+      'success' => [
+        'message' => 'Kudos record successfully deleted.',
+      ],
+    ];
   }
 
   return (new KudosTransformer)->delete($kudos_id);

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -192,11 +192,11 @@ function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
 
   if (variable_get('rogue_collection', FALSE)) {
     if (!isset($northstar_id)) {
-      $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
+      $northstar_id = dosomething_user_get_northstar_id($user->uid);
     }
 
     $data = [
-      'northstar_id' => $northstar_id ? $northstar_id : $northstar_user->id,
+      'northstar_id' => $northstar_id,
       'post_id' => $reportback_item_id,
     ];
 


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes a few lil' inconsistencies in the kudos proxy: making sure we have all the same fields in the "success" created response, and returning the same messages on failures.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
👏 

#### Relevant tickets
Fixes 🐛

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  