### PR TITLE
Remove 'type' field when posting to Rogue.

### DIFF
--- a/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
+++ b/lib/modules/dosomething/dosomething_rogue/includes/Rogue.php
@@ -49,6 +49,10 @@ class Rogue extends RestApiClient {
    */
   public function postReportback($data)
   {
+    // Remove 'type' => 'reportback' from payload, since
+    // this conflicts with optional field in Rogue's API.
+    unset($data['type']);
+
     $response = $this->post('v2/posts', $data);
 
     return $response;


### PR DESCRIPTION
#### What's this PR do?
This fixes an issue where posts were not making it to Rogue. We [added a validation rule](https://git.io/vxwLT) to Rogue's `POST v2/posts` endpoint to allow optional support for different post types, but didn't realize Phoenix had silently been sending a `'type' => 'reportback'` all along! 

#### How should this be reviewed?
This should allow posts to be successfully submitted to Rogue.

#### Any background context you want to provide?
Here's the [Slack conversation](https://dosomething.slack.com/archives/C02BBP0CU/p1522329042000579) related to this issue.

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  