### PR TITLE
Updating version of grunt-sass to fix compiling error

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/package.json
+++ b/lib/themes/dosomething/paraneue_dosomething/package.json
@@ -37,7 +37,7 @@
     "grunt-eslint": "^16.0.0",
     "grunt-modernizr": "^0.6.0",
     "grunt-postcss": "^0.2.0",
-    "grunt-sass": "^0.18.0",
+    "grunt-sass": "^2.0.0",
     "grunt-sasslint": "0.0.5",
     "grunt-webpack": "^1.0.8",
     "load-grunt-tasks": "^3.1.0",


### PR DESCRIPTION
Build of international site is failing: 

```
 DEBUG [8ed474a1]     Loading "sass.js" tasks...
 DEBUG [8ed474a1]     ERROR
 DEBUG [8ed474a1]     >> Error: `libsass` bindings not found. Try reinstalling `node-sass`?
 DEBUG [8ed474a1]     Warning: Task "sass:prod" not found. Use --force to continue.
 DEBUG [8ed474a1]     
 DEBUG [8ed474a1]     Aborted due to warnings.
 ```

I think this is due to an outdated version of grunt-sass
