### PR TITLE
Signupless Reportbacks -> Rogue script

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -134,4 +134,17 @@ class Rogue extends RestApiClient {
 
     return $response;
   }
+
+  /**
+   * Send a POST request to create a new post in Rogue
+   *
+   * @param array $data
+   * @return array - JSON response
+   */
+  public function postPost($data)
+  {
+    $response = $this->post('v2/posts', $data);
+
+    return $response;
+  }
 }

--- a/scripts/export-signupless-reportbacks-to-rogue.php
+++ b/scripts/export-signupless-reportbacks-to-rogue.php
@@ -46,7 +46,7 @@ foreach ($reportbacks as $reportback) {
     echo "\t" . 'Reportback ' . $reportback->rbid . ' has no files, sending just a signup' . PHP_EOL;
 
     // Match Rogue's timestamp format
-    $rb_created_at = date('Y-m-d H:i:s', $photo->timestamp);
+    $rb_created_at = date('Y-m-d H:i:s', $reportback->timestamp);
 
     $data = [
       'northstar_id' => $northstar_id,
@@ -69,12 +69,12 @@ foreach ($reportbacks as $reportback) {
 
       // Handle getting a 404
       if (!$response) {
-        echo '***ERROR: 404 on reportback ' . $reportback->rbid . ' file ' . $photo->fid . PHP_EOL;
+        echo '***ERROR: 404 on reportback ' . $reportback->rbid . PHP_EOL;
       }
     }
     catch (GuzzleHttp\Exception\ServerException $e) {
       // These aren't yet caught by Gateway
-      echo '***ERROR: SERVER EXCEPTION on reportback ' . $reportback->rbid . ' file ' . $photo->fid . PHP_EOL;
+      echo '***ERROR: SERVER EXCEPTION on reportback ' . $reportback->rbid . PHP_EOL;
     }
     catch (DoSomething\Gateway\Exceptions\ApiException $e) {
       echo '***ERROR: API EXCEPTION on reportback ' . $reportback->rbid . PHP_EOL;

--- a/scripts/export-signupless-reportbacks-to-rogue.php
+++ b/scripts/export-signupless-reportbacks-to-rogue.php
@@ -63,7 +63,7 @@ foreach ($reportbacks as $reportback) {
       $response = $client->postSignup($data);
 
       if ($response) {
-        echo "\t\t" . 'Migrated reportback ' . $reportback->rbid . ' to Rogue.' . PHP_EOL;
+        echo "\t\t" . 'Migrated data on reportback ' . $reportback->rbid . ' to Rogue.' . PHP_EOL;
         echo "\t\t\t" . 'Rogue Signup ID: ' . $response['data']['signup_id'] . PHP_EOL;
       }
 

--- a/scripts/export-signupless-reportbacks-to-rogue.php
+++ b/scripts/export-signupless-reportbacks-to-rogue.php
@@ -7,7 +7,7 @@
  */
 
 // Get all the signupless reportbacks
-$reportbacks = db_query("SELECT rb.rbid, rb.nid, rb.run_nid, rb.quantity, rb.why_participated, rb.rbid, rb.flagged, rb.uid
+$reportbacks = db_query("SELECT rb.rbid, rb.nid, rb.run_nid, rb.quantity, rb.why_participated, rb.rbid, rb.flagged, rb.uid, rb.created
   FROM dosomething.dosomething_reportback rb
   LEFT JOIN dosomething.dosomething_signup ds on rb.uid = ds.uid AND rb.run_nid = ds.run_nid
   WHERE ds.sid IS NULL
@@ -45,11 +45,14 @@ foreach ($reportbacks as $reportback) {
   if (!$photos) {
     echo "\t" . 'Reportback ' . $reportback->rbid . ' has no files, sending just a signup' . PHP_EOL;
 
+    // Match Rogue's timestamp format
+    $rb_created_at = date('Y-m-d H:i:s', $photo->timestamp);
+
     $data = [
       'northstar_id' => $northstar_id,
       'campaign_id' => $reportback->nid,
       'campaign_run_id' => $reportback->run_nid,
-      'created_at' => $photo_created_at,
+      'created_at' => $rb_created_at,
       'updated_at' => $sent_at,
       'quantity' => $reportback->quantity,
       'why_participated' => $reportback->why_participated,

--- a/scripts/export-signupless-reportbacks-to-rogue.php
+++ b/scripts/export-signupless-reportbacks-to-rogue.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Script to export Reportbacks that do not have a corresponding Signup from drupal into Rogue.
+ *
+ * to run:
+ * drush --script-path=../scripts/ php-script export-signupless-reportbacks-to-rogue.php
+ */
+
+// get all the signupless reportbacks
+$reportbacks = db_query("SELECT rb.rbid, rb.nid, rb.run_nid, rb.quantity, rb.why_participated, rb.rbid, rb.flagged, rb.uid
+  FROM dosomething.dosomething_reportback rb
+  LEFT JOIN dosomething.dosomething_signup ds on rb.uid = ds.uid AND rb.run_nid = ds.run_nid where ds.sid IS NULL");
+
+
+// for each reportback, send a request for each reportback file to POST /posts and Rogue will automatically create the signup
+foreach ($reportbacks as $reportback) {
+  echo 'On rbid ' . $reportback->rbid . '...' . PHP_EOL;
+
+  // Try to get Northstar ID
+  $northstar_id = dosomething_user_get_northstar_id($reportback->uid, 'drupal_id');
+
+  if (!$northstar_id) {
+    echo 'No northstar id, that is terrible ' . $reportback->rbid . PHP_EOL;
+
+    // @TODO: do we need this continue here?
+    continue;
+  }
+
+  // Get reportback files
+  $photos = db_query('SELECT rbf.fid, rbf.remote_addr, rbf.caption, rbf.status, rbf.reviewed, rbf.reviewer, rbf.source, rbf.status, rblog.timestamp
+                          FROM dosomething_reportback_file rbf
+                          INNER JOIN dosomething_reportback_log rblog ON rbf.fid = substring_index(rblog.files, \',\',-1)
+                          WHERE rbf.rbid = $reportback->rbid
+                          AND rbf.fid NOT IN (SELECT fid from dosomething_rogue_reportbacks)
+                          GROUP BY rbf.fid')->fetchAll();
+
+  foreach ($photos as $photo) {
+    $data = [];
+
+    echo "\t" . 'Trying fid ' . $photo->fid . '...' . PHP_EOL;
+
+    // we are also able to backdate the signup this way as long as we pass $data['created_at']
+    // Match Rogue's timestamp format
+    $photo_created_at = date('Y-m-d H:i:s', $photo->timestamp);
+    $sent_at = date('Y-m-d H:i:s');
+
+    echo "\t" . 'Sending at approximately ' . $sent_at . PHP_EOL;
+
+    // @TODO: log out NOW timestamp
+    $data = [
+      'northstar_id' => $northstar_id,
+      'campaign_id' => $reportback->nid,
+      'campaign_run_id' => $reportback->run_nid,
+      'created_at' => $photo_created_at,
+      'updated_at' => $sent_at,
+      'quantity' => $reportback->quantity,
+      'why_participated' => $reportback->why_participated,
+      'caption' => $photo->caption,
+      'status' => $photo->status,
+      // @TODO: I think if creating a new signup, the signup source will get set at this value
+      'source' => $photo->source,
+      'remote_addr' => $photo->remote_addr,
+      'file' => dosomething_helpers_get_data_uri_from_fid($photo->fid),
+    ];
+
+    // Send the request to Rogue
+    try {
+      $response = $client->postPost($data);
+
+      // Make sure we get a successful response
+      if ($response) {
+        echo 'Migrated reportback ' . $reportback->rbid . ' file ' . $photo->fid . ' to Rogue.' . PHP_EOL;
+
+        // Store reference to reportback so we don't try to send repeats upon further runs of the script
+        db_insert('dosomething_rogue_reportbacks')
+              ->fields([
+                'fid' => $photo->fid,
+                'rogue_post_id' => $response['data']['id'],
+                'rbid' => $reportback->rbid,
+                'rogue_signup_id' => $response['data']['signup_id'],
+                'created_at' => REQUEST_TIME,
+                ])
+              ->execute();
+
+        // Handle getting a 404
+        if (!$response) {
+          echo 'ERROR: 404 on reportback ' . $reportback->rbid . ' file ' . $photo->fid . ' to Rogue.' . PHP_EOL;
+        }
+      }
+    }
+    catch (GuzzleHttp\Exception\ServerException $e) {
+      // These aren't yet caught by Gateway
+
+      echo 'ERROR: SERVER EXCEPTION on reportback ' . $reportback->rbid . ' file ' . $photo->fid . ' to Rogue.' . PHP_EOL;
+    }
+    catch (DoSomething\Gateway\Exceptions\ApiException $e) {
+      echo 'ERROR: API EXCEPTION on reportback ' . $reportback->rbid . ' file ' . $photo->fid . ' to Rogue.' . PHP_EOL;
+    }
+  }
+}


### PR DESCRIPTION
#### What's this PR do?
This is a script to migrate Reportbacks that do not have a corresponding signup over to Rogue. It sends the lonely posts to the Rogue `/posts` endpoint, which creates a signup if there is not one already. Errors are handled gracefully, and no data will be duplicated in Rogue.

Documentation in progress [here](https://docs.google.com/document/d/157aE2SPT_rElkEBEclONwP_1XUYT1qtjY5glv5S9lN4/edit).

#### How should this be reviewed?
Will this mess up any data? Will this mess up Rogue?

#### Any background context you want to provide?
That darn pre-Gambit activity!

#### Relevant tickets
[Pivotal](https://www.pivotaltracker.com/story/show/151761727)

#### Checklist
- [ ] Tested on staging.
