### PR TITLE
Tagger Pupper script

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -107,4 +107,31 @@ class Rogue extends RestApiClient {
 
     return $response;
   }
+
+  /**
+   * Send a GET request to return all posts matching a given
+   * query from Rogue.
+   *
+   * @param array $inputs
+   * @return array - JSON response
+   */
+  public function getPosts($inputs = [])
+  {
+    $response = $this->get('v2/posts', $inputs);
+
+    return $response;
+  }
+
+  /**
+   * Send a POST request to add a the given tag to the given post in Rogue
+   *
+   * @param array $data
+   * @return array - JSON response
+   */
+  public function postTag($data)
+  {
+    $response = $this->post('v2/tags', $data);
+
+    return $response;
+  }
 }

--- a/scripts/tag-as-excluded-promoted-in-rogue.php
+++ b/scripts/tag-as-excluded-promoted-in-rogue.php
@@ -32,26 +32,27 @@ else {
 }
 
 // Get all the excluded posts to send
-// if ($last_excluded) {
-// 	$excluded_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
-// 										FROM dosomething_reportback_file f
-// 										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
-// 										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
-// 										WHERE f.status = \"excluded\"
-// 										AND r.rogue_post_id > $last_excluded
-// 										ORDER BY r.rogue_post_id");
-// }
-// else {
-// 	$excluded_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
-// 										FROM dosomething_reportback_file f
-// 										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
-// 										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
-// 										WHERE f.status = \"excluded\"
-// 										ORDER BY r.rogue_post_id");
-// }
+if ($last_excluded) {
+	$excluded_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
+										FROM dosomething_reportback_file f
+										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
+										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
+										WHERE f.status = \"excluded\"
+										AND r.rogue_post_id > $last_excluded
+										ORDER BY r.rogue_post_id");
+}
+else {
+	$excluded_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
+										FROM dosomething_reportback_file f
+										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
+										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
+										WHERE f.status = \"excluded\"
+										ORDER BY r.rogue_post_id");
+}
 
 $client = dosomething_rogue_client();
 
+// Tag promoted posts
 foreach ($promoted_posts_in_rogue as $promoted) {
 	echo 'Checking out Rogue post ' . $promoted->rogue_post_id . PHP_EOL;
     // @TODO: bust this out into a helper
@@ -121,4 +122,72 @@ foreach ($promoted_posts_in_rogue as $promoted) {
     }
 }
 
-// repeat for excluded
+// Tag excluded posts
+foreach ($excluded_posts_in_rogue as $excluded) {
+	echo 'Checking out Rogue post ' . $excluded->rogue_post_id . PHP_EOL;
+    // @TODO: bust this out into a helper
+    if (isset($last_excluded)) {
+	    $northstar_id = dosomething_user_get_northstar_id($excluded->uid);
+	    $params['filter'] = [
+			'campaign_id' => $excluded->nid,
+			'northstar_id' => $northstar_id,
+	    ];
+
+	    // Grab all posts for the given user for the given campaign from Rogue so we can check for existing tags
+	    $posts = $client->getPosts($params);
+
+
+	    // Grab the particular post we are looking for from the response
+	    $rogue_post = null;
+	    foreach ($posts['data'] as $post) {
+			if ($post['id'] == $excluded->rogue_post_id) {
+				$rogue_post = $post;
+			}
+	    }
+
+	    // If we cannot find the post in Rogue, skip it
+	    if (!$rogue_post) {
+			echo 'Could not find post ' . $excluded->rogue_post_id . ' in Rogue' . PHP_EOL;
+			continue;
+	    }
+
+	    // If the post is already tagged hide-in-gallery in Rogue, skip it
+	    if (in_array('hide-in-gallery', $rogue_post['tagged'])) {
+			echo 'Post ' . $excluded->rogue_post_id . ' already tagged hide-in-gallery in Rogue' . PHP_EOL;
+
+			// We can say that this post is done because it is already marked
+			variable_set('dosomething_rogue_last_post_excluded', $excluded->rogue_post_id);
+
+			continue;
+	    }
+    }
+
+	// Format request to tag post
+    $data = [
+      'post_id' => $excluded->rogue_post_id,
+      'tag_name' => 'Hide In Gallery',
+    ];
+
+    // Post tag to Rogue
+    try {
+		echo 'Trying to add tag Hide In Gallery to post id ' . $excluded->rogue_post_id . '...' . PHP_EOL;
+		$response = $client->postTag($data);
+
+		if ($response) {
+			echo 'Tagged Rogue post ' . $excluded->rogue_post_id . ' as Hide In Gallery' . PHP_EOL;
+
+			variable_set('dosomething_rogue_last_post_excluded', $excluded->rogue_post_id);
+		}
+		else {
+			// Handle failure
+			echo '***FAILED TO TAG ROGUE POST '. $excluded->rogue_post_id . ' as Hide In Gallery***' . PHP_EOL;
+		}
+    }
+    catch (GuzzleHttp\Exception\ServerException $e) {
+		// These aren't yet caught by Gateway
+		echo '***SERVER EXCEPTION ON ROGUE POST '. $excluded->rogue_post_id . ' as Hide In Gallery***' . PHP_EOL;
+    }
+    catch (DoSomething\Gateway\Exceptions\ApiException $e) {
+		echo '***API EXCEPTION ON ROGUE POST '. $excluded->rogue_post_id . ' as Hide In Gallery***' . PHP_EOL;
+    }
+}

--- a/scripts/tag-as-excluded-promoted-in-rogue.php
+++ b/scripts/tag-as-excluded-promoted-in-rogue.php
@@ -8,14 +8,60 @@
  * drush --script-path=../scripts/ php-script export-activity-to-rogue.php
  */
 
-$promoted_posts_in_rogue = db_query("SELECT r.rogue_post_id
+$promoted_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
 									FROM dosomething_reportback_file f
 									JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
+									JOIN dosomething_reportback rb ON f.rbid = rb.rbid
 									WHERE status = \"promoted\"");
 
+$client = dosomething_rogue_client();
+
 foreach ($promoted_posts_in_rogue as $promoted) {
-	// send to tags endpoint
-	// handle failure
+	// Format request
+    $data = [
+      'post_id' => $promoted->rogue_post_id,
+      'tag_name' => 'Good Photo',
+    ];
+
+    // @TODO: see if the post is tagged in Rogue
+    // need: northstar_id
+    // only need to do this if picking up from a given input, not on the first pass
+    $northstar_id = dosomething_user_get_northstar_id($promoted->uid);
+    $filter = [
+		'campaign_id' => $promoted->nid,
+		'northstar_id' => $northstar_id,
+    ];
+    $params['filter'] = $filter;
+    // @TODO: write getPosts
+    $posts = $client->getPosts($params);
+
+
+    // Post tag to Rogue
+    // @TODO: write postTag
+    try {
+		$response = $client->postTag($data);
+
+		// handle failure
+		// @TODO: how to make sure we tag everything and only send the request once? resending again on a post will cause it to be untagged - only send it if not tagged in Rogue? would need to get the post from Rogue
+		if ($response) {
+			echo 'Tagged Rogue post ' . $promoted->rogue_post_id . ' as Good Photo';
+		}
+		else {
+			echo '***FAILED TO TAG ROGUE POST '. $promoted->rogue_post_id . ' as Good Photo***';
+		}
+    }
+    catch (GuzzleHttp\Exception\ServerException $e) {
+		// These aren't yet caught by Gateway
+		echo '***SERVER EXCEPTION ON ROGUE POST '. $promoted->rogue_post_id . ' as Good Photo***';
+    }
+    catch (DoSomething\Gateway\Exceptions\ApiException $e) {
+      // Put request in failed table for future investigation
+      dosomething_rogue_handle_migration_failure($data, $signup->sid, $signup->rbid, $fids);
+
+      // Set where we left off so we don't keep trying this one forever
+      variable_set('dosomething_rogue_last_signup_migrated', $signup->sid);
+    }
+
 }
 
 // repeat for excluded

--- a/scripts/tag-as-excluded-promoted-in-rogue.php
+++ b/scripts/tag-as-excluded-promoted-in-rogue.php
@@ -5,7 +5,7 @@
  * RBs "promoted" here will be tagged with "Good Photo" in Rogue
  *
  * to run:
- * drush --script-path=../scripts/ php-script export-activity-to-rogue.php
+ * drush --script-path=../scripts/ php-script tag-as-excluded-promoted-in-rogue.php
  */
 
 // Pick up from where we left off
@@ -13,12 +13,12 @@ $last_promoted = variable_get('dosomething_rogue_last_post_promoted', NULL);
 $last_excluded = variable_get('dosomething_rogue_last_post_excluded', NULL);
 
 // Get all the promoted posts to send
-if ($last_promoted) {
+if (isset($last_promoted)) {
 	$promoted_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
 										FROM dosomething_reportback_file f
 										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
 										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
-										WHERE status = \"promoted\"
+										WHERE f.status = 'promoted'
 										AND r.rogue_post_id > $last_promoted
 										ORDER BY r.rogue_post_id");
 }
@@ -27,79 +27,98 @@ else {
 										FROM dosomething_reportback_file f
 										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
 										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
-										WHERE status = \"promoted\"
+										WHERE f.status = \"promoted\"
 										ORDER BY r.rogue_post_id");
 }
 
 // Get all the excluded posts to send
-if ($last_excluded) {
-	$excluded_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
-										FROM dosomething_reportback_file f
-										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
-										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
-										WHERE status = \"excluded\"
-										AND r.rogue_post_id > $last_excluded
-										ORDER BY r.rogue_post_id");
-}
-else {
-	$excluded_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
-										FROM dosomething_reportback_file f
-										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
-										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
-										WHERE status = \"excluded\"
-										ORDER BY r.rogue_post_id");
-}
+// if ($last_excluded) {
+// 	$excluded_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
+// 										FROM dosomething_reportback_file f
+// 										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
+// 										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
+// 										WHERE f.status = \"excluded\"
+// 										AND r.rogue_post_id > $last_excluded
+// 										ORDER BY r.rogue_post_id");
+// }
+// else {
+// 	$excluded_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
+// 										FROM dosomething_reportback_file f
+// 										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
+// 										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
+// 										WHERE f.status = \"excluded\"
+// 										ORDER BY r.rogue_post_id");
+// }
 
 $client = dosomething_rogue_client();
 
 foreach ($promoted_posts_in_rogue as $promoted) {
+	echo 'Checking out Rogue post ' . $promoted->rogue_post_id . PHP_EOL;
     // @TODO: bust this out into a helper
-    // @TODO: see if the post is tagged in Rogue
-    if ($last_promoted) {
+    if (isset($last_promoted)) {
 	    $northstar_id = dosomething_user_get_northstar_id($promoted->uid);
-	    $filter = [
+	    $params['filter'] = [
 			'campaign_id' => $promoted->nid,
 			'northstar_id' => $northstar_id,
 	    ];
-	    $params['filter'] = $filter;
 
-	    // @TODO: write getPosts
-	    // @TODO: bust posting tag out into a helper that takes post id and tag
+	    // Grab all posts for the given user for the given campaign from Rogue so we can check for existing tags
 	    $posts = $client->getPosts($params);
 
-	    // @TODO: if the tag already exists, continue
+
+	    // Grab the particular post we are looking for from the response
+	    $rogue_post = null;
+	    foreach ($posts['data'] as $post) {
+			if ($post['id'] == $promoted->rogue_post_id) {
+				$rogue_post = $post;
+			}
+	    }
+
+	    // If we cannot find the post in Rogue, skip it
+	    if (!$rogue_post) {
+			echo 'Could not find post ' . $promoted->rogue_post_id . ' in Rogue' . PHP_EOL;
+			continue;
+	    }
+
+	    // If the post is already tagged good-photo in Rogue, skip it
+	    if (in_array('good-photo', $rogue_post['tagged'])) {
+			echo 'Post ' . $promoted->rogue_post_id . ' already tagged good-photo in Rogue' . PHP_EOL;
+
+			// We can say that this post is done because it is already marked
+			variable_set('dosomething_rogue_last_post_promoted', $promoted->rogue_post_id);
+
+			continue;
+	    }
     }
 
-	// Format request
+	// Format request to tag post
     $data = [
       'post_id' => $promoted->rogue_post_id,
       'tag_name' => 'Good Photo',
     ];
 
     // Post tag to Rogue
-    // @TODO: write postTag
     try {
+		echo 'Trying to add tag Good Photo to post id ' . $promoted->rogue_post_id . '...' . PHP_EOL;
 		$response = $client->postTag($data);
 
-		// handle failure
-		// @TODO: how to make sure we tag everything and only send the request once? resending again on a post will cause it to be untagged - only send it if not tagged in Rogue? would need to get the post from Rogue
 		if ($response) {
-			echo 'Tagged Rogue post ' . $promoted->rogue_post_id . ' as Good Photo';
+			echo 'Tagged Rogue post ' . $promoted->rogue_post_id . ' as Good Photo' . PHP_EOL;
 
 			variable_set('dosomething_rogue_last_post_promoted', $promoted->rogue_post_id);
 		}
 		else {
-			echo '***FAILED TO TAG ROGUE POST '. $promoted->rogue_post_id . ' as Good Photo***';
+			// Handle failure
+			echo '***FAILED TO TAG ROGUE POST '. $promoted->rogue_post_id . ' as Good Photo***' . PHP_EOL;
 		}
     }
     catch (GuzzleHttp\Exception\ServerException $e) {
 		// These aren't yet caught by Gateway
-		echo '***SERVER EXCEPTION ON ROGUE POST '. $promoted->rogue_post_id . ' as Good Photo***';
+		echo '***SERVER EXCEPTION ON ROGUE POST '. $promoted->rogue_post_id . ' as Good Photo***' . PHP_EOL;
     }
     catch (DoSomething\Gateway\Exceptions\ApiException $e) {
-		echo '***API EXCEPTION ON ROGUE POST '. $promoted->rogue_post_id . ' as Good Photo***';
+		echo '***API EXCEPTION ON ROGUE POST '. $promoted->rogue_post_id . ' as Good Photo***' . PHP_EOL;
     }
-
 }
 
 // repeat for excluded

--- a/scripts/tag-as-excluded-promoted-in-rogue.php
+++ b/scripts/tag-as-excluded-promoted-in-rogue.php
@@ -27,17 +27,17 @@ else {
 										FROM dosomething_reportback_file f
 										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
 										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
-										WHERE f.status = \"promoted\"
+										WHERE f.status = 'promoted'
 										ORDER BY r.rogue_post_id");
 }
 
 // Get all the excluded posts to send
-if ($last_excluded) {
+if (isset($last_excluded)) {
 	$excluded_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
 										FROM dosomething_reportback_file f
 										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
 										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
-										WHERE f.status = \"excluded\"
+										WHERE f.status = 'excluded'
 										AND r.rogue_post_id > $last_excluded
 										ORDER BY r.rogue_post_id");
 }
@@ -46,7 +46,7 @@ else {
 										FROM dosomething_reportback_file f
 										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
 										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
-										WHERE f.status = \"excluded\"
+										WHERE f.status = 'excluded'
 										ORDER BY r.rogue_post_id");
 }
 
@@ -191,3 +191,5 @@ foreach ($excluded_posts_in_rogue as $excluded) {
 		echo '***API EXCEPTION ON ROGUE POST '. $excluded->rogue_post_id . ' as Hide In Gallery***' . PHP_EOL;
     }
 }
+
+echo 'Nothing else to tag!' . PHP_EOL;

--- a/scripts/tag-as-excluded-promoted-in-rogue.php
+++ b/scripts/tag-as-excluded-promoted-in-rogue.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Script to send more review data to Rogue.
+ * RBs "excluded" here will be tagged with "Hide In Gallery" in Rogue
+ * RBs "promoted" here will be tagged with "Good Photo" in Rogue
+ *
+ * to run:
+ * drush --script-path=../scripts/ php-script export-activity-to-rogue.php
+ */
+
+$promoted_posts_in_rogue = db_query("SELECT r.rogue_post_id
+									FROM dosomething_reportback_file f
+									JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
+									WHERE status = \"promoted\"");
+
+foreach ($promoted_posts_in_rogue as $promoted) {
+	// send to tags endpoint
+	// handle failure
+}
+
+// repeat for excluded

--- a/scripts/tag-as-excluded-promoted-in-rogue.php
+++ b/scripts/tag-as-excluded-promoted-in-rogue.php
@@ -8,33 +8,73 @@
  * drush --script-path=../scripts/ php-script export-activity-to-rogue.php
  */
 
-$promoted_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
-									FROM dosomething_reportback_file f
-									JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
-									JOIN dosomething_reportback rb ON f.rbid = rb.rbid
-									WHERE status = \"promoted\"");
+// Pick up from where we left off
+$last_promoted = variable_get('dosomething_rogue_last_post_promoted', NULL);
+$last_excluded = variable_get('dosomething_rogue_last_post_excluded', NULL);
+
+// Get all the promoted posts to send
+if ($last_promoted) {
+	$promoted_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
+										FROM dosomething_reportback_file f
+										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
+										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
+										WHERE status = \"promoted\"
+										AND r.rogue_post_id > $last_promoted
+										ORDER BY r.rogue_post_id");
+}
+else {
+	$promoted_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
+										FROM dosomething_reportback_file f
+										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
+										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
+										WHERE status = \"promoted\"
+										ORDER BY r.rogue_post_id");
+}
+
+// Get all the excluded posts to send
+if ($last_excluded) {
+	$excluded_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
+										FROM dosomething_reportback_file f
+										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
+										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
+										WHERE status = \"excluded\"
+										AND r.rogue_post_id > $last_excluded
+										ORDER BY r.rogue_post_id");
+}
+else {
+	$excluded_posts_in_rogue = db_query("SELECT r.rogue_post_id, rb.uid, rb.nid
+										FROM dosomething_reportback_file f
+										JOIN dosomething_rogue_reportbacks r ON f.fid = r.fid
+										JOIN dosomething_reportback rb ON f.rbid = rb.rbid
+										WHERE status = \"excluded\"
+										ORDER BY r.rogue_post_id");
+}
 
 $client = dosomething_rogue_client();
 
 foreach ($promoted_posts_in_rogue as $promoted) {
+    // @TODO: bust this out into a helper
+    // @TODO: see if the post is tagged in Rogue
+    if ($last_promoted) {
+	    $northstar_id = dosomething_user_get_northstar_id($promoted->uid);
+	    $filter = [
+			'campaign_id' => $promoted->nid,
+			'northstar_id' => $northstar_id,
+	    ];
+	    $params['filter'] = $filter;
+
+	    // @TODO: write getPosts
+	    // @TODO: bust posting tag out into a helper that takes post id and tag
+	    $posts = $client->getPosts($params);
+
+	    // @TODO: if the tag already exists, continue
+    }
+
 	// Format request
     $data = [
       'post_id' => $promoted->rogue_post_id,
       'tag_name' => 'Good Photo',
     ];
-
-    // @TODO: see if the post is tagged in Rogue
-    // need: northstar_id
-    // only need to do this if picking up from a given input, not on the first pass
-    $northstar_id = dosomething_user_get_northstar_id($promoted->uid);
-    $filter = [
-		'campaign_id' => $promoted->nid,
-		'northstar_id' => $northstar_id,
-    ];
-    $params['filter'] = $filter;
-    // @TODO: write getPosts
-    $posts = $client->getPosts($params);
-
 
     // Post tag to Rogue
     // @TODO: write postTag
@@ -45,6 +85,8 @@ foreach ($promoted_posts_in_rogue as $promoted) {
 		// @TODO: how to make sure we tag everything and only send the request once? resending again on a post will cause it to be untagged - only send it if not tagged in Rogue? would need to get the post from Rogue
 		if ($response) {
 			echo 'Tagged Rogue post ' . $promoted->rogue_post_id . ' as Good Photo';
+
+			// @TODO: update sent variable
 		}
 		else {
 			echo '***FAILED TO TAG ROGUE POST '. $promoted->rogue_post_id . ' as Good Photo***';
@@ -53,13 +95,13 @@ foreach ($promoted_posts_in_rogue as $promoted) {
     catch (GuzzleHttp\Exception\ServerException $e) {
 		// These aren't yet caught by Gateway
 		echo '***SERVER EXCEPTION ON ROGUE POST '. $promoted->rogue_post_id . ' as Good Photo***';
+
+		// @TODO: update sent variable
     }
     catch (DoSomething\Gateway\Exceptions\ApiException $e) {
-      // Put request in failed table for future investigation
-      dosomething_rogue_handle_migration_failure($data, $signup->sid, $signup->rbid, $fids);
+		echo '***API EXCEPTION ON ROGUE POST '. $promoted->rogue_post_id . ' as Good Photo***';
 
-      // Set where we left off so we don't keep trying this one forever
-      variable_set('dosomething_rogue_last_signup_migrated', $signup->sid);
+		// @TODO: update sent variable
     }
 
 }

--- a/scripts/tag-as-excluded-promoted-in-rogue.php
+++ b/scripts/tag-as-excluded-promoted-in-rogue.php
@@ -86,7 +86,7 @@ foreach ($promoted_posts_in_rogue as $promoted) {
 		if ($response) {
 			echo 'Tagged Rogue post ' . $promoted->rogue_post_id . ' as Good Photo';
 
-			// @TODO: update sent variable
+			variable_set('dosomething_rogue_last_post_promoted', $promoted->rogue_post_id);
 		}
 		else {
 			echo '***FAILED TO TAG ROGUE POST '. $promoted->rogue_post_id . ' as Good Photo***';
@@ -95,13 +95,9 @@ foreach ($promoted_posts_in_rogue as $promoted) {
     catch (GuzzleHttp\Exception\ServerException $e) {
 		// These aren't yet caught by Gateway
 		echo '***SERVER EXCEPTION ON ROGUE POST '. $promoted->rogue_post_id . ' as Good Photo***';
-
-		// @TODO: update sent variable
     }
     catch (DoSomething\Gateway\Exceptions\ApiException $e) {
 		echo '***API EXCEPTION ON ROGUE POST '. $promoted->rogue_post_id . ' as Good Photo***';
-
-		// @TODO: update sent variable
     }
 
 }


### PR DESCRIPTION
#### What's this PR do?

1. Adds `getPosts` to `Rogue.php` so the tag script can see if the current post already has the current tag. We want to make sure we don't send the tag request if the tag already lives on that post because that will untag it!
2. Adds `postTag` to `Rogue.php` so we can apply tags in Rogue.
3. The script! [Here is all the documentation!](https://docs.google.com/a/dosomething.org/document/d/1mPmQcwbfkgkhlfWJqLM0T7lXrFZvzv3BwSy-oz_QG6w/edit?usp=sharing) Feel free to leave comments on the Google Doc or in the code.

#### How should this be reviewed?
Check the logic. Make sure I didn't say `promoted` where I meant `excluded` or vice versa.

#### Any background context you want to provide?
We're doing this so Rogue will be able to show promoted/Good Photo items first in the gallery and will not show excluded/Hide In Gallery items. 

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/n/projects/2019429/stories/149207697)

#### Checklist
- [ ] Tested on staging.