### PR TITLE
Use a compound post_id|northstar_id format for kid.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -212,7 +212,7 @@ function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
     // Otherwise, return Phoenix-style success!
     return [
       [
-        'kid' => $response['data']['post_id'],
+        'kid' => $response['data']['post_id'] . '|' . $northstar_id,
         'fid' => $reportback_item_id,
         'uid' => $northstar_id,
         'tid' => $term_ids[0],
@@ -241,11 +241,23 @@ function _kudos_resource_delete($kudos_id) {
   global $user;
 
   if (variable_get('rogue_collection', FALSE)) {
-    $northstar_user = dosomething_northstar_get_user($user->uid, 'drupal_id');
+    list($post_id, $northstar_id) = explode($kudos_id, '|');
+
+    // Make sure authenticated user is an admin or the kudo owner.
+    $api_user_is_an_admin = user_access('view any reportback', $user);
+    $logged_in_user_matches_given_id = dosomething_user_get_northstar_id($user->uid) === $northstar_id;
+    if (!$api_user_is_an_admin && !$logged_in_user_matches_given_id) {
+        return [
+          'error' => [
+            'message' => 'There was an error deleting the specified kudos record.',
+          ],
+        ];
+      }
+    }
 
     $data = [
-      'northstar_id' => $northstar_user->id,
-      'post_id' => $kudos_id,
+      'northstar_id' => $northstar_id,
+      'post_id' => $post_id,
     ];
 
     $response = dosomething_rogue_client()->postReaction($data);


### PR DESCRIPTION
#### What's this PR do?
This pull request updates Phoenix's `POST /api/v1/kudos` and `DELETE /api/v1/kudos/:kid` endpoints so that we can easily delete a reaction in Rogue. This solves a little conundrum where we needed the Post ID & Northstar ID in the "delete" endpoint, but were only getting the Post ID. Now they're both provided in a `<post_id>|<northstar_id>` formatted string.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Here's the corresponding Rogue PR: DoSomething/rogue#316.

#### Relevant tickets
Fixes 🐞

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  