### PR TITLE
Adding feature flag to include Facebook Pixel script.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_html.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_html.inc
@@ -28,6 +28,8 @@ function paraneue_dosomething_preprocess_html(&$vars) {
   $member_count = dosomething_user_get_member_count(TRUE);
   $vars['head_title'] = token_replace($vars['head_title'], ['member-count-readable' => $member_count]);
 
+  $vars['use_facebook_pixel'] = theme_get_setting('use_facebook_pixel');
+
   $vars['enable_ad_tracking'] = variable_get('dosomething_setting_ad_tracking_enabled', FALSE);
 
   $update_url = variable_get('dosomething_settings_realtimefeed_update_url');

--- a/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
+++ b/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
@@ -16,6 +16,7 @@ features[] = secondary_menu
 ; Blocks
 settings[show_campaign_finder] = 0
 settings[show_sponsors] = 1
+settings[use_facebook_pixel] = 0
 ; Header
 settings[header_who_we_are_text] = 'What is DoSomething.org?'
 settings[header_who_we_are_subtext] = 'Young people + Social change'

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -36,6 +36,23 @@
   <?php print $head; ?>
 
   <script type="text/javascript" src="<?php print '/' . PARANEUE_PATH . '/dist/modernizr.js' ?>"></script>
+
+  <?php if ($variables['use_facebook_pixel']): ?>
+    <!-- Facebook Pixel Code -->
+    <script>
+      !function(f,b,e,v,n,t,s)
+      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+      n.queue=[];t=b.createElement(e);t.async=!0;
+      t.src=v;s=b.getElementsByTagName(e)[0];
+      s.parentNode.insertBefore(t,s)}(window, document,'script',
+      'https://connect.facebook.net/en_US/fbevents.js');
+      fbq('init', '809882989202123');
+      fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=809882989202123&ev=PageView&noscript=1" /></noscript>
+  <?php endif; ?>
 </head>
 
 <body class="<?php print $classes; if ($variables['is_affiliate']) print ' -affiliate'; ?>" <?php print $attributes;?>>
@@ -54,21 +71,6 @@
     <img height="1" width="1" style="display:none;" alt="" src="https://analytics.twitter.com/i/adsct?txn_id=nvo4z&p_id=Twitter&tw_sale_amount=0&tw_order_quantity=0" />
     <img height="1" width="1" style="display:none;" alt="" src="//t.co/i/adsct?txn_id=nvo4z&p_id=Twitter&tw_sale_amount=0&tw_order_quantity=0" />
     </noscript>
-
-    <!-- Facebook Pixel Code -->
-    <script>
-    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
-    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
-    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
-    document,'script','https://connect.facebook.net/en_US/fbevents.js');
-    fbq('init', '883788485091123');
-    fbq('track', 'PageView');
-    fbq('track', 'CompleteRegistration');
-    </script>
-    <noscript><img height="1" width="1" style="display:none"
-    src="https://www.facebook.com/tr?id=883788485091123&ev=PageView&noscript=1"
-    /></noscript>
   <?php endif; ?>
 
   <script src="https://my.hellobar.com/f70465b5f088ff5df39e838a358d27109b365641.js" type="text/javascript" charset="utf-8" async="async"></script>

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -29,6 +29,10 @@ function paraneue_dosomething_form_system_theme_settings_alter(&$form, &$form_st
       '#title' => t('Show problem statement share buttons'),
       '#description' => t('Toggles the display of problem statement share buttons on the action page.')
     ],
+    'use_facebook_pixel' => [
+      '#title' => t('Use the Facebook Pixel event tracking script'),
+      '#description' => t('Toggles including the Facebook Pixel event tracking script on all pages.'),
+    ],
   ];
 
   foreach ($flags as $name => $flag) {


### PR DESCRIPTION
#### What's this PR do?
This PR adds a feature flag that will include the Facebook Pixel ad tracking script on every page on Ashes. Since Facebook only gives you one FB Pixel ID and we don't want local development/qa staging activity muddying up the data, we only want to toggle the script to show up on production. The feature flag defaults to `0` (false) via the `paraneue_dosomething.info` file.

#### Any background context you want to provide?
As it turns out, after I finished coding this all up, I scrolled a bit farther down on the `html.tpl.php` file, only to find that a Facebook Pixel script was already included in 2016 via #7166 😱! 

Apparently it was behind a `enable_ad_tracking` toggle in the `dosomething_settings` module. However, that toggle bundles multiple scripts (a twitter ad tracking script as well), together. So to have finer grain control I felt that the feature flag I added would be more ideal. Thoughts?

Also, the FB Pixel ID for the old script doesn't seem to be something that we have on our account, so even if activated, not sure if it was tracking anything.

#### Relevant tickets
Refs [Pivotal ID #158462761](https://www.pivotaltracker.com/story/show/158462761)

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
