### PR TITLE
updates gallery request to add status accepted

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -164,6 +164,7 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
       'filter' => [
         'campaign_id' => $campaigns,
         'exclude' => $exclude,
+        'status' => 'accepted',
       ],
       // If `?as_user` provided with UID or Northstar ID, use that. Otherwise, send logged-in user's NS ID.
       'as_user' => dosomething_user_convert_to_northstar_id($as_user ? $as_user : $user->uid),

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
@@ -180,6 +180,7 @@ function _reportback_resource_index($ids, $campaigns, $status, $count, $random, 
     $response = dosomething_rogue_client()->getAllReportbacks([
       'filter' => [
         'campaign_id' => $campaigns,
+        'status' => 'accepted',
       ],
       'as_user' => $as_user,
       'limit' => $count,

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -239,10 +239,10 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars, $count = 6) 
   // If the Rogue feature flag is on, grab reportbacks from Rogue.
   if (variable_get('rogue_collection', FALSE)) {
     // Hit the GET /reportbacks endpoint in Rogue with campaign_id filter.
-    // On the Rogue side, it will only return 'approved', which will be shown in the gallery.
     $promotedReportbackItemsResponse = dosomething_rogue_get_reportback_items([
       'filter' => [
         'campaign_id' => $gallery['campaign_id'],
+        'status' => 'accepted',
       ],
       'as_user' => dosomething_user_get_field('field_northstar_id'),
       'limit' => 6


### PR DESCRIPTION
#### What's this PR do?
Updates gallery requests to Rogue to add `status=accepted` filter so we only show reviewed posts in the gallery. 
 
#### How should this be reviewed?
Only posts that have the `accepted` status should show up in the gallery (both in the first 6 posts and posts after you push 'view more' link).

#### Any background context you want to provide?
I _think_ I caught everything (did a search for where this endpoint is used)! Anywhere else I missed? 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
