### PR TITLE
Expose campaign run start date in /api/v1/campaigns/:nid

### DIFF
--- a/documentation/endpoints/campaigns.md
+++ b/documentation/endpoints/campaigns.md
@@ -56,7 +56,8 @@ Example response:
     campaign_runs: {
       current: {
         en: {
-          id: "1227"
+          id: "1227",
+          "start_date":"2015-10-19 00:00:00"
         }
       },
       past: [ ]

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -236,6 +236,11 @@ abstract class Transformer {
           }
         }
 
+        foreach ($data->campaign_runs['current'] as $language => $value) {
+          $run = node_load($value['id']);
+          $output['campaign_runs']['current'][$language]['start_date'] = $run->field_run_date[$language][0][value];
+        }
+
         $output['pre_step'] = $data->pre_step;
 
         $output['latest_news'] = $data->latest_news;

--- a/lib/modules/dosomething/dosomething_api/includes/Transformer.php
+++ b/lib/modules/dosomething/dosomething_api/includes/Transformer.php
@@ -236,10 +236,13 @@ abstract class Transformer {
           }
         }
 
-        foreach ($data->campaign_runs['current'] as $language => $value) {
-          $run = node_load($value['id']);
-          $output['campaign_runs']['current'][$language]['start_date'] = $run->field_run_date[$language][0][value];
+        foreach ($data->campaign_runs as $timeframe => $runs) {
+          foreach ($runs as $language => $value) {
+            $run = node_load($value['id']);
+            $output['campaign_runs'][$timeframe][$language]['start_date'] = $run->field_run_date[$language][0][value];
+          }
         }
+
 
         $output['pre_step'] = $data->pre_step;
 


### PR DESCRIPTION
#### What's this PR do?
Exposes campaign run state dates in `/api/v1/campaigns/:nid` in order to show this in the Rogue individual signup page for [this card](https://www.pivotaltracker.com/n/projects/2019429/stories/150849332). 

#### How should this be reviewed?
- Hit the `/api/v1/campaigns/:nid` endpoint. 
- You should now see a `start_date` returned for each campaign run. 
- e.g. 
```
{"data": {
    "id":"1485",
    "title":"Test Campaign GL",
    "campaign_runs": {
      "current": {
        "en": {
          "id":"1860",
          "start_date":"2015-10-19 00:00:00"
        },
        "en-global":{
          "id":"1860",
          "start_date":"2015-10-19 00:00:00"
        },
        "es-mx":{
          "id":"1860",
          "start_date":"2015-10-19 00:00:00"
        },
        "pt-br":{
          "id":"1860",
          "start_date":"2015-10-19 00:00:00"
        }
      },
      "past":[]
     },
...
```
#### Relevant tickets
Fixes https://www.pivotaltracker.com/n/projects/2019429/stories/151416179

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
