### PR TITLE
Fix usage of undefined variable.

### DIFF
--- a/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
+++ b/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc
@@ -83,7 +83,7 @@ function dosomething_user_preprocess_user_profile(&$variables) {
 
   // Collect Campaigns Doing.
   $variables['doing'] = array();
-  $doing = dosomething_campaign_get_campaigns_doing($user->uid);
+  $doing = dosomething_campaign_get_campaigns_doing($uid);
   // If user isn't doing anything:
   if (empty($doing)) {
     // Set No Signups Header.


### PR DESCRIPTION
#### What's this PR do?
@aaronschachter reported getting a white-screen error on his profile on Thor & Production, and passed along this stack trace:

```
Notice: Undefined variable: user in dosomething_user_preprocess_user_profile() (line 86 of /var/www/www.dosomething.org/releases/20180618150533/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc).
Notice: Trying to get property of non-object in dosomething_user_preprocess_user_profile() (line 86 of /var/www/www.dosomething.org/releases/20180618150533/lib/modules/dosomething/dosomething_user/dosomething_user.theme.inc).
GuzzleHttp\Exception\ServerException: Server error: `GET https://rogue-thor.dosomething.org/api/v2/posts?filter%5Bnorthstar_id%5D=5547be89469c64ec7d8b518d&include=signup&as_user=5547be89469c64ec7d8b518d` resulted in a `500 Internal Server Error` response: <!DOCTYPE html> <html lang="en"> <head> <meta charset="utf-8"> <meta http-equiv="X-UA-Compatible" co (truncated...) in GuzzleHttp\Exception\RequestException::cre
```

The `$user` variable referenced here doesn't exist. This PR replaces it with `$uid`, which does.

#### How should this be reviewed?
👀

#### Any background context you want to provide?
🍃 

#### Relevant tickets
[Slack conversation](https://dosomething.slack.com/archives/C02BBNZFA/p1529350169000112)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  