### PR TITLE
Drupal Security Updates for DS Indonesia

### DIFF
--- a/.docksal/commands/push-to-pantheon
+++ b/.docksal/commands/push-to-pantheon
@@ -19,6 +19,12 @@ rm -rf pantheon-codebase/*
 cp -r web/* pantheon-codebase
 
 git clone git@github.com:pantheon-systems/drops-7.git
+cp -r drops-7/includes pantheon-codebase/
+cp -r drops-7/modules pantheon-codebase/
+cp -r drops-7/profiles pantheon-codebase/
+cp -r drops-7/themes pantheon-codebase/
+cp -r drops-7/pantheon.upstream.yml pantheon-codebase/pantheon.upstream.yml
+cp drops-7/LICENSE.txt pantheon-codebase/LICENSE.txt
 cp -r drops-7/modules/pantheon pantheon-codebase/modules
 cp -r drops-7/misc/healthchecks pantheon-codebase/misc
 cp -r drops-7/profiles/pantheon pantheon-codebase/profiles

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -5,4 +5,4 @@ core = 7.x
 
 ; Drupal Core
 projects[drupal][type] = core
-projects[drupal][version] = 7.60
+projects[drupal][version] = 7.64

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -139,7 +139,7 @@ function dosomething_mbp_update_7007() {
  * Add config for Mailsystem and Mandrill modules.
  */
 function dosomething_mbp_update_7008() {
-  module_enable('mailsystem', 'mandrill');
+  module_enable(array('mailsystem', 'mandrill', 'mandrill_template'));
   $mailsystem_keys = array(
     'default-system' => 'MandrillMailSystem',
     'mandrill_user_register' => 'MandrillMailSystem',

--- a/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
+++ b/lib/modules/dosomething/dosomething_mbp/dosomething_mbp.install
@@ -139,7 +139,7 @@ function dosomething_mbp_update_7007() {
  * Add config for Mailsystem and Mandrill modules.
  */
 function dosomething_mbp_update_7008() {
-  module_enable(array('mailsystem', 'mandrill', 'mandrill_template'));
+  module_enable(array('mailsystem', 'mandrill'));
   $mailsystem_keys = array(
     'default-system' => 'MandrillMailSystem',
     'mandrill_user_register' => 'MandrillMailSystem',
@@ -187,6 +187,9 @@ function dosomething_mbp_update_7008() {
       "mailsystem_key" => "mandrill_campaign_reportback",
     ),
   );
+
+  module_enable(array('mandrill_template'));
+
   foreach ($templates as $template) {
     $map = entity_create('mandrill_template_map', $template);
     $map->save();

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -174,7 +174,7 @@ projects[seckit][subdir] = "contrib"
 projects[seckit][version] = "1.9"
 
 ; Services
-projects[services][version] = "3.21"
+projects[services][version] = "3.23"
 projects[services][subdir] = "contrib"
 
 ; Stathat

--- a/lib/profiles/dosomething/drupal-org.make
+++ b/lib/profiles/dosomething/drupal-org.make
@@ -24,7 +24,7 @@ projects[apachesolr_views][version] = "1.0-beta2"
 projects[apachesolr_views][subdir] = "contrib"
 
 ; Blockreference
-projects[blockreference][version] = "1.16"
+projects[blockreference][version] = "2.7"
 projects[blockreference][subdir] = "contrib"
 
 ; CDN
@@ -56,7 +56,7 @@ projects[entity_translation][version] = "1.0"
 projects[entity_translation][subdir] = "contrib"
 
 ; Entity Connect
-projects[entityconnect][version] = "1.0-rc1"
+projects[entityconnect][version] = "2.0-rc2"
 projects[entityconnect][subdir] = "contrib"
 
 ; Entity Reference
@@ -84,7 +84,7 @@ projects[flag][version] = "3.9"
 projects[flag][subdir] = "contrib"
 
 ; Google Analytics
-projects[google_analytics][version] = "2.5"
+projects[google_analytics][version] = "2.6"
 projects[google_analytics][subdir] = "contrib"
 
 ; Http Client
@@ -108,7 +108,7 @@ projects[libraries][version] = "2.2"
 projects[libraries][subdir] = "contrib"
 
 ; Link
-projects[link][version] = "1.2"
+projects[link][version] = "1.6"
 projects[link][subdir] = "contrib"
 
 ; Mailsystem
@@ -174,7 +174,7 @@ projects[seckit][subdir] = "contrib"
 projects[seckit][version] = "1.9"
 
 ; Services
-projects[services][version] = "3.20"
+projects[services][version] = "3.21"
 projects[services][subdir] = "contrib"
 
 ; Stathat


### PR DESCRIPTION
#### What's this PR do?
Well, I went to update the services module to 3.23 when I realized that I neglected to update the `intl-sites` branch with the last set of changes. So this PR has the changes from before the final Pantheon switch and also the services module update.

Updates are as follows:
- Update Drupal Core to 7.64
- Fixed install hook for `dosomething_mbp.install`
- Other security module updates: blockreference, entityconnect, google_analytics, link

#### Any background context you want to provide?
Also updates the docksal command for pushing to Pantheon. There were some missing files that weren't being copied over to the temporary pantheon build directory from drops 7.