### PR TITLE
Updates signup and post source from pheonix-ashes to phoenix-web

### DIFF
--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -402,7 +402,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
   if (array_key_exists('storage', $form_state)) {
     $file = $form_state['storage']['file'];
     $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
-    $values['source'] = variable_get('dosomething_northstar_app_id');;
+    $values['source'] = variable_get('dosomething_northstar_app_id');
   } else {
     // If there is no file and there is a RB in Phoenix, check the dosomething_rogue_reportback table to see if the RB already exists in Rogue.
     if ($rbid) {

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -402,7 +402,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
   if (array_key_exists('storage', $form_state)) {
     $file = $form_state['storage']['file'];
     $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
-    $values['source'] = 'phoenix-ashes';
+    $values['source'] = variable_get('dosomething_northstar_app_id');;
   } else {
     // If there is no file and there is a RB in Phoenix, check the dosomething_rogue_reportback table to see if the RB already exists in Rogue.
     if ($rbid) {
@@ -413,7 +413,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
         $reportback_file = entity_load('reportback_item', array($fid));
         $values['file'] = dosomething_helpers_get_data_uri_from_fid($fid);
         $values['caption'] = $reportback_file[$fid]->caption;
-        $values['source'] = isset($reportback_file[$fid]->source) ? $reportback_file[$fid]->source : 'phoenix-ashes';
+        $values['source'] = isset($reportback_file[$fid]->source) ? $reportback_file[$fid]->source : 'phoenix-web';
       }
     }
   }

--- a/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
+++ b/lib/modules/dosomething/dosomething_reportback/dosomething_reportback.forms.inc
@@ -402,7 +402,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
   if (array_key_exists('storage', $form_state)) {
     $file = $form_state['storage']['file'];
     $values['file'] = dosomething_helpers_get_data_uri_from_fid($file->fid);
-    $values['source'] = 'phoenix-web';
+    $values['source'] = 'phoenix-ashes';
   } else {
     // If there is no file and there is a RB in Phoenix, check the dosomething_rogue_reportback table to see if the RB already exists in Rogue.
     if ($rbid) {
@@ -413,7 +413,7 @@ function dosomething_reportback_form_submit($form, &$form_state) {
         $reportback_file = entity_load('reportback_item', array($fid));
         $values['file'] = dosomething_helpers_get_data_uri_from_fid($fid);
         $values['caption'] = $reportback_file[$fid]->caption;
-        $values['source'] = isset($reportback_file[$fid]->source) ? $reportback_file[$fid]->source : 'phoenix-web';
+        $values['source'] = isset($reportback_file[$fid]->source) ? $reportback_file[$fid]->source : 'phoenix-ashes';
       }
     }
   }

--- a/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
+++ b/lib/modules/dosomething/dosomething_rogue/dosomething_rogue.module
@@ -732,8 +732,8 @@ function dosomething_rogue_send_signup_to_rogue($values, $user = NULL, $failed_t
 
   $data = dosomething_rogue_transform_signup($values, $northstar_id, $user);
   $data['type'] = 'signup';
-
   try {
+
     $response = $client->postSignup($data);
 
     if (module_exists('stathat')) {
@@ -775,6 +775,7 @@ function dosomething_rogue_transform_signup($values, $northstar_id, $user) {
     'campaign_id' => $values['campaign_id'],
     'campaign_run_id' => $run->nid,
     'source' => $values['source'],
+    'source_details' => $values['source_details'],
   ];
 
  return $data;

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -45,6 +45,10 @@ function dosomething_signup_form($form, &$form_state, $nid, $label = "Sign Up") 
 
   // Check query string for signup source value.
   if ($source = dosomething_signup_get_query_source()) {
+    if ($source === NULL) {
+      $source = 'phoenix-ashes';
+    }
+
     $form['source'] = [
       '#type' => 'hidden',
       '#value' => $source,
@@ -88,7 +92,7 @@ function dosomething_signup_form_submit($form, &$form_state) {
 
   $nid = $form_state['values']['nid'];
 
-  $source = NULL;
+  $source = 'phoenix-ashes';
   if (isset($form_state['values']['source'])) {
     $source = $form_state['values']['source'];
   }

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -44,17 +44,13 @@ function dosomething_signup_form($form, &$form_state, $nid, $label = "Sign Up") 
   ];
 
   // Check query string for signup source value.
-  if ($source = dosomething_signup_get_query_source()) {
-    if ($source === NULL) {
-      $source = 'phoenix-ashes';
-    }
-
-    $form['source'] = [
-      '#type' => 'hidden',
-      '#value' => $source,
-      '#access' => FALSE,
-    ];
-  }
+  // if ($source_details = dosomething_signup_get_query_source()) {
+  //   $form['source_details'] = [
+  //     '#type' => 'hidden',
+  //     '#value' => $source_details,
+  //     '#access' => FALSE,
+  //   ];
+  // }
 
   $form['submit'] = [
     '#type' => 'submit',
@@ -92,17 +88,15 @@ function dosomething_signup_form_submit($form, &$form_state) {
 
   $nid = $form_state['values']['nid'];
 
-  $source = 'phoenix-ashes';
-  if (isset($form_state['values']['source'])) {
-    $source = $form_state['values']['source'];
-  }
+  $source = variable_get('dosomething_northstar_app_id');;
+  $source_details = dosomething_signup_get_query_source() ? dosomething_signup_get_query_source() : NULL;
 
   if (isset($form_state['values']['affiliate_messaging_opt_in'])) {
     $params['affiliate_messaging_opt_in'] = (bool) $form_state['values']['affiliate_messaging_opt_in'];
   }
 
   // Create signup for logged in user.
-  dosomething_signup_user_signup($nid, NULL, $source, $params);
+  dosomething_signup_user_signup($nid, NULL, $source, $params, $source_details);
 }
 
 /**

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.forms.inc
@@ -43,15 +43,6 @@ function dosomething_signup_form($form, &$form_state, $nid, $label = "Sign Up") 
     '#access' => FALSE,
   ];
 
-  // Check query string for signup source value.
-  // if ($source_details = dosomething_signup_get_query_source()) {
-  //   $form['source_details'] = [
-  //     '#type' => 'hidden',
-  //     '#value' => $source_details,
-  //     '#access' => FALSE,
-  //   ];
-  // }
-
   $form['submit'] = [
     '#type' => 'submit',
     '#value' => t($label),

--- a/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
+++ b/lib/modules/dosomething/dosomething_signup/dosomething_signup.module
@@ -228,6 +228,8 @@ function dosomething_signup_get_query_source() {
  *   If not provided, uses global $user->uid.
  * @param string $source
  *   (optional) Signup source.
+ * @param string $source_details
+ *   (optional) Signup source details (e.g. taken from the query string).
  * @param int $timestamp
  *   (optional) The timestamp of the signup.
  *   If not provided, uses @dries time.
@@ -238,7 +240,7 @@ function dosomething_signup_get_query_source() {
  * @return mixed
  *   The sid of the newly inserted signup, or FALSE if error.
  */
-function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp = NULL, $transactionals = TRUE) {
+function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $source_details = NULL, $timestamp = NULL, $transactionals = TRUE) {
   global $user;
 
   if (!isset($uid)) {
@@ -258,6 +260,7 @@ function dosomething_signup_create($nid, $uid = NULL, $source = NULL, $timestamp
     'uid' => $uid,
     'run_nid' => $run->nid,
     'source'=> $source,
+    'source_details' => $source_details,
     'timestamp' => $timestamp,
     'transactionals' => $transactionals,
   ];
@@ -513,15 +516,17 @@ function dosomething_signup_views_data() {
  *   If not provided, uses global $user.
  * @param string $source
  *   (optional) The signup source.
+ * @param string $source_details
+ *   (optional) The signup source details (e.g. taken from the query string).
  */
-function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL, $params = []) {
+function dosomething_signup_user_signup($nid, $account = NULL, $source = NULL, $params = [], $source_details = NULL) {
   if ($account == NULL) {
     global $user;
     $account = $user;
   }
 
   // Insert signup.
-  $sid = dosomething_signup_create($nid, $account->uid, $source);
+  $sid = dosomething_signup_create($nid, $account->uid, $source, $source_details);
 
   if ($sid && $params) {
     if (isset($params['affiliate_messaging_opt_in']) && $params['affiliate_messaging_opt_in']) {


### PR DESCRIPTION
#### What's this PR do?
Updates signup and post `source` from `phoenix-ashes` to `phoenix-web`.

This will pull `phoenix-ashes` from using `variable_get('dosomething_northstar_app_id');` for consistency. 

#### How should this be reviewed?
Is there any other place I missed where `source` should be updated?

#### Relevant tickets
Fixes [this](https://www.pivotaltracker.com/n/projects/2019429/stories/158349333) Pivotal Card. 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  
