### PR TITLE
Remove duplicate Northstar ID field.

### DIFF
--- a/lib/app/Auth/PhoenixOAuthUser.php
+++ b/lib/app/Auth/PhoenixOAuthUser.php
@@ -21,6 +21,7 @@ class PhoenixOAuthUser implements NorthstarUserContract {
    * @param $user
    */
   public function __construct($uid) {
+    $this->id = dosomething_user_get_northstar_id($uid);
     $this->user = user_load($uid);
     $this->role = 'user'; // Hardcoding this is acceptable in Phoenix for now.
   }
@@ -31,7 +32,7 @@ class PhoenixOAuthUser implements NorthstarUserContract {
    * @return string|null
    */
   public function getNorthstarIdentifier() {
-    return $this->user->field_northstar_id[LANGUAGE_NONE][0]['value'];
+    return $this->id;
   }
 
   /**
@@ -40,8 +41,9 @@ class PhoenixOAuthUser implements NorthstarUserContract {
    * @return void
    */
   public function setNorthstarIdentifier($id) {
-    $this->user->field_northstar_id[LANGUAGE_NONE][0]['value'];
-    user_save($this->user);
+    $this->id = $id;
+
+    openid_connect_connect_account('northstar', $id);
   }
 
   /**

--- a/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
+++ b/lib/modules/dosomething/dosomething_campaign/dosomething_campaign.theme.inc
@@ -223,7 +223,7 @@ function dosomething_campaign_preprocess_action_page(&$vars, &$wrapper) {
   ];
   $utm_params = dosomething_helpers_utm_parameters(null, $utm_params);
 
-  if (dosomething_user_get_field('field_northstar_id')) {
+  if (dosomething_user_get_northstar_id()) {
     $share_path = 'user/' . dosomething_user_get_field('field_northstar_id');
   }
   else {

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.install
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.install
@@ -131,3 +131,14 @@ function dosomething_northstar_update_7005(&$sandbox)
 
   $result = db_truncate($table)->execute();
 }
+
+/**
+ * Remove duplicate field.
+ */
+function dosomething_northstar_update_7006() {
+  $field = 'field_northstar_id';
+
+  db_truncate('field_data_' . $field)->execute();
+  db_truncate('field_revision_' . $field)->execute();
+  field_delete_field($field);
+}

--- a/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
+++ b/lib/modules/dosomething/dosomething_northstar/dosomething_northstar.module
@@ -177,11 +177,6 @@ function dosomething_northstar_save_id_field($uid, $northstar_response) {
 
   // Save a record to the `authmap` table if Northstar user exists:
   user_set_authmaps($user, ['authname_openid_connect_northstar' => $northstar_id]);
-
-  // Save the `field_northstar_id`:
-  $edit = [];
-  dosomething_user_set_fields($edit, ['northstar_id' => $northstar_id]);
-  user_save($user, $edit);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
+++ b/lib/modules/dosomething/dosomething_northstar/plugins/openid_connect_client/northstar/OpenIDConnectClientNorthstar.class.php
@@ -144,7 +144,13 @@ class OpenIDConnectClientNorthstar extends OpenIDConnectClientBase {
 
     $userinfo = $base['data'];
     $userinfo['email'] = $userinfo['id'] . '@dosomething.org';
-    $userinfo['birthdate'] = 0; // Jan 1st 1970!
+    $userinfo['birthdate'] = 0; // Jan 1st 1970d = $userinfo['id'];
+
+    // If the authmap doesn't exist, try to match it to an existing user.
+    $account = openid_connect_user_load_by_sub($id, $this->getName());
+    if (! $account && $existingEmail = user_load_by_mail($userinfo['email'])) {
+      dosomething_northstar_save_id_field($existingEmail->uid, $base);
+    }
 
     return $userinfo;
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.signup_data_form.inc
@@ -326,8 +326,9 @@ function dosomething_signup_user_signup_data_form($form, &$form_state, $signup) 
 
     $campaign_path = url(current_path(), array('absolute' => TRUE));
 
-    if (dosomething_user_get_field('field_northstar_id')) {
-      $share_path = 'user/' . dosomething_user_get_field('field_northstar_id');
+    $northstarId = dosomething_user_get_northstar_id();
+    if ($northstarId) {
+      $share_path = 'user/' . $northstarId;
     }
     else {
       $share_path = 'user/' . dosomething_user_get_field('uid');

--- a/lib/modules/dosomething/dosomething_user/dosomething_user.module
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.module
@@ -290,7 +290,6 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
         unset($form['field_partner']);
         unset($form['field_school_id']);
         unset($form['field_user_registration_source']);
-        unset($form['field_northstar_id']);
         unset($form['field_access_token']);
         unset($form['field_access_token_expiration']);
         unset($form['field_refresh_token']);
@@ -303,7 +302,6 @@ function dosomething_user_form_alter(&$form, $form_state, $form_id) {
       else {
         // Set read-only for fields that should not be editable.
         $form['field_user_registration_source']['#disabled'] = TRUE;
-        $form['field_northstar_id']['#disabled'] = TRUE;
         $form['field_access_token']['#disabled'] = TRUE;
         $form['field_access_token_expiration']['#disabled'] = TRUE;
         $form['field_refresh_token']['#disabled'] = TRUE;
@@ -833,18 +831,11 @@ function dosomething_user_register_validate($form, &$form_state) {
  * @param string $nid
  *   The northstar id for which you are searching.
  *
- * @return string/bool
- *   The user's id in phoenix, or false if no user was found.
+ * @return object/bool
+ *   The phoenix user account, or false if no user was found.
  */
 function dosomething_user_get_user_by_northstar_id($id) {
-  $query = db_select('field_data_field_northstar_id', 'f')
-          ->condition('f.field_northstar_id_value', $id)
-          ->fields('f', ['entity_id']);
-  $uid = $query->execute()->fetchField();
-  if ($uid) {
-    return user_load($uid);
-  }
-  return FALSE;
+  return openid_connect_user_load_by_sub($id, 'northstar');
 }
 
 /**
@@ -1023,14 +1014,16 @@ function dosomething_user_get_field_northstar_id($field_value) {
  * @param  string $drupal_id
  * @return mixed
  */
-function dosomething_user_get_northstar_id($drupal_id = NULL) {
-  $user = NULL;
+function dosomething_user_get_northstar_id($uid = NULL) {
+  global $user;
 
-  if ($drupal_id) {
-    $user = user_load($drupal_id);
+  if (! $uid) {
+    $uid = $user->uid;
   }
 
-  return dosomething_user_get_field('field_northstar_id', $user);
+  $authmap = db_query("SELECT authname FROM {authmap} WHERE uid = :uid", [':uid' => $uid])->fetch();
+
+  return $authmap ? $authmap->authname : NULL;
 }
 
 /**

--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_node.inc
@@ -241,7 +241,7 @@ function paraneue_dosomething_preprocess_reportback_gallery(&$vars, $count = 6) 
       'campaign_id' => $gallery['campaign_id'],
       'status' => 'accepted',
     ],
-    'as_user' => dosomething_user_get_field('field_northstar_id'),
+    'as_user' => dosomething_user_get_northstar_id(),
     'limit' => 6
   ]);
 


### PR DESCRIPTION
#### What's this PR do?
I noticed that we sometimes read and write to `field_northstar_id`, and sometimes to the mapping of OpenID Connect users from `authmap`. To make sure we don't have data that gets out of sync, let's read and write to the same place.

#### How should this be reviewed?
I ran this on my local and everything seems fine, but the easiest place to test is for sure Thor.

#### Any background context you want to provide?
This will also save us 4.4GB on the production database (from combined `field_data` and `field_revision` tables). We should probably revisit scaling down this RDS instance at some point since it's significantly shrunk from its peak size.

#### Relevant tickets
Follow-up to earlier OpenID Connect & field deletion work today.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
