### PR TITLE
Adding total user count on user_search view

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.views_default.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.views_default.inc
@@ -260,6 +260,10 @@ function dosomething_user_views_default_views() {
   $handler->display->display_options['pager']['type'] = 'full';
   $handler->display->display_options['pager']['options']['items_per_page'] = '50';
   $handler->display->display_options['style_plugin'] = 'table';
+  /* Header: Global: Result summary */
+  $handler->display->display_options['header']['result']['id'] = 'result';
+  $handler->display->display_options['header']['result']['table'] = 'views';
+  $handler->display->display_options['header']['result']['field'] = 'result';
   /* Field: User: Uid */
   $handler->display->display_options['fields']['uid']['id'] = 'uid';
   $handler->display->display_options['fields']['uid']['table'] = 'users';
@@ -416,6 +420,7 @@ function dosomething_user_views_default_views() {
     t('‹ previous'),
     t('next ›'),
     t('last »'),
+    t('Displaying @start - @end of @total'),
     t('Uid'),
     t('Email'),
     t('Mobile'),


### PR DESCRIPTION
#### What's this PR do?
Adds in a user count on the user_search view:

![User count on user search view](https://photos-5.dropbox.com/t/2/AAAq0YpzJFVrCy36FRk_C647w8NGIOlrwGMjpp11SobFbw/12/663344974/png/32x32/3/1526497200/0/2/Screenshot%202018-05-16%2010.31.37.png/ENjSt7QFGFIgAigC/gCIbBk_EHjkdA8IdfcNwJWfcCJnHLYxLVLOR1OMLP4k?dl=0&preserve_transparency=1&size=2048x1536&size_mode=3)

#### How should this be reviewed?
👀 - This is a simple view export - give it glance to make sure I didn't do anything weird.

#### Any background context you want to provide?
This what Indonesia uses to count how many members they have. @mshmsh5000 - since you've disabled suspicious accts, it might be good for us to let Demas know in case he's wondering why the user count # has dropped.

#### Relevant tickets
Related to https://github.com/DoSomething/devops/issues/406