### PR TITLE
Fix fatal error during authentication.

### DIFF
--- a/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
+++ b/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
@@ -144,6 +144,7 @@ class OpenIDConnectClientNorthstar extends OpenIDConnectClientBase {
 
     $userinfo = $base['data'];
     $userinfo['email'] = $userinfo['id'] . '@dosomething.org';
+    $userinfo['birthdate'] = 0; // Jan 1st 1970!
 
     return $userinfo;
   }


### PR DESCRIPTION
#### What's this PR do?
This pull request fixes a fatal error where the OpenID Connect module attempts to parse birthdates incorrectly (even though it shouldn't be using them...) This fixes things up.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
The original fix was [here](https://github.com/DoSomething/phoenix/commit/7a52be8b9ed84ab7a14e4c04473bf23f2e2d85ee#diff-b5fe2464497701d1518b40a8d5e00e7c), but we don't care about real data in Ashes now.

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  