### PR TITLE
Include pending posts on user profile

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -247,17 +247,13 @@ function _kudos_resource_delete($kudos_id) {
     $api_user_is_an_admin = user_access('view any reportback', $user);
 
     // Reactions from the user profile page will not have $northstar_id
-    if ($northstar_id) {
-      $logged_in_user_matches_given_id = dosomething_user_get_northstar_id($user->uid) === $northstar_id;
-      if (!$api_user_is_an_admin && !$logged_in_user_matches_given_id) {
-        return [
-          'error' => [
-            'message' => 'There was an error deleting the specified kudos record.',
-          ],
-        ];
-      }
-    } else {
-      $northstar_id = dosomething_user_get_northstar_id($user->uid);
+    $logged_in_user_matches_given_id = dosomething_user_get_northstar_id($user->uid) === $northstar_id;
+    if (!$api_user_is_an_admin && !$logged_in_user_matches_given_id) {
+      return [
+        'error' => [
+          'message' => 'There was an error deleting the specified kudos record.',
+        ],
+      ];
     }
 
     $data = [

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -245,13 +245,19 @@ function _kudos_resource_delete($kudos_id) {
 
     // Make sure authenticated user is an admin or the kudo owner.
     $api_user_is_an_admin = user_access('view any reportback', $user);
-    $logged_in_user_matches_given_id = dosomething_user_get_northstar_id($user->uid) === $northstar_id;
-    if (!$api_user_is_an_admin && !$logged_in_user_matches_given_id) {
-      return [
-        'error' => [
-          'message' => 'There was an error deleting the specified kudos record.',
-        ],
-      ];
+
+    // Reactions from the user profile page will not have $northstar_id
+    if ($northstar_id) {
+      $logged_in_user_matches_given_id = dosomething_user_get_northstar_id($user->uid) === $northstar_id;
+      if (!$api_user_is_an_admin && !$logged_in_user_matches_given_id) {
+        return [
+          'error' => [
+            'message' => 'There was an error deleting the specified kudos record.',
+          ],
+        ];
+      }
+    } else {
+      $northstar_id = dosomething_user_get_northstar_id($user->uid);
     }
 
     $data = [

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -245,8 +245,6 @@ function _kudos_resource_delete($kudos_id) {
 
     // Make sure authenticated user is an admin or the kudo owner.
     $api_user_is_an_admin = user_access('view any reportback', $user);
-
-    // Reactions from the user profile page will not have $northstar_id
     $logged_in_user_matches_given_id = dosomething_user_get_northstar_id($user->uid) === $northstar_id;
     if (!$api_user_is_an_admin && !$logged_in_user_matches_given_id) {
       return [

--- a/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
+++ b/lib/modules/dosomething/dosomething_kudos/dosomething_kudos.module
@@ -321,18 +321,16 @@ function dosomething_kudos_disable_reactions($nid) {
  * @return array Values needed to render Kudos markup
  */
 function dosomething_kudos_get_kudos_data_for_fid($fid = NULL, $total_rogue_kudos = NULL, $liked_by_current_user = NULL) {
+  global $user;
+
   if (! $fid) {
     return [];
   }
 
-  if (variable_get('rogue_collection', FALSE)) {
-    $total_kudos = $total_rogue_kudos;
-  } else {
-    $total_kudos = dosomething_kudos_get_total_for_file_by_term_name($fid, 'heart');
-  }
+  $total_kudos = $total_rogue_kudos;
 
   $kudos = [];
-  $kudos['fid'] = $fid;
+  $kudos['fid'] = $fid . '|' . dosomething_user_get_northstar_id($user->uid);
   $kudos['existing_kids'] = dosomething_kudos_get_kudos_for_user_by_file($fid);
   $kudos['reaction_totals'] = [
     'heart' =>

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1140,8 +1140,9 @@ function dosomething_reportback_rogue_mbp_request($rb, $signup) {
  * @return array
  */
 function dosomething_reportback_get_reportbacks($uid = NULL) {
+  global $user;
+
   if (!$uid) {
-    global $user;
     $uid = $user->uid;
   }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1158,22 +1158,28 @@ function dosomething_reportback_get_reportbacks($uid = NULL) {
       ],
     ]);
 
+    $response = dosomething_rogue_get_posts([
+      'filter' => [
+        'northstar_id' => $northstar_id,
+      ],
+      'include' => 'signup',
+    ]);
+
     foreach ($response['data'] as $delta => $reportback) {
       $reportback = (object) $reportback;
 
+      // @TODO: figure out how to get kudos (not included in response)
       $total_kudos = $reportback->kudos['data'][0]['term']['total'];
       $liked_by_current_user = $reportback->kudos['data'][0]['current_user']['reacted'] ? TRUE : FALSE;
-
-      $campaign = node_load($reportback->campaign['id']);
-
-      $impact = $reportback->reportback['quantity'] . ' ' . dosomething_helpers_extract_field_data($campaign->field_reportback_noun) . ' ' . dosomething_helpers_extract_field_data($campaign->field_reportback_verb);
+      $campaign = node_load($reportback->signup['data']['campaign_id']);
+      $impact = $reportback->signup['data']['quantity'] . ' ' . dosomething_helpers_extract_field_data($campaign->field_reportback_noun) . ' ' . dosomething_helpers_extract_field_data($campaign->field_reportback_verb);
 
       $args = [
-       'path' => $reportback->media['uri'],
+       'path' => $reportback->media['url'],
       ];
 
       $img = theme_image($args);
-      $url = dosomething_global_url('node/' . $reportback->campaign['id']);
+      $url = dosomething_global_url('node/' . $reportback->signup['data']['campaign_id']);
 
       $content = [
         'url' => $url,

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -1149,28 +1149,23 @@ function dosomething_reportback_get_reportbacks($uid = NULL) {
   // This will be okay because this function is only called in dosomething_user.theme.inc for user profile page.
   if (variable_get('rogue_collection', FALSE)) {
     $northstar_id = dosomething_user_get_northstar_id($uid);
+    $current_user_northstar_id = dosomething_user_get_northstar_id($user->uid);
 
     $reportback_items = [];
-
-    $response = dosomething_rogue_get_reportback_items([
-      'filter' => [
-        'northstar_id' => $northstar_id,
-      ],
-    ]);
 
     $response = dosomething_rogue_get_posts([
       'filter' => [
         'northstar_id' => $northstar_id,
       ],
       'include' => 'signup',
+      'as_user' => $current_user_northstar_id,
     ]);
 
     foreach ($response['data'] as $delta => $reportback) {
       $reportback = (object) $reportback;
 
-      // @TODO: figure out how to get kudos (not included in response)
-      $total_kudos = $reportback->kudos['data'][0]['term']['total'];
-      $liked_by_current_user = $reportback->kudos['data'][0]['current_user']['reacted'] ? TRUE : FALSE;
+      $total_kudos = $reportback->reactions['total'];
+      $liked_by_current_user = $reportback->reactions['reacted'] ? TRUE : FALSE;
       $campaign = node_load($reportback->signup['data']['campaign_id']);
       $impact = $reportback->signup['data']['quantity'] . ' ' . dosomething_helpers_extract_field_data($campaign->field_reportback_noun) . ' ' . dosomething_helpers_extract_field_data($campaign->field_reportback_verb);
 

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -68,7 +68,6 @@ function dosomething_rogue_get_reportback_items($inputs)
   */
 function dosomething_rogue_get_posts($inputs)
 {
-  // die(dump($inputs));
   $client = dosomething_rogue_client();
 
   $response = $client->getPosts($inputs);

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -61,6 +61,22 @@ function dosomething_rogue_get_reportback_items($inputs)
 }
 
 /**
+  * Send a GET request to return all posts matching a given
+  * query from Rogue.
+  *
+  * @param array $inputs
+  */
+function dosomething_rogue_get_posts($inputs)
+{
+  // die(dump($inputs));
+  $client = dosomething_rogue_client();
+
+  $response = $client->getPosts($inputs);
+
+  return $response;
+}
+
+/**
  * Send a GET request to return all activity matching a given
  * query from Rogue.
  *


### PR DESCRIPTION
#### What's this PR do?
Previously, the user profile page was using the Rogue `GET /reportbacks` endpoint, which also powers the gallery. This endpoint does not provide the option to include posts that have statuses other than `accepted`. Now the profile page uses the Rogue `GET /posts` endpoint, which provides all the data that we need. That endpoint gets hit with a filter for the `northstar_id` of the user whose profile page is being viewed. The `signup` is also included, and reaction data is retrieved `as_user` of the currently logged in user.

In order to unlike posts on the user profile, the Northstar ID had to be included with the Post ID in `dosomething_kudos_get_kudos_data_for_fid`.

#### How should this be reviewed?
Will this show all Posts a user has submitted on their profile page? Will you be able to properly react to these posts?

#### Any background context you want to provide?
While working on this I found a bug which is documented here: https://github.com/DoSomething/phoenix/issues/7498

#### Relevant tickets
[Pivotal card](https://www.pivotaltracker.com/story/show/150312987)

#### Checklist
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love