### PR TITLE
Use tagged release of title module.

### DIFF
--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -209,7 +209,7 @@ projects[taxonomy_access_fix][subdir] = "contrib"
 ; Title
 ; Dev branch used: 2015-Mar-23
 ; Fixes a bug with table layout on content type manage fields page.
-projects[title][version] = "1.x-dev"
+projects[title][version] = "1.0-alpha9"
 projects[title][subdir] = "contrib"
 ; Fixes #4973: title translation overwrites original title.
 ; See https://www.drupal.org/node/1991988.


### PR DESCRIPTION
#### What's this PR do?
This pull request updates to use a tagged release of the [title](https://www.drupal.org/project/title) module, from January 2017. This should include whatever `dev` features we were relying on for our [last successful build](https://jenkins.dosomething.org/job/Deploy-Staging/984/) in July, without the breaking changes [introduced in either August or September](https://cgit.drupalcode.org/title/log/).

#### How should this be reviewed?
I can't get my local running (because of [an issue with NFS exports, Virtualbox, and macOS Mojave](https://git.io/fx6Zm) that seems like a doozy to fix). This seems reasonable from poking around, so hopefully it builds once we merge. :v:

#### Any background context you want to provide?
This should unblock pushing #7554 to QA & production.

#### Relevant tickets
N/A

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love
- [ ] Post a message in #phoenix if this includes something that causes a rebuild!  