### PR TITLE
Update API endpoints to use Northstar ID instead of Drupal ID

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -261,7 +261,7 @@ function _campaign_resource_index($ids, $staff_pick, $term_ids, $count, $random,
  *   The Node nid to post the signup to.
  * @param array $values
  *   The signup data to post. Expected keys:
- *   - northstar_id: The user's Northstar ID uid (string).
+ *   - northstar_id: The user's Northstar ID (string).
  *   - source (string).
  *   - transactionals (bool). Optional flag to disable sending transactional messages.
  *       Defaults to sending messages.
@@ -303,7 +303,7 @@ function _campaign_resource_signup($nid, $values) {
  *   The Node nid to post the reportback to.
  * @param array $values
  *   The reportback data to post. Expected keys:
- *   - uid: The user uid (int).
+ *   - northstar_id: The user's Northstar ID (string).
  *   - file: Base64 encoded file string to save (required if using 'filename').
  *   - filename: The filename of the file provided as file (required if using 'file').
  *   - file_url: The URL of the reportback file to save (used if no 'file'/'filename' exist).

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -261,7 +261,7 @@ function _campaign_resource_index($ids, $staff_pick, $term_ids, $count, $random,
  *   The Node nid to post the signup to.
  * @param array $values
  *   The signup data to post. Expected keys:
- *   - uid: The user uid (int).  Optional, uses global $user if not set.
+ *   - northstar_id: The user's Northstar ID uid (string).
  *   - source (string).
  *   - transactionals (bool). Optional flag to disable sending transactional messages.
  *       Defaults to sending messages.
@@ -274,8 +274,8 @@ function _campaign_resource_signup($nid, $values) {
     unset($values['northstar_id']);
   }
 
-  // If we pass either a Northstar ID or Drupal UID to `uid`, convert it to a real UID.
-  $values['uid'] = dosomething_user_convert_to_legacy_id($values['uid']);
+  // If a Drupal UID is passed to `uid`, convert it to the user's Northstar ID.
+  $values['uid'] = dosomething_user_convert_to_northstar_id($values['uid']);
 
   if (!isset($values['uid'])) {
     return services_error('Cannot create signup without a `northstar_id` or `uid`.');

--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -327,14 +327,14 @@ function _campaign_resource_reportback($nid, $values) {
     unset($values['northstar_id']);
   }
 
-  // If we pass either a Northstar ID or Drupal UID to `uid`, convert it to a real UID.
-  $uid = dosomething_user_convert_to_legacy_id($values['uid']);
+  // If a Drupal UID is passed to `uid`, convert it to the user's Northstar ID.
+  $uid = dosomething_user_convert_to_northstar_id($values['uid']);
 
   if (empty($uid)) {
     return services_error('Cannot create reportback without a `northstar_id` or `uid`.');
   }
 
-  $user = user_load($uid);
+  $user = dosomething_user_get_user_by_northstar_id($uid);
 
   if (!$user) {
     return dosomething_helpers_basic_http_response(404, 'The specified user was not found.');

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -254,7 +254,6 @@ function dosomething_signup_get_query_source() {
  */
 function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp = NULL, $transactionals = TRUE) {
   global $user;
-
   if (!isset($uid)) {
     $uid = $user->uid;
   }
@@ -266,7 +265,6 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
   $campaign_node = node_load($nid);
   $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $user, $campaign);
   $account = user_load($uid);
-
   $values = [
     'nid' => $nid,
     'uid' => $uid,

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -254,6 +254,7 @@ function dosomething_signup_get_query_source() {
  */
 function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp = NULL, $transactionals = TRUE) {
   global $user;
+
   if (!isset($uid)) {
     $uid = $user->uid;
   }
@@ -265,6 +266,7 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
   $campaign_node = node_load($nid);
   $run = dosomething_helpers_get_current_campaign_run_for_user($nid, $user, $campaign);
   $account = user_load($uid);
+
   $values = [
     'nid' => $nid,
     'uid' => $uid,


### PR DESCRIPTION
#### What's this PR do?
Updates `/campaigns/:id/signup` and `/campaigns/:id/reportback` to use the user's Northstar ID instead of Drupal UID in logic in case a user doesn't have a Drupal UID. 

#### How should this be reviewed?
Sign up for a campaign via `/campaigns/:id/signup` and it should be reflected in Rogue.
Reportback for a campaign via `campaigns/:id/reportback` and it should be reflected in Rogue. 

#### Any background context you want to provide?
- @DFurnes this should squash the bug and not introduce any problems assuming everyone has a Northstar ID?
- Did I miss any other endpoints? 

#### Relevant tickets
Fixes https://github.com/DoSomething/gambit/issues/922
https://www.pivotaltracker.com/n/projects/2019429/stories/150138796

cc @aaronschachter 
#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
