### PR TITLE
Update method that was removed in jQuery 3.x.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUpload.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUpload.js
@@ -351,7 +351,7 @@ define(function(require) {
     var $preview = $("<img class='preview' src=''>");
     $imageContainer.html($preview);
 
-    $preview.attr("src", image.src).load(function() {
+    $preview.attr("src", image.src).on('load', function() {
       var $this = $(this);
 
       _this.resizeImage($this, $imageContainer);


### PR DESCRIPTION
#### What's this PR do?
This event handler shortcut was [deprecated & then removed in jQuery 3.x](http://api.jquery.com/load/). It's just a [shortcut](http://api.jquery.com/load-event/) for `.on( "load", handler )`.

#### How should this be reviewed?
I've tested this fix on my local.

#### Any background context you want to provide?
This addresses the one failing Ghost Inspector test after upgrading dependencies in #7516.

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  