### PR TITLE
Adding more details for customized login experience

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -52,12 +52,11 @@ function dosomething_northstar_openid_authorize() {
 
     $url_options['query'] = [
       'destination' => $campaign->title,
-      'options' => [
-        'title' => $campaign->title,
-        'callToAction' => $campaign->call_to_action,
-        'coverImage' => $campaign->image_cover['src'],
-      ],
+      'title' => $campaign->title,
+      'callToAction' => $campaign->call_to_action,
+      'coverImage' => $campaign->image_cover['src'],
     ];
+    print_r($url_options['query']);die();
   }
 
   drupal_goto($authorize_url, $url_options);

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -40,7 +40,8 @@ function dosomething_northstar_openid_authorize() {
     $url_options['query'] = ['mode' => $_GET['mode']];
   }
 
-  if(isset($_GET['action']) && isset($_GET['node'])) {
+  if (isset($_GET['action']) && isset($_GET['node'])) {
+    $campaign = dosomething_campaign_load(node_load($_GET['node']));
     $params = [];
 
     if (isset($_GET['affiliate_messaging_opt_in'])) {
@@ -49,8 +50,14 @@ function dosomething_northstar_openid_authorize() {
 
     dosomething_northstar_set_authorization_action($_GET['action'], $_GET['node'], $params);
 
-    // @TODO: Rename parameter on the Northstar side to 'title'.
-    $url_options['query'] = ['destination' => $_GET['title']];
+    $url_options['query'] = [
+      'destination' => $campaign->title,
+      'options' => [
+        'title' => $campaign->title,
+        'callToAction' => $campaign->call_to_action,
+        'coverImage' => $campaign->image_cover['src'],
+      ],
+    ];
   }
 
   drupal_goto($authorize_url, $url_options);

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -56,7 +56,6 @@ function dosomething_northstar_openid_authorize() {
       'callToAction' => $campaign->call_to_action,
       'coverImage' => $campaign->image_cover['src'],
     ];
-    print_r($url_options['query']);die();
   }
 
   drupal_goto($authorize_url, $url_options);


### PR DESCRIPTION
#### What's this PR do?
This PR sends more details about the campaign to Northstar when you go-to login

#### How should this be reviewed?
Add the following after the $url_options array to see the output

```php
print_r($url_options['query']);die();
```

![screen shot 2017-07-25 at 11 29 32 am](https://user-images.githubusercontent.com/897368/28580211-d90ee4e8-712c-11e7-94d8-3be8d9921e0c.png)