### PR TITLE
Add logic for reportback transactionals when Rogue is enabled.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -384,6 +384,17 @@ function _campaign_resource_reportback($nid, $values) {
   if (variable_get('rogue_collection', FALSE) && ! isset($headers['X-Request-Id'])) {
     $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
+    // Get signup associated with the post.
+    $rid = $rogue_reportback['data']['signup_id'];
+    $rogue_signup = dosomething_rogue_get_activity(['filter' => ['id' => $rid]]);
+
+    // Send an email if it is the first post.
+    if (dosomething_rogue_get_post_count($rogue_signup['data'][0]) === 1) {
+      if (module_exists('dosomething_mbp')) {
+        dosomething_reportback_rogue_mbp_request($rogue_reportback['data'], $rogue_signup['data'][0]);
+      }
+    }
+
     return isset($rogue_reportback['data']['id']) ? $rogue_reportback['data']['id'] : FALSE;
   }
   else {


### PR DESCRIPTION
#### What's this PR do?
One more thing! We weren't calling `dosomething_reportback_rogue_mbp_request` when creating reportbacks via the API (so, for example, when users upload a photo on Phoenix Next). This pull request adds that logic so it works the same as in [dosomething_reportback.forms.inc](https://github.com/DoSomething/phoenix/blob/730f67c61d7f848bcfd3c472ce08055ce44f93eb/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc#L433-L444).


#### How should this be reviewed?
👀

#### Any background context you want to provide?
🤔

#### Relevant tickets
Fixes 💌

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  