### PR TITLE
maintains filled in heart when refreshed

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/helpers.inc
@@ -367,7 +367,8 @@ function paraneue_dosomething_get_themed_reportback_item($data, $rogue_rb_item =
 
   if ($data->id && !dosomething_kudos_disable_reactions($data->campaign->id)) {
       if ($rogue_rb_item) {
-        $liked_by_current_user = $data->kudos['data']['current_user']['reacted'] ? true : false;
+
+        $liked_by_current_user = $data->kudos['data'][0]['current_user']['reacted'] ? true : false;
 
         // Let the front end know that Rogue is powering the gallery.
         drupal_add_js(


### PR DESCRIPTION
#### What's this PR do?
Fixes 🐛  when you like one of the first 6 photos in the gallery and refresh, the heart doesn't stay filled in. 

#### How should this be reviewed?
Like one of the first 6 photos in the gallery and the heart should be filled in. 
Refresh the page. 
The hearts should still be filled in. 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
