### PR TITLE
Updates Drupal 7 core to latest (7.59, April 2018)

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -5,4 +5,4 @@ core = 7.x
 
 ; Drupal Core
 projects[drupal][type] = core
-projects[drupal][version] = 7.43
+projects[drupal][version] = 7.59


### PR DESCRIPTION
#### What's this PR do?
Updates Drupal core to April 2018 version, which closes the massive security hole.

#### How should this be reviewed?
👀 on `drupal-org-core.make`

