### PR TITLE
Turn off cropping

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -10,7 +10,7 @@ include_once('dosomething_rogue.admin.inc');
 include_once('dosomething_rogue.cron.inc');
 include_once('includes/Rogue.php');
 
-define('ROGUE_API_URL', variable_get('dosomething_rogue_url', 'http://rogue.app/api'));
+define('ROGUE_API_URL', variable_get('dosomething_rogue_url', 'http://rogue.test/api'));
 define('ROGUE_API_VERSION', variable_get('dosomething_rogue_api_version', 'v1'));
 define('ROGUE_API_KEY', variable_get('dosomething_rogue_api_key', 'abc123'));
 

--- a/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUpload.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/images/ImageUpload.js
@@ -35,7 +35,7 @@ define(function(require) {
     this.$imageForm             = this.$cropModal.find("#dosomething-reportback-image-form");
     this.$imageCaption          = this.$imageForm.find("#modal-caption");
     this.$cropButton            = this.$imageForm.find(".button");
-    this.$imagePreview          = this.$cropModal.find(".image-preview");
+    this.$imagePreview          = $(".gigantor");
     this.$reportbackSubmissions = $(".reportback__submissions");
     this.imageValues            = {};
     this.readyToSave            = false;
@@ -349,14 +349,16 @@ define(function(require) {
     var _this = this;
 
     var $preview = $("<img class='preview' src=''>");
-    $imageContainer.html($preview);
+
+    $imageContainer.append($preview);
+
+    // Hack to toggle the display of the pseudo-class that controls the blue upload icon.
+    $imageContainer.toggleClass('hide-message-callout');
 
     $preview.attr("src", image.src).on('load', function() {
       var $this = $(this);
 
       _this.resizeImage($this, $imageContainer);
-
-      ImageCrop.dsCropperInit(image);
     });
   };
 
@@ -370,30 +372,13 @@ define(function(require) {
 
       _this.removeError();
 
-      if(isValidSize) {
-        // Open the modal.
-        _this.openModal();
-
-        // Add the preview image to the modal
-        _this.previewImage(image, _this.$imagePreview);
-
-        //Unbind before rebind so it doesnt fire twice.
-        _this.$cropButton.off("click");
-
-        // When the user submits the modal form, send crop values to the form.
-        _this.$cropButton.on("click", function(event) {
-          event.preventDefault();
-
-          // Validate the caption field and make sure we are good to proceed.
-          _this.validateCaption(_this.engageImageCrop, image);
-        });
-      }
-      // Show user an error if they upload an image that is too small.
-      else {
+      if (! isValidSize) {
         if (typeof ga !== 'undefined' && ga !== null) {
           ga('send', 'event', 'Reportback', 'image too small');
         }
         _this.showError(_this.dimensionsError);
+      } else {
+        _this.previewImage(image, _this.$imagePreview);
       }
     };
   };

--- a/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
+++ b/lib/themes/dosomething/paraneue_dosomething/js/reportback/Reportback.js
@@ -231,8 +231,6 @@ const Reportback = {
    */
   imageUploadInit: function() {
     this.uploader = new ImageUpload(this.$uploadButton);
-
-    this.$captionField.hide();
   },
 
 

--- a/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/content/_reportback.scss
@@ -236,7 +236,6 @@
     padding-bottom: 100%;
   }
 
-
   &:before {
     background-color: $blue;
     border-radius: 100%;
@@ -255,6 +254,10 @@
     width: 70px;
   }
 
+  &.hide-message-callout:before {
+    display: none;
+  }
+
   &:hover:before {
     background-color: lighten($blue, $color-tint);
   }
@@ -269,6 +272,10 @@
     @include media($medium) {
       bottom: 20%;
     }
+  }
+
+  &.hide-message-callout > .message-callout {
+    display: none;
   }
 
   .message-callout__copy {


### PR DESCRIPTION
#### What's this PR do?

Turns of image cropping on Phoenix Ashes! 

Instead of popping up the cropping modal. We just add a preview image to the `.gigantor` element and unhide the caption field so it is displayed on the main form (instead of the modal).

Video example (it was cut a little short but submission still successfully goes to rogue): https://cl.ly/1i3t0L1f3N0J

#### How should this be reviewed?

👀 

#### Any background context you want to provide?
In Rogue, we want to start using [Glide](http://glide.thephpleague.com/) to handle image orientation and cropping when serving images. 

To get this working on rogue, we need to turn off the user submitted cropping options so we can just default to auto orientation and a square crop in glide. 

#### Relevant tickets

Addresses https://www.pivotaltracker.com/story/show/154979852

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
