### PR TITLE
Fixing path alias on confirmation

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/reportback-confirmation.tpl.php
@@ -54,7 +54,7 @@
 
               <div class="figure__body">
                 <?php if (isset($rec['title'])): ?>
-                  <h3><?php print l($rec['title'], $rec['path_alias']); ?></h3>
+                  <h3><a href="/<?php print $rec['path_alias']; ?>"><?php print $rec['title']; ?></a></h3>
                 <?php endif; ?>
 
                 <?php if (isset($rec['call_to_action'])): ?>


### PR DESCRIPTION
#### What's this PR do?
The url for campaigns on the reportback confirmation had a double `/us` in them because of the drupal function screwing stuff up. just removed it and made the anchor myself. this is what we did for the image tag above, not sure why we didn't do that as well below. 

#### How should this be reviewed?
go to the confirmation page and check the link works.
