### PR TITLE
Pinned messagebroker-phplib to version 0.2.9

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -272,6 +272,7 @@ libraries[guzzle][download][url] = "https://github.com/guzzle/guzzle.git"
 ; Message Broker PHP Library
 libraries[messagebroker-phplib][download][type] = "git"
 libraries[messagebroker-phplib][download][url] = "https://github.com/DoSomething/messagebroker-phplib.git"
+libraries[messagebroker-phplib][download][tag] = "0.2.9"
 
 ; Message Broker Configuration
 libraries[messagebroker-config][download][type] = "git"


### PR DESCRIPTION
#### What's this PR do?
Need to pin to this older version of messagebroker-phplib because the method DoSomething\MessageBroker\MessageBroker::publishMessage() that’s being called in message_broker_producer.module doesn’t exist in the newer version of this library @_@

#### Relevant tickets
Related to https://github.com/DoSomething/devops/issues/406
