### PR TITLE
Update to remove Facebook Pixel related code.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_html.inc
+++ b/lib/themes/dosomething/paraneue_dosomething/includes/preprocess/preprocess_html.inc
@@ -28,8 +28,6 @@ function paraneue_dosomething_preprocess_html(&$vars) {
   $member_count = dosomething_user_get_member_count(TRUE);
   $vars['head_title'] = token_replace($vars['head_title'], ['member-count-readable' => $member_count]);
 
-  $vars['use_facebook_pixel'] = theme_get_setting('use_facebook_pixel');
-
   $vars['use_google_tag_manager'] = theme_get_setting('use_google_tag_manager');
 
   $vars['enable_ad_tracking'] = FALSE;

--- a/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
+++ b/lib/themes/dosomething/paraneue_dosomething/paraneue_dosomething.info
@@ -16,7 +16,6 @@ features[] = secondary_menu
 ; Blocks
 settings[show_campaign_finder] = 0
 settings[show_sponsors] = 1
-settings[use_facebook_pixel] = 0
 settings[use_google_tag_manager] = 0
 ; Header
 settings[header_who_we_are_text] = 'What is DoSomething.org?'

--- a/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
+++ b/lib/themes/dosomething/paraneue_dosomething/templates/system/html.tpl.php
@@ -37,22 +37,6 @@
 
   <script type="text/javascript" src="<?php print '/' . PARANEUE_PATH . '/dist/modernizr.js' ?>"></script>
 
-  <?php if ($variables['use_facebook_pixel']): ?>
-    <!-- Facebook Pixel Code -->
-    <script>
-      !function(f,b,e,v,n,t,s)
-      {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-      n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-      n.queue=[];t=b.createElement(e);t.async=!0;
-      t.src=v;s=b.getElementsByTagName(e)[0];
-      s.parentNode.insertBefore(t,s)}(window, document,'script',
-      'https://connect.facebook.net/en_US/fbevents.js');
-      fbq('init', '809882989202123');
-      fbq('track', 'PageView');
-    </script>
-  <?php endif; ?>
-
   <?php if ($variables['use_google_tag_manager']): ?>
     <!-- Google Tag Manager -->
     <script>

--- a/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
+++ b/lib/themes/dosomething/paraneue_dosomething/theme-settings.php
@@ -29,10 +29,6 @@ function paraneue_dosomething_form_system_theme_settings_alter(&$form, &$form_st
       '#title' => t('Show problem statement share buttons'),
       '#description' => t('Toggles the display of problem statement share buttons on the action page.')
     ],
-    'use_facebook_pixel' => [
-      '#title' => t('Use the Facebook Pixel event tracking script'),
-      '#description' => t('Toggles including the Facebook Pixel event tracking script on all pages.'),
-    ],
     'use_google_tag_manager' => [
       '#title' => t('Use the Google Tag Manager event tracking script'),
       '#description' => t('Toggles including the Google Tag Manager event tracking script on all pages.'),


### PR DESCRIPTION
#### What's this PR do?

This PR removes the code related to the Facebook Pixel.

#### Any background context you want to provide?

Round and round we go! After some further clarification, we only want to include the Google Tag Manager script, since you can use Google's container script to include other scripts, such as the Facebook Pixel script with a bit more fine-tuned control.

#### Relevant tickets
Refs [Pivotal ID #158462761](https://www.pivotaltracker.com/story/show/158462761)
