### PR TITLE
Fix fatal crash on some closed campaigns.

### DIFF
--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -204,9 +204,17 @@ function dosomething_signup_presignup_form_submit($form, &$form_state) {
  *   Number of inputs to provide for friends' numbers.
  */
 function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_friends = 3) {
+  global $user;
+
   $nid = $node->nid;
   // Add relevant configuration form elements.
   dosomething_signup_sms_game_form_config($form, $nid);
+
+  if (user_is_logged_in()) {
+    $userProfile = dosomething_northstar_get_user(
+      dosomething_user_get_northstar_id($user->uid)
+    );
+  }
 
   $form['nid'] = array(
     '#type' => 'hidden',
@@ -233,14 +241,11 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
     '#markup' => $all_participants_copy,
     '#suffix' => '</p></div></div>',
   );
-  $nsUser = dosomething_northstar_get_user(
-    dosomething_user_get_northstar_id($uid)
-  );
   $form['alpha_first_name'] = array(
     '#type' => 'textfield',
     '#required' => TRUE,
     '#title' => 'Your First Name',
-    '#default_value' => $nsUser->first_name,
+    '#default_value' => $userProfile ? $userProfile->first_name : NULL,
     '#attributes' => array(
       'data-validate' => 'fname',
       'data-validate-required' => '',
@@ -251,7 +256,7 @@ function dosomething_signup_sms_game_form($form, &$form_state, $node, $num_frien
     '#type' => 'textfield',
     '#required' => TRUE,
     '#title' => 'Your Cell Number',
-    '#default_value' => $nsUser->mobile,
+    '#default_value' => $userProfile ? $userProfile->mobile : NULL,
     '#attributes' => array(
       'data-validate' => 'phone',
       'data-validate-required' => '',


### PR DESCRIPTION
#### What's this PR do?
This pull request addresses an issue causing closed campaigns to fatally crash when users aren't logged in. In addition to being a kinda cruddy user experience, it's also causing these campaigns to disappear from Google search results! Bleh!

![big ol 500](https://user-images.githubusercontent.com/583202/41544462-cf83caa8-72e6-11e8-808f-ed022254e5ac.png)


#### How should this be reviewed?
👀 and then we'll test on Thor!

#### Any background context you want to provide?
It looks like this is a side-effect of ripping profile data out of Ashes a little while back.

#### Relevant tickets
[#157792340](https://www.pivotaltracker.com/story/show/157792340)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  