### PR TITLE
Don't send null query strings to Rogue.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -203,16 +203,18 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
     $user = implode(',', $user);
     $parameters['user'] = $user;
 
-    $rogue_response = dosomething_rogue_get_activity([
-      'filter' => [
+    // Transform Phoenix Ashes query string into equivalent
+    // query for Rogue's `api/v2/activity` endpoint:
+    $rogue_response = dosomething_rogue_get_activity(array_filter([
+      'filter' => array_filter([
         'campaign_id' => data_get($parameters, 'campaigns'),
         'campaign_run_id' => data_get($parameters, 'runs'),
         'northstar_id' => data_get($parameters, 'user'),
         'id' => data_get($parameters, 'id'),
-      ],
+      ]),
       'limit' => data_get($parameters, 'count'),
       'page' => data_get($parameters, 'page'),
-    ]);
+    ]));
 
     return json_decode(dosomething_rogue_format_activity($rogue_response));
   }


### PR DESCRIPTION
#### What's this PR do?
This should fix the issue where `api/v1/signups` was showing an empty page. Before, we'd send null values for some query strings, for example `?filter%5Bnorthstar_id%5D=&limit=25&page=1`. Now we don't: `?limit=25&page=1`.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
Was this always broken?! 🤔

#### Relevant tickets
[#150481585](https://www.pivotaltracker.com/story/show/150481585)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  