### PR TITLE
Reverting logo on Ashes.

### DIFF
--- a/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
+++ b/lib/themes/dosomething/paraneue_dosomething/scss/app.scss
@@ -61,8 +61,3 @@ $asset-path: "";
 
 // Variables
 $off-white: #f7f7f7;
-
-// Temporary overide for Pride 2018!
-.navigation__logo:after {
-  background: url('./rainbow-logo.svg');
-}


### PR DESCRIPTION
## _PULL REQUEST OVERVIEW_

### What does this PR do?

This PR reverts back to our regular logo. I left the SVG Pride version of the logo so we'd have it for next time (if we haven't figured out by next year a better way to do this change across all our platforms in one go).


### What are the relevant tickets/cards?

Refs [Pivotal ID #158839991](https://www.pivotaltracker.com/story/show/158839991)
