### PR TITLE
Add support for `northstar_id` parameter on reportback proxy.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -321,18 +321,27 @@ function _campaign_resource_reportback($nid, $values) {
     return dosomething_helpers_basic_http_response(401, 'Unauthorized.');
   }
 
-  if (empty($values['uid'])) {
-    return dosomething_helpers_basic_http_response(422, 'Missing uid query parameter specifying a user id.');
+  // Include support for passing user ID as `northstar_id`.
+  if (isset($values['northstar_id'])) {
+    $values['uid'] = $values['northstar_id'];
+    unset($values['northstar_id']);
   }
 
-  $user = user_load(dosomething_user_convert_to_legacy_id($values['uid']));
+  // If we pass either a Northstar ID or Drupal UID to `uid`, convert it to a real UID.
+  $uid = dosomething_user_convert_to_legacy_id($values['uid']);
+
+  if (empty($uid)) {
+    return services_error('Cannot create reportback without a `northstar_id` or `uid`.');
+  }
+
+  $user = user_load($uid);
 
   if (!$user) {
     return dosomething_helpers_basic_http_response(404, 'The specified user was not found.');
   }
 
   // Set uid to member user submitting reportback.
-  $values['uid'] = $uid = $user->uid;
+  $values['uid'] = $uid;
 
   // @todo: Return error if signup doesn't exist.
 


### PR DESCRIPTION
#### What's this PR do?
This pull request adds support for passing `northstar_id` as a parameter to the reportback endpoint, like [indicated in the docs](https://github.com/DoSomething/phoenix/pull/7480). This is now consistent with how the signup endpoint works and sets us up for completely bypassing Phoenix UIDs sometime in the near-ish future.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
This unblocks DoSomething/gambit#941.

#### Relevant tickets
Fixes #7484.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  