### PR TITLE
Gets rid of all Rogue conditional flags since Rogue is always on

### DIFF
--- a/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/campaign_resource.inc
@@ -390,30 +390,18 @@ function _campaign_resource_reportback($nid, $values) {
 
   $headers = getallheaders();
 
-  if (variable_get('rogue_collection', FALSE) && ! isset($headers['X-Request-Id'])) {
-    $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
+  $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
 
-    // Get signup associated with the post.
-    $rid = $rogue_reportback['data']['signup_id'];
-    $rogue_signup = dosomething_rogue_get_activity(['filter' => ['id' => $rid]]);
+  // Get signup associated with the post.
+  $rid = $rogue_reportback['data']['signup_id'];
+  $rogue_signup = dosomething_rogue_get_activity(['filter' => ['id' => $rid]]);
 
-    // Send an email if it is the first post.
-    if (dosomething_rogue_get_post_count($rogue_signup['data'][0]) === 1) {
-      if (module_exists('dosomething_mbp')) {
-        dosomething_reportback_rogue_mbp_request($rogue_reportback['data'], $rogue_signup['data'][0]);
-      }
+  // Send an email if it is the first post.
+  if (dosomething_rogue_get_post_count($rogue_signup['data'][0]) === 1) {
+    if (module_exists('dosomething_mbp')) {
+      dosomething_reportback_rogue_mbp_request($rogue_reportback['data'], $rogue_signup['data'][0]);
     }
-
-    return isset($rogue_reportback['data']['id']) ? $rogue_reportback['data']['id'] : FALSE;
   }
-  else {
-    if (isset($headers['X-Request-Id'])) {
-      // Increment transaction id and log that the request has been received with new transaction id.
-      $incremented_transaction_id = dosomething_api_increment_transaction_id($headers['X-Request-Id']);
 
-      watchdog('PhoenixTransactionBridge', 'Request received. Transaction ID: !incremented_transaction_id', ['!incremented_transaction_id' => $incremented_transaction_id], WATCHDOG_INFO);
-    }
-
-    return dosomething_reportback_save($values, $user);
-  }
+  return isset($rogue_reportback['data']['id']) ? $rogue_reportback['data']['id'] : FALSE;
 }

--- a/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/kudos_resource.inc
@@ -192,42 +192,32 @@ function _kudos_resource_index($reportbackitems, $count) {
 function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
   global $user;
 
-  if (variable_get('rogue_collection', FALSE)) {
-    if (!isset($northstar_id)) {
-      $northstar_id = dosomething_user_get_northstar_id($user->uid);
-    }
-
-    $data = [
-      'northstar_id' => $northstar_id,
-      'post_id' => $reportback_item_id,
-    ];
-
-    $response = dosomething_rogue_client()->postReaction($data);
-
-    // If Rogue doesn't acknowledge that we liked a post, return Phoenix-style failure.
-    if ($response['meta']['action'] !== 'liked') {
-      return [false];
-    }
-
-    // Otherwise, return Phoenix-style success!
-    return [
-      [
-        'kid' => $response['data']['post_id'] . '|' . $northstar_id,
-        'fid' => $reportback_item_id,
-        'uid' => $northstar_id,
-        'tid' => $term_ids[0],
-        'created' => (new Carbon($response['data']['created_at']))->timestamp,
-      ]
-    ];
+  if (!isset($northstar_id)) {
+    $northstar_id = dosomething_user_get_northstar_id($user->uid);
   }
 
-  $parameters = [
-    'fid' => $reportback_item_id,
-    'tids' => $term_ids,
+  $data = [
     'northstar_id' => $northstar_id,
+    'post_id' => $reportback_item_id,
   ];
 
-  return (new KudosTransformer)->create($parameters);
+  $response = dosomething_rogue_client()->postReaction($data);
+
+  // If Rogue doesn't acknowledge that we liked a post, return Phoenix-style failure.
+  if ($response['meta']['action'] !== 'liked') {
+    return [false];
+  }
+
+  // Otherwise, return Phoenix-style success!
+  return [
+    [
+      'kid' => $response['data']['post_id'] . '|' . $northstar_id,
+      'fid' => $reportback_item_id,
+      'uid' => $northstar_id,
+      'tid' => $term_ids[0],
+      'created' => (new Carbon($response['data']['created_at']))->timestamp,
+    ]
+  ];
 }
 
 /**
@@ -240,43 +230,39 @@ function _kudos_resource_create($reportback_item_id, $term_ids, $northstar_id) {
 function _kudos_resource_delete($kudos_id) {
   global $user;
 
-  if (variable_get('rogue_collection', FALSE)) {
-    list($post_id, $northstar_id) = explode('|', $kudos_id);
+  list($post_id, $northstar_id) = explode('|', $kudos_id);
 
-    // Make sure authenticated user is an admin or the kudo owner.
-    $api_user_is_an_admin = user_access('view any reportback', $user);
-    $logged_in_user_matches_given_id = dosomething_user_get_northstar_id($user->uid) === $northstar_id;
-    if (!$api_user_is_an_admin && !$logged_in_user_matches_given_id) {
-      return [
-        'error' => [
-          'message' => 'There was an error deleting the specified kudos record.',
-        ],
-      ];
-    }
-
-    $data = [
-      'northstar_id' => $northstar_id,
-      'post_id' => $post_id,
-    ];
-
-    $response = dosomething_rogue_client()->postReaction($data);
-
-    // If Rogue doesn't acknowledge that we unliked a post, return Phoenix-style failure.
-    if ($response['meta']['action'] !== 'unliked') {
-      return [
-        'error' => [
-          'message' => 'There was an error deleting the specified kudos record.',
-        ],
-      ];
-    }
-
-    // Otherwise, return Phoenix-style success!
+  // Make sure authenticated user is an admin or the kudo owner.
+  $api_user_is_an_admin = user_access('view any reportback', $user);
+  $logged_in_user_matches_given_id = dosomething_user_get_northstar_id($user->uid) === $northstar_id;
+  if (!$api_user_is_an_admin && !$logged_in_user_matches_given_id) {
     return [
-      'success' => [
-        'message' => 'Kudos record successfully deleted.',
+      'error' => [
+        'message' => 'There was an error deleting the specified kudos record.',
       ],
     ];
   }
 
-  return (new KudosTransformer)->delete($kudos_id);
+  $data = [
+    'northstar_id' => $northstar_id,
+    'post_id' => $post_id,
+  ];
+
+  $response = dosomething_rogue_client()->postReaction($data);
+
+  // If Rogue doesn't acknowledge that we unliked a post, return Phoenix-style failure.
+  if ($response['meta']['action'] !== 'unliked') {
+    return [
+      'error' => [
+        'message' => 'There was an error deleting the specified kudos record.',
+      ],
+    ];
+  }
+
+  // Otherwise, return Phoenix-style success!
+  return [
+    'success' => [
+      'message' => 'Kudos record successfully deleted.',
+    ],
+  ];
 }

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_item_resource.inc
@@ -158,51 +158,46 @@ function _reportback_item_resource_index($campaigns, $exclude, $status, $count, 
     'as_user' => $as_user,
   ];
 
-  // If Rogue is enabled, fetch reportback items from there.
-  if (variable_get('rogue_collection', FALSE)) {
-    $response = dosomething_rogue_client()->getAllReportbacks([
-      'filter' => [
-        'campaign_id' => $campaigns,
-        'exclude' => $exclude,
-        'status' => 'accepted',
-      ],
-      // If `?as_user` provided with UID or Northstar ID, use that. Otherwise, send logged-in user's NS ID.
-      'as_user' => dosomething_user_convert_to_northstar_id($as_user ? $as_user : $user->uid),
-      'limit' => $count,
-      'page' => $page,
-    ]);
+  // Fetch reportback items from Rogue.
+  $response = dosomething_rogue_client()->getAllReportbacks([
+    'filter' => [
+      'campaign_id' => $campaigns,
+      'exclude' => $exclude,
+      'status' => 'accepted',
+    ],
+    // If `?as_user` provided with UID or Northstar ID, use that. Otherwise, send logged-in user's NS ID.
+    'as_user' => dosomething_user_convert_to_northstar_id($as_user ? $as_user : $user->uid),
+    'limit' => $count,
+    'page' => $page,
+  ]);
 
-    $response['data'] = collect($response['data'])->map(function ($item) use ($load_user) {
-      // Add campaign to each item:
-      try {
-        $campaign = Campaign::get($item['campaign']['id']);
-        $item['campaign'] = $campaign;
-      } catch (Exception $e) {
-        // Oh well!
-      }
+  $response['data'] = collect($response['data'])->map(function ($item) use ($load_user) {
+    // Add campaign to each item:
+    try {
+      $campaign = Campaign::get($item['campaign']['id']);
+      $item['campaign'] = $campaign;
+    } catch (Exception $e) {
+      // Oh well!
+    }
 
-      // If requested, add full user to each item:
-      if ($load_user) {
-        $profile = dosomething_northstar_get_user($item['user']['id']);
+    // If requested, add full user to each item:
+    if ($load_user) {
+      $profile = dosomething_northstar_get_user($item['user']['id']);
 
-        $item['user'] = [
-          'id' => $profile->id,
-          'drupal_id' => $profile->drupal_id,
-          'first_name' => $profile->first_name,
-          'last_initial' => $profile->last_initial,
-          'photo' => $profile->photo,
-          'country' => $profile->country,
-        ];
-      }
+      $item['user'] = [
+        'id' => $profile->id,
+        'drupal_id' => $profile->drupal_id,
+        'first_name' => $profile->first_name,
+        'last_initial' => $profile->last_initial,
+        'photo' => $profile->photo,
+        'country' => $profile->country,
+      ];
+    }
 
-      return $item;
-    });
+    return $item;
+  });
 
-    return $response;
-  }
-
-  $reportbackItems = new ReportbackItemTransformer;
-  return $reportbackItems->index($parameters);
+  return $response;
 }
 
 

--- a/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/reportback_resource.inc
@@ -175,22 +175,18 @@ function _reportback_resource_index($ids, $campaigns, $status, $count, $random, 
     'runs' => $runs,
   ];
 
-  // If Rogue is enabled, fetch reportback items from there.
-  if (variable_get('rogue_collection', FALSE)) {
-    $response = dosomething_rogue_client()->getAllReportbacks([
-      'filter' => [
-        'campaign_id' => $campaigns,
-        'status' => 'accepted',
-      ],
-      'as_user' => $as_user,
-      'limit' => $count,
-      'page' => $page,
-    ]);
+  // Fetch reportback items from Rogue.
+  $response = dosomething_rogue_client()->getAllReportbacks([
+    'filter' => [
+      'campaign_id' => $campaigns,
+      'status' => 'accepted',
+    ],
+    'as_user' => $as_user,
+    'limit' => $count,
+    'page' => $page,
+  ]);
 
-    return $response;
-  }
-
-  return (new ReportbackTransformer)->index($parameters);
+  return $response;
 }
 
 

--- a/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
+++ b/lib/modules/dosomething/dosomething_api/resources/signup_resource.inc
@@ -189,37 +189,33 @@ function _signup_resource_index($user, $users, $campaigns, $count, $page, $compe
     'runs' => $runs,
   ];
 
-  // Return data from Rogue if Rogue is turned on
-  if (variable_get('rogue_collection', FALSE)) {
-    // Replace all drupal ids with northstar ids
-    $user = explode(',', $user);
+  // Return data from Rogue
+  // Replace all drupal ids with northstar ids
+  $user = explode(',', $user);
 
-    foreach ($user as $key=>$current_user) {
-      if (is_numeric($current_user)) {
-        $user[$key] = dosomething_user_get_northstar_id($current_user);
-      }
+  foreach ($user as $key=>$current_user) {
+    if (is_numeric($current_user)) {
+      $user[$key] = dosomething_user_get_northstar_id($current_user);
     }
-
-    $user = implode(',', $user);
-    $parameters['user'] = $user;
-
-    // Transform Phoenix Ashes query string into equivalent
-    // query for Rogue's `api/v2/activity` endpoint:
-    $rogue_response = dosomething_rogue_get_activity(array_filter([
-      'filter' => array_filter([
-        'campaign_id' => data_get($parameters, 'campaigns'),
-        'campaign_run_id' => data_get($parameters, 'runs'),
-        'northstar_id' => data_get($parameters, 'user'),
-        'id' => data_get($parameters, 'id'),
-      ]),
-      'limit' => data_get($parameters, 'count'),
-      'page' => data_get($parameters, 'page'),
-    ]));
-
-    return json_decode(dosomething_rogue_format_activity($rogue_response));
   }
 
-  return (new SignupTransformer)->index($parameters);
+  $user = implode(',', $user);
+  $parameters['user'] = $user;
+
+  // Transform Phoenix Ashes query string into equivalent
+  // query for Rogue's `api/v2/activity` endpoint:
+  $rogue_response = dosomething_rogue_get_activity(array_filter([
+    'filter' => array_filter([
+      'campaign_id' => data_get($parameters, 'campaigns'),
+      'campaign_run_id' => data_get($parameters, 'runs'),
+      'northstar_id' => data_get($parameters, 'user'),
+      'id' => data_get($parameters, 'id'),
+    ]),
+    'limit' => data_get($parameters, 'count'),
+    'page' => data_get($parameters, 'page'),
+  ]));
+
+  return json_decode(dosomething_rogue_format_activity($rogue_response));
 }
 
 /**
@@ -250,30 +246,25 @@ function _signup_resource_create($campaign_id, $campaign_run_id, $key, $user_id)
  * @return array
  */
 function _signup_resource_retrieve($sid) {
-  // Return data from Rogue if Rogue is turned on
-  if (variable_get('rogue_collection', FALSE)) {
+  // Return data from Rogue
+  $rogue_response = dosomething_rogue_get_activity([
+    'filter'=> [
+      'id' => $sid,
+    ],
+  ]);
 
-    $rogue_response = dosomething_rogue_get_activity([
-      'filter'=> [
-        'id' => $sid,
+  // If Rogue response is empty, return expected error.
+  if (empty($rogue_response['data'])) {
+    return [
+      'error' => [
+        'message' => 'No signup data found.',
       ],
-    ]);
-
-    // If Rogue response is empty, return expected error.
-    if (empty($rogue_response['data'])) {
-      return [
-        'error' => [
-          'message' => 'No signup data found.',
-        ],
-      ];
-    }
-
-    $formatted_signup = (object) dosomething_rogue_format_signup($rogue_response['data'][0]);
-
-    $data['data'] = $formatted_signup;
-
-    return $data;
+    ];
   }
 
-  return (new SignupTransformer)->show($sid);
+  $formatted_signup = (object) dosomething_rogue_format_signup($rogue_response['data'][0]);
+
+  $data['data'] = $formatted_signup;
+
+  return $data;
 }

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.module
@@ -519,34 +519,22 @@ function dosomething_campaign_get_campaigns_doing($uid = NULL) {
   }
 
   // Get all signups.
-  if (variable_get('rogue_collection', FALSE)) {
-    $northstar_id = dosomething_user_get_northstar_id($uid);
+  $northstar_id = dosomething_user_get_northstar_id($uid);
 
-    $rogue_signups = dosomething_rogue_get_activity([
-      'filter' => [
-        'northstar_id' => $northstar_id,
-      ],
-    ]);
+  $rogue_signups = dosomething_rogue_get_activity([
+    'filter' => [
+      'northstar_id' => $northstar_id,
+    ],
+  ]);
 
-    // Filter through response and put all signup ids with no posts in an array
-    $signup_nids = [];
+  // Filter through response and put all signup ids with no posts in an array
+  $signup_nids = [];
 
-    foreach ($rogue_signups['data'] as $signup) {
-      if ($signup['posts']['data']) {
-        continue;
-      } else {
-        array_push($signup_nids, $signup['campaign_id']);
-      }
-    }
-  }
-  else {
-    $signup_nids = dosomething_signup_get_signup_nids_by_uid($uid);
-
-    // Remove signups that have already been reported back for.
-    foreach ($signup_nids as $delta => $nid) {
-      if (dosomething_reportback_exists($nid, NULL, $uid)) {
-        unset($signup_nids[$delta]);
-      }
+  foreach ($rogue_signups['data'] as $signup) {
+    if ($signup['posts']['data']) {
+      continue;
+    } else {
+      array_push($signup_nids, $signup['campaign_id']);
     }
   }
 
@@ -787,12 +775,7 @@ function dosomething_campaign_add_signup_data_form_vars(&$node, $langcode) {
   $node->content['signup_data_form'] = drupal_get_form('dosomething_signup_user_signup_data_form', $signup);
 
   // If the signup_data_form is required and user has not submitted form yet:
-  if (!variable_get('rogue_collection', FALSE)) {
-    $hasCompetitionRecordedLocally = $signup->signup_data_form_timestamp;
-    $shouldShowCompetitionPrompt = $config['required'] && !$hasCompetitionRecordedLocally;
-  } else {
-    $shouldShowCompetitionPrompt = $config['required'];
-  }
+  $shouldShowCompetitionPrompt = $config['required'];
 
   // If Gladiator is enabled, check there too!
   if (module_exists('dosomething_gladiator')) {

--- a/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
+++ b/lib/modules/dosomething/dosomething_gladiator/dosomething_gladiator.module
@@ -68,12 +68,6 @@ function dosomething_gladiator_in_a_competition($signup) {
   $json = json_decode($response->data, TRUE);
   $already_in_gladiator = !empty($json['data']['waitingRoom']) || !empty($json['data']['competition']);
 
-  // If signup exists in Gladiator (from Phoenix Next, for example), set
-  // the "signup data form" timestamp so we know not to ask again.
-  if ($already_in_gladiator && !variable_get('rogue_collection', FALSE)) {
-    dosomething_signup_update_signup_data(['sid' => $sid], ['competition_signup' => $already_in_gladiator]);
-  }
-
   return $already_in_gladiator;
 }
 

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -82,8 +82,9 @@ function dosomething_metatag_preprocess_page(&$vars) {
 
   // Add special share info to the permalink page.
   $isReportbackFailure = in_array('page__reportback__failure', $vars['theme_hook_suggestions']);
+  $isRogueReportback = variable_get('rogue_collection', FALSE);
 
-  if (in_array('page__reportback', $vars['theme_hook_suggestions']) && !$isReportbackFailure) {
+  if (in_array('page__reportback', $vars['theme_hook_suggestions']) && !$isReportbackFailure && !$isRogueReportback) {
     dosomething_metatag_get_permalink_vars();
   }
 }

--- a/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
+++ b/lib/modules/dosomething/dosomething_metatag/dosomething_metatag.module
@@ -82,9 +82,8 @@ function dosomething_metatag_preprocess_page(&$vars) {
 
   // Add special share info to the permalink page.
   $isReportbackFailure = in_array('page__reportback__failure', $vars['theme_hook_suggestions']);
-  $isRogueReportback = variable_get('rogue_collection', FALSE);
 
-  if (in_array('page__reportback', $vars['theme_hook_suggestions']) && !$isReportbackFailure && !$isRogueReportback) {
+  if (in_array('page__reportback', $vars['theme_hook_suggestions']) && !$isReportbackFailure) {
     dosomething_metatag_get_permalink_vars();
   }
 }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.admin.inc
@@ -334,36 +334,32 @@ function dosomething_reportback_files_form_submit($form, &$form_state) {
       image_path_flush($image->source);
     }
 
-    // Check to see if Rogue feature flag is enabled.
-    if (variable_get('rogue_collection', FALSE)) {
-      $rogue_item_id = dosomething_rogue_get_by_file_id($fid);
-      // If there is a rogue_item_id in the dosomething_rogue_reportbacks table, send update to Rogue.
-      if ($rogue_item_id[0]->rogue_event_id) {
-        if ($values['status'] === 'promoted' || $values['status'] === 'approved' || $values['status'] === 'excluded') {
-          $rogue_status = 'accepted';
-        } else {
-          $rogue_status = 'rejected';
-        }
+    $rogue_item_id = dosomething_rogue_get_by_file_id($fid);
 
-        $data = [
-          'rogue_event_id' => $rogue_item_id[0]->rogue_event_id,
-          'status' => $rogue_status,
-          'event_type' => 'review_photo',
-        ];
-
-        $updates_to_send_to_rogue[] = $data;
+    // If there is a rogue_item_id in the dosomething_rogue_reportbacks table, send update to Rogue.
+    if ($rogue_item_id[0]->rogue_event_id) {
+      if ($values['status'] === 'promoted' || $values['status'] === 'approved' || $values['status'] === 'excluded') {
+        $rogue_status = 'accepted';
+      } else {
+        $rogue_status = 'rejected';
       }
+
+      $data = [
+        'rogue_event_id' => $rogue_item_id[0]->rogue_event_id,
+        'status' => $rogue_status,
+        'event_type' => 'review_photo',
+      ];
+
+      $updates_to_send_to_rogue[] = $data;
     }
   }
 
   // Send updates to Rogue.
-  if (variable_get('rogue_collection', FALSE)) {
-    $response = dosomething_rogue_update_rogue_reportback_items($updates_to_send_to_rogue);
-    if ($response->code != 201) {
-      drupal_set_message(print_r($response->code, TRUE) . ' ' . print_r($response->status_message, TRUE), 'warning');
-    } else {
-      drupal_set_message(t("Updated."));
-    }
+  $response = dosomething_rogue_update_rogue_reportback_items($updates_to_send_to_rogue);
+  if ($response->code != 201) {
+    drupal_set_message(print_r($response->code, TRUE) . ' ' . print_r($response->status_message, TRUE), 'warning');
+  } else {
+    drupal_set_message(t("Updated."));
   }
 }
 

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -331,23 +331,19 @@ function dosomething_reportback_form_validate($form, &$form_state) {
     drupal_goto('node/' . $campaign_id);
   }
 
-  if (variable_get('rogue_collection', FALSE)) {
-    global $user;
-    $northstar_user_id = dosomething_user_get_northstar_id($user->uid);
+  global $user;
+  $northstar_user_id = dosomething_user_get_northstar_id($user->uid);
 
-    $rogue = dosomething_rogue_client();
+  $rogue = dosomething_rogue_client();
 
-    $response = $rogue->getActivity([
-      'filter' => [
-        'northstar_id' => $northstar_user_id,
-        'campaign_id' => $campaign_id,
-      ],
-    ]);
+  $response = $rogue->getActivity([
+    'filter' => [
+      'northstar_id' => $northstar_user_id,
+      'campaign_id' => $campaign_id,
+    ],
+  ]);
 
-    $signup_exists = $response['data'][0]['signup_id'] ? TRUE : FALSE;
-  } else {
-    $signup_exists = dosomething_signup_exists($campaign_id);
-  }
+  $signup_exists = $response['data'][0]['signup_id'] ? TRUE : FALSE;
 
   // If user isn't signed up for the campaign.
   if (!dosomething_user_is_staff() && !$signup_exists) {
@@ -393,65 +389,53 @@ function dosomething_reportback_form_submit($form, &$form_state) {
     $values['uid'] = $user->uid;
   }
 
-  // Collect reportbacks in Rogue if rogue collection is turned on for this campaign.
-  if (variable_get('rogue_collection', FALSE)) {
-    // If this is a reportback update, grab the file most recent file in case we need it later
-    $rbid = dosomething_reportback_exists($values['nid'], $values['run_nid'], $values['uid']);
+  // Collect reportbacks in Rogue.
+  // If this is a reportback update, grab the file most recent file in case we need it later
+  $rbid = dosomething_reportback_exists($values['nid'], $values['run_nid'], $values['uid']);
 
-    if ($rbid) {
-      $reportback = reportback_load($rbid);
-      $fid = array_pop($reportback->fids);
-    }
+  if ($rbid) {
+    $reportback = reportback_load($rbid);
+    $fid = array_pop($reportback->fids);
+  }
 
-    // Store the base64 encoded data uri of the file in the values array to send to rogue.
-    if (array_key_exists('storage', $form_state)) {
-      $file = $form_state['storage']['file'];
-      $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
-      $values['source'] = 'phoenix-web';
-    } else {
-      // If there is no file and there is a RB in Phoenix, check the dosomething_rogue_reportback table to see if the RB already exists in Rogue.
-      if ($rbid) {
-        $exists_in_rogue = dosomething_rogue_rb_exists_in_rogue($rbid);
-
-        // If the RB does not yet exist in Rogue, send along the most recently created reportback_item so the RB can be created in Rogue.
-        if (! $exists_in_rogue) {
-          $reportback_file = entity_load('reportback_item', array($fid));
-          $values['file'] = dosomething_helpers_get_data_uri_from_fid($fid);
-          $values['caption'] = $reportback_file[$fid]->caption;
-          $values['source'] = isset($reportback_file[$fid]->source) ? $reportback_file[$fid]->source : 'phoenix-web';
-        }
-      }
-    }
-
-    // Send the reportback to rogue.
-    $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
-
-    if (! $rogue_reportback) {
-      return $form_state['redirect'] = 'reportback/failure/' . $values['nid'];
-    }
-
-    $rid = $rogue_reportback['data']['signup_id'];
-    $fid = $rogue_reportback['data']['id'];
-
-    // Get signup associated with the post.
-    $rogue_signup = dosomething_rogue_get_activity(['filter' => ['id' => $rid]]);
-
-    // Send an email if it is the first post.
-    if (dosomething_rogue_get_post_count($rogue_signup['data'][0]) === 1) {
-      if (module_exists('dosomething_mbp')) {
-        dosomething_reportback_rogue_mbp_request($rogue_reportback['data'], $rogue_signup['data'][0]);
-      }
-    }
+  // Store the base64 encoded data uri of the file in the values array to send to rogue.
+  if (array_key_exists('storage', $form_state)) {
+    $file = $form_state['storage']['file'];
+    $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
+    $values['source'] = 'phoenix-web';
   } else {
-    // Save uploaded file.
-    if ($file = dosomething_reportback_form_save_file($form_state)) {
-      // Store new file's fid into values.
-      $values['fid'] = $file->fid;
-    }
+    // If there is no file and there is a RB in Phoenix, check the dosomething_rogue_reportback table to see if the RB already exists in Rogue.
+    if ($rbid) {
+      $exists_in_rogue = dosomething_rogue_rb_exists_in_rogue($rbid);
 
-    // Save values into reportback.
-    $rid = dosomething_reportback_save($values, $user);
-    $fid = $values['fid'];
+      // If the RB does not yet exist in Rogue, send along the most recently created reportback_item so the RB can be created in Rogue.
+      if (! $exists_in_rogue) {
+        $reportback_file = entity_load('reportback_item', array($fid));
+        $values['file'] = dosomething_helpers_get_data_uri_from_fid($fid);
+        $values['caption'] = $reportback_file[$fid]->caption;
+        $values['source'] = isset($reportback_file[$fid]->source) ? $reportback_file[$fid]->source : 'phoenix-web';
+      }
+    }
+  }
+
+  // Send the reportback to rogue.
+  $rogue_reportback = dosomething_rogue_send_reportback_to_rogue($values, $user);
+
+  if (! $rogue_reportback) {
+    return $form_state['redirect'] = 'reportback/failure/' . $values['nid'];
+  }
+
+  $rid = $rogue_reportback['data']['signup_id'];
+  $fid = $rogue_reportback['data']['id'];
+
+  // Get signup associated with the post.
+  $rogue_signup = dosomething_rogue_get_activity(['filter' => ['id' => $rid]]);
+
+  // Send an email if it is the first post.
+  if (dosomething_rogue_get_post_count($rogue_signup['data'][0]) === 1) {
+    if (module_exists('dosomething_mbp')) {
+      dosomething_reportback_rogue_mbp_request($rogue_reportback['data'], $rogue_signup['data'][0]);
+    }
   }
 
   // Redirect to permalink page.

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.module
@@ -526,11 +526,7 @@ function dosomething_reportback_form_alter(&$form, &$form_state, $form_id) {
 function dosomething_reportback_permalink_view($rbid) {
   $fid = $_GET['fid'];
 
-  if (variable_get('rogue_collection', FALSE)) {
-    return dosomething_reportback_view_rogue($rbid, $fid);
-  }
-
-  return dosomething_reportback_view_entity(reportback_load($rbid));
+  return dosomething_reportback_view_rogue($rbid, $fid);
 }
 
 /**
@@ -1146,61 +1142,51 @@ function dosomething_reportback_get_reportbacks($uid = NULL) {
     $uid = $user->uid;
   }
 
-  // If Rogue is on, return array of themed reportbacks as done in https://github.com/DoSomething/phoenix/blob/76164b2006fb5a266e8166688472742556eae33e/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc#L32-L51 for user profile page.
+  // Return array of themed reportbacks as done in https://github.com/DoSomething/phoenix/blob/76164b2006fb5a266e8166688472742556eae33e/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc#L32-L51 for user profile page.
   // This will be okay because this function is only called in dosomething_user.theme.inc for user profile page.
-  if (variable_get('rogue_collection', FALSE)) {
-    $northstar_id = dosomething_user_get_northstar_id($uid);
-    $current_user_northstar_id = dosomething_user_get_northstar_id($user->uid);
+  $northstar_id = dosomething_user_get_northstar_id($uid);
+  $current_user_northstar_id = dosomething_user_get_northstar_id($user->uid);
 
-    $reportback_items = [];
+  $reportback_items = [];
 
-    $response = dosomething_rogue_get_posts([
-      'filter' => [
-        'northstar_id' => $northstar_id,
-      ],
-      'include' => 'signup',
-      'as_user' => $current_user_northstar_id,
-    ]);
+  $response = dosomething_rogue_get_posts([
+    'filter' => [
+      'northstar_id' => $northstar_id,
+    ],
+    'include' => 'signup',
+    'as_user' => $current_user_northstar_id,
+  ]);
 
-    foreach ($response['data'] as $delta => $reportback) {
-      $reportback = (object) $reportback;
+  foreach ($response['data'] as $delta => $reportback) {
+    $reportback = (object) $reportback;
 
-      $total_kudos = $reportback->reactions['total'];
-      $liked_by_current_user = $reportback->reactions['reacted'] ? TRUE : FALSE;
-      $campaign = node_load($reportback->signup['data']['campaign_id']);
-      $impact = $reportback->signup['data']['quantity'] . ' ' . dosomething_helpers_extract_field_data($campaign->field_reportback_noun) . ' ' . dosomething_helpers_extract_field_data($campaign->field_reportback_verb);
+    $total_kudos = $reportback->reactions['total'];
+    $liked_by_current_user = $reportback->reactions['reacted'] ? TRUE : FALSE;
+    $campaign = node_load($reportback->signup['data']['campaign_id']);
+    $impact = $reportback->signup['data']['quantity'] . ' ' . dosomething_helpers_extract_field_data($campaign->field_reportback_noun) . ' ' . dosomething_helpers_extract_field_data($campaign->field_reportback_verb);
 
-      $args = [
-       'path' => $reportback->media['url'],
-      ];
+    $args = [
+     'path' => $reportback->media['url'],
+    ];
 
-      $img = theme_image($args);
-      $url = dosomething_global_url('node/' . $reportback->signup['data']['campaign_id']);
+    $img = theme_image($args);
+    $url = dosomething_global_url('node/' . $reportback->signup['data']['campaign_id']);
 
-      $content = [
-        'url' => $url,
-        'title' => htmlspecialchars_decode($campaign->title, ENT_QUOTES),
-        'image' => $img,
-        'description' => $impact,
-      ];
+    $content = [
+      'url' => $url,
+      'title' => htmlspecialchars_decode($campaign->title, ENT_QUOTES),
+      'image' => $img,
+      'description' => $impact,
+    ];
 
-      if (! dosomething_kudos_disable_reactions($campaign->nid)) {
-        $content['kudos'] = dosomething_kudos_get_kudos_data_for_fid($reportback->id, $total_kudos, $liked_by_current_user);
-      }
-
-      $reportback_items[$delta] = paraneue_dosomething_get_gallery_item($content, 'figure', TRUE, ['-left', '-medium']);
+    if (! dosomething_kudos_disable_reactions($campaign->nid)) {
+      $content['kudos'] = dosomething_kudos_get_kudos_data_for_fid($reportback->id, $total_kudos, $liked_by_current_user);
     }
 
-    return $reportback_items;
+    $reportback_items[$delta] = paraneue_dosomething_get_gallery_item($content, 'figure', TRUE, ['-left', '-medium']);
   }
-  else {
-    return db_select('dosomething_reportback', 'rb')
-      ->fields('rb', array('rbid'))
-      ->condition('uid', $uid)
-      ->orderBy('created', 'DESC')
-      ->execute()
-      ->fetchCol(0);
-  }
+
+  return $reportback_items;
 }
 
 

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -186,18 +186,14 @@ function dosomething_signup_permission() {
  * Menu autoloader for /signup.
  */
 function signup_load($id) {
-  // If rogue is on load signup from rogue.
-  if (variable_get('rogue_collection', FALSE)) {
-    $response = dosomething_rogue_get_activity([
-      'filter' => [
-        'id' => $id
-      ],
-    ]);
+  // Load signup from rogue.
+  $response = dosomething_rogue_get_activity([
+    'filter' => [
+      'id' => $id
+    ],
+  ]);
 
-    return isset($response['data']) && count($response['data']) === 1 ? $response['data'][0] : FALSE;
-  } else {
-    return entity_load_single('signup', $id);
-  }
+  return isset($response['data']) && count($response['data']) === 1 ? $response['data'][0] : FALSE;
 }
 
 /**
@@ -281,41 +277,21 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
     return $existing_id;
   }
 
-  // If Rogue is enabled, create the signup there.
-  if (variable_get('rogue_collection', FALSE)) {
-    $response = dosomething_rogue_send_signup_to_rogue($values, $account);
+  // Create signup in Rogue.
+  $response = dosomething_rogue_send_signup_to_rogue($values, $account);
 
-    $sid = $response ? $response['data']['signup_id'] : NULL;
-    _dosomething_signup_log_signup($sid, $source);
+  $sid = $response ? $response['data']['signup_id'] : NULL;
+  _dosomething_signup_log_signup($sid, $source);
 
-    // Send relevant third-party subscribe requests.
-    // @NOTE: For legacy signups, this was handled in an entity save hook.
-    dosomething_signup_third_party_subscribe($account, $campaign_node, [
-      'transactionals' => $transactionals,
-      'source' => $source,
-      'signup_id' => $sid,
-    ]);
+  // Send relevant third-party subscribe requests.
+  // @NOTE: For legacy signups, this was handled in an entity save hook.
+  dosomething_signup_third_party_subscribe($account, $campaign_node, [
+    'transactionals' => $transactionals,
+    'source' => $source,
+    'signup_id' => $sid,
+  ]);
 
-    return $sid ? $sid : FALSE;
-  }
-
-  // Otherwise, create a local Phoenix entity.
-  // @TODO: Remove this once Rogue is shipped.
-  try {
-    // Create a signup entity.
-    // @see: SignupsController.php save()
-    $entity = entity_create('signup', $values);
-    $entity->save();
-
-    _dosomething_signup_log_signup($entity->sid, $source);
-
-    return isset($entity->sid) ? $entity->sid : FALSE;
-  }
-  catch (Exception $e) {
-    _dosomething_signup_log_signup(NULL);
-
-    return FALSE;
-  }
+  return $sid ? $sid : FALSE;
 }
 
 /**
@@ -396,44 +372,17 @@ function dosomething_signup_exists($nid, $run_nid = NULL, $uid = NULL, $presignu
     $run_nid = $run->nid;
   }
 
-  if (variable_get('rogue_collection', FALSE)) {
-    $response = dosomething_rogue_get_activity([
-      'filter' => [
-        'northstar_id' => dosomething_user_get_northstar_id($uid),
-        'campaign_id' => $nid,
-        'campaign_run_id' => $run_nid,
-      ],
-    ]);
+  $response = dosomething_rogue_get_activity([
+    'filter' => [
+      'northstar_id' => dosomething_user_get_northstar_id($uid),
+      'campaign_id' => $nid,
+      'campaign_run_id' => $run_nid,
+    ],
+  ]);
 
-    $has_signup = isset($response['data']) && count($response['data']) === 1;
-    return $has_signup ? $response['data'][0]['signup_id'] : FALSE;
-  }
+  $has_signup = isset($response['data']) && count($response['data']) === 1;
 
-  if ($presignup) {
-    $result = db_select('dosomething_signup_presignup', 's')
-      ->condition('uid', $uid)
-      ->condition('nid', $nid)
-      ->fields('s', array('sid'))
-      ->execute();
-  }
-  else {
-    // First check to see if a user has a signup with a run.
-    $result = db_select('dosomething_signup', 's')
-      ->condition('uid', $uid)
-      ->condition('nid', $nid)
-      ->condition('run_nid', $run_nid)
-      ->fields('s', ['sid'])
-      ->execute();
-  }
-  $sid = $result->fetchField();
-
-  // If a sid was found, return it.
-  if (is_numeric($sid)) {
-    return $sid;
-  }
-
-  // Otherwise return FALSE.
-  return FALSE;
+  return $has_signup ? $response['data'][0]['signup_id'] : FALSE;
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -354,22 +354,6 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
     );
   }
 
-  // If the user has submitted form already:
-  if (!variable_get('rogue_collection', FALSE)) {
-    if (($timestamp = $signup->signup_data_form_timestamp) && $signup->signup_data_form_response == 1) {
-      // Get filtered form_submitted_copy.
-      $copy = dosomething_signup_filter_form_submitted_copy($config['form_submitted_copy'], $timestamp);
-      // Display the form submitted copy:
-      $form['submitted_copy'] = array(
-        '#prefix' => '<div class="modal__block"><p>',
-        '#markup' => $copy,
-        '#suffix' => '</p></div>',
-      );
-      // Return form as is (without a submit button).
-      return $form;
-    }
-  }
-
   // Container for form elements
   $form['elements'] = array(
     '#type' => 'container',
@@ -551,11 +535,6 @@ function dosomething_signup_user_signup_data_form_submit($form, &$form_state) {
     dosomething_user_save_school_id($values['school_id']);
   }
 
-  // Update signup record.
-  if (!variable_get('rogue_collection', FALSE)) {
-    dosomething_signup_update_signup_data($values, $config);
-  }
-
   // If this is a competition sign up, send it to gladiator.
   if ($config['competition_signup'] && module_exists('dosomething_gladiator')) {
     dosomething_gladiator_send_user_to_gladiator($user, $values);
@@ -576,16 +555,6 @@ function dosomething_signup_user_signup_data_form_validate_school($form, &$form_
   if ($values['school_not_affiliated'] != 1 && empty($values['school_id'])) {
     // No form submit for you.
     form_set_error('school_id', t("Please select a school."));
-  }
-}
-
-/*
- * Form submit handler for dosomething_signup_user_skip_signup_data_form().
- */
-function dosomething_signup_user_skip_signup_data_form_submit($form, &$form_state) {
-  // Update signup record with response = 0.
-  if (!variable_get('rogue_collection', FALSE)) {
-    dosomething_signup_update_signup_data($form_state['values'], NULL, 0);
   }
 }
 

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -235,49 +235,31 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars, $count = 6) 
     'random' => TRUE,
   ];
 
-  // If the Rogue feature flag is on, grab reportbacks from Rogue.
-  if (variable_get('rogue_collection', FALSE)) {
-    // Hit the GET /reportbacks endpoint in Rogue with campaign_id filter.
-    $promotedReportbackItemsResponse = dosomething_rogue_get_reportback_items([
-      'filter' => [
-        'campaign_id' => $gallery['campaign_id'],
-        'status' => 'accepted',
-      ],
-      'as_user' => dosomething_user_get_field('field_northstar_id'),
-      'limit' => 6
-    ]);
+  // Hit the GET /reportbacks endpoint in Rogue with campaign_id filter.
+  $promotedReportbackItemsResponse = dosomething_rogue_get_reportback_items([
+    'filter' => [
+      'campaign_id' => $gallery['campaign_id'],
+      'status' => 'accepted',
+    ],
+    'as_user' => dosomething_user_get_field('field_northstar_id'),
+    'limit' => 6
+  ]);
 
-    $promotedReportbackItems = $promotedReportbackItemsResponse['data'];
+  $promotedReportbackItems = $promotedReportbackItemsResponse['data'];
 
-    foreach ($promotedReportbackItems as $key => $promotedReportbackItem) {
-      if ($promotedReportbackItem['media']['uri'] === 'default') {
-        unset($promotedReportbackItems[$key]);
-      }
+  foreach ($promotedReportbackItems as $key => $promotedReportbackItem) {
+    if ($promotedReportbackItem['media']['uri'] === 'default') {
+      unset($promotedReportbackItems[$key]);
     }
-
-    $gallery['initial_promoted_count'] = count($promotedReportbackItems);
-
-    // Since Rogue only sends back approved reportbacks, we can just set total_approved to total_promoted.
-    $gallery['total_promoted'] = $promotedReportbackItemsResponse['meta']['pagination']['total'];
-
-    // # Approved Reportbacks:
-    $gallery['total_approved'] = $gallery['total_promoted'];
   }
-  else {
-    // # Promoted Reportbacks:
-    try {
-      $promotedReportbackItems = (new ReportbackItem)->find($filters);
-    }
-    catch (Exception $error) {
-      $promotedReportbackItems = [];
-    }
-    $gallery['initial_promoted_count'] = count($promotedReportbackItems);
 
-    $gallery['total_promoted'] = dosomething_reportback_get_reportback_items_total_by_filters(['nid' => $gallery['campaign_id'], 'status' => 'promoted']);
+  $gallery['initial_promoted_count'] = count($promotedReportbackItems);
 
-    // # Approved Reportbacks:
-    $gallery['total_approved'] = dosomething_reportback_get_reportback_items_total_by_filters(['nid' => $gallery['campaign_id'], 'status' => 'approved']);
-  }
+  // Since Rogue only sends back approved reportbacks, we can just set total_approved to total_promoted.
+  $gallery['total_promoted'] = $promotedReportbackItemsResponse['meta']['pagination']['total'];
+
+  // # Approved Reportbacks:
+  $gallery['total_approved'] = $gallery['total_promoted'];
 
   // # Build the full initial gallery:
 
@@ -291,30 +273,16 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars, $count = 6) 
   }
 
   foreach ($reportbackItems as $item) {
-    if (variable_get('rogue_collection', FALSE)) {
-      $item = (object) $item;
-      $gallery['item_ids'][] = $item->id;
-      $gallery['items'][] = paraneue_dosomething_get_themed_reportback_item($item, TRUE);
-    }
-    else {
-      if ($item instanceof ReportbackItem) {
-        $gallery['item_ids'][] = $item->id;
-      }
-
-      $gallery['items'][] = paraneue_dosomething_get_themed_reportback_item($item);
-    }
+    $item = (object) $item;
+    $gallery['item_ids'][] = $item->id;
+    $gallery['items'][] = paraneue_dosomething_get_themed_reportback_item($item, TRUE);
   }
 
   // Get total of Promoted & Approved RB Items prefetched.
   $gallery['prefetched'] = count($gallery['item_ids']);
 
-  if (variable_get('rogue_collection', FALSE)) {
-    $gallery['total_sum'] = $gallery['total_approved'];
-  }
-  else {
-    // Get total of Promoted & Approved RB Items for Campaign.
-    $gallery['total_sum'] = $gallery['total_promoted'] + $gallery['total_approved'];
-  }
+  $gallery['total_sum'] = $gallery['total_approved'];
+
 
   // Get total remaining after subtracting the RB Items already retrieved.
   $gallery['remaining'] = $gallery['total_sum'] - $gallery['prefetched'];

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_user.inc
@@ -25,46 +25,8 @@ function paraneue_dosomething_preprocess_user_profile(&$vars) {
     $vars['doing_gallery'] = paraneue_dosomething_get_gallery($doing_items, 'triad', array(), TRUE);
   }
 
-  if (variable_get('rogue_collection', FALSE)) {
-    $reportback_items = $vars['reportbacks'];
-  }
-  else {
-    // Get an array of reportbacks.
-    $reportbacks = $vars['reportbacks'];
+  $reportback_items = $vars['reportbacks'];
 
-    if (!empty($reportbacks)) {
-      // Theme each reportback and create an array.
-      foreach ($reportbacks as $delta => $rbid) {
-        $reportback = reportback_load((int) $rbid);
-        $impact = $reportback->quantity . ' ' . $reportback->noun . ' ' . $reportback->verb;
-        $fid = end($reportback->fids);
-        if (user_access('view any reportback')) {
-          // Link to the full reportback entity view.
-          $impact = l($impact, 'admin/reportback/' . $rbid);
-        }
-        else {
-          $impact = l($impact, 'reportback/' . $rbid);
-        }
-
-        $img = dosomething_image_get_themed_image_by_fid($fid, '300x300');
-
-        // Media gallery template expects a full URL.
-        $url = dosomething_global_url('node/' . $reportback->nid);
-        $content = array(
-          'url' => $url,
-          'title' => htmlspecialchars_decode($reportback->node_title, ENT_QUOTES),
-          'image' => $img,
-          'description' => $impact,
-        );
-
-        if (! dosomething_kudos_disable_reactions($reportback->nid)) {
-          $content['kudos'] = dosomething_kudos_get_kudos_data_for_fid($fid);
-        }
-
-        $reportback_items[$delta] = paraneue_dosomething_get_gallery_item($content, 'figure', TRUE, ['-left', '-medium']);
-      }
-    }
-  }
   // Theme a gallery of reportbacks, and give the user profile template access to it.
   $vars['reportback_gallery'] = paraneue_dosomething_get_gallery($reportback_items, 'duo', [], TRUE);
 }

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/figure.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/figure.tpl.php
@@ -28,11 +28,7 @@
     <?php if (isset($content['kudos']) && isset($content['kudos']['fid'])): ?>
       <ul class="form-actions -inline kudos" <?php print $content['kudos']['fid'] ? 'data-reportback-item-id="' . $content['kudos']['fid'] . '"' : ''; ?>>
         <li>
-          <?php if (variable_get('rogue_collection', FALSE)): ?>
-            <button class="js-kudos-button kudos__icon <?php print $content['kudos']['liked_in_rogue'] ? 'is-active' : '' ?>" data-kudos-term-id="1" data-kid="<?php print $content['kudos']['liked_in_rogue'] ? $content['kudos']['fid'] : null ?>"></button>
-          <?php else: ?>
-            <button class="js-kudos-button kudos__icon <?php print dosomething_kudos_term_is_selected($content['kudos'], 'heart') ? 'is-active' : '' ?>" data-kudos-term-id="<?php print $content['kudos']['allowed_reactions'][0]; ?>" data-kid="<?php print array_key_exists($content['kudos']['allowed_reactions'][0], $content['kudos']['existing_kids']) ? dosomething_helpers_isset($content['kudos']['existing_kids'][$content['kudos']['allowed_reactions'][0]], 'kid') : false ?>"></button>
-          <?php endif; ?>
+          <button class="js-kudos-button kudos__icon <?php print $content['kudos']['liked_in_rogue'] ? 'is-active' : '' ?>" data-kudos-term-id="1" data-kid="<?php print $content['kudos']['liked_in_rogue'] ? $content['kudos']['fid'] : null ?>"></button>
           <span class="counter"><?php print $content['kudos']['reaction_totals']['heart']; ?></span>
         </li>
       </ul>

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/patterns/photo.tpl.php
@@ -16,11 +16,7 @@
   <?php if (isset($content->kudos) && isset($content->kudos['fid'])): ?>
     <ul class="form-actions -inline kudos">
       <li>
-        <?php if (variable_get('rogue_collection', FALSE)): ?>
-          <button class="js-kudos-button kudos__icon <?php print $content->kudos['liked_in_rogue'] ? 'is-active' : '' ?>" data-kudos-term-id="1" data-kid="<?php print $content->kudos['liked_in_rogue'] ? $content->id : null ?>"></button>
-        <?php else: ?>
-          <button class="js-kudos-button kudos__icon <?php print dosomething_kudos_term_is_selected($content->kudos, 'heart') ? 'is-active' : '' ?>" data-kudos-term-id="<?php print $content->kudos['allowed_reactions'][0]; ?>" data-kid="<?php print data_get($content->kudos['existing_kids'], [$content->kudos['allowed_reactions'][0], 'kid']) ?>"></button>
-        <?php endif; ?>
+        <button class="js-kudos-button kudos__icon <?php print $content->kudos['liked_in_rogue'] ? 'is-active' : '' ?>" data-kudos-term-id="1" data-kid="<?php print $content->kudos['liked_in_rogue'] ? $content->id : null ?>"></button>
         <span class="counter"><?php print $content->kudos['reaction_totals']['heart']; ?></span>
       </li>
     </ul>


### PR DESCRIPTION
#### What's this PR do?
- Gets rid of Rogue conditional logic because Rogue will never be turned off!

#### How should this be reviewed?
- Make sure all the logic is still working that you can: 
  - Signup
  - Reportback
  - Update quantity/why participated
  - Gallery is working
  - Gallery pagination is working
  - Kudos / reactions are working (and are persisted when you refresh the page) 
  - User profile page and is working and all data shows up as expected 
  - @sbsmith86 does anything with competitions need to be tested for this?
  - Did I miss anything? 

#### Relevant tickets
Fixes the issue in this [Pivotal Card](https://www.pivotaltracker.com/n/projects/2019429/stories/151415698).

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
