### PR TITLE
Allow linking directly to winners with '#congrats'.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/campaign/node--campaign--closed.tpl.php
@@ -225,7 +225,7 @@
 
   <?php if ($display_winners): ?>
   <?php // CONGRATULATIONS TO... ////////////////////////////////////////////////////// ?>
-  <section class="container container--congrats">
+  <section id="congrats" class="container container--congrats">
     <h2 class="heading -banner"><span><?php print t('Congrats to&hellip;'); ?></span></h2>
 
     <div class="wrapper">


### PR DESCRIPTION
#### What's this PR do?
This pull request adds a lil' ID attribute to the "Congrats To..." section on the closed campaign template so that marketing can link directly to the winners like so: 

```
https://www.dosomething.org/us/campaigns/5-cans-challenge#congrats
```

#### How should this be reviewed?
🎃

#### Any background context you want to provide?
🚳 

#### Relevant tickets
Fixes [#151856692](https://www.pivotaltracker.com/story/show/151856692).

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  