### PR TITLE
Return null reportback property if no rb exists

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -200,7 +200,7 @@ function dosomething_rogue_format_signup($signup) {
   ];
 
   // REPORTBACK IS CONDITIONAL
-  if (array_key_exists('posts', $signup)) {
+  if (array_key_exists('posts', $signup) && !empty($signup['posts']['data'])) {
     $reportback_data = [
         'id' => $signup['signup_id'],
         'created_at' => strtotime($signup['created_at']),
@@ -254,6 +254,11 @@ function dosomething_rogue_format_signup($signup) {
 
     // Add reportback data to the response for this signup
     $signup_data['reportback'] = $reportback_data;
+
+    return $signup_data;
+  } else {
+    // Add reportback data to the response for this signup
+    $signup_data['reportback'] = null;
 
     return $signup_data;
   }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -254,14 +254,11 @@ function dosomething_rogue_format_signup($signup) {
 
     // Add reportback data to the response for this signup
     $signup_data['reportback'] = $reportback_data;
-
-    return $signup_data;
   } else {
-    // Add reportback data to the response for this signup
     $signup_data['reportback'] = null;
-
-    return $signup_data;
   }
+
+  return $signup_data;
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?

Fixes a bug in the rogue proxy response for `GET api/v1/signups/:id` 

* We were checking if `array_key_exists('posts', $signup)` to determine if there were posts on the signup and if we should return a reportback property. Turns out rogue always returns the `posts` property whether it is empty or not (should we fix this?). So this PR updates the check to see if posts are, in fact, empty.

* In the old phoenix response, `reportback: null` was returned in the response when a reportback didn't exists. This updates the proxy response to reflect that. 

#### How should this be reviewed?

👀 

#### Any background context you want to provide?

Gambit was relying on the response being in this format. Without this fix, it thinks that all signups have reportbacks under them and are giving users the wrong flow.

#### Relevant tickets
Fixes 🐛 