### PR TITLE
X button to close competition modal

### DIFF
--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -804,9 +804,8 @@ function dosomething_campaign_add_signup_data_form_vars(&$node, $langcode) {
     $node->required_signup_data_form = 1;
     // If form is configured to include a skip button:
     if ($config['required_allow_skip']) {
-      // Include the skip form:
+    // Include the skip form:
       $node->skippable_signup_data_form = 1;
-      $node->content['skip_signup_data_form'] = drupal_get_form('dosomething_signup_user_skip_signup_data_form', $signup);
     }
   }
 }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -85,7 +85,7 @@ function dosomething_signup_node_signup_data_form($form, &$form_state, $node) {
     '#type' => 'checkbox',
     '#title' => t('Allow skip'),
     '#default_value' => $values['required_allow_skip'],
-    '#description' => t('If checked, the form modal will provide a Skip button when the user is first prompted.'),
+    '#description' => t('If checked, the form modal will provide a Skip (X) button when the user is first prompted.'),
     // Should only be visible if form is required.
     '#states' => array(
       'visible' => array(
@@ -122,12 +122,6 @@ function dosomething_signup_node_signup_data_form($form, &$form_state, $node) {
     '#title' => t('Submit Button Text'),
     '#default_value' => $values['submit_text'],
     '#description' => t('This will be used as the label of the submit button.'),
-  );
-  $form[$fieldset]['config'][$prefix . 'skip_text'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Skip button text'),
-    '#default_value' => $values['skip_text'],
-    '#description' => t('This will be used as the lable of the skip button.'),
   );
   $form[$fieldset]['config'][$prefix . 'form_header'] = array(
     '#type' => 'textfield',
@@ -259,7 +253,6 @@ function dosomething_signup_node_signup_data_form_submit(&$form, &$form_state) {
         'custom_social_share_signup' => $values[$prefix . 'custom_social_share_signup'],
         'link_text' => $values[$prefix . 'link_text'],
         'submit_text' => $values[$prefix . 'submit_text'],
-        'skip_text' => $values[$prefix . 'skip_text'],
         'form_header' => $values[$prefix . 'form_header'],
         'form_copy' => $values[$prefix . 'form_copy'],
         'form_submitted_copy' => $values[$prefix . 'form_submitted_copy'],
@@ -584,39 +577,6 @@ function dosomething_signup_user_signup_data_form_validate_school($form, &$form_
     // No form submit for you.
     form_set_error('school_id', t("Please select a school."));
   }
-}
-
-/**
- * Form constructor for a user skip signup data form.
- *
- * @param object $signup
- *   The signup entity to save additional data to.
- */
-function dosomething_signup_user_skip_signup_data_form($form, &$form_state, $signup) {
-  $nid = isset($signup->nid) ? $signup->nid : $signup['campaign_id'];
-  $sid = isset($signup->sid) ? $signup->sid : $signup['signup_id'];
-  $run_nid = isset($signup->run_nid) ? $signup->run_nid : $signup['campaign_run_id'];
-
-  $config = dosomething_signup_get_signup_data_form_info($nid);
-  $skip_label = ($config['skip_text']) ? t($config['skip_text']) : t('Skip');
-
-  $form['#attributes']['class'] = ['modal__block', 'form-actions'];
-  $form['sid'] = [
-    '#type' => 'hidden',
-    '#value' => $sid,
-    '#access' => FALSE,
-  ];
-  $form['submit'] = [
-    '#type' => 'submit',
-    '#value' => $skip_label,
-    '#attributes' => [
-      'class' => [
-        'button',
-        '-tertiary',
-      ],
-    ],
-  ];
-  return $form;
 }
 
 /*

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -196,14 +196,13 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
     // Add JS to open the signup data form modal.
     $id = 'modal-signup-data-form';
     $closeButton = 'false';
-    $skipForm = '#dosomething-signup-user-skip-signup-data-form';
 
     // Add skip button if setting is enabled
     if (isset($vars['node']->skippable_signup_data_form)) {
-      $closeButton = 'skip';
+      $closeButton = 'X';
     }
 
-    $js = 'jQuery(document).ready(function() { DSModal.open( jQuery("#' . $id . '"), {animated: false, closeButton: "' . $closeButton . '", skipForm: "' . $skipForm . '"}); });';
+    $js = 'jQuery(document).ready(function() { DSModal.open( jQuery("#' . $id . '"), {animated: false, closeButton: "' . $closeButton . '"}); });';
     drupal_add_js($js, 'inline');
   }
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -199,7 +199,7 @@ function paraneue_dosomething_preprocess_node_campaign(&$vars) {
 
     // Add skip button if setting is enabled
     if (isset($vars['node']->skippable_signup_data_form)) {
-      $closeButton = 'X';
+      $closeButton = '×';
     }
 
     $js = 'jQuery(document).ready(function() { DSModal.open( jQuery("#' . $id . '"), {animated: false, closeButton: "' . $closeButton . '"}); });';


### PR DESCRIPTION
#### What's this PR do?
- Removes the "skip" signup data form and changes the "skip" button to an "X" that doesn't submit a form and simply closes out the box. 

#### How should this be reviewed?
- Go to a campaign page with a Competition. 
- Close the box. 
- Refresh the page - competition modal should pop up again. @sbsmith86 this is what we want, right? 


#### Relevant tickets
Fixes https://www.pivotaltracker.com/n/projects/2019429/stories/149262347

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
