### PR TITLE
Small fix to the custom cover photo sent to Northstar

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -54,7 +54,7 @@ function dosomething_northstar_openid_authorize() {
       'destination' => $campaign->title,
       'title' => $campaign->title,
       'callToAction' => $campaign->call_to_action,
-      'coverImage' => $campaign->image_cover['src'],
+      'coverPhoto' => $campaign->image_cover['url']['landscape']['raw'],
     ];
   }
 

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.auth.inc
@@ -55,6 +55,7 @@ function dosomething_northstar_openid_authorize() {
       'title' => $campaign->title,
       'callToAction' => $campaign->call_to_action,
       'coverPhoto' => $campaign->image_cover['url']['landscape']['raw'],
+      'coverImage' => $campaign->image_cover['url']['landscape']['raw'],
     ];
   }
 


### PR DESCRIPTION
#### What's this PR do?
- Changes the key to match Northstar's `coverPhoto` instead of `coverImage` (I'm realizing now our naming convention has been cover image, not sure if we'd rather update this in Northstar)

- Makes the image sent to Northstar a larger landscape hero instead of a stretched 300x300

#### How should this be reviewed?
When you hit signup you should see the hero image on Northstar QA