### PR TITLE
Don't enforce email/mobile uniqueness for Phoenix users.

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/member_resource.inc
@@ -212,26 +212,9 @@ function _member_resource_create($request) {
   }
 
   // Check if email is formatted correctly and not already in use.
-  $email = $request['email'];
-  if ($user = user_load_by_mail($email)) {
-    return services_error(t('Email @email is registered to User uid @uid.', ['@email' => $email, '@uid' => $user->uid]), 403);
-  }
-  if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-    return services_error(t('Email @email is not a valid email address.', ['@email' => $email]), 422);
-  }
-
-  // Check if account exists for phone.
-  $mobile = $request['mobile'];
-  if ($mobile && $user = dosomething_user_get_user_by_mobile($mobile)) {
-    return services_error(t('Mobile @mobile is registered to User uid @uid.', ['@mobile' => $mobile, '@uid' => $user->uid]), 403);
-  }
-  if ($mobile && !dosomething_user_valid_mobile($mobile)) {
-    return services_error(t('Mobile @mobile is not a valid phone number.', ['@mobile' => $mobile]), 422);
-  }
-
   // Initialize array to pass to user_save().
   $edit = [
-    'mail' => $email,
+    'mail' => $request['email'],
     'name' => user_password(), // Overridden below.
     'status' => 1,
     'created' => REQUEST_TIME,


### PR DESCRIPTION
#### What's this PR do?
Phoenix's "create user" API endpoint is still enforcing email/mobile uniqueness, which we don't want anymore since the canonical source for these fields is in Northstar. By continuing to enforce this, we end up with some edge cases where accounts can't be created if a email/mobile was changed in Aurora (but the change wasn't pushed to Phoenix).

#### How should this be reviewed?
👀

#### Any background context you want to provide?
This will fix an issue that was causing some Northstar accounts to be missing Phoenix IDs – specifically @lkpttn's, since he changed his mobile on Aurora to a new "test account" but the old Phoenix account was not updated (and so the new account with the mobile was a conflict oy oy oy).

There isn't a database uniqueness constraint on this column & we don't treat these `email` or `mobile` values as a source of truth on Phoenix, so there's no reason to enforce it on this endpoint.

#### Relevant tickets
Fixes 🐛.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  